### PR TITLE
feat: page category selector and css accent variables

### DIFF
--- a/cms/src/api/page/content-types/page/lifecycles.ts
+++ b/cms/src/api/page/content-types/page/lifecycles.ts
@@ -163,6 +163,7 @@ interface Page {
   title: string
   slug: string
   locale?: string
+  category?: 'default' | 'tech' | 'mission' | 'vision' | 'values'
   hero?: Hero
   seo?: Seo
   content?: ContentBlock[]
@@ -546,6 +547,11 @@ function generateMDX(page: Page): string {
         `canonicalUrl: "${escapeQuotes(page.seo.canonicalUrl)}"`
       )
     }
+  }
+
+  // Add category for theming
+  if (page.category) {
+    frontmatterLines.push(`category: "${page.category}"`)
   }
 
   // Add locale and contentId for localized pages

--- a/cms/src/api/page/content-types/page/schema.json
+++ b/cms/src/api/page/content-types/page/schema.json
@@ -52,6 +52,16 @@
         "blocks.ambassadors-grid",
         "blocks.blockquote"
       ]
+    },
+    "category": {
+      "type": "enumeration",
+      "enum": ["default", "tech", "mission", "vision", "values"],
+      "default": "default",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
     }
   }
 }

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -606,6 +606,15 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
     }
   }
   attributes: {
+    category: Schema.Attribute.Enumeration<
+      ['default', 'tech', 'mission', 'vision', 'values']
+    > &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false
+        }
+      }> &
+      Schema.Attribute.DefaultTo<'default'>
     content: Schema.Attribute.DynamicZone<
       [
         'blocks.paragraph',

--- a/src/components/blockquote/Blockquote.astro
+++ b/src/components/blockquote/Blockquote.astro
@@ -39,7 +39,7 @@ if (
 const formattedQuote = `“${trimmedQuote.trim()}”`
 ---
 
-<div class="ps-space-s py-space-2xs border-l-4 border-primary mb-space-s">
+<div class="ps-space-s py-space-2xs border-l-4 border-(--accent-color) mb-space-s">
   <blockquote class="text-step-1">
     <p>{formattedQuote}</p>
   </blockquote>

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -18,12 +18,13 @@ export async function getStaticPaths() {
 const { page } = Astro.props
 const { Content } = await render(page)
 
-const { title, heroTitle, heroDescription, description } = page.data
+const { title, heroTitle, heroDescription, description, category } = page.data
 const pageTitle = title || page.data.slug
+const pageCategory = category || 'default'
 ---
 
 <BaseLayout title={pageTitle} description={description}>
-  <main class="pb-space-l">
+  <main class="pb-space-l" data-category={pageCategory}>
     {
       heroTitle && (
         <section class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[40vh] py-space-xl text-white flex items-center">

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -138,6 +138,8 @@
     --color-header-accent: #eee;
     --color-table-stripe: #f6f7f9;
     --color-bg-inline-code: #edeef3;
+    /* Accent color for themed elements (blockquotes, etc.) */
+    --accent-color: var(--color-primary);
     --option1: linear-gradient(
       to bottom,
       hsla(162, 86%, 12%, 1),
@@ -148,6 +150,23 @@
   [data-theme='dark'] {
     --color-bg: var(--color-black);
     --color-text: var(--color-white);
+  }
+
+  /* Category-based theming */
+  [data-category='tech'] {
+    --accent-color: oklch(51.54% 0.088 194.77); /* Using primary for now */
+  }
+
+  [data-category='mission'] {
+    --accent-color: oklch(55.27% 0.205 32.62); /* Using mission color */
+  }
+
+  [data-category='vision'] {
+    --accent-color: oklch(51.54% 0.088 194.77); /* Using primary for now */
+  }
+
+  [data-category='values'] {
+    --accent-color: oklch(51.54% 0.088 194.77); /* Using primary for now */
   }
 
   main {


### PR DESCRIPTION
## PR Checklist
- [ ] Linked issue added (e.g., `Fixes #123`)
- [ ] I have run `bun run format` to ensure code is properly formatted
- [ ] I have verified that `bun run lint` passes without errors
- [ ] If blog post was added:
  - [ ] Ensure images have been optimised
  - [ ] Update dates to reflect the actual publishing date when merged (file names, folder names, and frontmatter)

## Summary
- Category-specific accent colors defined in `tailwind.css`
- Blockquote border automatically uses accent color based on page category
- Foundation pages can now set different accent colors via category selection in Strapi

Category field in Strapi - Pages can now be categorized as:
- default (uses primary color)
- tech (uses primary for now)
- mission (uses mission color)
- vision (uses primary for now)
- values (uses primary for now)
- 
Category in page data - The category is added to the MDX frontmatter and passed to the page template
Data attribute on main element - <main data-category="mission"> sets the context

CSS variable overrides - Different categories set different --accent-color values

**How to use it:**

In Strapi: When creating/editing a page, select a category from the dropdown
Blockquotes automatically pick up the accent color based on the page's category
Add more themed elements: Any component can use `var(--accent-color)` and it will automatically adjust

To customize colors:
Edit `src/styles/tailwind.css` and change the color values for each category.

<img width="1470" height="837" alt="Screenshot 2026-02-10 at 4 17 02 PM" src="https://github.com/user-attachments/assets/0ce951d2-161f-4505-b8a8-3c6301af75a5" />
