### PR TITLE
test(sync-mdx): add sync-mdx test coverage jon/intorg-399

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -11,7 +11,8 @@
     "sync:mdx": "tsx scripts/sync-mdx/index.ts",
     "sync:mdx:dry-run": "tsx scripts/sync-mdx/index.ts --dry-run",
     "sync:navigation": "tsx scripts/sync-navigation.ts",
-    "sync:navigation:dry-run": "tsx scripts/sync-navigation.ts --dry-run"
+    "sync:navigation:dry-run": "tsx scripts/sync-navigation.ts --dry-run",
+    "test:sync-mdx": "vitest run scripts/sync-mdx"
   },
   "strapi": {
     "uuid": "d5c8f4e2-9a1b-4c3d-8e7f-6a5b4c3d2e1f"
@@ -38,7 +39,8 @@
     "@types/node": "^22.10.1",
     "@types/turndown": "^5.0.6",
     "tsx": "^4.20.6",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.0"
   },
   "engines": {
     "node": ">=18.0.0 <=22.x.x",

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.11)(terser@5.46.0)
 
 packages:
 
@@ -1298,79 +1301,67 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2130,79 +2121,66 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -2523,28 +2501,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.11':
     resolution: {integrity: sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.11':
     resolution: {integrity: sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.11':
     resolution: {integrity: sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.11':
     resolution: {integrity: sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==}
@@ -2889,6 +2863,35 @@ packages:
     peerDependencies:
       vite: ^4 || ^5
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -3093,6 +3096,10 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -3220,6 +3227,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cache-content-type@1.0.1:
     resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
     engines: {node: '>= 6.0.0'}
@@ -3263,6 +3274,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -3291,6 +3306,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -3643,6 +3662,10 @@ packages:
     resolution: {integrity: sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==}
     engines: {node: '>=10'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-equal@1.0.1:
     resolution: {integrity: sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==}
 
@@ -3882,6 +3905,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -3976,6 +4002,9 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -4003,6 +4032,10 @@ packages:
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -5065,6 +5098,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
@@ -5095,6 +5131,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   mailcomposer@3.12.0:
     resolution: {integrity: sha512-zBeDoKUTNI8IAsazoMQFt3eVSVRtDtgrvBjBVdBjxDEX+5KLlKtEFCrBXnxPhs8aTYufUS1SmbFnGpjHS53deg==}
@@ -5732,6 +5771,13 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
@@ -6421,6 +6467,9 @@ packages:
   sift@16.0.1:
     resolution: {integrity: sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -6541,6 +6590,9 @@ packages:
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
@@ -6555,6 +6607,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -6762,9 +6817,27 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   title-case@4.3.2:
     resolution: {integrity: sha512-I/nkcBo73mO42Idfv08jhInV61IMb61OdIFxk+B4Gu1oBjWBPOLmhZdsli+oJCVaD+86pYQA93cJfFt224ZFAA==}
@@ -7062,6 +7135,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.19:
     resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -7122,6 +7200,31 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vscode-oniguruma@1.7.0:
@@ -7185,6 +7288,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@3.1.0:
@@ -8766,18 +8874,6 @@ snapshots:
   '@formatjs/intl-localematcher@0.6.2':
     dependencies:
       tslib: 2.8.1
-
-  '@formatjs/intl@2.10.0(typescript@5.4.4)':
-    dependencies:
-      '@formatjs/ecma402-abstract': 1.18.2
-      '@formatjs/fast-memoize': 2.2.0
-      '@formatjs/icu-messageformat-parser': 2.7.6
-      '@formatjs/intl-displaynames': 6.6.6
-      '@formatjs/intl-listformat': 7.5.5
-      intl-messageformat: 10.5.11
-      tslib: 2.8.1
-    optionalDependencies:
-      typescript: 5.4.4
 
   '@formatjs/intl@2.10.0(typescript@5.9.3)':
     dependencies:
@@ -11383,6 +11479,46 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.11)(terser@5.46.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.11)(terser@5.46.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -11599,6 +11735,8 @@ snapshots:
 
   asap@2.0.6: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -11737,6 +11875,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   cache-content-type@1.0.1:
     dependencies:
       mime-types: 2.1.35
@@ -11783,6 +11923,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -11803,6 +11951,8 @@ snapshots:
   chardet@0.7.0: {}
 
   chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -12204,6 +12354,8 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  deep-eql@5.0.2: {}
+
   deep-equal@1.0.1: {}
 
   deep-extend@0.6.0: {}
@@ -12432,6 +12584,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
@@ -12610,6 +12764,10 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
@@ -12648,6 +12806,8 @@ snapshots:
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
+
+  expect-type@1.3.0: {}
 
   extend-shallow@2.0.1:
     dependencies:
@@ -13842,6 +14002,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -13868,6 +14030,10 @@ snapshots:
   luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   mailcomposer@3.12.0:
     dependencies:
@@ -14615,6 +14781,10 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
   pause@0.0.1: {}
 
   pg-connection-string@2.6.1: {}
@@ -14862,7 +15032,7 @@ snapshots:
     dependencies:
       '@formatjs/ecma402-abstract': 1.18.2
       '@formatjs/icu-messageformat-parser': 2.7.6
-      '@formatjs/intl': 2.10.0(typescript@5.4.4)
+      '@formatjs/intl': 2.10.0(typescript@5.9.3)
       '@formatjs/intl-displaynames': 6.6.6
       '@formatjs/intl-listformat': 7.5.5
       '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.28)
@@ -15427,6 +15597,8 @@ snapshots:
 
   sift@16.0.1: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -15578,6 +15750,8 @@ snapshots:
 
   stack-trace@0.0.10: {}
 
+  stackback@0.0.2: {}
+
   stackframe@1.3.4: {}
 
   statuses@1.5.0: {}
@@ -15585,6 +15759,8 @@ snapshots:
   statuses@2.0.1: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -15788,10 +15964,20 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   title-case@4.3.2: {}
 
@@ -16051,6 +16237,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9(@types/node@22.19.11)(terser@5.46.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@5.5.0)
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.11)(terser@5.46.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.19(@types/node@22.19.11)(terser@5.46.0):
     dependencies:
       esbuild: 0.21.5
@@ -16070,6 +16274,41 @@ snapshots:
       '@types/node': 22.19.11
       fsevents: 2.3.3
       terser: 5.46.0
+
+  vitest@2.1.9(@types/node@22.19.11)(terser@5.46.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.11)(terser@5.46.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@5.5.0)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.11)(terser@5.46.0)
+      vite-node: 2.1.9(@types/node@22.19.11)(terser@5.46.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.11
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vscode-oniguruma@1.7.0: {}
 
@@ -16171,6 +16410,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@3.1.0:
     dependencies:

--- a/cms/scripts/sync-mdx/localeMatch.test.ts
+++ b/cms/scripts/sync-mdx/localeMatch.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  buildMdxSlugsByLocale,
+  hasMdxFile,
+  findMatchingLocales
+} from './localeMatch'
+import type { MDXFile } from './scan'
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+// Builds a lookup table so we can quickly check if an MDX file exists for a given locale
+// before deleting Strapi entries. Without this, we'd have to scan the file list on every check.
+describe('buildMdxSlugsByLocale', () => {
+  it('returns empty map for empty input', () => {
+    const map = buildMdxSlugsByLocale([])
+
+    expect(map.size).toBe(0)
+  })
+
+  it('groups single file by locale', () => {
+    const mdx = { slug: 'about-us', locale: 'en' } as unknown as MDXFile
+
+    const map = buildMdxSlugsByLocale([mdx])
+
+    expect(map.get('en')?.has('about-us')).toBe(true)
+  })
+
+  it('groups multiple files by their locales', () => {
+    const files = [
+      { slug: 'about', locale: 'en' },
+      { slug: 'home', locale: 'en' },
+      { slug: 'sobre-nosotros', locale: 'es' }
+    ] as unknown as MDXFile[]
+
+    const map = buildMdxSlugsByLocale(files)
+
+    expect(map.get('en')?.has('about')).toBe(true)
+    expect(map.get('en')?.has('home')).toBe(true)
+    expect(map.get('es')?.has('sobre-nosotros')).toBe(true)
+  })
+
+  // English files often have empty string locale from the scanner. We need to normalize
+  // these to 'en' so they match how Strapi stores the default locale.
+  it('defaults locale to en when locale is empty string', () => {
+    const mdx = { slug: 'page', locale: '' } as unknown as MDXFile
+
+    const map = buildMdxSlugsByLocale([mdx])
+
+    expect(map.get('en')?.has('page')).toBe(true)
+    // Should not create an empty-string key — that would cause lookups to fail
+    expect(map.has('')).toBe(false)
+  })
+
+  // Same as above, but for undefined instead of empty string
+  it('defaults locale to en when locale is undefined', () => {
+    const mdx = { slug: 'page', locale: undefined } as unknown as MDXFile
+
+    const map = buildMdxSlugsByLocale([mdx])
+
+    expect(map.get('en')?.has('page')).toBe(true)
+  })
+
+  it('handles multiple slugs in same locale', () => {
+    const files = [
+      { slug: 'page-1', locale: 'de' },
+      { slug: 'page-2', locale: 'de' },
+      { slug: 'page-3', locale: 'de' }
+    ] as unknown as MDXFile[]
+
+    const map = buildMdxSlugsByLocale(files)
+
+    expect(map.get('de')?.size).toBe(3)
+  })
+})
+
+// Simple lookup used by deleteOrphanedEntries to check if a Strapi entry
+// still has a corresponding MDX file before deleting it.
+describe('hasMdxFile', () => {
+  it('returns true when slug exists for locale', () => {
+    const map = new Map<string, Set<string>>([['es', new Set(['sobre-nosotros'])]])
+
+    expect(hasMdxFile(map, 'es', 'sobre-nosotros')).toBe(true)
+  })
+
+  it('returns false when locale does not exist in map', () => {
+    const map = new Map<string, Set<string>>()
+
+    expect(hasMdxFile(map, 'es', 'any-slug')).toBe(false)
+  })
+
+  it('returns false when slug does not exist in locale', () => {
+    const map = new Map<string, Set<string>>([['es', new Set(['existing-slug'])]])
+
+    expect(hasMdxFile(map, 'es', 'different-slug')).toBe(false)
+  })
+
+  it('returns false for empty set', () => {
+    const map = new Map<string, Set<string>>([['en', new Set()]])
+
+    expect(hasMdxFile(map, 'en', 'any-slug')).toBe(false)
+  })
+})
+
+// Finds which locale MDX files translate a given English entry by checking the `localizes`
+// frontmatter field. This powers the main sync loop where we process English files first,
+// then sync their translations.
+describe('findMatchingLocales', () => {
+  it('matches locale file via localizes field', () => {
+    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const localeFiles = [
+      { slug: 'sobre-nosotros', locale: 'es', localizes: 'about-us' }
+    ] as unknown as MDXFile[]
+
+    const matches = findMatchingLocales(englishMdx, localeFiles)
+
+    expect(matches).toHaveLength(1)
+    expect(matches[0].localeMdx.slug).toBe('sobre-nosotros')
+    expect(matches[0].matchReason).toBe('localizes: about-us')
+  })
+
+  // If localizes points to a different slug, it's not a match for this English entry.
+  // It might be a valid translation of a different page.
+  it('returns empty array when localizes points to different slug', () => {
+    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const localeFiles = [
+      { slug: 'sobre-nosotros', locale: 'es', localizes: 'other-page' }
+    ] as unknown as MDXFile[]
+
+    const matches = findMatchingLocales(englishMdx, localeFiles)
+
+    expect(matches).toHaveLength(0)
+  })
+
+  it('returns empty array when localizes is null', () => {
+    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const localeFiles = [
+      { slug: 'sobre-nosotros', locale: 'es', localizes: null }
+    ] as unknown as MDXFile[]
+
+    const matches = findMatchingLocales(englishMdx, localeFiles)
+
+    expect(matches).toHaveLength(0)
+  })
+
+  it('returns empty array for empty locale files', () => {
+    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+
+    const matches = findMatchingLocales(englishMdx, [])
+
+    expect(matches).toHaveLength(0)
+  })
+
+  // A single English page can have translations in multiple languages
+  it('matches multiple locale files for same English entry', () => {
+    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const localeFiles = [
+      { slug: 'sobre-nosotros', locale: 'es', localizes: 'about-us' },
+      { slug: 'uber-uns', locale: 'de', localizes: 'about-us' },
+      { slug: 'a-propos', locale: 'fr', localizes: 'about-us' }
+    ] as unknown as MDXFile[]
+
+    const matches = findMatchingLocales(englishMdx, localeFiles)
+
+    expect(matches).toHaveLength(3)
+    expect(matches.map((m) => m.localeMdx.slug)).toEqual([
+      'sobre-nosotros',
+      'uber-uns',
+      'a-propos'
+    ])
+  })
+
+  // Must be exact match — "about" should not match "about-us" or "aboutpage"
+  it('only matches files where localizes equals english slug exactly', () => {
+    const englishMdx = { slug: 'about' } as unknown as MDXFile
+    const localeFiles = [
+      { slug: 'match', locale: 'es', localizes: 'about' },
+      { slug: 'no-match-1', locale: 'de', localizes: 'about-us' },
+      { slug: 'no-match-2', locale: 'fr', localizes: 'aboutpage' }
+    ] as unknown as MDXFile[]
+
+    const matches = findMatchingLocales(englishMdx, localeFiles)
+
+    expect(matches).toHaveLength(1)
+    expect(matches[0].localeMdx.slug).toBe('match')
+  })
+
+  // Locale files without localizes are "orphans" — they'll be handled separately
+  // by syncUnmatchedLocales which tries to find their English parent in Strapi
+  it('returns empty array when localizes is undefined', () => {
+    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const localeFiles = [
+      { slug: 'orphan', locale: 'es', localizes: undefined }
+    ] as unknown as MDXFile[]
+
+    const matches = findMatchingLocales(englishMdx, localeFiles)
+
+    expect(matches).toHaveLength(0)
+  })
+})

--- a/cms/scripts/sync-mdx/localeMatch.test.ts
+++ b/cms/scripts/sync-mdx/localeMatch.test.ts
@@ -80,7 +80,9 @@ describe('buildMdxSlugsByLocale', () => {
 // still has a corresponding MDX file before deleting it.
 describe('hasMdxFile', () => {
   it('returns true when slug exists for locale', () => {
-    const map = new Map<string, Set<string>>([['es', new Set(['sobre-nosotros'])]])
+    const map = new Map<string, Set<string>>([
+      ['es', new Set(['sobre-nosotros'])]
+    ])
 
     expect(hasMdxFile(map, 'es', 'sobre-nosotros')).toBe(true)
   })
@@ -92,7 +94,9 @@ describe('hasMdxFile', () => {
   })
 
   it('returns false when slug does not exist in locale', () => {
-    const map = new Map<string, Set<string>>([['es', new Set(['existing-slug'])]])
+    const map = new Map<string, Set<string>>([
+      ['es', new Set(['existing-slug'])]
+    ])
 
     expect(hasMdxFile(map, 'es', 'different-slug')).toBe(false)
   })

--- a/cms/scripts/sync-mdx/localeMatch.test.ts
+++ b/cms/scripts/sync-mdx/localeMatch.test.ts
@@ -4,7 +4,7 @@ import {
   hasMdxFile,
   findMatchingLocales
 } from './localeMatch'
-import type { MDXFile } from './scan'
+import { createMdxFile } from './test-utils'
 
 beforeEach(() => {
   vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -21,7 +21,7 @@ describe('buildMdxSlugsByLocale', () => {
   })
 
   it('groups single file by locale', () => {
-    const mdx = { slug: 'about-us', locale: 'en' } as unknown as MDXFile
+    const mdx = createMdxFile({ slug: 'about-us' })
 
     const map = buildMdxSlugsByLocale([mdx])
 
@@ -30,10 +30,10 @@ describe('buildMdxSlugsByLocale', () => {
 
   it('groups multiple files by their locales', () => {
     const files = [
-      { slug: 'about', locale: 'en' },
-      { slug: 'home', locale: 'en' },
-      { slug: 'sobre-nosotros', locale: 'es' }
-    ] as unknown as MDXFile[]
+      createMdxFile({ slug: 'about' }),
+      createMdxFile({ slug: 'home' }),
+      createMdxFile({ slug: 'sobre-nosotros', locale: 'es' })
+    ]
 
     const map = buildMdxSlugsByLocale(files)
 
@@ -45,7 +45,7 @@ describe('buildMdxSlugsByLocale', () => {
   // English files often have empty string locale from the scanner. We need to normalize
   // these to 'en' so they match how Strapi stores the default locale.
   it('defaults locale to en when locale is empty string', () => {
-    const mdx = { slug: 'page', locale: '' } as unknown as MDXFile
+    const mdx = createMdxFile({ slug: 'page', locale: '' })
 
     const map = buildMdxSlugsByLocale([mdx])
 
@@ -56,7 +56,7 @@ describe('buildMdxSlugsByLocale', () => {
 
   // Same as above, but for undefined instead of empty string
   it('defaults locale to en when locale is undefined', () => {
-    const mdx = { slug: 'page', locale: undefined } as unknown as MDXFile
+    const mdx = createMdxFile({ slug: 'page', locale: undefined })
 
     const map = buildMdxSlugsByLocale([mdx])
 
@@ -65,10 +65,10 @@ describe('buildMdxSlugsByLocale', () => {
 
   it('handles multiple slugs in same locale', () => {
     const files = [
-      { slug: 'page-1', locale: 'de' },
-      { slug: 'page-2', locale: 'de' },
-      { slug: 'page-3', locale: 'de' }
-    ] as unknown as MDXFile[]
+      createMdxFile({ slug: 'page-1', locale: 'de' }),
+      createMdxFile({ slug: 'page-2', locale: 'de' }),
+      createMdxFile({ slug: 'page-3', locale: 'de' })
+    ]
 
     const map = buildMdxSlugsByLocale(files)
 
@@ -113,10 +113,14 @@ describe('hasMdxFile', () => {
 // then sync their translations.
 describe('findMatchingLocales', () => {
   it('matches locale file via localizes field', () => {
-    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const englishMdx = createMdxFile({ slug: 'about-us' })
     const localeFiles = [
-      { slug: 'sobre-nosotros', locale: 'es', localizes: 'about-us' }
-    ] as unknown as MDXFile[]
+      createMdxFile({
+        slug: 'sobre-nosotros',
+        locale: 'es',
+        localizes: 'about-us'
+      })
+    ]
 
     const matches = findMatchingLocales(englishMdx, localeFiles)
 
@@ -128,10 +132,14 @@ describe('findMatchingLocales', () => {
   // If localizes points to a different slug, it's not a match for this English entry.
   // It might be a valid translation of a different page.
   it('returns empty array when localizes points to different slug', () => {
-    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const englishMdx = createMdxFile({ slug: 'about-us' })
     const localeFiles = [
-      { slug: 'sobre-nosotros', locale: 'es', localizes: 'other-page' }
-    ] as unknown as MDXFile[]
+      createMdxFile({
+        slug: 'sobre-nosotros',
+        locale: 'es',
+        localizes: 'other-page'
+      })
+    ]
 
     const matches = findMatchingLocales(englishMdx, localeFiles)
 
@@ -139,10 +147,10 @@ describe('findMatchingLocales', () => {
   })
 
   it('returns empty array when localizes is null', () => {
-    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const englishMdx = createMdxFile({ slug: 'about-us' })
     const localeFiles = [
-      { slug: 'sobre-nosotros', locale: 'es', localizes: null }
-    ] as unknown as MDXFile[]
+      createMdxFile({ slug: 'sobre-nosotros', locale: 'es', localizes: null })
+    ]
 
     const matches = findMatchingLocales(englishMdx, localeFiles)
 
@@ -150,7 +158,7 @@ describe('findMatchingLocales', () => {
   })
 
   it('returns empty array for empty locale files', () => {
-    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const englishMdx = createMdxFile({ slug: 'about-us' })
 
     const matches = findMatchingLocales(englishMdx, [])
 
@@ -159,12 +167,16 @@ describe('findMatchingLocales', () => {
 
   // A single English page can have translations in multiple languages
   it('matches multiple locale files for same English entry', () => {
-    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const englishMdx = createMdxFile({ slug: 'about-us' })
     const localeFiles = [
-      { slug: 'sobre-nosotros', locale: 'es', localizes: 'about-us' },
-      { slug: 'uber-uns', locale: 'de', localizes: 'about-us' },
-      { slug: 'a-propos', locale: 'fr', localizes: 'about-us' }
-    ] as unknown as MDXFile[]
+      createMdxFile({
+        slug: 'sobre-nosotros',
+        locale: 'es',
+        localizes: 'about-us'
+      }),
+      createMdxFile({ slug: 'uber-uns', locale: 'de', localizes: 'about-us' }),
+      createMdxFile({ slug: 'a-propos', locale: 'fr', localizes: 'about-us' })
+    ]
 
     const matches = findMatchingLocales(englishMdx, localeFiles)
 
@@ -178,12 +190,20 @@ describe('findMatchingLocales', () => {
 
   // Must be exact match — "about" should not match "about-us" or "aboutpage"
   it('only matches files where localizes equals english slug exactly', () => {
-    const englishMdx = { slug: 'about' } as unknown as MDXFile
+    const englishMdx = createMdxFile({ slug: 'about' })
     const localeFiles = [
-      { slug: 'match', locale: 'es', localizes: 'about' },
-      { slug: 'no-match-1', locale: 'de', localizes: 'about-us' },
-      { slug: 'no-match-2', locale: 'fr', localizes: 'aboutpage' }
-    ] as unknown as MDXFile[]
+      createMdxFile({ slug: 'match', locale: 'es', localizes: 'about' }),
+      createMdxFile({
+        slug: 'no-match-1',
+        locale: 'de',
+        localizes: 'about-us'
+      }),
+      createMdxFile({
+        slug: 'no-match-2',
+        locale: 'fr',
+        localizes: 'aboutpage'
+      })
+    ]
 
     const matches = findMatchingLocales(englishMdx, localeFiles)
 
@@ -194,10 +214,10 @@ describe('findMatchingLocales', () => {
   // Locale files without localizes are "orphans" — they'll be handled separately
   // by syncUnmatchedLocales which tries to find their English parent in Strapi
   it('returns empty array when localizes is undefined', () => {
-    const englishMdx = { slug: 'about-us' } as unknown as MDXFile
+    const englishMdx = createMdxFile({ slug: 'about-us' })
     const localeFiles = [
-      { slug: 'orphan', locale: 'es', localizes: undefined }
-    ] as unknown as MDXFile[]
+      createMdxFile({ slug: 'orphan', locale: 'es', localizes: undefined })
+    ]
 
     const matches = findMatchingLocales(englishMdx, localeFiles)
 

--- a/cms/scripts/sync-mdx/localeMatch.ts
+++ b/cms/scripts/sync-mdx/localeMatch.ts
@@ -1,8 +1,19 @@
+/**
+ * Locale Matching Utilities
+ *
+ * Functions for matching MDX files across locales:
+ * - Building locale-to-slug maps for quick lookups
+ * - Checking if MDX files exist for specific locale/slug combinations
+ * - Finding locale files that translate English entries via the `localizes` field
+ */
 import type { MDXFile } from './scan'
 
 /**
- * Builds a map of all MDX slugs by locale.
- * Used to prevent deleting Strapi entries that have corresponding MDX files.
+ * Builds a map of all MDX slugs grouped by locale.
+ * Used to quickly check if an MDX file exists before deleting Strapi entries.
+ *
+ * @param mdxFiles - Array of MDX files to index
+ * @returns Map where keys are locale codes and values are Sets of slugs
  */
 export function buildMdxSlugsByLocale(
   mdxFiles: MDXFile[]
@@ -21,6 +32,11 @@ export function buildMdxSlugsByLocale(
 
 /**
  * Checks if a slug exists in MDX files for a given locale.
+ *
+ * @param mdxSlugsByLocale - Map built by buildMdxSlugsByLocale
+ * @param localeCode - Locale to check (e.g., 'en', 'es')
+ * @param slug - Slug to look for
+ * @returns True if the slug exists for that locale
  */
 export function hasMdxFile(
   mdxSlugsByLocale: Map<string, Set<string>>,
@@ -36,15 +52,19 @@ export function hasMdxFile(
 export interface LocaleMatch {
   /** The MDX file for the locale version */
   localeMdx: MDXFile
-  /** Explanation of why this match was found */
+  /** Explanation of why this match was found (e.g., "localizes: about-us") */
   matchReason: string
 }
 
 /**
- * Finds locale files that match an English entry via the `localizes` field.
+ * Finds locale files that translate an English entry via the `localizes` field.
  *
- * Searches through locale files to find those that reference the English entry's slug
- * in their `localizes` frontmatter field.
+ * Searches through locale files to find those whose `localizes` frontmatter
+ * field matches the English entry's slug.
+ *
+ * @param englishMdx - The English MDX file to find translations for
+ * @param localeFiles - Array of non-English MDX files to search
+ * @returns Array of matches with the locale file and match reason
  */
 export function findMatchingLocales(
   englishMdx: MDXFile,

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./siteSchemas', () => {
+  const { z } = require('zod')
+  const schema = z.object({
+    title: z.string().min(1),
+    slug: z.string().min(1),
+    heroTitle: z.string().optional(),
+    heroDescription: z.string().optional()
+  })
+  return {
+    foundationPageFrontmatterSchema: schema,
+    summitPageFrontmatterSchema: schema
+  }
+})
+
+import { getEntryField, isPageType, mdxToStrapiPayload } from './mdxTransformer'
+import type { StrapiEntry } from './strapiClient'
+import type { MDXFile } from './scan'
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+// Safe field accessor for Strapi entries. Returns null instead of throwing
+// when accessing fields on null entries (common for new/create operations).
+describe('getEntryField', () => {
+  it('returns null when entry is null', () => {
+    expect(getEntryField(null, 'title')).toBeNull()
+  })
+
+  it('returns field value when field exists on entry', () => {
+    const entry: StrapiEntry = {
+      documentId: '1',
+      slug: 'test',
+      title: 'My Title'
+    }
+
+    expect(getEntryField(entry, 'title')).toBe('My Title')
+  })
+
+  it('returns null when field does not exist on entry', () => {
+    const entry: StrapiEntry = { documentId: '1', slug: 'test' }
+
+    expect(getEntryField(entry, 'hero')).toBeNull()
+  })
+
+  it('returns complex objects as-is', () => {
+    const entry: StrapiEntry = {
+      documentId: '1',
+      slug: 'test',
+      hero: { title: 'Hero Title', description: 'Hero Desc' }
+    }
+
+    expect(getEntryField(entry, 'hero')).toEqual({
+      title: 'Hero Title',
+      description: 'Hero Desc'
+    })
+  })
+
+  it('returns arrays as-is', () => {
+    const entry: StrapiEntry = {
+      documentId: '1',
+      slug: 'test',
+      content: [{ __component: 'blocks.paragraph', content: 'text' }]
+    }
+
+    expect(getEntryField(entry, 'content')).toEqual([
+      { __component: 'blocks.paragraph', content: 'text' }
+    ])
+  })
+})
+
+// Determines if a content type should be treated as a "page" with hero sections
+// and content blocks. Other content types (like blog-posts) aren't supported yet.
+describe('isPageType', () => {
+  it('returns true for foundation-pages', () => {
+    expect(isPageType('foundation-pages')).toBe(true)
+  })
+
+  it('returns true for summit-pages', () => {
+    expect(isPageType('summit-pages')).toBe(true)
+  })
+
+  it('returns false for blog-posts', () => {
+    expect(isPageType('blog-posts' as any)).toBe(false)
+  })
+
+  it('returns false for unknown content types', () => {
+    expect(isPageType('unknown-type' as any)).toBe(false)
+  })
+})
+
+// Core transformation from MDX files to Strapi API payloads.
+// Handles validation, hero section logic, and content block creation.
+describe('mdxToStrapiPayload', () => {
+  describe('error handling', () => {
+    it('throws for unsupported content type', () => {
+      const mdx = {
+        slug: 'test',
+        frontmatter: { title: 'Test' },
+        content: ''
+      } as unknown as MDXFile
+
+      expect(() => mdxToStrapiPayload('blog-posts' as any, mdx)).toThrow(
+        'Unsupported content type'
+      )
+    })
+
+    it('throws when frontmatter fails validation', () => {
+      const mdx = {
+        slug: 'test',
+        frontmatter: {},
+        content: ''
+      } as unknown as MDXFile
+
+      expect(() => mdxToStrapiPayload('foundation-pages', mdx, null)).toThrow()
+    })
+  })
+
+  describe('base payload fields', () => {
+    it('includes title from frontmatter', () => {
+      const mdx = {
+        slug: 'about',
+        frontmatter: { title: 'About Us' },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.title).toBe('About Us')
+    })
+
+    it('includes slug from mdx file', () => {
+      const mdx = {
+        slug: 'about-page',
+        frontmatter: { title: 'About' },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.slug).toBe('about-page')
+    })
+
+    it('includes publishedAt timestamp', () => {
+      const mdx = {
+        slug: 'test',
+        frontmatter: { title: 'Test' },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.publishedAt).toBeDefined()
+      expect(typeof payload.publishedAt).toBe('string')
+    })
+  })
+
+  // Hero section can come from MDX frontmatter OR be preserved from existing Strapi entry.
+  // This lets us update title/content without losing hero images set in Strapi admin.
+  describe('hero fallback logic', () => {
+    it('uses frontmatter heroTitle and heroDescription when provided', () => {
+      const mdx = {
+        slug: 'about',
+        frontmatter: {
+          title: 'About',
+          heroTitle: 'Welcome',
+          heroDescription: 'Learn about us'
+        },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.hero).toEqual({
+        title: 'Welcome',
+        description: 'Learn about us'
+      })
+    })
+
+    // If only description is provided, use the page title as hero title
+    it('uses title as hero title when heroTitle not provided but heroDescription is', () => {
+      const mdx = {
+        slug: 'about',
+        frontmatter: {
+          title: 'About Page',
+          heroDescription: 'Description only'
+        },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.hero).toEqual({
+        title: 'About Page',
+        description: 'Description only'
+      })
+    })
+
+    it('uses empty description when heroTitle provided but heroDescription is not', () => {
+      const mdx = {
+        slug: 'about',
+        frontmatter: {
+          title: 'About',
+          heroTitle: 'Hero Only'
+        },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.hero).toEqual({
+        title: 'Hero Only',
+        description: ''
+      })
+    })
+
+    // Key feature: if MDX doesn't have hero fields, keep whatever's in Strapi.
+    // This preserves hero images uploaded via Strapi admin UI.
+    it('preserves existing hero when no hero fields in frontmatter', () => {
+      const existingEntry: StrapiEntry = {
+        documentId: '1',
+        slug: 'about',
+        hero: { title: 'Existing Hero', description: 'Kept intact' }
+      }
+      const mdx = {
+        slug: 'about',
+        frontmatter: { title: 'About' },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, existingEntry)
+
+      expect(payload.hero).toEqual({
+        title: 'Existing Hero',
+        description: 'Kept intact'
+      })
+    })
+
+    // No hero in MDX + no existing entry = no hero in payload
+    it('does not include hero when no frontmatter hero and no existing entry', () => {
+      const mdx = {
+        slug: 'about',
+        frontmatter: { title: 'About' },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.hero).toBeUndefined()
+    })
+
+    // MDX hero fields take precedence over Strapi — intentional override
+    it('overrides existing hero when frontmatter has hero fields', () => {
+      const existingEntry: StrapiEntry = {
+        documentId: '1',
+        slug: 'about',
+        hero: { title: 'Old Hero', description: 'Old desc' }
+      }
+      const mdx = {
+        slug: 'about',
+        frontmatter: {
+          title: 'About',
+          heroTitle: 'New Hero',
+          heroDescription: 'New desc'
+        },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, existingEntry)
+
+      expect(payload.hero).toEqual({
+        title: 'New Hero',
+        description: 'New desc'
+      })
+    })
+  })
+
+  // Content is stored as a paragraph block component. Empty content preserves existing.
+  describe('content block handling', () => {
+    it('creates content block with markdown when mdx has body', () => {
+      const mdx = {
+        slug: 'about',
+        frontmatter: { title: 'About' },
+        content: '## Heading\n\nParagraph text'
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.content).toEqual([
+        {
+          __component: 'blocks.paragraph',
+          content: '## Heading\n\nParagraph text'
+        }
+      ])
+    })
+
+    // Same fallback logic as hero — empty MDX body preserves Strapi content
+    it('preserves existing content when mdx body is empty', () => {
+      const existingEntry: StrapiEntry = {
+        documentId: '1',
+        slug: 'about',
+        content: [{ __component: 'blocks.paragraph', content: 'Existing' }]
+      }
+      const mdx = {
+        slug: 'about',
+        frontmatter: { title: 'About' },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, existingEntry)
+
+      expect(payload.content).toEqual([
+        { __component: 'blocks.paragraph', content: 'Existing' }
+      ])
+    })
+
+    // Whitespace-only should be treated as empty
+    it('preserves existing content when mdx body is whitespace only', () => {
+      const existingEntry: StrapiEntry = {
+        documentId: '1',
+        slug: 'about',
+        content: [{ __component: 'blocks.paragraph', content: 'Kept' }]
+      }
+      const mdx = {
+        slug: 'about',
+        frontmatter: { title: 'About' },
+        content: '   \n\n   '
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, existingEntry)
+
+      expect(payload.content).toEqual([
+        { __component: 'blocks.paragraph', content: 'Kept' }
+      ])
+    })
+
+    it('does not include content when no mdx body and no existing entry', () => {
+      const mdx = {
+        slug: 'about',
+        frontmatter: { title: 'About' },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.content).toBeUndefined()
+    })
+
+    it('overrides existing content when mdx has body', () => {
+      const existingEntry: StrapiEntry = {
+        documentId: '1',
+        slug: 'about',
+        content: [{ __component: 'blocks.paragraph', content: 'Old content' }]
+      }
+      const mdx = {
+        slug: 'about',
+        frontmatter: { title: 'About' },
+        content: 'New content'
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, existingEntry)
+
+      expect(payload.content).toEqual([
+        { __component: 'blocks.paragraph', content: 'New content' }
+      ])
+    })
+
+    it('handles content with null existing entry', () => {
+      const mdx = {
+        slug: 'about',
+        frontmatter: { title: 'About' },
+        content: undefined
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.content).toBeUndefined()
+    })
+  })
+
+  describe('summit-pages content type', () => {
+    it('processes summit-pages same as foundation-pages', () => {
+      const mdx = {
+        slug: 'schedule',
+        frontmatter: { title: 'Schedule' },
+        content: 'Summit content'
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('summit-pages', mdx, null)
+
+      expect(payload.title).toBe('Schedule')
+      expect(payload.slug).toBe('schedule')
+      expect(payload.content).toEqual([
+        { __component: 'blocks.paragraph', content: 'Summit content' }
+      ])
+    })
+  })
+})

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -33,7 +33,7 @@ vi.mock('./siteSchemas', async () => {
 
 import { getEntryField, isPageType, mdxToStrapiPayload } from './mdxTransformer'
 import type { StrapiEntry } from './strapiClient'
-import type { MDXFile } from './scan'
+import { createMdxFile } from './test-utils'
 
 beforeEach(() => {
   vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -116,11 +116,10 @@ describe('isPageType', () => {
 describe('mdxToStrapiPayload', () => {
   describe('error handling', () => {
     it('throws for unsupported content type', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'test',
-        frontmatter: { title: 'Test' },
-        content: ''
-      } as unknown as MDXFile
+        frontmatter: { title: 'Test' }
+      })
 
       // @ts-expect-error - testing with invalid content type
       expect(() => mdxToStrapiPayload('blog-posts', mdx)).toThrow(
@@ -129,11 +128,9 @@ describe('mdxToStrapiPayload', () => {
     })
 
     it('throws when frontmatter fails validation', () => {
-      const mdx = {
-        slug: 'test',
-        frontmatter: {},
-        content: ''
-      } as unknown as MDXFile
+      const mdx = createMdxFile({
+        slug: 'test'
+      })
 
       expect(() => mdxToStrapiPayload('foundation-pages', mdx, null)).toThrow()
     })
@@ -141,11 +138,10 @@ describe('mdxToStrapiPayload', () => {
 
   describe('base payload fields', () => {
     it('includes title from frontmatter', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
-        frontmatter: { title: 'About Us' },
-        content: ''
-      } as unknown as MDXFile
+        frontmatter: { title: 'About Us' }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -153,11 +149,10 @@ describe('mdxToStrapiPayload', () => {
     })
 
     it('includes slug from mdx file', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about-page',
-        frontmatter: { title: 'About' },
-        content: ''
-      } as unknown as MDXFile
+        frontmatter: { title: 'About' }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -165,11 +160,10 @@ describe('mdxToStrapiPayload', () => {
     })
 
     it('includes publishedAt timestamp', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'test',
-        frontmatter: { title: 'Test' },
-        content: ''
-      } as unknown as MDXFile
+        frontmatter: { title: 'Test' }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -178,7 +172,7 @@ describe('mdxToStrapiPayload', () => {
     })
 
     it('accepts optional schema fields (description, heroImage, sections)', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
         frontmatter: {
           title: 'About',
@@ -192,9 +186,8 @@ describe('mdxToStrapiPayload', () => {
               ctas: [{ label: 'Learn', href: '/learn' }]
             }
           ]
-        },
-        content: ''
-      } as unknown as MDXFile
+        }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -207,15 +200,14 @@ describe('mdxToStrapiPayload', () => {
   // This lets us update title/content without losing hero images set in Strapi admin.
   describe('hero fallback logic', () => {
     it('uses frontmatter heroTitle and heroDescription when provided', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
         frontmatter: {
           title: 'About',
           heroTitle: 'Welcome',
           heroDescription: 'Learn about us'
-        },
-        content: ''
-      } as unknown as MDXFile
+        }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -227,14 +219,13 @@ describe('mdxToStrapiPayload', () => {
 
     // If only description is provided, use the page title as hero title
     it('uses title as hero title when heroTitle not provided but heroDescription is', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
         frontmatter: {
           title: 'About Page',
           heroDescription: 'Description only'
-        },
-        content: ''
-      } as unknown as MDXFile
+        }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -245,14 +236,13 @@ describe('mdxToStrapiPayload', () => {
     })
 
     it('uses empty description when heroTitle provided but heroDescription is not', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
         frontmatter: {
           title: 'About',
           heroTitle: 'Hero Only'
-        },
-        content: ''
-      } as unknown as MDXFile
+        }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -270,11 +260,10 @@ describe('mdxToStrapiPayload', () => {
         slug: 'about',
         hero: { title: 'Existing Hero', description: 'Kept intact' }
       }
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
-        frontmatter: { title: 'About' },
-        content: ''
-      } as unknown as MDXFile
+        frontmatter: { title: 'About' }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, existingEntry)
 
@@ -286,11 +275,10 @@ describe('mdxToStrapiPayload', () => {
 
     // No hero in MDX + no existing entry = no hero in payload
     it('does not include hero when no frontmatter hero and no existing entry', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
-        frontmatter: { title: 'About' },
-        content: ''
-      } as unknown as MDXFile
+        frontmatter: { title: 'About' }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -304,15 +292,14 @@ describe('mdxToStrapiPayload', () => {
         slug: 'about',
         hero: { title: 'Old Hero', description: 'Old desc' }
       }
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
         frontmatter: {
           title: 'About',
           heroTitle: 'New Hero',
           heroDescription: 'New desc'
-        },
-        content: ''
-      } as unknown as MDXFile
+        }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, existingEntry)
 
@@ -326,11 +313,11 @@ describe('mdxToStrapiPayload', () => {
   // Content is stored as a paragraph block component. Empty content preserves existing.
   describe('content block handling', () => {
     it('creates content block with markdown when mdx has body', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
         frontmatter: { title: 'About' },
         content: '## Heading\n\nParagraph text'
-      } as unknown as MDXFile
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -349,11 +336,10 @@ describe('mdxToStrapiPayload', () => {
         slug: 'about',
         content: [{ __component: 'blocks.paragraph', content: 'Existing' }]
       }
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
-        frontmatter: { title: 'About' },
-        content: ''
-      } as unknown as MDXFile
+        frontmatter: { title: 'About' }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, existingEntry)
 
@@ -369,11 +355,11 @@ describe('mdxToStrapiPayload', () => {
         slug: 'about',
         content: [{ __component: 'blocks.paragraph', content: 'Kept' }]
       }
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
         frontmatter: { title: 'About' },
         content: '   \n\n   '
-      } as unknown as MDXFile
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, existingEntry)
 
@@ -383,11 +369,10 @@ describe('mdxToStrapiPayload', () => {
     })
 
     it('does not include content when no mdx body and no existing entry', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
-        frontmatter: { title: 'About' },
-        content: ''
-      } as unknown as MDXFile
+        frontmatter: { title: 'About' }
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -400,11 +385,11 @@ describe('mdxToStrapiPayload', () => {
         slug: 'about',
         content: [{ __component: 'blocks.paragraph', content: 'Old content' }]
       }
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
         frontmatter: { title: 'About' },
         content: 'New content'
-      } as unknown as MDXFile
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, existingEntry)
 
@@ -414,11 +399,11 @@ describe('mdxToStrapiPayload', () => {
     })
 
     it('handles content with null existing entry', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'about',
         frontmatter: { title: 'About' },
         content: undefined
-      } as unknown as MDXFile
+      })
 
       const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
 
@@ -428,11 +413,11 @@ describe('mdxToStrapiPayload', () => {
 
   describe('summit-pages content type', () => {
     it('processes summit-pages same as foundation-pages', () => {
-      const mdx = {
+      const mdx = createMdxFile({
         slug: 'schedule',
         frontmatter: { title: 'Schedule' },
         content: 'Summit content'
-      } as unknown as MDXFile
+      })
 
       const payload = mdxToStrapiPayload('summit-pages', mdx, null)
 

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -1,18 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { z } from 'zod'
 
-vi.mock('./siteSchemas', () => {
-  const { z } = require('zod')
-  const schema = z.object({
-    title: z.string().min(1),
-    slug: z.string().min(1),
-    heroTitle: z.string().optional(),
-    heroDescription: z.string().optional()
-  })
-  return {
-    foundationPageFrontmatterSchema: schema,
-    summitPageFrontmatterSchema: schema
-  }
+const mockSchema = z.object({
+  title: z.string().min(1),
+  slug: z.string().min(1),
+  heroTitle: z.string().optional(),
+  heroDescription: z.string().optional()
 })
+
+vi.mock('./siteSchemas', () => ({
+  foundationPageFrontmatterSchema: mockSchema,
+  summitPageFrontmatterSchema: mockSchema
+}))
 
 import { getEntryField, isPageType, mdxToStrapiPayload } from './mdxTransformer'
 import type { StrapiEntry } from './strapiClient'
@@ -84,11 +83,13 @@ describe('isPageType', () => {
   })
 
   it('returns false for blog-posts', () => {
-    expect(isPageType('blog-posts' as any)).toBe(false)
+    // @ts-expect-error - testing with invalid content type
+    expect(isPageType('blog-posts')).toBe(false)
   })
 
   it('returns false for unknown content types', () => {
-    expect(isPageType('unknown-type' as any)).toBe(false)
+    // @ts-expect-error - testing with invalid content type
+    expect(isPageType('unknown-type')).toBe(false)
   })
 })
 
@@ -103,7 +104,8 @@ describe('mdxToStrapiPayload', () => {
         content: ''
       } as unknown as MDXFile
 
-      expect(() => mdxToStrapiPayload('blog-posts' as any, mdx)).toThrow(
+      // @ts-expect-error - testing with invalid content type
+      expect(() => mdxToStrapiPayload('blog-posts', mdx)).toThrow(
         'Unsupported content type'
       )
     })

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -1,17 +1,35 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { z } from 'zod'
 
-const mockSchema = z.object({
-  title: z.string().min(1),
-  slug: z.string().min(1),
-  heroTitle: z.string().optional(),
-  heroDescription: z.string().optional()
+vi.mock('./siteSchemas', async () => {
+  const { z } = await import('zod')
+  const sectionSchema = z.object({
+    title: z.string(),
+    content: z.string(),
+    ctas: z
+      .array(
+        z.object({
+          label: z.string(),
+          href: z.string()
+        })
+      )
+      .optional()
+  })
+  const pageSchema = z.object({
+    title: z.string().min(1, 'title is required'),
+    slug: z.string().min(1, 'slug is required'),
+    description: z.string().optional(),
+    heroTitle: z.string().optional(),
+    heroDescription: z.string().optional(),
+    heroImage: z.string().optional(),
+    sections: z.array(sectionSchema).optional(),
+    localizes: z.string().optional(),
+    locale: z.string().optional()
+  })
+  return {
+    foundationPageFrontmatterSchema: pageSchema,
+    summitPageFrontmatterSchema: pageSchema
+  }
 })
-
-vi.mock('./siteSchemas', () => ({
-  foundationPageFrontmatterSchema: mockSchema,
-  summitPageFrontmatterSchema: mockSchema
-}))
 
 import { getEntryField, isPageType, mdxToStrapiPayload } from './mdxTransformer'
 import type { StrapiEntry } from './strapiClient'
@@ -157,6 +175,31 @@ describe('mdxToStrapiPayload', () => {
 
       expect(payload.publishedAt).toBeDefined()
       expect(typeof payload.publishedAt).toBe('string')
+    })
+
+    it('accepts optional schema fields (description, heroImage, sections)', () => {
+      const mdx = {
+        slug: 'about',
+        frontmatter: {
+          title: 'About',
+          description: 'Page description',
+          heroImage: '/images/hero.jpg',
+          sections: [
+            { title: 'Section 1', content: 'Content 1' },
+            {
+              title: 'Section 2',
+              content: 'Content 2',
+              ctas: [{ label: 'Learn', href: '/learn' }]
+            }
+          ]
+        },
+        content: ''
+      } as unknown as MDXFile
+
+      const payload = mdxToStrapiPayload('foundation-pages', mdx, null)
+
+      expect(payload.title).toBe('About')
+      expect(payload.slug).toBe('about')
     })
   })
 

--- a/cms/scripts/sync-mdx/syncOperations.test.ts
+++ b/cms/scripts/sync-mdx/syncOperations.test.ts
@@ -1,0 +1,838 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  syncEnglishEntry,
+  syncLocaleEntry,
+  deleteOrphanedEntries,
+  syncUnmatchedLocales
+} from './syncOperations'
+import type { StrapiEntry } from './strapiClient'
+import type { ContentTypes } from './config'
+import type { SyncContext, SyncResults } from './types'
+import type { MDXFile } from './scan'
+
+vi.mock('./mdxTransformer', () => ({
+  mdxToStrapiPayload: vi.fn(() => ({ title: 'Mocked Payload', slug: 'mocked' }))
+}))
+
+vi.mock('./localeMatch', () => ({
+  hasMdxFile: vi.fn(() => false)
+}))
+
+vi.mock('./scan', () => ({
+  getLocalesToCheck: vi.fn(() => ['en', 'es'])
+}))
+
+import { mdxToStrapiPayload } from './mdxTransformer'
+import { hasMdxFile } from './localeMatch'
+import { getLocalesToCheck } from './scan'
+
+const mockedMdxToStrapiPayload = vi.mocked(mdxToStrapiPayload)
+const mockedHasMdxFile = vi.mocked(hasMdxFile)
+const mockedGetLocalesToCheck = vi.mocked(getLocalesToCheck)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+function createMockStrapi() {
+  return {
+    request: vi.fn().mockResolvedValue({}),
+    getAllEntries: vi.fn().mockResolvedValue([]),
+    findBySlug: vi.fn().mockResolvedValue(undefined),
+    createEntry: vi
+      .fn()
+      .mockResolvedValue({ data: { documentId: 'new-1', slug: 'test' } }),
+    updateEntry: vi
+      .fn()
+      .mockResolvedValue({ data: { documentId: '1', slug: 'test' } }),
+    createLocalization: vi.fn().mockResolvedValue({}),
+    updateLocalization: vi.fn().mockResolvedValue({}),
+    deleteEntry: vi.fn().mockResolvedValue({}),
+    deleteLocalization: vi.fn().mockResolvedValue({})
+  }
+}
+
+const baseConfig: ContentTypes['foundation-pages'] = {
+  dir: '/content/foundation-pages',
+  apiId: 'foundation-pages'
+}
+
+const contentTypes: ContentTypes = {
+  'foundation-pages': baseConfig,
+  'summit-pages': { dir: '/content/summit', apiId: 'summit-pages' }
+}
+
+function createResults(): SyncResults {
+  return { created: 0, updated: 0, deleted: 0, errors: 0 }
+}
+
+// Syncs English entries to Strapi — creates new or updates existing.
+// English entries are synced first because locale entries link to them.
+describe('syncEnglishEntry', () => {
+  it('creates entry when no existing entry found', async () => {
+    const strapi = createMockStrapi()
+    // findBySlug returns undefined = no existing entry, so we create
+    strapi.findBySlug.mockResolvedValue(undefined)
+    strapi.createEntry.mockResolvedValue({
+      data: { documentId: 'created-1', slug: 'about' }
+    })
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = {
+      slug: 'about',
+      locale: 'en',
+      frontmatter: { title: 'About', slug: 'about' },
+      content: 'Body'
+    } as unknown as MDXFile
+
+    const entry = await syncEnglishEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      ctx,
+      results,
+      false
+    )
+
+    expect(strapi.createEntry).toHaveBeenCalledWith(
+      'foundation-pages',
+      expect.any(Object)
+    )
+    expect(results.created).toBe(1)
+    expect(results.updated).toBe(0)
+    expect(entry?.documentId).toBe('created-1')
+  })
+
+  it('updates entry when existing entry found', async () => {
+    // Simulate finding an existing entry in Strapi
+    const existing: StrapiEntry = { documentId: 'doc-1', slug: 'about' }
+    const strapi = createMockStrapi()
+    strapi.findBySlug.mockResolvedValue(existing)
+    strapi.updateEntry.mockResolvedValue({ data: existing })
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = {
+      slug: 'about',
+      locale: 'en',
+      frontmatter: { title: 'About', slug: 'about' }
+    } as unknown as MDXFile
+
+    await syncEnglishEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      ctx,
+      results,
+      false
+    )
+
+    expect(strapi.updateEntry).toHaveBeenCalledWith(
+      'foundation-pages',
+      'doc-1',
+      expect.any(Object)
+    )
+    expect(results.created).toBe(0)
+    expect(results.updated).toBe(1)
+  })
+
+  // Existing entry is passed to transformer so it can preserve hero/content
+  // that wasn't specified in the MDX file
+  it('passes existing entry to mdxToStrapiPayload for hero fallback', async () => {
+    const existing: StrapiEntry = {
+      documentId: 'doc-1',
+      slug: 'about',
+      hero: { url: '/existing-hero.jpg' }
+    }
+    const strapi = createMockStrapi()
+    strapi.findBySlug.mockResolvedValue(existing)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = {
+      slug: 'about',
+      locale: 'en',
+      frontmatter: { title: 'About', slug: 'about' }
+    } as unknown as MDXFile
+
+    await syncEnglishEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      ctx,
+      results,
+      false
+    )
+
+    expect(mockedMdxToStrapiPayload).toHaveBeenCalledWith(
+      'foundation-pages',
+      mdx,
+      existing
+    )
+  })
+
+  // Dry run mode: count what would happen without actually calling Strapi
+  it('dry run increments created counter without calling createEntry', async () => {
+    const strapi = createMockStrapi()
+    strapi.findBySlug.mockResolvedValue(undefined)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = {
+      slug: 'about',
+      locale: 'en',
+      frontmatter: { title: 'About', slug: 'about' }
+    } as unknown as MDXFile
+
+    await syncEnglishEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      ctx,
+      results,
+      true
+    )
+
+    // Should NOT actually create — that's the point of dry run
+    expect(strapi.createEntry).not.toHaveBeenCalled()
+    expect(results.created).toBe(1)
+  })
+
+  it('dry run increments updated counter without calling updateEntry', async () => {
+    const existing: StrapiEntry = { documentId: 'doc-1', slug: 'about' }
+    const strapi = createMockStrapi()
+    strapi.findBySlug.mockResolvedValue(existing)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = {
+      slug: 'about',
+      locale: 'en',
+      frontmatter: { title: 'About', slug: 'about' }
+    } as unknown as MDXFile
+
+    await syncEnglishEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      ctx,
+      results,
+      true
+    )
+
+    expect(strapi.updateEntry).not.toHaveBeenCalled()
+    expect(results.updated).toBe(1)
+  })
+
+  it('returns existing entry on dry run update', async () => {
+    const existing: StrapiEntry = { documentId: 'doc-1', slug: 'about' }
+    const strapi = createMockStrapi()
+    strapi.findBySlug.mockResolvedValue(existing)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = { slug: 'about', locale: 'en' } as unknown as MDXFile
+
+    const entry = await syncEnglishEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      ctx,
+      results,
+      true
+    )
+
+    expect(entry).toBe(existing)
+  })
+
+  // Dry run creates need to return something so locale sync can continue
+  it('returns dry run placeholder entry on dry run create', async () => {
+    const strapi = createMockStrapi()
+    strapi.findBySlug.mockResolvedValue(undefined)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = { slug: 'new-page', locale: 'en' } as unknown as MDXFile
+
+    const entry = await syncEnglishEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      ctx,
+      results,
+      true
+    )
+
+    expect(entry?.documentId).toBe('dry-run-id')
+    expect(entry?.slug).toBe('new-page')
+  })
+})
+
+// Syncs locale entries as localizations of an English parent entry.
+// Uses Strapi's i18n localization API rather than creating standalone entries.
+describe('syncLocaleEntry', () => {
+  const englishEntry: StrapiEntry = {
+    documentId: 'en-1',
+    slug: 'about',
+    locale: 'en'
+  }
+
+  it('creates localization when none exists', async () => {
+    const strapi = createMockStrapi()
+    // No existing locale entry = create new localization
+    strapi.findBySlug.mockResolvedValue(undefined)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = {
+      slug: 'sobre-nosotros',
+      locale: 'es',
+      isLocalization: true,
+      frontmatter: { title: 'Sobre', slug: 'sobre-nosotros', localizes: 'about' }
+    } as unknown as MDXFile
+
+    await syncLocaleEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      englishEntry,
+      ctx,
+      results,
+      false
+    )
+
+    expect(strapi.createLocalization).toHaveBeenCalledWith(
+      'foundation-pages',
+      'en-1',
+      'es',
+      expect.any(Object)
+    )
+    expect(results.created).toBe(1)
+  })
+
+  it('updates localization when it exists', async () => {
+    // Simulate existing Spanish localization
+    const existingLocale: StrapiEntry = {
+      documentId: 'es-1',
+      slug: 'sobre-nosotros',
+      locale: 'es'
+    }
+    const strapi = createMockStrapi()
+    strapi.findBySlug.mockResolvedValue(existingLocale)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = {
+      slug: 'sobre-nosotros',
+      locale: 'es',
+      isLocalization: true,
+      frontmatter: { title: 'Sobre', slug: 'sobre-nosotros', localizes: 'about' }
+    } as unknown as MDXFile
+
+    await syncLocaleEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      englishEntry,
+      ctx,
+      results,
+      false
+    )
+
+    expect(strapi.updateLocalization).toHaveBeenCalledWith(
+      'foundation-pages',
+      'en-1',
+      'es',
+      expect.any(Object)
+    )
+    expect(results.updated).toBe(1)
+  })
+
+  // Same locale defaulting as buildMdxSlugsByLocale — keeps behavior consistent
+  it('defaults locale to en when mdx.locale is undefined', async () => {
+    const strapi = createMockStrapi()
+    strapi.findBySlug.mockResolvedValue(undefined)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = {
+      slug: 'some-page',
+      locale: undefined,
+      frontmatter: { title: 'Some', slug: 'some-page' }
+    } as unknown as MDXFile
+
+    await syncLocaleEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      englishEntry,
+      ctx,
+      results,
+      false
+    )
+
+    expect(strapi.findBySlug).toHaveBeenCalledWith(
+      'foundation-pages',
+      'some-page',
+      'en'
+    )
+  })
+
+  it('dry run increments created counter without calling createLocalization', async () => {
+    const strapi = createMockStrapi()
+    strapi.findBySlug.mockResolvedValue(undefined)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = {
+      slug: 'sobre-nosotros',
+      locale: 'es'
+    } as unknown as MDXFile
+
+    await syncLocaleEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      englishEntry,
+      ctx,
+      results,
+      true
+    )
+
+    expect(strapi.createLocalization).not.toHaveBeenCalled()
+    expect(results.created).toBe(1)
+  })
+
+  it('dry run increments updated counter without calling updateLocalization', async () => {
+    const existingLocale: StrapiEntry = {
+      documentId: 'es-1',
+      slug: 'sobre-nosotros',
+      locale: 'es'
+    }
+    const strapi = createMockStrapi()
+    strapi.findBySlug.mockResolvedValue(existingLocale)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdx = {
+      slug: 'sobre-nosotros',
+      locale: 'es'
+    } as unknown as MDXFile
+
+    await syncLocaleEntry(
+      'foundation-pages',
+      baseConfig,
+      mdx,
+      englishEntry,
+      ctx,
+      results,
+      true
+    )
+
+    expect(strapi.updateLocalization).not.toHaveBeenCalled()
+    expect(results.updated).toBe(1)
+  })
+})
+
+// Removes Strapi entries that no longer have corresponding MDX files.
+// Runs after sync to clean up deleted pages.
+describe('deleteOrphanedEntries', () => {
+  it('deletes entries that have no matching MDX file', async () => {
+    mockedGetLocalesToCheck.mockReturnValue(['en'])
+    // hasMdxFile returns false = no MDX file exists, so this is an orphan
+    mockedHasMdxFile.mockReturnValue(false)
+    const strapi = createMockStrapi()
+    strapi.getAllEntries.mockResolvedValue([
+      { documentId: '1', slug: 'orphan', locale: 'en' }
+    ])
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdxSlugsByLocale = new Map<string, Set<string>>()
+
+    await deleteOrphanedEntries(
+      'foundation-pages',
+      baseConfig,
+      contentTypes,
+      mdxSlugsByLocale,
+      ctx,
+      results,
+      false
+    )
+
+    expect(strapi.deleteLocalization).toHaveBeenCalledWith(
+      'foundation-pages',
+      '1',
+      'en'
+    )
+    expect(results.deleted).toBe(1)
+  })
+
+  it('skips entries that have matching MDX file', async () => {
+    mockedGetLocalesToCheck.mockReturnValue(['en'])
+    // hasMdxFile returns true = MDX file exists, don't delete
+    mockedHasMdxFile.mockReturnValue(true)
+    const strapi = createMockStrapi()
+    strapi.getAllEntries.mockResolvedValue([
+      { documentId: '2', slug: 'kept', locale: 'en' }
+    ])
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdxSlugsByLocale = new Map([['en', new Set(['kept'])]])
+
+    await deleteOrphanedEntries(
+      'foundation-pages',
+      baseConfig,
+      contentTypes,
+      mdxSlugsByLocale,
+      ctx,
+      results,
+      false
+    )
+
+    // Should NOT delete — the MDX file still exists
+    expect(strapi.deleteLocalization).not.toHaveBeenCalled()
+    expect(results.deleted).toBe(0)
+  })
+
+  it('processes multiple locales', async () => {
+    mockedGetLocalesToCheck.mockReturnValue(['en', 'es'])
+    mockedHasMdxFile.mockReturnValue(false)
+    const strapi = createMockStrapi()
+    strapi.getAllEntries
+      .mockResolvedValueOnce([{ documentId: '1', slug: 'orphan-en', locale: 'en' }])
+      .mockResolvedValueOnce([{ documentId: '2', slug: 'orphan-es', locale: 'es' }])
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdxSlugsByLocale = new Map<string, Set<string>>()
+
+    await deleteOrphanedEntries(
+      'foundation-pages',
+      baseConfig,
+      contentTypes,
+      mdxSlugsByLocale,
+      ctx,
+      results,
+      false
+    )
+
+    expect(strapi.getAllEntries).toHaveBeenCalledTimes(2)
+    expect(results.deleted).toBe(2)
+  })
+
+  // Entry.locale might differ from the query locale if Strapi returns mixed results.
+  // We use the actual entry locale for the hasMdxFile check and delete call.
+  it('uses entry.locale when available instead of loop locale', async () => {
+    mockedGetLocalesToCheck.mockReturnValue(['en'])
+    mockedHasMdxFile.mockReturnValue(false)
+    const strapi = createMockStrapi()
+    // Querying 'en' but entry has locale 'fr' — use 'fr' for operations
+    strapi.getAllEntries.mockResolvedValue([
+      { documentId: '1', slug: 'test', locale: 'fr' }
+    ])
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdxSlugsByLocale = new Map<string, Set<string>>()
+
+    await deleteOrphanedEntries(
+      'foundation-pages',
+      baseConfig,
+      contentTypes,
+      mdxSlugsByLocale,
+      ctx,
+      results,
+      false
+    )
+
+    expect(mockedHasMdxFile).toHaveBeenCalledWith(
+      mdxSlugsByLocale,
+      'fr',
+      'test'
+    )
+    expect(strapi.deleteLocalization).toHaveBeenCalledWith(
+      'foundation-pages',
+      '1',
+      'fr'
+    )
+  })
+
+  it('dry run increments deleted counter without calling deleteLocalization', async () => {
+    mockedGetLocalesToCheck.mockReturnValue(['en'])
+    mockedHasMdxFile.mockReturnValue(false)
+    const strapi = createMockStrapi()
+    strapi.getAllEntries.mockResolvedValue([
+      { documentId: '1', slug: 'orphan', locale: 'en' }
+    ])
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdxSlugsByLocale = new Map<string, Set<string>>()
+
+    await deleteOrphanedEntries(
+      'foundation-pages',
+      baseConfig,
+      contentTypes,
+      mdxSlugsByLocale,
+      ctx,
+      results,
+      true
+    )
+
+    expect(strapi.deleteLocalization).not.toHaveBeenCalled()
+    expect(results.deleted).toBe(1)
+  })
+
+  // Delete errors shouldn't crash the whole sync — log and continue
+  it('increments errors counter when delete fails', async () => {
+    mockedGetLocalesToCheck.mockReturnValue(['en'])
+    mockedHasMdxFile.mockReturnValue(false)
+    const strapi = createMockStrapi()
+    strapi.getAllEntries.mockResolvedValue([
+      { documentId: '1', slug: 'failing', locale: 'en' }
+    ])
+    strapi.deleteLocalization.mockRejectedValue(new Error('Delete failed'))
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const mdxSlugsByLocale = new Map<string, Set<string>>()
+
+    await deleteOrphanedEntries(
+      'foundation-pages',
+      baseConfig,
+      contentTypes,
+      mdxSlugsByLocale,
+      ctx,
+      results,
+      false
+    )
+
+    expect(results.errors).toBe(1)
+    expect(results.deleted).toBe(0)
+  })
+})
+
+// Handles locale MDX files that weren't matched during the main English sync pass.
+// This can happen when the English file doesn't exist in MDX but does exist in Strapi.
+describe('syncUnmatchedLocales', () => {
+  it('creates localization when match found in Strapi', async () => {
+    const localeMdx = {
+      slug: 'sobre-nosotros',
+      locale: 'es',
+      isLocalization: true,
+      localizes: 'about-us',
+      frontmatter: { title: 'Sobre', slug: 'sobre-nosotros', localizes: 'about-us' }
+    } as unknown as MDXFile
+    // Simulate English entry existing in Strapi (but not in MDX)
+    const allStrapiEntries: StrapiEntry[] = [
+      { documentId: 'en-1', slug: 'about-us', locale: 'en' }
+    ]
+    const strapi = createMockStrapi()
+    strapi.getAllEntries.mockResolvedValue(allStrapiEntries)
+    strapi.findBySlug.mockResolvedValue(undefined)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const matchedSlugs = new Set<string>()
+
+    await syncUnmatchedLocales(
+      'foundation-pages',
+      baseConfig,
+      [localeMdx],
+      matchedSlugs,
+      ctx,
+      results,
+      false
+    )
+
+    expect(strapi.createLocalization).toHaveBeenCalledWith(
+      'foundation-pages',
+      'en-1',
+      'es',
+      expect.any(Object)
+    )
+    expect(results.created).toBe(1)
+  })
+
+  // Track which locales we've processed to avoid duplicates
+  it('adds matched locale to matchedSlugs set', async () => {
+    const localeMdx = {
+      slug: 'sobre-nosotros',
+      locale: 'es',
+      isLocalization: true,
+      localizes: 'about-us'
+    } as unknown as MDXFile
+    const strapi = createMockStrapi()
+    strapi.getAllEntries.mockResolvedValue([
+      { documentId: 'en-1', slug: 'about-us', locale: 'en' }
+    ])
+    strapi.findBySlug.mockResolvedValue(undefined)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const matchedSlugs = new Set<string>()
+
+    await syncUnmatchedLocales(
+      'foundation-pages',
+      baseConfig,
+      [localeMdx],
+      matchedSlugs,
+      ctx,
+      results,
+      false
+    )
+
+    expect(matchedSlugs.has('es:sobre-nosotros')).toBe(true)
+  })
+
+  // Can't create a localization without an English parent
+  it('does not create when no matching English entry in Strapi', async () => {
+    const localeMdx = {
+      slug: 'sobre-nosotros',
+      locale: 'es',
+      isLocalization: true,
+      localizes: 'nonexistent'
+    } as unknown as MDXFile
+    const strapi = createMockStrapi()
+    strapi.getAllEntries.mockResolvedValue([])
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const matchedSlugs = new Set<string>()
+
+    await syncUnmatchedLocales(
+      'foundation-pages',
+      baseConfig,
+      [localeMdx],
+      matchedSlugs,
+      ctx,
+      results,
+      false
+    )
+
+    // Should NOT create — no English parent to attach to
+    expect(strapi.createLocalization).not.toHaveBeenCalled()
+    expect(results.created).toBe(0)
+  })
+
+  // Skip locales already processed in the main sync loop
+  it('skips already matched locale slugs', async () => {
+    const localeMdx = {
+      slug: 'sobre-nosotros',
+      locale: 'es',
+      isLocalization: true,
+      localizes: 'about-us'
+    } as unknown as MDXFile
+    const strapi = createMockStrapi()
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const matchedSlugs = new Set<string>(['es:sobre-nosotros'])
+
+    await syncUnmatchedLocales(
+      'foundation-pages',
+      baseConfig,
+      [localeMdx],
+      matchedSlugs,
+      ctx,
+      results,
+      false
+    )
+
+    // Should skip entirely — no API calls
+    expect(strapi.getAllEntries).not.toHaveBeenCalled()
+    expect(results.created).toBe(0)
+  })
+
+  it('returns early when no unmatched locales', async () => {
+    const strapi = createMockStrapi()
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const matchedSlugs = new Set<string>()
+
+    await syncUnmatchedLocales(
+      'foundation-pages',
+      baseConfig,
+      [],
+      matchedSlugs,
+      ctx,
+      results,
+      false
+    )
+
+    expect(strapi.getAllEntries).not.toHaveBeenCalled()
+  })
+
+  it('defaults locale to en when mdx.locale is undefined', async () => {
+    const localeMdx = {
+      slug: 'some-page',
+      locale: undefined,
+      isLocalization: true,
+      localizes: 'english-page'
+    } as unknown as MDXFile
+    const strapi = createMockStrapi()
+    strapi.getAllEntries.mockResolvedValue([
+      { documentId: 'en-1', slug: 'english-page', locale: 'en' }
+    ])
+    strapi.findBySlug.mockResolvedValue(undefined)
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const matchedSlugs = new Set<string>()
+
+    await syncUnmatchedLocales(
+      'foundation-pages',
+      baseConfig,
+      [localeMdx],
+      matchedSlugs,
+      ctx,
+      results,
+      false
+    )
+
+    expect(matchedSlugs.has('en:some-page')).toBe(true)
+  })
+
+  it('increments errors counter when syncLocaleEntry fails', async () => {
+    const localeMdx = {
+      slug: 'sobre-nosotros',
+      locale: 'es',
+      isLocalization: true,
+      localizes: 'about-us'
+    } as unknown as MDXFile
+    const strapi = createMockStrapi()
+    strapi.getAllEntries.mockResolvedValue([
+      { documentId: 'en-1', slug: 'about-us', locale: 'en' }
+    ])
+    strapi.findBySlug.mockResolvedValue(undefined)
+    strapi.createLocalization.mockRejectedValue(new Error('API error'))
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const matchedSlugs = new Set<string>()
+
+    await syncUnmatchedLocales(
+      'foundation-pages',
+      baseConfig,
+      [localeMdx],
+      matchedSlugs,
+      ctx,
+      results,
+      false
+    )
+
+    expect(results.errors).toBe(1)
+  })
+
+  // localizes: null means this locale file doesn't know which English page it translates
+  it('does not match when localizes is null', async () => {
+    const localeMdx = {
+      slug: 'orphan-page',
+      locale: 'es',
+      isLocalization: true,
+      localizes: null
+    } as unknown as MDXFile
+    const strapi = createMockStrapi()
+    strapi.getAllEntries.mockResolvedValue([
+      { documentId: 'en-1', slug: 'about-us', locale: 'en' }
+    ])
+    const ctx: SyncContext = { contentTypes, strapi }
+    const results = createResults()
+    const matchedSlugs = new Set<string>()
+
+    await syncUnmatchedLocales(
+      'foundation-pages',
+      baseConfig,
+      [localeMdx],
+      matchedSlugs,
+      ctx,
+      results,
+      false
+    )
+
+    // Can't match without knowing which English page to link to
+    expect(strapi.createLocalization).not.toHaveBeenCalled()
+    expect(results.created).toBe(0)
+  })
+})

--- a/cms/scripts/sync-mdx/syncOperations.test.ts
+++ b/cms/scripts/sync-mdx/syncOperations.test.ts
@@ -283,7 +283,11 @@ describe('syncLocaleEntry', () => {
       slug: 'sobre-nosotros',
       locale: 'es',
       isLocalization: true,
-      frontmatter: { title: 'Sobre', slug: 'sobre-nosotros', localizes: 'about' }
+      frontmatter: {
+        title: 'Sobre',
+        slug: 'sobre-nosotros',
+        localizes: 'about'
+      }
     } as unknown as MDXFile
 
     await syncLocaleEntry(
@@ -320,7 +324,11 @@ describe('syncLocaleEntry', () => {
       slug: 'sobre-nosotros',
       locale: 'es',
       isLocalization: true,
-      frontmatter: { title: 'Sobre', slug: 'sobre-nosotros', localizes: 'about' }
+      frontmatter: {
+        title: 'Sobre',
+        slug: 'sobre-nosotros',
+        localizes: 'about'
+      }
     } as unknown as MDXFile
 
     await syncLocaleEntry(
@@ -490,8 +498,12 @@ describe('deleteOrphanedEntries', () => {
     mockedHasMdxFile.mockReturnValue(false)
     const strapi = createMockStrapi()
     strapi.getAllEntries
-      .mockResolvedValueOnce([{ documentId: '1', slug: 'orphan-en', locale: 'en' }])
-      .mockResolvedValueOnce([{ documentId: '2', slug: 'orphan-es', locale: 'es' }])
+      .mockResolvedValueOnce([
+        { documentId: '1', slug: 'orphan-en', locale: 'en' }
+      ])
+      .mockResolvedValueOnce([
+        { documentId: '2', slug: 'orphan-es', locale: 'es' }
+      ])
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
     const mdxSlugsByLocale = new Map<string, Set<string>>()
@@ -608,7 +620,11 @@ describe('syncUnmatchedLocales', () => {
       locale: 'es',
       isLocalization: true,
       localizes: 'about-us',
-      frontmatter: { title: 'Sobre', slug: 'sobre-nosotros', localizes: 'about-us' }
+      frontmatter: {
+        title: 'Sobre',
+        slug: 'sobre-nosotros',
+        localizes: 'about-us'
+      }
     } as unknown as MDXFile
     // Simulate English entry existing in Strapi (but not in MDX)
     const allStrapiEntries: StrapiEntry[] = [

--- a/cms/scripts/sync-mdx/syncOperations.test.ts
+++ b/cms/scripts/sync-mdx/syncOperations.test.ts
@@ -8,7 +8,7 @@ import {
 import type { StrapiEntry } from './strapiClient'
 import type { ContentTypes } from './config'
 import type { SyncContext, SyncResults } from './types'
-import type { MDXFile } from './scan'
+import { createMdxFile } from './test-utils'
 
 vi.mock('./mdxTransformer', () => ({
   mdxToStrapiPayload: vi.fn(() => ({ title: 'Mocked Payload', slug: 'mocked' }))
@@ -80,12 +80,11 @@ describe('syncEnglishEntry', () => {
     })
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = {
+    const mdx = createMdxFile({
       slug: 'about',
-      locale: 'en',
       frontmatter: { title: 'About', slug: 'about' },
       content: 'Body'
-    } as unknown as MDXFile
+    })
 
     const entry = await syncEnglishEntry(
       'foundation-pages',
@@ -113,11 +112,10 @@ describe('syncEnglishEntry', () => {
     strapi.updateEntry.mockResolvedValue({ data: existing })
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = {
+    const mdx = createMdxFile({
       slug: 'about',
-      locale: 'en',
       frontmatter: { title: 'About', slug: 'about' }
-    } as unknown as MDXFile
+    })
 
     await syncEnglishEntry(
       'foundation-pages',
@@ -149,11 +147,10 @@ describe('syncEnglishEntry', () => {
     strapi.findBySlug.mockResolvedValue(existing)
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = {
+    const mdx = createMdxFile({
       slug: 'about',
-      locale: 'en',
       frontmatter: { title: 'About', slug: 'about' }
-    } as unknown as MDXFile
+    })
 
     await syncEnglishEntry(
       'foundation-pages',
@@ -177,11 +174,10 @@ describe('syncEnglishEntry', () => {
     strapi.findBySlug.mockResolvedValue(undefined)
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = {
+    const mdx = createMdxFile({
       slug: 'about',
-      locale: 'en',
       frontmatter: { title: 'About', slug: 'about' }
-    } as unknown as MDXFile
+    })
 
     await syncEnglishEntry(
       'foundation-pages',
@@ -203,11 +199,10 @@ describe('syncEnglishEntry', () => {
     strapi.findBySlug.mockResolvedValue(existing)
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = {
+    const mdx = createMdxFile({
       slug: 'about',
-      locale: 'en',
       frontmatter: { title: 'About', slug: 'about' }
-    } as unknown as MDXFile
+    })
 
     await syncEnglishEntry(
       'foundation-pages',
@@ -228,7 +223,7 @@ describe('syncEnglishEntry', () => {
     strapi.findBySlug.mockResolvedValue(existing)
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = { slug: 'about', locale: 'en' } as unknown as MDXFile
+    const mdx = createMdxFile({ slug: 'about' })
 
     const entry = await syncEnglishEntry(
       'foundation-pages',
@@ -248,7 +243,7 @@ describe('syncEnglishEntry', () => {
     strapi.findBySlug.mockResolvedValue(undefined)
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = { slug: 'new-page', locale: 'en' } as unknown as MDXFile
+    const mdx = createMdxFile({ slug: 'new-page' })
 
     const entry = await syncEnglishEntry(
       'foundation-pages',
@@ -279,7 +274,7 @@ describe('syncLocaleEntry', () => {
     strapi.findBySlug.mockResolvedValue(undefined)
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = {
+    const mdx = createMdxFile({
       slug: 'sobre-nosotros',
       locale: 'es',
       isLocalization: true,
@@ -288,7 +283,7 @@ describe('syncLocaleEntry', () => {
         slug: 'sobre-nosotros',
         localizes: 'about'
       }
-    } as unknown as MDXFile
+    })
 
     await syncLocaleEntry(
       'foundation-pages',
@@ -320,7 +315,7 @@ describe('syncLocaleEntry', () => {
     strapi.findBySlug.mockResolvedValue(existingLocale)
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = {
+    const mdx = createMdxFile({
       slug: 'sobre-nosotros',
       locale: 'es',
       isLocalization: true,
@@ -329,7 +324,7 @@ describe('syncLocaleEntry', () => {
         slug: 'sobre-nosotros',
         localizes: 'about'
       }
-    } as unknown as MDXFile
+    })
 
     await syncLocaleEntry(
       'foundation-pages',
@@ -356,11 +351,11 @@ describe('syncLocaleEntry', () => {
     strapi.findBySlug.mockResolvedValue(undefined)
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = {
+    const mdx = createMdxFile({
       slug: 'some-page',
       locale: undefined,
       frontmatter: { title: 'Some', slug: 'some-page' }
-    } as unknown as MDXFile
+    })
 
     await syncLocaleEntry(
       'foundation-pages',
@@ -384,10 +379,10 @@ describe('syncLocaleEntry', () => {
     strapi.findBySlug.mockResolvedValue(undefined)
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = {
+    const mdx = createMdxFile({
       slug: 'sobre-nosotros',
       locale: 'es'
-    } as unknown as MDXFile
+    })
 
     await syncLocaleEntry(
       'foundation-pages',
@@ -413,10 +408,10 @@ describe('syncLocaleEntry', () => {
     strapi.findBySlug.mockResolvedValue(existingLocale)
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
-    const mdx = {
+    const mdx = createMdxFile({
       slug: 'sobre-nosotros',
       locale: 'es'
-    } as unknown as MDXFile
+    })
 
     await syncLocaleEntry(
       'foundation-pages',
@@ -615,7 +610,7 @@ describe('deleteOrphanedEntries', () => {
 // This can happen when the English file doesn't exist in MDX but does exist in Strapi.
 describe('syncUnmatchedLocales', () => {
   it('creates localization when match found in Strapi', async () => {
-    const localeMdx = {
+    const localeMdx = createMdxFile({
       slug: 'sobre-nosotros',
       locale: 'es',
       isLocalization: true,
@@ -625,7 +620,7 @@ describe('syncUnmatchedLocales', () => {
         slug: 'sobre-nosotros',
         localizes: 'about-us'
       }
-    } as unknown as MDXFile
+    })
     // Simulate English entry existing in Strapi (but not in MDX)
     const allStrapiEntries: StrapiEntry[] = [
       { documentId: 'en-1', slug: 'about-us', locale: 'en' }
@@ -658,12 +653,12 @@ describe('syncUnmatchedLocales', () => {
 
   // Track which locales we've processed to avoid duplicates
   it('adds matched locale to matchedSlugs set', async () => {
-    const localeMdx = {
+    const localeMdx = createMdxFile({
       slug: 'sobre-nosotros',
       locale: 'es',
       isLocalization: true,
       localizes: 'about-us'
-    } as unknown as MDXFile
+    })
     const strapi = createMockStrapi()
     strapi.getAllEntries.mockResolvedValue([
       { documentId: 'en-1', slug: 'about-us', locale: 'en' }
@@ -688,12 +683,12 @@ describe('syncUnmatchedLocales', () => {
 
   // Can't create a localization without an English parent
   it('does not create when no matching English entry in Strapi', async () => {
-    const localeMdx = {
+    const localeMdx = createMdxFile({
       slug: 'sobre-nosotros',
       locale: 'es',
       isLocalization: true,
       localizes: 'nonexistent'
-    } as unknown as MDXFile
+    })
     const strapi = createMockStrapi()
     strapi.getAllEntries.mockResolvedValue([])
     const ctx: SyncContext = { contentTypes, strapi }
@@ -717,12 +712,12 @@ describe('syncUnmatchedLocales', () => {
 
   // Skip locales already processed in the main sync loop
   it('skips already matched locale slugs', async () => {
-    const localeMdx = {
+    const localeMdx = createMdxFile({
       slug: 'sobre-nosotros',
       locale: 'es',
       isLocalization: true,
       localizes: 'about-us'
-    } as unknown as MDXFile
+    })
     const strapi = createMockStrapi()
     const ctx: SyncContext = { contentTypes, strapi }
     const results = createResults()
@@ -763,12 +758,12 @@ describe('syncUnmatchedLocales', () => {
   })
 
   it('defaults locale to en when mdx.locale is undefined', async () => {
-    const localeMdx = {
+    const localeMdx = createMdxFile({
       slug: 'some-page',
       locale: undefined,
       isLocalization: true,
       localizes: 'english-page'
-    } as unknown as MDXFile
+    })
     const strapi = createMockStrapi()
     strapi.getAllEntries.mockResolvedValue([
       { documentId: 'en-1', slug: 'english-page', locale: 'en' }
@@ -792,12 +787,12 @@ describe('syncUnmatchedLocales', () => {
   })
 
   it('increments errors counter when syncLocaleEntry fails', async () => {
-    const localeMdx = {
+    const localeMdx = createMdxFile({
       slug: 'sobre-nosotros',
       locale: 'es',
       isLocalization: true,
       localizes: 'about-us'
-    } as unknown as MDXFile
+    })
     const strapi = createMockStrapi()
     strapi.getAllEntries.mockResolvedValue([
       { documentId: 'en-1', slug: 'about-us', locale: 'en' }
@@ -823,12 +818,12 @@ describe('syncUnmatchedLocales', () => {
 
   // localizes: null means this locale file doesn't know which English page it translates
   it('does not match when localizes is null', async () => {
-    const localeMdx = {
+    const localeMdx = createMdxFile({
       slug: 'orphan-page',
       locale: 'es',
       isLocalization: true,
       localizes: null
-    } as unknown as MDXFile
+    })
     const strapi = createMockStrapi()
     strapi.getAllEntries.mockResolvedValue([
       { documentId: 'en-1', slug: 'about-us', locale: 'en' }

--- a/cms/scripts/sync-mdx/syncOperations.ts
+++ b/cms/scripts/sync-mdx/syncOperations.ts
@@ -1,3 +1,14 @@
+/**
+ * Sync Operations
+ *
+ * Core functions for syncing MDX content to Strapi CMS:
+ * - syncEnglishEntry: Create/update English entries (synced first, as locale parents)
+ * - syncLocaleEntry: Create/update localized entries linked to English parents
+ * - syncUnmatchedLocales: Handle locale files whose English parent is in Strapi but not MDX
+ * - deleteOrphanedEntries: Remove Strapi entries that no longer have MDX files
+ *
+ * All operations support dry-run mode for previewing changes.
+ */
 import { type MDXFile, getLocalesToCheck } from './scan'
 import type { ContentTypes } from './config'
 import type { StrapiEntry } from './strapiClient'

--- a/cms/scripts/sync-mdx/test-utils.ts
+++ b/cms/scripts/sync-mdx/test-utils.ts
@@ -1,0 +1,20 @@
+import type { MDXFile } from './scan'
+
+// Allow undefined values to test edge cases without casts
+type MdxFileOverrides = Partial<{
+  [K in keyof MDXFile]: MDXFile[K] | undefined
+}>
+
+export function createMdxFile(overrides: MdxFileOverrides = {}): MDXFile {
+  return {
+    file: 'test.mdx',
+    filepath: '/content/test.mdx',
+    slug: 'test',
+    locale: 'en',
+    frontmatter: {},
+    content: '',
+    isLocalization: false,
+    localizes: null,
+    ...overrides
+  } as MDXFile
+}

--- a/cms/scripts/sync-mdx/validateFrontmatter.test.ts
+++ b/cms/scripts/sync-mdx/validateFrontmatter.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect } from 'vitest'
 import { validateFrontmatter, validateMdxFiles } from './validateFrontmatter'
-import type { MDXFile } from './scan'
+import { createMdxFile } from './test-utils'
 
 // Validates MDX frontmatter against Zod schemas before syncing to Strapi.
 // Invalid files are skipped during sync to avoid corrupting CMS data.
 describe('validateFrontmatter', () => {
   it('returns null for valid foundation-pages frontmatter', () => {
-    const mdx = {
+    const mdx = createMdxFile({
       filepath: '/content/about.mdx',
       slug: 'about-us',
-      locale: 'en',
       frontmatter: { title: 'About Us' }
-    } as unknown as MDXFile
+    })
 
     const result = validateFrontmatter('foundation-pages', mdx)
 
@@ -19,12 +18,11 @@ describe('validateFrontmatter', () => {
   })
 
   it('returns null for valid summit-pages frontmatter', () => {
-    const mdx = {
+    const mdx = createMdxFile({
       filepath: '/content/schedule.mdx',
       slug: 'schedule',
-      locale: 'en',
       frontmatter: { title: 'Schedule' }
-    } as unknown as MDXFile
+    })
 
     const result = validateFrontmatter('summit-pages', mdx)
 
@@ -32,12 +30,10 @@ describe('validateFrontmatter', () => {
   })
 
   it('returns error with filepath when title is missing', () => {
-    const mdx = {
+    const mdx = createMdxFile({
       filepath: '/content/invalid.mdx',
-      slug: 'invalid',
-      locale: 'en',
-      frontmatter: {}
-    } as unknown as MDXFile
+      slug: 'invalid'
+    })
 
     const result = validateFrontmatter('foundation-pages', mdx)
 
@@ -46,12 +42,7 @@ describe('validateFrontmatter', () => {
   })
 
   it('returns error with slug from mdx file', () => {
-    const mdx = {
-      filepath: '/content/test.mdx',
-      slug: 'test-slug',
-      locale: 'en',
-      frontmatter: {}
-    } as unknown as MDXFile
+    const mdx = createMdxFile({ slug: 'test-slug' })
 
     const result = validateFrontmatter('foundation-pages', mdx)
 
@@ -60,12 +51,7 @@ describe('validateFrontmatter', () => {
   })
 
   it('returns error with locale from mdx file', () => {
-    const mdx = {
-      filepath: '/content/test.mdx',
-      slug: 'test',
-      locale: 'es',
-      frontmatter: {}
-    } as unknown as MDXFile
+    const mdx = createMdxFile({ locale: 'es' })
 
     const result = validateFrontmatter('foundation-pages', mdx)
 
@@ -74,12 +60,7 @@ describe('validateFrontmatter', () => {
   })
 
   it('returns error array with validation messages', () => {
-    const mdx = {
-      filepath: '/content/test.mdx',
-      slug: 'test',
-      locale: 'en',
-      frontmatter: {}
-    } as unknown as MDXFile
+    const mdx = createMdxFile({})
 
     const result = validateFrontmatter('foundation-pages', mdx)
 
@@ -92,12 +73,7 @@ describe('validateFrontmatter', () => {
 
   // Empty string is not the same as missing — Zod's min(1) catches both
   it('returns error when title is empty string', () => {
-    const mdx = {
-      filepath: '/content/test.mdx',
-      slug: 'test',
-      locale: 'en',
-      frontmatter: { title: '' }
-    } as unknown as MDXFile
+    const mdx = createMdxFile({ frontmatter: { title: '' } })
 
     const result = validateFrontmatter('foundation-pages', mdx)
 
@@ -109,12 +85,10 @@ describe('validateFrontmatter', () => {
 
   // Slug comes from MDX file metadata, not frontmatter, but we still validate it
   it('returns error when slug is empty in mdx file', () => {
-    const mdx = {
-      filepath: '/content/test.mdx',
+    const mdx = createMdxFile({
       slug: '',
-      locale: 'en',
       frontmatter: { title: 'Valid Title' }
-    } as unknown as MDXFile
+    })
 
     const result = validateFrontmatter('foundation-pages', mdx)
 
@@ -130,19 +104,16 @@ describe('validateFrontmatter', () => {
 describe('validateMdxFiles', () => {
   it('partitions files into valid and invalid arrays', () => {
     const files = [
-      {
+      createMdxFile({
         filepath: '/content/good.mdx',
         slug: 'good',
-        locale: 'en',
         frontmatter: { title: 'Good' }
-      },
-      {
+      }),
+      createMdxFile({
         filepath: '/content/bad.mdx',
-        slug: 'bad',
-        locale: 'en',
-        frontmatter: {}
-      }
-    ] as unknown as MDXFile[]
+        slug: 'bad'
+      })
+    ]
 
     const { valid, invalid } = validateMdxFiles('foundation-pages', files)
 
@@ -152,19 +123,17 @@ describe('validateMdxFiles', () => {
 
   it('places valid files in valid array', () => {
     const files = [
-      {
+      createMdxFile({
         filepath: '/content/page1.mdx',
         slug: 'page1',
-        locale: 'en',
         frontmatter: { title: 'Page 1' }
-      },
-      {
+      }),
+      createMdxFile({
         filepath: '/content/page2.mdx',
         slug: 'page2',
-        locale: 'en',
         frontmatter: { title: 'Page 2' }
-      }
-    ] as unknown as MDXFile[]
+      })
+    ]
 
     const { valid, invalid } = validateMdxFiles('foundation-pages', files)
 
@@ -176,13 +145,11 @@ describe('validateMdxFiles', () => {
 
   it('places invalid files in invalid array with error details', () => {
     const files = [
-      {
+      createMdxFile({
         filepath: '/content/missing-title.mdx',
-        slug: 'missing-title',
-        locale: 'en',
-        frontmatter: {}
-      }
-    ] as unknown as MDXFile[]
+        slug: 'missing-title'
+      })
+    ]
 
     const { valid, invalid } = validateMdxFiles('foundation-pages', files)
 
@@ -203,25 +170,23 @@ describe('validateMdxFiles', () => {
   // while English and German files pass
   it('handles mixed valid and invalid files across locales', () => {
     const files = [
-      {
+      createMdxFile({
         filepath: '/content/en/page.mdx',
         slug: 'page',
-        locale: 'en',
         frontmatter: { title: 'English Page' }
-      },
-      {
+      }),
+      createMdxFile({
         filepath: '/content/es/page.mdx',
         slug: 'pagina',
-        locale: 'es',
-        frontmatter: {}
-      },
-      {
+        locale: 'es'
+      }),
+      createMdxFile({
         filepath: '/content/de/page.mdx',
         slug: 'seite',
         locale: 'de',
         frontmatter: { title: 'Deutsche Seite' }
-      }
-    ] as unknown as MDXFile[]
+      })
+    ]
 
     const { valid, invalid } = validateMdxFiles('foundation-pages', files)
 

--- a/cms/scripts/sync-mdx/validateFrontmatter.test.ts
+++ b/cms/scripts/sync-mdx/validateFrontmatter.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { z } from 'zod'
+
+vi.mock('./siteSchemas', () => {
+  const { z } = require('zod')
+  return {
+    foundationPageFrontmatterSchema: z.object({
+      title: z.string().min(1),
+      slug: z.string().min(1)
+    }),
+    summitPageFrontmatterSchema: z.object({
+      title: z.string().min(1),
+      slug: z.string().min(1)
+    })
+  }
+})
+
+import { validateFrontmatter, validateMdxFiles } from './validateFrontmatter'
+import type { MDXFile } from './scan'
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+// Validates MDX frontmatter against Zod schemas before syncing to Strapi.
+// Invalid files are skipped during sync to avoid corrupting CMS data.
+describe('validateFrontmatter', () => {
+  it('returns null for valid foundation-pages frontmatter', () => {
+    const mdx = {
+      filepath: '/content/about.mdx',
+      slug: 'about-us',
+      locale: 'en',
+      frontmatter: { title: 'About Us' }
+    } as unknown as MDXFile
+
+    const result = validateFrontmatter('foundation-pages', mdx)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null for valid summit-pages frontmatter', () => {
+    const mdx = {
+      filepath: '/content/schedule.mdx',
+      slug: 'schedule',
+      locale: 'en',
+      frontmatter: { title: 'Schedule' }
+    } as unknown as MDXFile
+
+    const result = validateFrontmatter('summit-pages', mdx)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns error with filepath when title is missing', () => {
+    const mdx = {
+      filepath: '/content/invalid.mdx',
+      slug: 'invalid',
+      locale: 'en',
+      frontmatter: {}
+    } as unknown as MDXFile
+
+    const result = validateFrontmatter('foundation-pages', mdx)
+
+    expect(result).not.toBeNull()
+    expect(result!.filepath).toBe('/content/invalid.mdx')
+  })
+
+  it('returns error with slug from mdx file', () => {
+    const mdx = {
+      filepath: '/content/test.mdx',
+      slug: 'test-slug',
+      locale: 'en',
+      frontmatter: {}
+    } as unknown as MDXFile
+
+    const result = validateFrontmatter('foundation-pages', mdx)
+
+    expect(result).not.toBeNull()
+    expect(result!.slug).toBe('test-slug')
+  })
+
+  it('returns error with locale from mdx file', () => {
+    const mdx = {
+      filepath: '/content/test.mdx',
+      slug: 'test',
+      locale: 'es',
+      frontmatter: {}
+    } as unknown as MDXFile
+
+    const result = validateFrontmatter('foundation-pages', mdx)
+
+    expect(result).not.toBeNull()
+    expect(result!.locale).toBe('es')
+  })
+
+  it('returns error array with validation messages', () => {
+    const mdx = {
+      filepath: '/content/test.mdx',
+      slug: 'test',
+      locale: 'en',
+      frontmatter: {}
+    } as unknown as MDXFile
+
+    const result = validateFrontmatter('foundation-pages', mdx)
+
+    expect(result).not.toBeNull()
+    expect(result!.errors.length).toBeGreaterThan(0)
+    expect(result!.errors.some((e) => e.toLowerCase().includes('title'))).toBe(true)
+  })
+
+  // Empty string is not the same as missing — Zod's min(1) catches both
+  it('returns error when title is empty string', () => {
+    const mdx = {
+      filepath: '/content/test.mdx',
+      slug: 'test',
+      locale: 'en',
+      frontmatter: { title: '' }
+    } as unknown as MDXFile
+
+    const result = validateFrontmatter('foundation-pages', mdx)
+
+    expect(result).not.toBeNull()
+    expect(result!.errors.some((e) => e.toLowerCase().includes('title'))).toBe(true)
+  })
+
+  // Slug comes from MDX file metadata, not frontmatter, but we still validate it
+  it('returns error when slug is empty in mdx file', () => {
+    const mdx = {
+      filepath: '/content/test.mdx',
+      slug: '',
+      locale: 'en',
+      frontmatter: { title: 'Valid Title' }
+    } as unknown as MDXFile
+
+    const result = validateFrontmatter('foundation-pages', mdx)
+
+    expect(result).not.toBeNull()
+    expect(result!.errors.some((e) => e.toLowerCase().includes('slug'))).toBe(true)
+  })
+
+  // Content types without schemas (like blog-posts) pass validation — they're
+  // handled differently or don't need frontmatter validation
+  it('returns null for unknown content type (no schema)', () => {
+    const mdx = {
+      filepath: '/content/test.mdx',
+      slug: 'test',
+      locale: 'en',
+      frontmatter: {}
+    } as unknown as MDXFile
+
+    const result = validateFrontmatter('blog-posts' as any, mdx)
+
+    expect(result).toBeNull()
+  })
+
+  // We merge mdx.slug into frontmatter before validation so the schema can
+  // validate the slug even though it's not in the frontmatter YAML
+  it('merges mdx.slug into frontmatter for validation', () => {
+    const mdx = {
+      filepath: '/content/test.mdx',
+      slug: 'valid-slug',
+      locale: 'en',
+      frontmatter: { title: 'Valid Title' }
+    } as unknown as MDXFile
+
+    const result = validateFrontmatter('foundation-pages', mdx)
+
+    expect(result).toBeNull()
+  })
+})
+
+// Batch validation helper that partitions files into valid/invalid arrays.
+// Used at sync start to filter out bad files before processing.
+describe('validateMdxFiles', () => {
+  it('partitions files into valid and invalid arrays', () => {
+    const files = [
+      {
+        filepath: '/content/good.mdx',
+        slug: 'good',
+        locale: 'en',
+        frontmatter: { title: 'Good' }
+      },
+      {
+        filepath: '/content/bad.mdx',
+        slug: 'bad',
+        locale: 'en',
+        frontmatter: {}
+      }
+    ] as unknown as MDXFile[]
+
+    const { valid, invalid } = validateMdxFiles('foundation-pages', files)
+
+    expect(valid).toHaveLength(1)
+    expect(invalid).toHaveLength(1)
+  })
+
+  it('places valid files in valid array', () => {
+    const files = [
+      {
+        filepath: '/content/page1.mdx',
+        slug: 'page1',
+        locale: 'en',
+        frontmatter: { title: 'Page 1' }
+      },
+      {
+        filepath: '/content/page2.mdx',
+        slug: 'page2',
+        locale: 'en',
+        frontmatter: { title: 'Page 2' }
+      }
+    ] as unknown as MDXFile[]
+
+    const { valid, invalid } = validateMdxFiles('foundation-pages', files)
+
+    expect(valid).toHaveLength(2)
+    expect(valid[0].slug).toBe('page1')
+    expect(valid[1].slug).toBe('page2')
+    expect(invalid).toHaveLength(0)
+  })
+
+  it('places invalid files in invalid array with error details', () => {
+    const files = [
+      {
+        filepath: '/content/missing-title.mdx',
+        slug: 'missing-title',
+        locale: 'en',
+        frontmatter: {}
+      }
+    ] as unknown as MDXFile[]
+
+    const { valid, invalid } = validateMdxFiles('foundation-pages', files)
+
+    expect(valid).toHaveLength(0)
+    expect(invalid).toHaveLength(1)
+    expect(invalid[0].slug).toBe('missing-title')
+    expect(invalid[0].errors.length).toBeGreaterThan(0)
+  })
+
+  it('returns empty arrays for empty input', () => {
+    const { valid, invalid } = validateMdxFiles('foundation-pages', [])
+
+    expect(valid).toHaveLength(0)
+    expect(invalid).toHaveLength(0)
+  })
+
+  // Validation is per-file, not per-locale — a Spanish file can fail
+  // while English and German files pass
+  it('handles mixed valid and invalid files across locales', () => {
+    const files = [
+      {
+        filepath: '/content/en/page.mdx',
+        slug: 'page',
+        locale: 'en',
+        frontmatter: { title: 'English Page' }
+      },
+      {
+        filepath: '/content/es/page.mdx',
+        slug: 'pagina',
+        locale: 'es',
+        frontmatter: {}
+      },
+      {
+        filepath: '/content/de/page.mdx',
+        slug: 'seite',
+        locale: 'de',
+        frontmatter: { title: 'Deutsche Seite' }
+      }
+    ] as unknown as MDXFile[]
+
+    const { valid, invalid } = validateMdxFiles('foundation-pages', files)
+
+    expect(valid).toHaveLength(2)
+    expect(invalid).toHaveLength(1)
+    expect(invalid[0].locale).toBe('es')
+  })
+})

--- a/cms/scripts/sync-mdx/validateFrontmatter.test.ts
+++ b/cms/scripts/sync-mdx/validateFrontmatter.test.ts
@@ -1,27 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { z } from 'zod'
-
-vi.mock('./siteSchemas', () => {
-  const { z } = require('zod')
-  return {
-    foundationPageFrontmatterSchema: z.object({
-      title: z.string().min(1),
-      slug: z.string().min(1)
-    }),
-    summitPageFrontmatterSchema: z.object({
-      title: z.string().min(1),
-      slug: z.string().min(1)
-    })
-  }
-})
-
+import { describe, it, expect } from 'vitest'
 import { validateFrontmatter, validateMdxFiles } from './validateFrontmatter'
 import type { MDXFile } from './scan'
-
-beforeEach(() => {
-  vi.spyOn(console, 'log').mockImplementation(() => {})
-  vi.spyOn(console, 'error').mockImplementation(() => {})
-})
 
 // Validates MDX frontmatter against Zod schemas before syncing to Strapi.
 // Invalid files are skipped during sync to avoid corrupting CMS data.
@@ -106,7 +85,9 @@ describe('validateFrontmatter', () => {
 
     expect(result).not.toBeNull()
     expect(result!.errors.length).toBeGreaterThan(0)
-    expect(result!.errors.some((e) => e.toLowerCase().includes('title'))).toBe(true)
+    expect(result!.errors.some((e) => e.toLowerCase().includes('title'))).toBe(
+      true
+    )
   })
 
   // Empty string is not the same as missing — Zod's min(1) catches both
@@ -121,7 +102,9 @@ describe('validateFrontmatter', () => {
     const result = validateFrontmatter('foundation-pages', mdx)
 
     expect(result).not.toBeNull()
-    expect(result!.errors.some((e) => e.toLowerCase().includes('title'))).toBe(true)
+    expect(result!.errors.some((e) => e.toLowerCase().includes('title'))).toBe(
+      true
+    )
   })
 
   // Slug comes from MDX file metadata, not frontmatter, but we still validate it
@@ -136,37 +119,9 @@ describe('validateFrontmatter', () => {
     const result = validateFrontmatter('foundation-pages', mdx)
 
     expect(result).not.toBeNull()
-    expect(result!.errors.some((e) => e.toLowerCase().includes('slug'))).toBe(true)
-  })
-
-  // Content types without schemas (like blog-posts) pass validation — they're
-  // handled differently or don't need frontmatter validation
-  it('returns null for unknown content type (no schema)', () => {
-    const mdx = {
-      filepath: '/content/test.mdx',
-      slug: 'test',
-      locale: 'en',
-      frontmatter: {}
-    } as unknown as MDXFile
-
-    const result = validateFrontmatter('blog-posts' as any, mdx)
-
-    expect(result).toBeNull()
-  })
-
-  // We merge mdx.slug into frontmatter before validation so the schema can
-  // validate the slug even though it's not in the frontmatter YAML
-  it('merges mdx.slug into frontmatter for validation', () => {
-    const mdx = {
-      filepath: '/content/test.mdx',
-      slug: 'valid-slug',
-      locale: 'en',
-      frontmatter: { title: 'Valid Title' }
-    } as unknown as MDXFile
-
-    const result = validateFrontmatter('foundation-pages', mdx)
-
-    expect(result).toBeNull()
+    expect(result!.errors.some((e) => e.toLowerCase().includes('slug'))).toBe(
+      true
+    )
   })
 })
 

--- a/cms/scripts/sync-mdx/validateFrontmatter.ts
+++ b/cms/scripts/sync-mdx/validateFrontmatter.ts
@@ -39,10 +39,12 @@ export function validateFrontmatter(
     const result = schema.safeParse(toValidate)
 
     if (!result.success) {
-      const errors = result.error.issues.map((issue: { path: (string | number)[]; message: string }) => {
-        const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
-        return `${path}${issue.message}`
-      })
+      const errors = result.error.issues.map(
+        (issue: { path: (string | number)[]; message: string }) => {
+          const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
+          return `${path}${issue.message}`
+        }
+      )
 
       validationError = {
         filepath: mdx.filepath,

--- a/cms/scripts/sync-mdx/validateFrontmatter.ts
+++ b/cms/scripts/sync-mdx/validateFrontmatter.ts
@@ -1,3 +1,9 @@
+/**
+ * Frontmatter Validation
+ *
+ * Validates MDX frontmatter against Zod schemas before syncing to Strapi.
+ * Invalid files are filtered out during sync to prevent corrupting CMS data.
+ */
 import type { ContentTypes } from './config'
 import type { MDXFile } from './scan'
 import {
@@ -33,7 +39,7 @@ export function validateFrontmatter(
     const result = schema.safeParse(toValidate)
 
     if (!result.success) {
-      const errors = result.error.issues.map((issue) => {
+      const errors = result.error.issues.map((issue: { path: (string | number)[]; message: string }) => {
         const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
         return `${path}${issue.message}`
       })

--- a/cms/vitest.config.ts
+++ b/cms/vitest.config.ts
@@ -1,0 +1,10 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@site': path.resolve(__dirname, '../src')
+    }
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0)
 
 packages:
 
@@ -4070,6 +4073,35 @@ packages:
     peerDependencies:
       vite: ^4 || ^5
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@vue/compiler-core@3.5.28':
     resolution: {integrity: sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ==}
 
@@ -4374,6 +4406,10 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-module-types@6.0.1:
     resolution: {integrity: sha512-WHw67kLXYbZuHTmcdbIrVArCq5wxo6NEuj3hiYAWr8mwJeC+C2mMCIBIWCiDoCye/OF/xelc+teJ1ERoWmnEIA==}
     engines: {node: '>=18'}
@@ -4589,6 +4625,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cache-content-type@1.0.1:
     resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
     engines: {node: '>= 6.0.0'}
@@ -4643,6 +4683,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -4671,6 +4715,10 @@ packages:
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chevrotain-allstar@0.3.1:
     resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
@@ -5329,6 +5377,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-equal@1.0.1:
     resolution: {integrity: sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==}
 
@@ -5939,6 +5991,10 @@ packages:
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expressive-code@0.41.6:
     resolution: {integrity: sha512-W/5+IQbrpCIM5KGLjO35wlp1NCwDOOVQb+PAvzEoGkW1xjGM807ZGfBKptNWH6UECvt6qgmLyWolCMYKh7eQmA==}
@@ -7572,6 +7628,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
@@ -8589,6 +8648,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
@@ -9524,6 +9587,9 @@ packages:
   sift@16.0.1:
     resolution: {integrity: sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -9655,6 +9721,9 @@ packages:
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
@@ -9962,6 +10031,12 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -9969,6 +10044,18 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   title-case@4.3.2:
     resolution: {integrity: sha512-I/nkcBo73mO42Idfv08jhInV61IMb61OdIFxk+B4Gu1oBjWBPOLmhZdsli+oJCVaD+86pYQA93cJfFt224ZFAA==}
@@ -10464,6 +10551,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.19:
     resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -10572,6 +10664,31 @@ packages:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vscode-jsonrpc@8.2.0:
@@ -10688,6 +10805,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@3.1.0:
@@ -14415,7 +14537,7 @@ snapshots:
       '@strapi/design-system': 2.0.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(@strapi/icons@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/permissions': 5.31.3
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.31.3
       '@strapi/utils': 5.31.3
       '@testing-library/dom': 10.1.0
@@ -14612,7 +14734,7 @@ snapshots:
       '@strapi/database': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)
       '@strapi/design-system': 2.0.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(@strapi/icons@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/utils': 5.31.3
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
@@ -14713,7 +14835,7 @@ snapshots:
       '@strapi/generators': 5.31.3(@types/node@22.19.11)
       '@strapi/logger': 5.31.3
       '@strapi/permissions': 5.31.3
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.31.3
       '@strapi/utils': 5.31.3
       '@vercel/stega': 0.1.2
@@ -15243,7 +15365,7 @@ snapshots:
       '@strapi/openapi': 5.31.3
       '@strapi/permissions': 5.31.3
       '@strapi/review-workflows': 5.31.3(681caf389605bd5fac823ee0158edb2f)
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.31.3
       '@strapi/upload': 5.31.3(c76dd935e99411c3ec50b97509689cc7)
       '@strapi/utils': 5.31.3
@@ -15346,36 +15468,6 @@ snapshots:
       - webpack-cli
       - webpack-dev-server
       - webpack-plugin-serve
-
-  '@strapi/types@5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)':
-    dependencies:
-      '@casl/ability': 6.5.0
-      '@koa/cors': 5.0.0
-      '@koa/router': 12.0.2
-      '@strapi/database': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)
-      '@strapi/logger': 5.31.3
-      '@strapi/permissions': 5.31.3
-      '@strapi/utils': 5.31.3
-      commander: 8.3.0
-      json-logic-js: 2.0.5
-      koa: 2.16.1
-      koa-body: 6.0.1
-      node-schedule: 2.1.1
-      typedoc: 0.25.10(typescript@5.4.4)
-      typedoc-github-wiki-theme: 1.1.0(typedoc-plugin-markdown@3.17.1(typedoc@0.25.10(typescript@5.9.3)))(typedoc@0.25.10(typescript@5.9.3))
-      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.10(typescript@5.9.3))
-      zod: 3.25.67
-    transitivePeerDependencies:
-      - '@types/node'
-      - better-sqlite3
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-      - typescript
 
   '@strapi/types@5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)':
     dependencies:
@@ -16351,6 +16443,46 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@vue/compiler-core@3.5.28':
     dependencies:
       '@babel/parser': 7.29.0
@@ -16705,6 +16837,8 @@ snapshots:
 
   asap@2.0.6: {}
 
+  assertion-error@2.0.1: {}
+
   ast-module-types@6.0.1: {}
 
   ast-types@0.16.1:
@@ -17029,6 +17163,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   cache-content-type@1.0.1:
     dependencies:
       mime-types: 2.1.35
@@ -17086,6 +17222,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -17106,6 +17250,8 @@ snapshots:
   chardet@0.7.0: {}
 
   chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
 
   chevrotain-allstar@0.3.1(chevrotain@11.1.1):
     dependencies:
@@ -17838,6 +17984,8 @@ snapshots:
   dedent@1.7.1(babel-plugin-macros@3.1.0):
     optionalDependencies:
       babel-plugin-macros: 3.1.0
+
+  deep-eql@5.0.2: {}
 
   deep-equal@1.0.1: {}
 
@@ -18660,6 +18808,8 @@ snapshots:
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
+
+  expect-type@1.3.0: {}
 
   expressive-code@0.41.6:
     dependencies:
@@ -20547,6 +20697,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -21855,6 +22007,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   pause@0.0.1: {}
 
   peberminta@0.9.0: {}
@@ -23080,6 +23234,8 @@ snapshots:
 
   sift@16.0.1: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -23241,6 +23397,8 @@ snapshots:
   sprintf-js@1.1.3: {}
 
   stack-trace@0.0.10: {}
+
+  stackback@0.0.2: {}
 
   stackframe@1.3.4: {}
 
@@ -23577,12 +23735,22 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   title-case@4.3.2: {}
 
@@ -23730,14 +23898,6 @@ snapshots:
     dependencies:
       handlebars: 4.7.8
       typedoc: 0.25.10(typescript@5.9.3)
-
-  typedoc@0.25.10(typescript@5.4.4):
-    dependencies:
-      lunr: 2.3.9
-      marked: 4.3.0
-      minimatch: 9.0.5
-      shiki: 0.14.7
-      typescript: 5.4.4
 
   typedoc@0.25.10(typescript@5.9.3):
     dependencies:
@@ -24001,6 +24161,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@5.5.0)
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.19(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0):
     dependencies:
       esbuild: 0.21.5
@@ -24043,6 +24221,41 @@ snapshots:
   vitefu@1.1.1(vite@6.4.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
       vite: 6.4.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  vitest@2.1.9(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@5.5.0)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0)
+      vite-node: 2.1.9(@types/node@22.19.11)(lightningcss@1.31.1)(terser@5.46.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.11
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vscode-jsonrpc@8.2.0: {}
 
@@ -24215,6 +24428,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@3.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for the sync-mdx scripts that sync MDX content to Strapi CMS.

**New test files:**
- `localeMatch.test.ts` - Tests for locale matching and MDX slug mapping
- `mdxTransformer.test.ts` - Tests for MDX to Strapi payload transformation
- `syncOperations.test.ts` - Tests for sync operations (create, update, delete)
- `validateFrontmatter.test.ts` - Tests for frontmatter validation against Zod schemas

**Supporting changes:**
- Add vitest config for cms package
- Export additional functions needed for testing
- Fix ESLint errors (replace `require()` with ES imports, use `@ts-expect-error`)

## Related Issue

Fixes JON/INTORG-399

## Manual Test

```bash
cd cms && pnpm test
