### PR TITLE
feat: add Netlify-backed contact form

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -135,9 +135,9 @@ import FoundationPageLayout from '../layouts/FoundationPageLayout.astro'
     const recaptchaError = document.getElementById('recaptcha-error')
     const fieldsValid = form.checkValidity()
     const recaptchaDone = !!(
-      document.querySelector('textarea[name="g-recaptcha-response"]') as
-        | HTMLTextAreaElement
-        | null
+      document.querySelector(
+        'textarea[name="g-recaptcha-response"]'
+      ) as HTMLTextAreaElement | null
     )?.value?.trim()
 
     recaptchaError?.classList.add('hidden')

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,155 @@
+---
+import FoundationPageLayout from '../layouts/FoundationPageLayout.astro'
+---
+
+<FoundationPageLayout
+  title="Contact"
+  description="Get in touch with the Interledger Foundation."
+>
+  <main class="pt-space-m pb-space-xl">
+    <div class="mx-auto max-w-[1440px] min-w-[360px] px-[5%] min-[1600px]:px-0">
+      <header class="pt-space-s pb-space-m">
+        <h1 class="text-step-3 font-bold">Contact</h1>
+      </header>
+      <div class="max-w-[640px]">
+        <!-- Success message (shown via JS when ?success=true) -->
+        <div
+          id="success-message"
+          class="hidden mb-space-l p-space-m rounded border border-green-400 bg-green-50 text-green-800"
+        >
+          <p class="font-semibold mb-space-2xs">Message sent!</p>
+          <p>
+            Thank you for reaching out. We'll get back to you as soon as
+            possible.
+          </p>
+        </div>
+
+        <!-- Contact form -->
+        <form
+          id="contact-form"
+          name="contact"
+          method="POST"
+          action="/contact?success=true"
+          data-netlify="true"
+          data-netlify-honeypot="bot-field"
+          data-netlify-recaptcha="true"
+          class="flex flex-col gap-space-m"
+        >
+          <input type="hidden" name="form-name" value="contact" />
+
+          <!-- Honeypot field (hidden from real users) -->
+          <p class="hidden">
+            <label>Don't fill this out: <input name="bot-field" /></label>
+          </p>
+
+          <div class="flex flex-col gap-space-2xs">
+            <label for="name" class="font-semibold text-[0.95rem]">Name</label>
+            <input
+              id="name"
+              type="text"
+              name="name"
+              required
+              placeholder="Enter your preferred name"
+              class="w-full rounded border border-[var(--sl-color-gray-4)] bg-white px-space-xs py-space-2xs text-[1rem] outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-colors"
+            />
+          </div>
+
+          <div class="flex flex-col gap-space-2xs">
+            <label for="email" class="font-semibold text-[0.95rem]">Email</label
+            >
+            <input
+              id="email"
+              type="email"
+              name="email"
+              required
+              placeholder="Enter the email address you would like to be contacted at"
+              class="w-full rounded border border-[var(--sl-color-gray-4)] bg-white px-space-xs py-space-2xs text-[1rem] outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-colors"
+            />
+          </div>
+
+          <div class="flex flex-col gap-space-2xs">
+            <label for="topic" class="font-semibold text-[0.95rem]">Topic</label
+            >
+            <select
+              id="topic"
+              name="topic"
+              required
+              class="w-full rounded border border-[var(--sl-color-gray-4)] px-space-xs py-space-2xs text-[1rem] outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-colors bg-white"
+            >
+              <option value="" disabled selected>Select a topic</option>
+              <option value="Grants">Grants</option>
+              <option value="Media">Media</option>
+              <option value="Technology">Technology</option>
+              <option value="Other">Other</option>
+            </select>
+          </div>
+
+          <div class="flex flex-col gap-space-2xs">
+            <label for="message" class="font-semibold text-[0.95rem]"
+              >Message</label
+            >
+            <textarea
+              id="message"
+              name="message"
+              required
+              rows="6"
+              placeholder="Your message"
+              class="w-full rounded border border-[var(--sl-color-gray-4)] bg-white px-space-xs py-space-2xs text-[1rem] outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-colors resize-y"
+            ></textarea>
+          </div>
+
+          <div class="flex flex-col gap-space-2xs">
+            <div data-netlify-recaptcha="true"></div>
+            <p
+              id="recaptcha-error"
+              class="hidden text-red-600 text-sm"
+              role="alert"
+            >
+              Please complete the reCAPTCHA challenge.
+            </p>
+          </div>
+
+          <div>
+            <button
+              type="submit"
+              class="rounded-pill bg-primary px-space-s py-space-xs text-white font-semibold cursor-pointer hover:opacity-90 transition-opacity border-0"
+            >
+              Send message
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </main>
+</FoundationPageLayout>
+
+<script>
+  const params = new URLSearchParams(window.location.search)
+  if (params.get('success') === 'true') {
+    document.getElementById('success-message')?.classList.remove('hidden')
+    document.getElementById('contact-form')?.classList.add('hidden')
+  }
+
+  document.getElementById('contact-form')?.addEventListener('submit', (e) => {
+    const form = e.target as HTMLFormElement
+    const recaptchaError = document.getElementById('recaptcha-error')
+    const fieldsValid = form.checkValidity()
+    const recaptchaDone = !!(
+      document.querySelector('textarea[name="g-recaptcha-response"]') as
+        | HTMLTextAreaElement
+        | null
+    )?.value?.trim()
+
+    recaptchaError?.classList.add('hidden')
+
+    if (!fieldsValid || !recaptchaDone) {
+      e.preventDefault()
+      if (fieldsValid) {
+        recaptchaError?.classList.remove('hidden')
+        recaptchaError?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      } else {
+        form.reportValidity()
+      }
+    }
+  })
+</script>


### PR DESCRIPTION
## Summary
Adds a new `/contact` page for the Interledger Foundation using a Netlify form.

## Related Issue
Fixes INTORG-291

## Manual Test
Reviewer steps:
1. Open the Netlify deploy preview and navigate to `/contact`.
2. Verify the form renders with name, email, topic, and message fields plus the reCAPTCHA widget.
3. Submit a valid test message.
4. Confirm the page redirects to `/contact?success=true`, shows the success banner, and hides the form.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits 
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
