### PR TITLE
chore: rename frontmatter variable "lang" to "locale"

### DIFF
--- a/src/content/developers-blog-posts/2018-01-29-simplifying-interledger-the-graveyard-of-possible-protocol-features.md
+++ b/src/content/developers-blog-posts/2018-01-29-simplifying-interledger-the-graveyard-of-possible-protocol-features.md
@@ -3,7 +3,7 @@ title: 'Simplifying Interledger: The Graveyard of Possible Protocol Features'
 description: As the development of the Interledger Protocol (ILP) nears completion, I thought we should take a moment to remember some of the many core protocol features we’ve killed off along the way.
 date: 2018-01-29
 slug: simplifying-interledger-the-graveyard-of-possible-protocol-features
-lang: en
+locale: en
 authors:
   - Evan Schwartz
 author_urls:

--- a/src/content/developers-blog-posts/2018-10-03-interledger-how-to-interconnect-all-blockchains-and-value-networks.md
+++ b/src/content/developers-blog-posts/2018-10-03-interledger-how-to-interconnect-all-blockchains-and-value-networks.md
@@ -3,7 +3,7 @@ title: 'Interledger: How to Interconnect All Blockchains and Value Networks'
 description: 'Interledger was born out of a project to build a blockchain-agnostic smart contracts platform. A key challenge was neutrality: how could a decentralized app buy resources like storage and computing, without being tied to a specific blockchain?'
 date: 2018-10-03
 slug: interledger-how-to-interconnect-all-blockchains-and-value-networks
-lang: en
+locale: en
 authors:
   - Evan Schwartz
 author_urls:

--- a/src/content/developers-blog-posts/2019-01-23-thoughts-on-scaling-interledger-connectors.md
+++ b/src/content/developers-blog-posts/2019-01-23-thoughts-on-scaling-interledger-connectors.md
@@ -3,7 +3,7 @@ title: Thoughts on Scaling Interledger Connectors
 description: Streaming payments mean that Interledger connectors need to process huge volumes of Interledger packets, but the current reference implementation is hard to run at scale.
 date: 2019-01-23
 slug: thoughts-on-scaling-interledger-connectors
-lang: en
+locale: en
 authors:
   - Evan Schwartz
 author_urls:

--- a/src/content/developers-blog-posts/2024-04-10-the-telemetry-tale.md
+++ b/src/content/developers-blog-posts/2024-04-10-the-telemetry-tale.md
@@ -3,7 +3,7 @@ title: 'The Telemetry Tale: A Journey into the Metrics of Interledger'
 description: When simple metrics are paired with complex cloud solutions and important privacy considerations, the implementation process becomes significantly more complicated.
 date: 2024-04-10
 slug: the-telemetry-tale
-lang: en
+locale: en
 authors:
   - Sarah Jones
 author_urls:

--- a/src/content/developers-blog-posts/2024-07-09-simple-open-payments-guide.md
+++ b/src/content/developers-blog-posts/2024-07-09-simple-open-payments-guide.md
@@ -3,7 +3,7 @@ title: 'A Simple Guide to the Open Payments Standard'
 description: Learn how the Open Payments standard makes online payments easier and more accessible for everyone.
 date: 2024-07-09
 slug: simple-open-payments-guide
-lang: en
+locale: en
 authors:
   - Sarah Jones
 author_urls:

--- a/src/content/developers-blog-posts/2024-07-30-open-payments-cinderella-story.mdx
+++ b/src/content/developers-blog-posts/2024-07-30-open-payments-cinderella-story.mdx
@@ -3,7 +3,7 @@ title: 'Open Payments: The Cinderella Story of Finding a Fitting Authorization M
 description: A breakdown of the unique needs that an authorization method for Open Payments needs to be able to fulfill.
 date: 2024-07-30
 slug: open-payments-cinderella-story
-lang: en
+locale: en
 authors:
   - Nathan Lie
 author_urls:

--- a/src/content/developers-blog-posts/2024-08-13-interledger-universe.mdx
+++ b/src/content/developers-blog-posts/2024-08-13-interledger-universe.mdx
@@ -4,7 +4,7 @@ description: 'Or: “What the heck are all those products and protocols?”'
 ogImageUrl: /img/blog/2024-08-13/og-image.png
 date: 2024-08-13
 slug: interledger-universe
-lang: en
+locale: en
 authors:
   - Sabine Schaller
 author_urls:

--- a/src/content/developers-blog-posts/2024-09-06-integration-tests.mdx
+++ b/src/content/developers-blog-posts/2024-09-06-integration-tests.mdx
@@ -3,7 +3,7 @@ title: 'Leveling Up Rafiki Testing: Shifting from Manual to Automated'
 description: 'How we automated our manual payment flow tests.'
 date: 2024-09-06
 slug: integration-tests
