### PR TITLE
Jm/intorg 444 mdx components import

### DIFF
--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -47,27 +47,27 @@ export interface ContentTypes {
 
 export function buildContentTypes(projectRoot: string): ContentTypes {
   return {
-    'foundation-pages': {
-      dir: getContentPath(projectRoot, 'foundationPages'),
-      apiId: 'foundation-pages',
-      schema: foundationPageFrontmatterSchema,
-      buildPayload: async (mdx, _strapi, existing) =>
-        buildPagePayload(foundationPageFrontmatterSchema, mdx, existing)
-    },
-    'summit-pages': {
-      dir: getContentPath(projectRoot, 'summitPages'),
-      apiId: 'summit-pages',
-      schema: summitPageFrontmatterSchema,
-      buildPayload: async (mdx, _strapi, existing) =>
-        buildPagePayload(summitPageFrontmatterSchema, mdx, existing)
-    },
-    'foundation-blog-posts': {
-      dir: getContentPath(projectRoot, 'blog'),
-      apiId: 'foundation-blog-posts',
-      schema: foundationBlogFrontmatterSchema,
-      buildPayload: async (mdx, _strapi, _existing) =>
-        buildBlogPayload(foundationBlogFrontmatterSchema, mdx)
-    },
+    // 'foundation-pages': {
+    //   dir: getContentPath(projectRoot, 'foundationPages'),
+    //   apiId: 'foundation-pages',
+    //   schema: foundationPageFrontmatterSchema,
+    //   buildPayload: async (mdx, _strapi, existing) =>
+    //     buildPagePayload(foundationPageFrontmatterSchema, mdx, existing)
+    // },
+    // 'summit-pages': {
+    //   dir: getContentPath(projectRoot, 'summitPages'),
+    //   apiId: 'summit-pages',
+    //   schema: summitPageFrontmatterSchema,
+    //   buildPayload: async (mdx, _strapi, existing) =>
+    //     buildPagePayload(summitPageFrontmatterSchema, mdx, existing)
+    // },
+    // 'foundation-blog-posts': {
+    //   dir: getContentPath(projectRoot, 'blog'),
+    //   apiId: 'foundation-blog-posts',
+    //   schema: foundationBlogFrontmatterSchema,
+    //   buildPayload: async (mdx, _strapi, _existing) =>
+    //     buildBlogPayload(foundationBlogFrontmatterSchema, mdx)
+    // },
     ambassadors: {
       dir: getContentPath(projectRoot, 'ambassadors'),
       apiId: 'ambassadors',

--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -1,16 +1,10 @@
 import { getContentPath } from '@/utils/paths'
 import type { MDXFile } from './mdxTypes'
 import type { StrapiClient, StrapiEntry } from './strapiClient'
-import {
-  buildPagePayload,
-  buildBlogPayload,
-  buildAmbassadorPayload
-} from './mdxTransformer'
+import { buildPagePayload, buildAmbassadorPayload } from './mdxTransformer'
 import {
   ambassadorFrontmatterSchema,
-  foundationBlogFrontmatterSchema,
-  foundationPageFrontmatterSchema,
-  summitPageFrontmatterSchema
+  foundationPageFrontmatterSchema
 } from './siteSchemas'
 
 /**

--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -47,19 +47,19 @@ export interface ContentTypes {
 
 export function buildContentTypes(projectRoot: string): ContentTypes {
   return {
-    // 'foundation-pages': {
-    //   dir: getContentPath(projectRoot, 'foundationPages'),
-    //   apiId: 'foundation-pages',
-    //   schema: foundationPageFrontmatterSchema,
-    //   buildPayload: async (mdx, _strapi, existing) =>
-    //     buildPagePayload(foundationPageFrontmatterSchema, mdx, existing)
-    // },
+    'foundation-pages': {
+      dir: getContentPath(projectRoot, 'foundationPages'),
+      apiId: 'foundation-pages',
+      schema: foundationPageFrontmatterSchema,
+      buildPayload: async (mdx, strapi, existing) =>
+        buildPagePayload(foundationPageFrontmatterSchema, mdx, existing, strapi)
+    },
     // 'summit-pages': {
     //   dir: getContentPath(projectRoot, 'summitPages'),
     //   apiId: 'summit-pages',
     //   schema: summitPageFrontmatterSchema,
-    //   buildPayload: async (mdx, _strapi, existing) =>
-    //     buildPagePayload(summitPageFrontmatterSchema, mdx, existing)
+    //   buildPayload: async (mdx, strapi, existing) =>
+    //     buildPagePayload(summitPageFrontmatterSchema, mdx, existing, strapi)
     // },
     // 'foundation-blog-posts': {
     //   dir: getContentPath(projectRoot, 'blog'),
@@ -75,5 +75,5 @@ export function buildContentTypes(projectRoot: string): ContentTypes {
       buildPayload: (mdx, strapi, _existing) =>
         buildAmbassadorPayload(ambassadorFrontmatterSchema, mdx, strapi)
     }
-  }
+  } as ContentTypes
 }

--- a/cms/scripts/sync-mdx/mdxComponentParser.ts
+++ b/cms/scripts/sync-mdx/mdxComponentParser.ts
@@ -1,0 +1,95 @@
+/**
+ * Parses MDX body content into structured blocks for Strapi sync.
+ * Supports: <Paragraph>, <AmbassadorGrid>, <Blockquote>, and plain text.
+ */
+
+export type ParsedBlock =
+  | { type: 'paragraph'; content: string }
+  | { type: 'ambassadors-grid'; heading?: string; slugs: string[] }
+  | { type: 'blockquote'; quote: string; source?: string }
+
+/**
+ * Extract string attribute from JSX: heading="value" or heading='value'
+ */
+function extractStringAttr(
+  attrs: string,
+  name: string
+): string | undefined {
+  const regex = new RegExp(`${name}=["']([^"']*)["']`, 'i')
+  const m = attrs.match(regex)
+  return m ? m[1] : undefined
+}
+
+/**
+ * Extract slugs array from JSX: slugs={["a","b"]} or slugs={['a','b']}
+ */
+function extractSlugsAttr(attrs: string): string[] {
+  const m = attrs.match(/slugs=\{\s*\[(.*?)\]\s*\}/s)
+  if (!m) return []
+  const inner = m[1]
+  const slugs: string[] = []
+  const matches = inner.matchAll(/"([^"]*)"|'([^']*)'/g)
+  for (const match of matches) {
+    slugs.push(match[1] ?? match[2] ?? '')
+  }
+  return slugs.filter(Boolean)
+}
+
+/**
+ * Parse MDX content into blocks.
+ * - <Paragraph>...</Paragraph> or plain text → paragraph block
+ * - <AmbassadorGrid heading="..." slugs={[...]} /> → ambassadors-grid block
+ * - <Blockquote source="...">...</Blockquote> → blockquote block
+ */
+export function parseMdxComponents(content: string): ParsedBlock[] {
+  const blocks: ParsedBlock[] = []
+  const trimmed = (content || '').trim()
+  if (!trimmed) return blocks
+
+  // Split by component boundaries while preserving order
+  // Pattern: <ComponentName> or <ComponentName ...> or <ComponentName ... />
+  const componentRegex =
+    /<(Paragraph|AmbassadorGrid|Blockquote)(\s[^>]*?)?(?:\/>|>([\s\S]*?)<\/\1>)/gi
+
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = componentRegex.exec(trimmed)) !== null) {
+    const [fullMatch, componentName, attrs, childContent] = match
+    const before = trimmed.slice(lastIndex, match.index).trim()
+
+    // Plain text before this component → paragraph
+    if (before.length > 0) {
+      blocks.push({ type: 'paragraph', content: before })
+    }
+
+    const name = componentName.toLowerCase()
+
+    if (name === 'paragraph') {
+      blocks.push({ type: 'paragraph', content: (childContent || '').trim() })
+    } else if (name === 'ambassadorgrid') {
+      const heading = extractStringAttr(attrs, 'heading')
+      const slugs = extractSlugsAttr(attrs)
+      blocks.push({ type: 'ambassadors-grid', heading, slugs })
+    } else if (name === 'blockquote') {
+      const source = extractStringAttr(attrs, 'source')
+      const quote = (childContent || '').trim().replace(/^["']|["']$/g, '')
+      blocks.push({ type: 'blockquote', quote, source })
+    }
+
+    lastIndex = match.index + fullMatch.length
+  }
+
+  // Remaining content after last component
+  const after = trimmed.slice(lastIndex).trim()
+  if (after.length > 0) {
+    blocks.push({ type: 'paragraph', content: after })
+  }
+
+  // If no components matched, treat entire content as one paragraph
+  if (blocks.length === 0 && trimmed.length > 0) {
+    blocks.push({ type: 'paragraph', content: trimmed })
+  }
+
+  return blocks
+}

--- a/cms/scripts/sync-mdx/mdxComponentParser.ts
+++ b/cms/scripts/sync-mdx/mdxComponentParser.ts
@@ -11,10 +11,7 @@ export type ParsedBlock =
 /**
  * Extract string attribute from JSX: heading="value" or heading='value'
  */
-function extractStringAttr(
-  attrs: string,
-  name: string
-): string | undefined {
+function extractStringAttr(attrs: string, name: string): string | undefined {
   const regex = new RegExp(`${name}=["']([^"']*)["']`, 'i')
   const m = attrs.match(regex)
   return m ? m[1] : undefined

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -7,13 +7,15 @@
  *
  * Handles page content types by:
  * - Validating frontmatter against Zod schemas
- * - Importing MDX content as markdown (preserving original format)
- * - Preserving existing Strapi entry data when appropriate
+ * - Parsing MDX body into blocks (<Paragraph>, <AmbassadorGrid>, <Blockquote>, plain text)
+ * - Building Strapi dynamic zone content from parsed blocks
  */
 
 import type { MDXFile } from './mdxTypes'
 import type { StrapiClient, StrapiEntry } from './strapiClient'
 import type { FrontmatterSchema } from './config'
+import type { ParsedBlock } from './mdxComponentParser'
+import { parseMdxComponents } from './mdxComponentParser'
 
 /**
  * Extracts a field value from a Strapi entry.
@@ -29,24 +31,58 @@ export function getEntryField(entry: StrapiEntry | null, key: string): unknown {
 }
 
 /**
+ * Builds a Strapi block from a parsed MDX block.
+ */
+async function buildStrapiBlock(
+  block: ParsedBlock,
+  strapi: StrapiClient
+): Promise<Record<string, unknown>> {
+  switch (block.type) {
+    case 'paragraph':
+      return {
+        __component: 'blocks.paragraph',
+        content: block.content
+      }
+    case 'ambassadors-grid': {
+      const ambassadors = await strapi.findAmbassadorsBySlugs(block.slugs)
+      const documentIds = ambassadors.map((a) => a.documentId)
+      return {
+        __component: 'blocks.ambassadors-grid',
+        heading: block.heading || null,
+        ambassadors:
+          documentIds.length > 0 ? { connect: documentIds } : undefined
+      }
+    }
+    case 'blockquote':
+      return {
+        __component: 'blocks.blockquote',
+        quote: block.quote,
+        source: block.source || null
+      }
+  }
+}
+
+/**
  * Builds a Strapi payload for a page-type MDX file.
  *
  * This function:
  * 1. Validates frontmatter against the provided Zod schema
  * 2. Builds the base payload with required fields (title, slug, publishedAt)
  * 3. Handles hero section (from frontmatter or preserves existing)
- * 4. Imports MDX content as markdown (preserves original format, no HTML conversion)
+ * 4. Parses MDX body into blocks and builds Strapi dynamic zone content
  *
  * @param schema - Zod schema to validate/parse the frontmatter
  * @param mdx - MDX file data with frontmatter and content
  * @param existingEntry - Existing Strapi entry (optional, for updates)
+ * @param strapi - Strapi client for resolving relations (e.g. ambassador slugs)
  * @returns Strapi payload object
  */
-export function buildPagePayload(
+export async function buildPagePayload(
   schema: FrontmatterSchema,
   mdx: MDXFile,
-  existingEntry: StrapiEntry | null = null
-): Record<string, unknown> {
+  existingEntry: StrapiEntry | null = null,
+  strapi: StrapiClient
+): Promise<Record<string, unknown>> {
   // Validate frontmatter against schema (throws if invalid)
   const parsed = schema.parse({
     ...mdx.frontmatter,
@@ -75,18 +111,16 @@ export function buildPagePayload(
     }
   }
 
-  // Handle content import
-  // Import MDX content as markdown (preserve original format, no HTML conversion)
+  // Handle content import: parse MDX blocks and build Strapi dynamic zone
   const mdxBody = (mdx.content || '').trim()
   if (mdxBody.length > 0) {
-    // Store markdown content in a Strapi paragraph block component
-    // Strapi's richtext field can accept markdown and will handle rendering
-    data.content = [
-      {
-        __component: 'blocks.paragraph',
-        content: mdx.content
-      }
-    ]
+    const parsedBlocks = parseMdxComponents(mdx.content || '')
+    const strapiBlocks: Record<string, unknown>[] = []
+    for (const block of parsedBlocks) {
+      const strapiBlock = await buildStrapiBlock(block, strapi)
+      strapiBlocks.push(strapiBlock)
+    }
+    data.content = strapiBlocks
   } else {
     // Preserve existing content if MDX file has no body
     const existingContent = getEntryField(existingEntry, 'content')

--- a/cms/scripts/sync-mdx/strapiClient.ts
+++ b/cms/scripts/sync-mdx/strapiClient.ts
@@ -15,6 +15,8 @@ export interface StrapiClient {
   ) => Promise<StrapiEntry | undefined>
   /** Look up a Strapi upload file by URL. Returns the file's integer ID, or null. */
   findUploadByUrl: (url: string) => Promise<number | null>
+  /** Resolve ambassador slugs to documentIds for relation fields. */
+  findAmbassadorsBySlugs: (slugs: string[]) => Promise<StrapiEntry[]>
   createLocalization: (
     apiId: string,
     documentId: string,
@@ -214,6 +216,21 @@ export function createStrapiClient({
     return files.length > 0 ? files[0].id : null
   }
 
+  async function findAmbassadorsBySlugs(
+    slugs: string[]
+  ): Promise<StrapiEntry[]> {
+    if (slugs.length === 0) return []
+    const results: StrapiEntry[] = []
+    for (const slug of slugs) {
+      const entry = await findBySlug('ambassadors', slug)
+      if (entry) results.push(entry)
+      else {
+        console.warn(`   ⚠️  Ambassador not found for slug: ${slug}`)
+      }
+    }
+    return results
+  }
+
   async function deleteLocalization(
     apiId: string,
     documentId: string,
@@ -229,6 +246,7 @@ export function createStrapiClient({
     getAllEntries,
     findBySlug,
     findUploadByUrl,
+    findAmbassadorsBySlugs,
     createLocalization,
     updateLocalization,
     createEntry,

--- a/cms/src/serializers/blocks/paragraph.serializer.ts
+++ b/cms/src/serializers/blocks/paragraph.serializer.ts
@@ -11,8 +11,9 @@ export function serialize(block: {
     ? htmlToMarkdown(block.content)
     : block.content
 
-  if (block.alignment && block.alignment !== 'left') {
-    return `<div class="text-${block.alignment}">\n\n${content}\n\n</div>`
-  }
-  return content
+  const alignmentAttr =
+    block.alignment && block.alignment !== 'left'
+      ? ` alignment="${block.alignment}"`
+      : ''
+  return `<Paragraph${alignmentAttr}>\n${content}\n</Paragraph>`
 }

--- a/src/components/paragraph/Paragraph.astro
+++ b/src/components/paragraph/Paragraph.astro
@@ -1,0 +1,32 @@
+---
+/**
+ * Paragraph component for MDX content
+ * Renders markdown/rich text with prose styling.
+ * Usage: <Paragraph>content</Paragraph> or <Paragraph content="..." />
+ */
+import { parseMarkdown } from '@/utils/mdx'
+
+interface Props {
+  /** Markdown content. If omitted, slot content is used (MDX usage). */
+  content?: string
+  alignment?: 'left' | 'center' | 'right'
+}
+
+const { content, alignment = 'left' } = Astro.props
+
+const htmlContent = content ? await parseMarkdown(content) : null
+
+const alignmentClass = `text-${alignment}`
+---
+
+<div
+  class={`${alignmentClass} [&_p]:mb-space-s [&_p]:leading-relaxed [&_a]:text-primary [&_a]:underline [&_a:hover]:no-underline [&_h2]:mt-space-l [&_h2]:mb-space-s [&_h2]:text-[1.75rem] [&_h2]:font-semibold [&_h2]:text-primary [&_h3]:mt-space-m [&_h3]:mb-space-xs [&_h3]:text-[1.25rem] [&_h3]:font-semibold [&_ul]:mb-space-s [&_ul]:ps-space-m [&_ol]:mb-space-s [&_ol]:ps-space-m [&_li]:mb-space-xs`}
+>
+  {htmlContent ? <Fragment set:html={htmlContent} /> : <slot />}
+</div>
+
+<style>
+  div :global(p:last-child) {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -11,6 +11,7 @@ import Ambassador from '../components/ambassadors/Ambassador.astro'
 import AmbassadorGrid from '../components/ambassadors/AmbassadorGrid.astro'
 import Blockquote from '../components/blockquote/Blockquote.astro'
 import CalloutText from '../components/callout/CalloutText.astro'
+import Paragraph from '../components/paragraph/Paragraph.astro'
 
 export async function getStaticPaths() {
   return getPagePaths('foundation-pages', { excludeSlug: 'home' })
@@ -76,6 +77,7 @@ if (isNotFound) Astro.response.status = 404
               <div class="mx-auto max-w-narrow [&_h2]:mt-space-l [&_h2]:mb-space-s [&_h2]:text-[1.75rem] [&_h2]:font-semibold [&_h2]:text-primary [&_h3]:mt-space-m [&_h3]:mb-space-xs [&_h3]:text-[1.25rem] [&_h3]:font-semibold [&_p]:mb-space-s [&_p]:leading-[1.6] [&_ul]:mb-space-s [&_ul]:ps-space-m [&_li]:mb-space-xs [&_a]:text-primary [&_a]:underline [&_a:hover]:no-underline">
                 <MdxContent
                   components={{
+                    Paragraph,
                     Ambassador,
                     AmbassadorGrid,
                     Blockquote,


### PR DESCRIPTION
## Summary
Adds support for importing foundation page MDX components into Strapi as structured dynamic-zone blocks instead of treating the body as a single markdown blob.

This change:
- parses `<Paragraph>`, `<AmbassadorGrid>`, `<Blockquote>`, and plain text into Strapi blocks during sync
- resolves ambassador slugs to Strapi document IDs for ambassador grid relationships
- adds a reusable `Paragraph` Astro component and registers it in the page renderer so synced content renders correctly on the site

## Related Issue
Fixes INTORG-444

## Manual Test
Reviewer steps:
1. Run the MDX sync against a foundation page that includes `Paragraph`, `AmbassadorGrid`, and `Blockquote` components, such as `src/content/foundation-pages/about-us.mdx`.
2. In Strapi, confirm the imported `foundation-page` entry stores those sections as dynamic-zone blocks instead of one raw markdown block.
3. Verify ambassador grid blocks connect the expected ambassador entries by slug.
4. Start the site and open the synced page route to confirm paragraph content, blockquotes, and ambassador grids render correctly.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat(cms): sync foundation page MDX components as Strapi blocks`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