-lang: en
+locale: en
 authors:
   - Blair Currey
 author_urls:

--- a/src/content/developers-blog-posts/2024-09-23-rafiki-code-architecture.mdx
+++ b/src/content/developers-blog-posts/2024-09-23-rafiki-code-architecture.mdx
@@ -3,7 +3,7 @@ title: 'Breaking Down Rafiki: What Makes Our Friend Tick'
 description: 'A low-level introduction to the software packages that comprise Rafiki.'
 date: 2024-09-23
 slug: rafiki-low-level-intro
-lang: en
+locale: en
 authors:
   - Nathan Lie
 author_urls:

--- a/src/content/developers-blog-posts/2024-10-11-where-did-rafiki-money-go.mdx
+++ b/src/content/developers-blog-posts/2024-10-11-where-did-rafiki-money-go.mdx
@@ -3,7 +3,7 @@ title: 'Where did rafiki.money go?'
 description: 'Or “The need for rebranding when something confuses people.”'
 date: 2024-10-11
 slug: where-did-rafiki-money-go
-lang: en
+locale: en
 authors:
   - Timea Nagy
 author_urls:

--- a/src/content/developers-blog-posts/2024-10-25-rafikis-first-security-audit.mdx
+++ b/src/content/developers-blog-posts/2024-10-25-rafikis-first-security-audit.mdx
@@ -3,7 +3,7 @@ title: "Rafiki's First Security Audit"
 description: "Takeaways from Rafiki's 2024 security audit."
 date: 2024-10-25
 slug: rafikis-first-security-audit
-lang: en
+locale: en
 authors:
   - Max Kurapov
 author_urls:

--- a/src/content/developers-blog-posts/2024-12-03-e2e-testing-wm-browser-extension.mdx
+++ b/src/content/developers-blog-posts/2024-12-03-e2e-testing-wm-browser-extension.mdx
@@ -3,7 +3,7 @@ title: 'End-to-end testing the Web Monetization browser extension'
 description: "E2E testing browser extensions? It's tricky, but we've got it covered."
 date: 2024-12-03
 slug: e2e-testing-wm-browser-extension
-lang: en
+locale: en
 authors:
   - Sid Vishnoi
 author_urls:

--- a/src/content/developers-blog-posts/2024-12-11-rafiki-beta-release.mdx
+++ b/src/content/developers-blog-posts/2024-12-11-rafiki-beta-release.mdx
@@ -3,7 +3,7 @@ title: 'Rafiki Beta Release'
 description: 'The Wild is Calling.'
 date: 2024-12-11
 slug: rafiki-beta-release
-lang: en
+locale: en
 authors:
   - Tadej Golobic
 author_urls:

--- a/src/content/developers-blog-posts/2024-12-17-rafiki-tigerbeetle-integration.mdx
+++ b/src/content/developers-blog-posts/2024-12-17-rafiki-tigerbeetle-integration.mdx
@@ -3,7 +3,7 @@ title: "Balancing the Ledger: Rafiki's TigerBeetle Integration"
 description: 'How TigerBeetle Supercharges Rafiki’s Financial Core.'
 date: 2024-12-17
 slug: rafiki-tigerbeetle-integration
-lang: en
+locale: en
 authors:
   - Jason Bruwer
 author_urls:

--- a/src/content/developers-blog-posts/2025-02-05-ilp-packet-lifecycle.mdx
+++ b/src/content/developers-blog-posts/2025-02-05-ilp-packet-lifecycle.mdx
@@ -3,7 +3,7 @@ title: 'The Lifecycle of an Interledger Packet'
 description: 'A look under the hood of how Rafiki orchestrates an Interledger payment.'
 date: 2025-02-05
 slug: ilp-packet-lifecycle
-lang: en
+locale: en
 authors:
   - Nathan Lie
 author_urls:

--- a/src/content/developers-blog-posts/2025-03-12-breakpoint-it-work-week.mdx
+++ b/src/content/developers-blog-posts/2025-03-12-breakpoint-it-work-week.mdx
@@ -3,7 +3,7 @@ title: 'The first work week of the season - BreakPoint IT Work Week'
 description: 'The first work week of the season'
 date: 2025-03-12
 slug: breakpoint-it-work-week
-lang: en
+locale: en
 authors:
   - Timea Nagy
 author_urls:

--- a/src/content/developers-blog-posts/2025-05-06-introducing-open-payments-php.mdx
+++ b/src/content/developers-blog-posts/2025-05-06-introducing-open-payments-php.mdx
@@ -3,7 +3,7 @@ title: 'Introducing Open Payments PHP: A New Bridge for Financial Interoperabili
 description: 'Explaining the Open Payments PHP Library features and how it works'
 date: 2025-05-06
 slug: introducing-open-payments-php
-lang: en
+locale: en
 authors:
   - Adi Boros
 author_urls:

--- a/src/content/developers-blog-posts/2025-05-20-Introducing-publisher-tools.mdx
+++ b/src/content/developers-blog-posts/2025-05-20-Introducing-publisher-tools.mdx
@@ -3,7 +3,7 @@ title: 'Introducing publisher tools: simple monetization for content owners and 
 description: 'An overview of the toolset and a sneak peek of the future plans'
 date: 2025-05-20
 slug: introducing-publisher-tools
-lang: en
+locale: en
 authors:
   - Arpad Lengyel
 author_urls:

--- a/src/content/developers-blog-posts/2025-06-04-ES-El-Universo-Interledger.mdx
+++ b/src/content/developers-blog-posts/2025-06-04-ES-El-Universo-Interledger.mdx
@@ -2,7 +2,7 @@
 title: 'El Universo Interledger'
 description: 'Explora el sistema abierto que conecta pagos globales con Interledger.'
 date: 2025-07-02
-lang: es
+locale: es
 slug: el-universo-interledger
 authors:
   - Marian Villa

--- a/src/content/developers-blog-posts/2025-09-09-memorable-wallet-addresses-custom-domain.md
+++ b/src/content/developers-blog-posts/2025-09-09-memorable-wallet-addresses-custom-domain.md
@@ -3,7 +3,7 @@ title: 'Memorable wallet addresses on your own domain'
 description: 'If you own a domain, you can set your Open Payments wallet address to be the same as your domain!'
 date: 2025-09-09
 slug: memorable-wallet-addresses-custom-domain
-lang: en
+locale: en
 authors:
   - Sid Vishnoi
 author_urls:

--- a/src/content/developers-blog-posts/2025-09-30-wallet-address-smart-redirect.mdx
+++ b/src/content/developers-blog-posts/2025-09-30-wallet-address-smart-redirect.mdx
@@ -3,7 +3,7 @@ title: 'Wallet Address Smart Redirect'
 description: 'One Wallet Address, Two Experiences: Introducing Wallet Address Smart Redirect in Rafiki'
 date: 2025-09-30
 slug: wallet-address-smart-redirect
-lang: en
+locale: en
 authors:
   - Cozmin Ungureanu
 author_urls:

--- a/src/content/developers-blog-posts/2025-12-03-web-monetization-open-payments-part-1-connecting-wallet.md
+++ b/src/content/developers-blog-posts/2025-12-03-web-monetization-open-payments-part-1-connecting-wallet.md
@@ -3,7 +3,7 @@ title: 'How Web Monetization uses Open Payments - Part 1: Connecting Wallet'
 description: 'Understanding how the browser extension uses Open Payments to securely connect your wallet for Web Monetization'
 date: 2025-12-03
 slug: web-monetization-open-payments-part-1-connecting-wallet
-lang: en
+locale: en
 authors:
   - Sid Vishnoi
 author_urls:

--- a/src/content/developers-blog-posts/2025-12-09-redesigned-publisher-tools-guide.md
+++ b/src/content/developers-blog-posts/2025-12-09-redesigned-publisher-tools-guide.md
@@ -3,7 +3,7 @@ title: 'How the Redesigned Publisher Tools Work: A Technical Guide'
 description: 'A technical dive into the architecture behind the redesigned Web Monetization Publisher Tools'
 date: 2025-12-09
 slug: redesigned-publisher-tools-guide
-lang: en
+locale: en
 authors:
   - Darian Avasan
 author_urls: []

--- a/src/content/developers-blog-posts/2025-12-10-web-monetization-open-payments-part-2-connecting-wallet.md
+++ b/src/content/developers-blog-posts/2025-12-10-web-monetization-open-payments-part-2-connecting-wallet.md
@@ -3,7 +3,7 @@ title: 'How Web Monetization uses Open Payments - Part 2: Payment Sessions'
 description: 'Explore next steps for sending money: how the extension finds receiving wallet addresses and sets up the necessary payment sessions.'
 date: 2025-12-10
 slug: web-monetization-open-payments-part-2-payment-sessions
-lang: en
+locale: en
 authors:
   - Sid Vishnoi
 author_urls:

--- a/src/content/developers-blog-posts/2025-12-17-web-monetization-wrapped-2025.md
+++ b/src/content/developers-blog-posts/2025-12-17-web-monetization-wrapped-2025.md
@@ -3,7 +3,7 @@ title: 'Web Monetization Wrapped 2025'
 description: 'Welcome to Web Monetization Wrapped, a look back at the progress we made in 2025 and everything we shipped, fixed, revived, and pushed forward this year. '
 date: 2025-12-17
 slug: web-monetization-wrapped-2025
-lang: en
+locale: en
 authors:
   - Rabeb Othmani
 author_urls:

--- a/src/content/developers-blog-posts/2025-12-19-go-further-with-open-payments.mdx
+++ b/src/content/developers-blog-posts/2025-12-19-go-further-with-open-payments.mdx
@@ -3,7 +3,7 @@ title: 'Go Further with Open Payments'
 description: 'Announcing the Open Payments Go SDK'
 date: 2026-01-22
 slug: go-further-with-open-payments
-lang: en
+locale: en
 authors:
   - Blair Currey
 author_urls:

--- a/src/content/developers-blog-posts/2025-12-31-rafiki-card-integration.mdx
+++ b/src/content/developers-blog-posts/2025-12-31-rafiki-card-integration.mdx
@@ -3,7 +3,7 @@ title: 'From Tap to Packet: Exploring Card Payments on Interledger'
 description: 'A Journey from POS Onboarding to Transaction Processing.'
 date: 2025-12-31
 slug: rafiki-card-integration
-lang: en
+locale: en
 authors:
   - Jason Bruwer
 author_urls:

--- a/src/content/developers-blog-posts/2026-02-17-frontend-work-week.mdx
+++ b/src/content/developers-blog-posts/2026-02-17-frontend-work-week.mdx
@@ -3,7 +3,7 @@ title: 'Frontend Work Week: bonding and big decisions'
 description: 'Frontend team bonds, aligns, and makes key decisions while planning a full website redesign.'
 date: 2026-02-17
 slug: frontend-work-week
-lang: en
+locale: en
 authors:
   - Anca Matei
 author_urls:

--- a/src/content/es/developer-blog-posts/2024-08-13-interledger-universe.mdx
+++ b/src/content/es/developer-blog-posts/2024-08-13-interledger-universe.mdx
@@ -3,7 +3,7 @@ title: 'El Universo Interledger'
 description: 'Explora el sistema abierto que conecta pagos globales con Interledger.'
 date: 2024-08-13
 slug: el-universo-interledger
-lang: es
+locale: es
 authors:
   - Sabine Schaller
   - Marian Villa

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -68,7 +68,7 @@ const { page } = Astro.props
                   )}
                 </div>
                 <div class="flex flex-col flex-1">
-                  {blogPostEntry.data.lang === 'es' ? (
+                  {blogPostEntry.data.locale === 'es' ? (
                     <div class="flex items-start gap-space-2xs">
                       <h2 class="text-step-1 mb-space-3xs">
                         <a

--- a/src/pages/blog/es.astro
+++ b/src/pages/blog/es.astro
@@ -5,7 +5,7 @@ import { createExcerpt } from '@/utils/create-excerpt'
 
 // Only return posts with `draft: true` in the frontmatter
 const esEntries = await getCollection('foundation-blog', ({ data }) => {
-  return data.lang === 'es'
+  return data.locale === 'es'
 })
 ---
 

--- a/src/pages/developers/blog/[...page].astro
+++ b/src/pages/developers/blog/[...page].astro
@@ -82,7 +82,7 @@ const { page } = Astro.props
                   >
                     {blogPostEntry.data.date.toDateString()}
                   </time>
-                  {blogPostEntry.data.lang === 'es' ? (
+                  {blogPostEntry.data.locale === 'es' ? (
                     <div class="flex items-start gap-space-2xs">
                       <h2 class="text-step-1">
                         <a

--- a/src/pages/developers/blog/es.astro
+++ b/src/pages/developers/blog/es.astro
@@ -5,7 +5,7 @@ import { createExcerpt } from '@/utils/create-excerpt'
 
 // Only return posts with `draft: true` in the frontmatter
 const esEntries = await getCollection('developers-blog', ({ data }) => {
-  return data.lang === 'es'
+  return data.locale === 'es'
 })
 ---
 

--- a/src/schemas/content.ts
+++ b/src/schemas/content.ts
@@ -5,7 +5,7 @@ export const developersBlogFrontmatterSchema = z.object({
   description: z.string(),
   date: z.date(),
   slug: z.string(),
-  lang: z.string().optional(),
+  locale: z.string().optional(),
   authors: z.array(z.string()).optional(),
   author_urls: z.array(z.string()).optional(),
   tags: z.array(


### PR DESCRIPTION
## Summary
The frontmatter variable in developers-blog-posts is named `lang`, while the one in foundation-blog-post is called `locale`. 
This PR renames frontmatter variable "lang" to "locale", for consistency. 

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
