### PR TITLE
feat: add MDX block parser foundation for JSX imports

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -28,9 +28,12 @@
     "is-html": "^3.2.0",
     "jsesc": "^3.1.0",
     "marked": "^17.0.3",
+    "mdast-util-mdx-jsx": "^3.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.2",
+    "remark": "^15.0.1",
+    "remark-mdx": "^3.1.1",
     "styled-components": "^6.1.19",
     "turndown": "^7.2.2",
     "zod": "^4.3.6"

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       marked:
         specifier: ^17.0.3
         version: 17.0.3
+      mdast-util-mdx-jsx:
+        specifier: ^3.2.0
+        version: 3.2.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -51,6 +54,12 @@ importers:
       react-router-dom:
         specifier: ^6.30.2
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark:
+        specifier: ^15.0.1
+        version: 15.0.1
+      remark-mdx:
+        specifier: ^3.1.1
+        version: 3.1.1
       styled-components:
         specifier: ^6.1.19
         version: 6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2663,6 +2672,11 @@ packages:
     peerDependencies:
       acorn: ^8.14.0
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
@@ -3701,6 +3715,9 @@ packages:
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -4921,6 +4938,9 @@ packages:
   mdast-util-mdx-jsx@3.2.0:
     resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
 
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
@@ -4973,11 +4993,29 @@ packages:
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
 
   micromark-factory-label@2.0.1:
     resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
 
   micromark-factory-space@2.0.1:
     resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
@@ -5008,6 +5046,9 @@ packages:
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
 
   micromark-util-html-tag-name@2.0.1:
     resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
@@ -5923,11 +5964,20 @@ packages:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
     engines: {node: '>= 0.10'}
 
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remark@15.0.1:
+    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
   remove-accents@0.5.0:
     resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
@@ -6708,6 +6758,9 @@ packages:
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
@@ -11156,6 +11209,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
@@ -11882,6 +11939,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -12256,6 +12317,11 @@ snapshots:
   estraverse@5.3.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
 
   estree-walker@3.0.3:
     dependencies:
@@ -13636,6 +13702,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -13721,6 +13797,57 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-factory-destination@2.0.1:
     dependencies:
       micromark-util-character: 2.1.1
@@ -13733,6 +13860,18 @@ snapshots:
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
 
   micromark-factory-space@2.0.1:
     dependencies:
@@ -13786,6 +13925,16 @@ snapshots:
 
   micromark-util-encode@2.0.1: {}
 
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
   micromark-util-html-tag-name@2.0.1: {}
 
   micromark-util-normalize-identifier@2.0.1:
@@ -13816,7 +13965,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -14782,6 +14931,13 @@ snapshots:
 
   relateurl@0.2.7: {}
 
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -14798,6 +14954,21 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remark@15.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remove-accents@0.5.0: {}
 
@@ -15622,6 +15793,10 @@ snapshots:
       crypto-random-string: 2.0.0
 
   unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
     dependencies:
       '@types/unist': 3.0.3
 

--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -47,6 +47,13 @@ export interface ContentTypes {
 
 export function buildContentTypes(projectRoot: string): ContentTypes {
   return {
+    ambassadors: {
+      dir: getContentPath(projectRoot, 'ambassadors'),
+      apiId: 'ambassadors',
+      schema: ambassadorFrontmatterSchema,
+      buildPayload: (mdx, strapi, _existing) =>
+        buildAmbassadorPayload(ambassadorFrontmatterSchema, mdx, strapi)
+    },
     'foundation-pages': {
       dir: getContentPath(projectRoot, 'foundationPages'),
       apiId: 'foundation-pages',
@@ -67,13 +74,6 @@ export function buildContentTypes(projectRoot: string): ContentTypes {
       schema: foundationBlogFrontmatterSchema,
       buildPayload: async (mdx, _strapi, _existing) =>
         buildBlogPayload(foundationBlogFrontmatterSchema, mdx)
-    },
-    ambassadors: {
-      dir: getContentPath(projectRoot, 'ambassadors'),
-      apiId: 'ambassadors',
-      schema: ambassadorFrontmatterSchema,
-      buildPayload: (mdx, strapi, _existing) =>
-        buildAmbassadorPayload(ambassadorFrontmatterSchema, mdx, strapi)
     }
   }
 }

--- a/cms/scripts/sync-mdx/jsxExtract.test.ts
+++ b/cms/scripts/sync-mdx/jsxExtract.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkMdx from 'remark-mdx'
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
+import type { Root } from 'mdast'
+
+import { getStringAttr, getBooleanAttr, getStringArrayAttr } from './jsxExtract'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+// ---------------------------------------------------------------------------
+// Helper: parse MDX snippet and extract the first JSX flow element
+// ---------------------------------------------------------------------------
+
+function parseJsx(mdx: string): MdxJsxFlowElement {
+  const tree = unified().use(remarkParse).use(remarkMdx).parse(mdx) as Root
+  const node = tree.children.find((n) => n.type === 'mdxJsxFlowElement')
+  if (!node) throw new Error('No JSX flow element found in snippet')
+  return node as MdxJsxFlowElement
+}
+
+// ---------------------------------------------------------------------------
+// getStringAttr
+// ---------------------------------------------------------------------------
+
+describe('getStringAttr', () => {
+  it('extracts a string literal attribute', () => {
+    const node = parseJsx('<Foo bar="hello" />')
+    expect(getStringAttr(node, 'bar')).toBe('hello')
+  })
+
+  it('returns undefined for missing optional attribute', () => {
+    const node = parseJsx('<Foo />')
+    expect(getStringAttr(node, 'bar')).toBeUndefined()
+  })
+
+  it('throws MISSING_REQUIRED_PROP for missing required attribute', () => {
+    const node = parseJsx('<Foo />')
+    expect(() => getStringAttr(node, 'bar', { required: true })).toThrow(
+      MdxParserError
+    )
+    expect(() => getStringAttr(node, 'bar', { required: true })).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.MISSING_REQUIRED_PROP,
+        prop: 'bar'
+      })
+    )
+  })
+
+  it('throws DYNAMIC_EXPRESSION for expression values', () => {
+    const node = parseJsx('<Foo bar={someVar} />')
+    expect(() => getStringAttr(node, 'bar')).toThrow(MdxParserError)
+    expect(() => getStringAttr(node, 'bar')).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION
+      })
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getBooleanAttr
+// ---------------------------------------------------------------------------
+
+describe('getBooleanAttr', () => {
+  it('returns true for valueless attribute (<Foo bar />)', () => {
+    const node = parseJsx('<Foo bar />')
+    expect(getBooleanAttr(node, 'bar')).toBe(true)
+  })
+
+  it('returns true for expression {true}', () => {
+    const node = parseJsx('<Foo bar={true} />')
+    expect(getBooleanAttr(node, 'bar')).toBe(true)
+  })
+
+  it('returns false for expression {false}', () => {
+    const node = parseJsx('<Foo bar={false} />')
+    expect(getBooleanAttr(node, 'bar')).toBe(false)
+  })
+
+  it('returns undefined for missing attribute', () => {
+    const node = parseJsx('<Foo />')
+    expect(getBooleanAttr(node, 'bar')).toBeUndefined()
+  })
+
+  it('throws DYNAMIC_EXPRESSION for non-boolean expression', () => {
+    const node = parseJsx('<Foo bar={someVar} />')
+    expect(() => getBooleanAttr(node, 'bar')).toThrow(MdxParserError)
+    expect(() => getBooleanAttr(node, 'bar')).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION
+      })
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getStringArrayAttr
+// ---------------------------------------------------------------------------
+
+describe('getStringArrayAttr', () => {
+  it('extracts a static string array', () => {
+    const node = parseJsx('<Foo items={["a","b","c"]} />')
+    expect(getStringArrayAttr(node, 'items')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns undefined for missing optional attribute', () => {
+    const node = parseJsx('<Foo />')
+    expect(getStringArrayAttr(node, 'items')).toBeUndefined()
+  })
+
+  it('throws MISSING_REQUIRED_PROP for missing required attribute', () => {
+    const node = parseJsx('<Foo />')
+    expect(() => getStringArrayAttr(node, 'items', { required: true })).toThrow(
+      MdxParserError
+    )
+    expect(() => getStringArrayAttr(node, 'items', { required: true })).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.MISSING_REQUIRED_PROP
+      })
+    )
+  })
+
+  it('throws INVALID_PROP_VALUE for plain string attribute', () => {
+    const node = parseJsx('<Foo items="not-an-array" />')
+    expect(() => getStringArrayAttr(node, 'items')).toThrow(MdxParserError)
+    expect(() => getStringArrayAttr(node, 'items')).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.INVALID_PROP_VALUE
+      })
+    )
+  })
+
+  it('throws DYNAMIC_EXPRESSION for non-static expression', () => {
+    const node = parseJsx('<Foo items={someVar} />')
+    expect(() => getStringArrayAttr(node, 'items')).toThrow(MdxParserError)
+    expect(() => getStringArrayAttr(node, 'items')).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION
+      })
+    )
+  })
+})

--- a/cms/scripts/sync-mdx/jsxExtract.ts
+++ b/cms/scripts/sync-mdx/jsxExtract.ts
@@ -1,0 +1,266 @@
+/**
+ * JSX attribute extraction utilities for MDX AST nodes.
+ *
+ * Provides safe, typed accessors for reading props from
+ * `mdast-util-mdx-jsx` JSX element nodes. All accessors
+ * throw `MdxParserError` on unexpected shapes so callers
+ * get strict, actionable failures.
+ */
+
+import type { MdxJsxFlowElement, MdxJsxAttribute } from 'mdast-util-mdx-jsx'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find a JSX attribute by name on an MDX JSX element.
+ * Returns `undefined` when the attribute is absent.
+ */
+function findAttr(
+  node: MdxJsxFlowElement,
+  name: string
+): MdxJsxAttribute | undefined {
+  return node.attributes.find(
+    (attr): attr is MdxJsxAttribute =>
+      attr.type === 'mdxJsxAttribute' && attr.name === name
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a string attribute value.
+ *
+ * @example
+ * ```ts
+ * // <Ambassador slug="caroline-sinders" />
+ * getStringAttr(node, 'slug')                        // → "caroline-sinders"
+ * getStringAttr(node, 'bio')                          // → undefined
+ * getStringAttr(node, 'slug', { required: true })     // → "caroline-sinders"
+ * getStringAttr(node, 'bio', { required: true })      // → throws MISSING_REQUIRED_PROP
+ * // <Ambassador slug={dynamicVar} />
+ * getStringAttr(node, 'slug')                         // → throws DYNAMIC_EXPRESSION
+ * ```
+ *
+ * @param node - JSX AST node
+ * @param name - Attribute name
+ * @param opts.required - When true, throws if the attribute is missing
+ * @returns The string value, or `undefined` if absent and not required
+ */
+export function getStringAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts: { required: true }
+): string
+export function getStringAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts?: { required?: false }
+): string | undefined
+export function getStringAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts: { required?: boolean } = {}
+): string | undefined {
+  const attr = findAttr(node, name)
+
+  if (!attr) {
+    if (opts.required) {
+      throw new MdxParserError({
+        code: ParserErrorCode.MISSING_REQUIRED_PROP,
+        message: `Required prop "${name}" is missing.`,
+        component: node.name ?? undefined,
+        prop: name,
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
+    return undefined
+  }
+
+  // String literal: <Foo bar="baz" />
+  if (typeof attr.value === 'string') {
+    return attr.value
+  }
+
+  // Expression container: <Foo bar={"baz"} /> or <Foo bar={`baz`} />
+  if (
+    attr.value &&
+    typeof attr.value === 'object' &&
+    attr.value.type === 'mdxJsxAttributeValueExpression'
+  ) {
+    throw new MdxParserError({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION,
+      message: `Prop "${name}" must be a static string, not an expression.`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+
+  if (opts.required) {
+    throw new MdxParserError({
+      code: ParserErrorCode.INVALID_PROP_VALUE,
+      message: `Prop "${name}" has an unexpected value shape.`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+
+  return undefined
+}
+
+/**
+ * Extract a boolean attribute value.
+ *
+ * @example
+ * ```ts
+ * // <Ambassador showLinks />           → true  (valueless)
+ * // <Ambassador showLinks={true} />    → true
+ * // <Ambassador showLinks={false} />   → false
+ * // <Ambassador />                     → undefined (absent)
+ * // <Ambassador showLinks={someVar} /> → throws DYNAMIC_EXPRESSION
+ * getBooleanAttr(node, 'showLinks')
+ * ```
+ *
+ * @returns The boolean value, or `undefined` if absent
+ */
+export function getBooleanAttr(
+  node: MdxJsxFlowElement,
+  name: string
+): boolean | undefined {
+  const attr = findAttr(node, name)
+  if (!attr) return undefined
+
+  // Valueless: <Foo showLinks /> → true
+  if (attr.value === null || attr.value === undefined) {
+    return true
+  }
+
+  // String "true" / "false" (rare but valid in some MDX)
+  if (attr.value === 'true') return true
+  if (attr.value === 'false') return false
+
+  // Expression: <Foo bar={true} /> or <Foo bar={false} />
+  if (
+    typeof attr.value === 'object' &&
+    attr.value.type === 'mdxJsxAttributeValueExpression'
+  ) {
+    const raw = attr.value.value.trim()
+    if (raw === 'true') return true
+    if (raw === 'false') return false
+
+    throw new MdxParserError({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION,
+      message: `Prop "${name}" must be a static boolean (true/false), got "${raw}".`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+
+  return undefined
+}
+
+/**
+ * Extract a string-array attribute from a JSX expression.
+ *
+ * Only static JSON arrays are supported. Dynamic expressions throw.
+ *
+ * @example
+ * ```ts
+ * // <AmbassadorGrid slugs={["caroline-sinders","alex-smith"]} />
+ * getStringArrayAttr(node, 'slugs')  // → ["caroline-sinders", "alex-smith"]
+ * // <AmbassadorGrid slugs={myArray} />
+ * getStringArrayAttr(node, 'slugs')  // → throws DYNAMIC_EXPRESSION
+ * ```
+ *
+ * @returns The string array, or `undefined` if absent
+ */
+export function getStringArrayAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts: { required: true }
+): string[]
+export function getStringArrayAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts?: { required?: false }
+): string[] | undefined
+export function getStringArrayAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts: { required?: boolean } = {}
+): string[] | undefined {
+  const attr = findAttr(node, name)
+
+  if (!attr) {
+    if (opts.required) {
+      throw new MdxParserError({
+        code: ParserErrorCode.MISSING_REQUIRED_PROP,
+        message: `Required prop "${name}" is missing.`,
+        component: node.name ?? undefined,
+        prop: name,
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
+    return undefined
+  }
+
+  // Must be an expression: slugs={["a","b"]}
+  if (
+    !attr.value ||
+    typeof attr.value !== 'object' ||
+    attr.value.type !== 'mdxJsxAttributeValueExpression'
+  ) {
+    throw new MdxParserError({
+      code: ParserErrorCode.INVALID_PROP_VALUE,
+      message: `Prop "${name}" must be a JSX expression array (e.g. {["a","b"]}).`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+
+  const raw = attr.value.value.trim()
+
+  // Try JSON parse – handles ["a", "b", "c"]
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((item) => typeof item === 'string')
+    ) {
+      return parsed as string[]
+    }
+    throw new MdxParserError({
+      code: ParserErrorCode.INVALID_PROP_VALUE,
+      message: `Prop "${name}" must be an array of strings, got ${typeof parsed}.`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  } catch (err) {
+    if (err instanceof MdxParserError) throw err
+
+    throw new MdxParserError({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION,
+      message: `Prop "${name}" contains a dynamic expression that cannot be statically evaluated.`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+}

--- a/cms/scripts/sync-mdx/mdxBlockParser.test.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { parseMdxToBlocks, getRegisteredComponents } from './mdxBlockParser'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+// ---------------------------------------------------------------------------
+// parseMdxToBlocks
+// ---------------------------------------------------------------------------
+
+describe('parseMdxToBlocks', () => {
+  const ctx = { locale: 'en' }
+
+  it('returns empty array for empty body', async () => {
+    expect(await parseMdxToBlocks('', ctx)).toEqual([])
+  })
+
+  it('returns empty array for whitespace-only body', async () => {
+    expect(await parseMdxToBlocks('   \n\n  ', ctx)).toEqual([])
+  })
+
+  it('throws MdxParserError for malformed MDX', async () => {
+    // Unclosed JSX tag that remark-mdx cannot parse
+    await expect(parseMdxToBlocks('<Broken attr={>', ctx)).rejects.toThrow(
+      MdxParserError
+    )
+
+    await expect(
+      parseMdxToBlocks('<Broken attr={>', ctx)
+    ).rejects.toMatchObject({ code: ParserErrorCode.MDX_PARSE_ERROR })
+  })
+
+  it('throws UNSUPPORTED_COMPONENT for unregistered JSX', async () => {
+    await expect(
+      parseMdxToBlocks('<UnknownWidget foo="bar" />', ctx)
+    ).rejects.toThrow(MdxParserError)
+
+    await expect(
+      parseMdxToBlocks('<UnknownWidget foo="bar" />', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.UNSUPPORTED_COMPONENT,
+      component: 'UnknownWidget'
+    })
+  })
+
+  it('throws DYNAMIC_EXPRESSION for bare top-level expressions', async () => {
+    // {someVariable} becomes mdxFlowExpression in the AST
+    await expect(parseMdxToBlocks('{someVariable}', ctx)).rejects.toThrow(
+      MdxParserError
+    )
+
+    await expect(parseMdxToBlocks('{someVariable}', ctx)).rejects.toMatchObject(
+      {
+        code: ParserErrorCode.DYNAMIC_EXPRESSION
+      }
+    )
+  })
+
+  it('throws DYNAMIC_EXPRESSION for arrow function expressions', async () => {
+    await expect(
+      parseMdxToBlocks('{() => doSomething()}', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION
+    })
+  })
+
+  it('throws DYNAMIC_EXPRESSION for import statements', async () => {
+    await expect(
+      parseMdxToBlocks('import { foo } from "bar"', ctx)
+    ).rejects.toThrow(MdxParserError)
+
+    await expect(
+      parseMdxToBlocks('import { foo } from "bar"', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION
+    })
+  })
+
+  it('throws DYNAMIC_EXPRESSION for export statements', async () => {
+    await expect(
+      parseMdxToBlocks('export const x = 1', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION
+    })
+  })
+
+  it('throws UNSUPPORTED_COMPONENT for JSX fragments', async () => {
+    await expect(parseMdxToBlocks('<>\n  content\n</>', ctx)).rejects.toThrow(
+      MdxParserError
+    )
+
+    await expect(
+      parseMdxToBlocks('<>\n  content\n</>', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.UNSUPPORTED_COMPONENT
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getRegisteredComponents
+// ---------------------------------------------------------------------------
+
+describe('getRegisteredComponents', () => {
+  it('returns an array', () => {
+    const names = getRegisteredComponents()
+    expect(Array.isArray(names)).toBe(true)
+  })
+})

--- a/cms/scripts/sync-mdx/mdxBlockParser.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.ts
@@ -113,7 +113,7 @@ export async function parseMdxToBlocks(
   // Walk top-level AST nodes
   for (const node of tree.children) {
     if (node.type === 'mdxJsxFlowElement') {
-      const jsxNode = node as MdxJsxFlowElement
+      const jsxNode = node
       const componentName = jsxNode.name
 
       if (!componentName) {

--- a/cms/scripts/sync-mdx/mdxBlockParser.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.ts
@@ -1,0 +1,199 @@
+/**
+ * MDX Block Parser
+ *
+ * Parses MDX body content into an ordered array of Strapi dynamic-zone
+ * block payloads using remark + remark-mdx AST walking.
+ *
+ * Entry point: `parseMdxToBlocks()`
+ *
+ * Design:
+ * - AST-first: parse once, walk once, map each node to a block handler.
+ * - Strict: unsupported JSX, dynamic expressions, and missing required
+ *   props produce hard errors via `MdxParserError`.
+ * - Extensible: component handlers are registered in `COMPONENT_HANDLERS`
+ *   and new components only need a handler function + type entry.
+ */
+
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkMdx from 'remark-mdx'
+import type { Root } from 'mdast'
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
+
+import type { ParsedBlock } from './types.blocks'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for a single JSX component.
+ *
+ * Receives the AST node and an opaque context (for relation resolution
+ * etc.) and returns one or more block payloads.
+ *
+ * Handlers are async to support relation lookups (e.g. ambassador slug
+ * resolution).
+ */
+export type ComponentHandler = (
+  node: MdxJsxFlowElement,
+  ctx: ParserContext
+) => Promise<ParsedBlock[]>
+
+/**
+ * Context passed to component handlers during parsing.
+ *
+ * Contains the services handlers may need (e.g. relation resolver).
+ */
+export interface ParserContext {
+  /** Locale of the MDX file being parsed. */
+  locale: string
+}
+
+// ---------------------------------------------------------------------------
+// Handler registry
+// ---------------------------------------------------------------------------
+
+/** Map of JSX component name → handler function. */
+const COMPONENT_HANDLERS: Record<string, ComponentHandler> = {}
+
+// ---------------------------------------------------------------------------
+// Core parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an MDX body string into an ordered array of Strapi dynamic-zone
+ * block payloads.
+ *
+ * @example
+ * ```ts
+ * // Given MDX body:
+ * //   <Ambassador slug="caroline-sinders" showLinks={false} />
+ * //   <AmbassadorGrid heading="Our Team" slugs={["alice","bob"]} />
+ * //
+ * // Returns (once handlers are registered):
+ * // [
+ * //   { __component: 'blocks.ambassador', ambassador: { documentId: '...' }, showLinks: false },
+ * //   { __component: 'blocks.ambassadors-grid', heading: 'Our Team', ambassadors: [...] }
+ * // ]
+ *
+ * const blocks = await parseMdxToBlocks(mdxBody, { locale: 'en' })
+ * ```
+ *
+ * @param mdxBody - Raw MDX body content (no frontmatter)
+ * @param ctx - Parser context (locale, services, etc.)
+ * @returns Ordered array of block payloads ready for Strapi import
+ *
+ * @throws {MdxParserError} on unsupported JSX, bad props, parse errors
+ */
+export async function parseMdxToBlocks(
+  mdxBody: string,
+  ctx: ParserContext
+): Promise<ParsedBlock[]> {
+  if (!mdxBody.trim()) return []
+
+  // Parse MDX into AST.
+  // unified() creates the processing pipeline that remark plugins attach to.
+  // remarkParse adds markdown parsing, remarkMdx extends it with JSX syntax
+  // support (<Component />, {expressions}). The .parse() call produces the
+  // AST without running any transforms.
+  let tree: Root
+  try {
+    tree = unified().use(remarkParse).use(remarkMdx).parse(mdxBody)
+  } catch (err) {
+    throw new MdxParserError({
+      code: ParserErrorCode.MDX_PARSE_ERROR,
+      message: `Failed to parse MDX: ${err instanceof Error ? err.message : String(err)}`
+    })
+  }
+
+  const blocks: ParsedBlock[] = []
+
+  // Walk top-level AST nodes
+  for (const node of tree.children) {
+    if (node.type === 'mdxJsxFlowElement') {
+      const jsxNode = node as MdxJsxFlowElement
+      const componentName = jsxNode.name
+
+      if (!componentName) {
+        throw new MdxParserError({
+          code: ParserErrorCode.UNSUPPORTED_COMPONENT,
+          message:
+            'Encountered a JSX fragment (<>...</>). Fragments are not supported.',
+          line: jsxNode.position?.start.line,
+          column: jsxNode.position?.start.column
+        })
+      }
+
+      const handler = COMPONENT_HANDLERS[componentName]
+      if (!handler) {
+        throw new MdxParserError({
+          code: ParserErrorCode.UNSUPPORTED_COMPONENT,
+          message: `Unsupported JSX component "${componentName}".`,
+          component: componentName,
+          line: jsxNode.position?.start.line,
+          column: jsxNode.position?.start.column
+        })
+      }
+
+      const result = await handler(jsxNode, ctx)
+      blocks.push(...result)
+    }
+    // Bare expressions like {someVar} or {() => fn()} are not allowed.
+    if (
+      node.type === 'mdxFlowExpression' ||
+      node.type === 'mdxTextExpression'
+    ) {
+      const expr = node as { value?: string; position?: Root['position'] }
+      throw new MdxParserError({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION,
+        message: `Top-level expression "{${expr.value ?? '...'}}" is not supported.`,
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
+
+    // ESM import/export statements are not allowed — MDX content in this
+    // pipeline is converted to Strapi blocks, not executed as JS modules.
+    if (node.type === 'mdxjsEsm') {
+      const esm = node as { value?: string; position?: Root['position'] }
+      throw new MdxParserError({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION,
+        message: `Import/export statements are not supported: "${esm.value ?? '...'}"`,
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
+
+    // Markdown nodes (paragraph, heading, etc.) are handled by the
+    // Paragraph handler once registered. Until then, they pass through
+    // unmatched — the caller (buildPagePayload) only invokes the parser
+    // when JSX components are present in the body.
+  }
+
+  return blocks
+}
+
+// ---------------------------------------------------------------------------
+// Handler registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a component handler. Called by individual handler modules
+ * during their initialization.
+ */
+export function registerComponentHandler(
+  name: string,
+  handler: ComponentHandler
+): void {
+  COMPONENT_HANDLERS[name] = handler
+}
+
+/**
+ * Get a read-only snapshot of registered handler names.
+ * Useful for testing and diagnostics.
+ */
+export function getRegisteredComponents(): string[] {
+  return Object.keys(COMPONENT_HANDLERS)
+}

--- a/cms/scripts/sync-mdx/mdxBlockParser.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.ts
@@ -58,6 +58,25 @@ export interface ParserContext {
 /** Map of JSX component name → handler function. */
 const COMPONENT_HANDLERS: Record<string, ComponentHandler> = {}
 
+interface PositionedNode {
+  position?: Root['position']
+}
+
+function parserError(
+  code: ParserErrorCode,
+  message: string,
+  node?: PositionedNode,
+  extras: { component?: string } = {}
+): MdxParserError {
+  return new MdxParserError({
+    code,
+    message,
+    component: extras.component,
+    line: node?.position?.start.line,
+    column: node?.position?.start.column
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Core parser
 // ---------------------------------------------------------------------------
@@ -117,24 +136,21 @@ export async function parseMdxToBlocks(
       const componentName = jsxNode.name
 
       if (!componentName) {
-        throw new MdxParserError({
-          code: ParserErrorCode.UNSUPPORTED_COMPONENT,
-          message:
-            'Encountered a JSX fragment (<>...</>). Fragments are not supported.',
-          line: jsxNode.position?.start.line,
-          column: jsxNode.position?.start.column
-        })
+        throw parserError(
+          ParserErrorCode.UNSUPPORTED_COMPONENT,
+          'Encountered a JSX fragment (<>...</>). Fragments are not supported.',
+          jsxNode
+        )
       }
 
       const handler = COMPONENT_HANDLERS[componentName]
       if (!handler) {
-        throw new MdxParserError({
-          code: ParserErrorCode.UNSUPPORTED_COMPONENT,
-          message: `Unsupported JSX component "${componentName}".`,
-          component: componentName,
-          line: jsxNode.position?.start.line,
-          column: jsxNode.position?.start.column
-        })
+        throw parserError(
+          ParserErrorCode.UNSUPPORTED_COMPONENT,
+          `Unsupported JSX component "${componentName}".`,
+          jsxNode,
+          { component: componentName }
+        )
       }
 
       const result = await handler(jsxNode, ctx)
@@ -146,24 +162,22 @@ export async function parseMdxToBlocks(
       node.type === 'mdxTextExpression'
     ) {
       const expr = node as { value?: string; position?: Root['position'] }
-      throw new MdxParserError({
-        code: ParserErrorCode.DYNAMIC_EXPRESSION,
-        message: `Top-level expression "{${expr.value ?? '...'}}" is not supported.`,
-        line: node.position?.start.line,
-        column: node.position?.start.column
-      })
+      throw parserError(
+        ParserErrorCode.DYNAMIC_EXPRESSION,
+        `Top-level expression "{${expr.value ?? '...'}}" is not supported.`,
+        node
+      )
     }
 
     // ESM import/export statements are not allowed — MDX content in this
     // pipeline is converted to Strapi blocks, not executed as JS modules.
     if (node.type === 'mdxjsEsm') {
       const esm = node as { value?: string; position?: Root['position'] }
-      throw new MdxParserError({
-        code: ParserErrorCode.DYNAMIC_EXPRESSION,
-        message: `Import/export statements are not supported: "${esm.value ?? '...'}"`,
-        line: node.position?.start.line,
-        column: node.position?.start.column
-      })
+      throw parserError(
+        ParserErrorCode.DYNAMIC_EXPRESSION,
+        `Import/export statements are not supported: "${esm.value ?? '...'}"`,
+        node
+      )
     }
 
     // Markdown nodes (paragraph, heading, etc.) are handled by the

--- a/cms/scripts/sync-mdx/parserErrors.test.ts
+++ b/cms/scripts/sync-mdx/parserErrors.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+describe('MdxParserError', () => {
+  it('sets code, message, and component', () => {
+    const err = new MdxParserError({
+      code: ParserErrorCode.MISSING_REQUIRED_PROP,
+      message: 'Required prop "slug" is missing.',
+      component: 'Ambassador',
+      prop: 'slug'
+    })
+
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(MdxParserError)
+    expect(err.name).toBe('MdxParserError')
+    expect(err.code).toBe(ParserErrorCode.MISSING_REQUIRED_PROP)
+    expect(err.component).toBe('Ambassador')
+    expect(err.prop).toBe('slug')
+    expect(err.message).toContain('Ambassador')
+    expect(err.message).toContain('slug')
+  })
+
+  it('includes line/column in message when provided', () => {
+    const err = new MdxParserError({
+      code: ParserErrorCode.UNSUPPORTED_COMPONENT,
+      message: 'Unsupported JSX component "Foo".',
+      component: 'Foo',
+      line: 5,
+      column: 3
+    })
+
+    expect(err.line).toBe(5)
+    expect(err.column).toBe(3)
+    expect(err.message).toContain('line 5:3')
+  })
+
+  it('omits location from message when line is not provided', () => {
+    const err = new MdxParserError({
+      code: ParserErrorCode.MDX_PARSE_ERROR,
+      message: 'Failed to parse MDX.'
+    })
+
+    expect(err.line).toBeUndefined()
+    expect(err.message).not.toContain('line')
+    expect(err.message).toContain('[parser]')
+  })
+
+  it('exposes all error codes', () => {
+    expect(ParserErrorCode.UNSUPPORTED_COMPONENT).toBe('UNSUPPORTED_COMPONENT')
+    expect(ParserErrorCode.MISSING_REQUIRED_PROP).toBe('MISSING_REQUIRED_PROP')
+    expect(ParserErrorCode.INVALID_PROP_VALUE).toBe('INVALID_PROP_VALUE')
+    expect(ParserErrorCode.DYNAMIC_EXPRESSION).toBe('DYNAMIC_EXPRESSION')
+    expect(ParserErrorCode.MDX_PARSE_ERROR).toBe('MDX_PARSE_ERROR')
+    expect(ParserErrorCode.UNRESOLVED_RELATION).toBe('UNRESOLVED_RELATION')
+    expect(ParserErrorCode.CONFLICTING_PROPS).toBe('CONFLICTING_PROPS')
+  })
+})

--- a/cms/scripts/sync-mdx/parserErrors.ts
+++ b/cms/scripts/sync-mdx/parserErrors.ts
@@ -1,0 +1,84 @@
+/**
+ * Strict error model for the MDX block parser.
+ *
+ * The parser fails loudly on unsupported syntax rather than silently
+ * dropping content. Every error carries enough context (component name,
+ * position, reason) for the caller to produce actionable diagnostics.
+ */
+
+// ---------------------------------------------------------------------------
+// Error codes
+// ---------------------------------------------------------------------------
+
+export const ParserErrorCode = {
+  /** JSX component not in the supported handler registry. */
+  UNSUPPORTED_COMPONENT: 'UNSUPPORTED_COMPONENT',
+
+  /** A required prop is missing from a JSX element. */
+  MISSING_REQUIRED_PROP: 'MISSING_REQUIRED_PROP',
+
+  /** A prop value has an unexpected type or format. */
+  INVALID_PROP_VALUE: 'INVALID_PROP_VALUE',
+
+  /** A JSX expression (`{...}`) could not be statically evaluated. */
+  DYNAMIC_EXPRESSION: 'DYNAMIC_EXPRESSION',
+
+  /** MDX AST could not be parsed by remark + remark-mdx. */
+  MDX_PARSE_ERROR: 'MDX_PARSE_ERROR',
+
+  /** Relation slug could not be resolved to a Strapi document ID. */
+  UNRESOLVED_RELATION: 'UNRESOLVED_RELATION',
+
+  /** Conflicting props (e.g. both children and content on Paragraph). */
+  CONFLICTING_PROPS: 'CONFLICTING_PROPS'
+} as const
+
+export type ParserErrorCode =
+  (typeof ParserErrorCode)[keyof typeof ParserErrorCode]
+
+// ---------------------------------------------------------------------------
+// Error class
+// ---------------------------------------------------------------------------
+
+export interface ParserErrorContext {
+  /** Error classification. */
+  code: ParserErrorCode
+  /** Human-readable explanation. */
+  message: string
+  /** JSX component name (e.g. "Ambassador"), if applicable. */
+  component?: string
+  /** Prop name that caused the error, if applicable. */
+  prop?: string
+  /** 1-based line number in the source MDX, if available. */
+  line?: number
+  /** 1-based column number in the source MDX, if available. */
+  column?: number
+}
+
+/**
+ * Thrown by the MDX block parser on any irrecoverable issue.
+ *
+ * Callers should catch this at the pipeline boundary and surface
+ * the structured context for debugging.
+ */
+export class MdxParserError extends Error {
+  public readonly code: ParserErrorCode
+  public readonly component?: string
+  public readonly prop?: string
+  public readonly line?: number
+  public readonly column?: number
+
+  constructor(ctx: ParserErrorContext) {
+    const location =
+      ctx.line != null ? ` (line ${ctx.line}:${ctx.column ?? 0})` : ''
+    const prefix = ctx.component ? `[${ctx.component}]` : '[parser]'
+    super(`${prefix}${location} ${ctx.message}`)
+
+    this.name = 'MdxParserError'
+    this.code = ctx.code
+    this.component = ctx.component
+    this.prop = ctx.prop
+    this.line = ctx.line
+    this.column = ctx.column
+  }
+}

--- a/cms/scripts/sync-mdx/types.blocks.ts
+++ b/cms/scripts/sync-mdx/types.blocks.ts
@@ -1,0 +1,81 @@
+/**
+ * Block type definitions for MDX ↔ Strapi dynamic zone import.
+ *
+ * These types represent the Strapi REST API payload shapes produced by
+ * the MDX block parser — NOT the Strapi schema types (those live in
+ * cms/types/generated/components.d.ts and use Schema.Attribute.*).
+ *
+ * Each type maps to a Strapi component schema under
+ * cms/src/components/blocks/ but describes the JSON body sent to the
+ * Strapi REST API during import.
+ *
+ */
+
+// ---------------------------------------------------------------------------
+// Shared
+// ---------------------------------------------------------------------------
+
+/** Discriminator present on every Strapi dynamic-zone block payload. */
+export interface StrapiBlockBase {
+  __component: string
+}
+
+// ---------------------------------------------------------------------------
+// Block Payloads
+// ---------------------------------------------------------------------------
+
+/** blocks.paragraph – rich text content block. */
+export interface ParagraphBlock extends StrapiBlockBase {
+  __component: 'blocks.paragraph'
+  content: string
+  alignment?: 'left' | 'center' | 'right'
+}
+
+/**
+ * blocks.ambassador – single ambassador relation block.
+ *
+ * The `ambassador` field holds a Strapi relation connect payload
+ * (documentId resolved from slug at parse time).
+ */
+export interface AmbassadorBlock extends StrapiBlockBase {
+  __component: 'blocks.ambassador'
+  ambassador: { documentId: string }
+  showLinks?: boolean
+}
+
+/**
+ * blocks.ambassadors-grid – ordered grid of ambassador relations.
+ *
+ * `ambassadors` is an array of relation connect payloads whose order
+ * must match the input slug order.
+ */
+export interface AmbassadorsGridBlock extends StrapiBlockBase {
+  __component: 'blocks.ambassadors-grid'
+  heading?: string
+  ambassadors: Array<{ documentId: string }>
+}
+
+/** blocks.blockquote – styled quote with optional attribution. */
+export interface BlockquoteBlock extends StrapiBlockBase {
+  __component: 'blocks.blockquote'
+  quote: string
+  source?: string
+}
+
+/** blocks.callout-text – highlighted text block. */
+export interface CalloutTextBlock extends StrapiBlockBase {
+  __component: 'blocks.callout-text'
+  content: string
+}
+
+// ---------------------------------------------------------------------------
+// Union
+// ---------------------------------------------------------------------------
+
+/** Any block the parser can produce. */
+export type ParsedBlock =
+  | ParagraphBlock
+  | AmbassadorBlock
+  | AmbassadorsGridBlock
+  | BlockquoteBlock
+  | CalloutTextBlock

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       marked:
         specifier: ^17.0.3
         version: 17.0.3
+      mdast-util-mdx-jsx:
+        specifier: ^3.2.0
+        version: 3.2.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -153,6 +156,12 @@ importers:
       react-router-dom:
         specifier: ^6.30.2
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark:
+        specifier: ^15.0.1
+        version: 15.0.1
+      remark-mdx:
+        specifier: ^3.1.1
+        version: 3.1.1
       styled-components:
         specifier: ^6.1.19
         version: 6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9271,6 +9280,9 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  remark@15.0.1:
+    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
+
   remove-accents@0.5.0:
     resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
 
@@ -14534,7 +14546,7 @@ snapshots:
       '@strapi/design-system': 2.0.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(@strapi/icons@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/permissions': 5.31.3
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.31.3
       '@strapi/utils': 5.31.3
       '@testing-library/dom': 10.1.0
@@ -14731,7 +14743,7 @@ snapshots:
       '@strapi/database': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)
       '@strapi/design-system': 2.0.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(@strapi/icons@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/utils': 5.31.3
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
@@ -14832,7 +14844,7 @@ snapshots:
       '@strapi/generators': 5.31.3(@types/node@22.19.11)
       '@strapi/logger': 5.31.3
       '@strapi/permissions': 5.31.3
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.31.3
       '@strapi/utils': 5.31.3
       '@vercel/stega': 0.1.2
@@ -15362,7 +15374,7 @@ snapshots:
       '@strapi/openapi': 5.31.3
       '@strapi/permissions': 5.31.3
       '@strapi/review-workflows': 5.31.3(681caf389605bd5fac823ee0158edb2f)
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.31.3
       '@strapi/upload': 5.31.3(c76dd935e99411c3ec50b97509689cc7)
       '@strapi/utils': 5.31.3
@@ -15465,36 +15477,6 @@ snapshots:
       - webpack-cli
       - webpack-dev-server
       - webpack-plugin-serve
-
-  '@strapi/types@5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)':
-    dependencies:
-      '@casl/ability': 6.5.0
-      '@koa/cors': 5.0.0
-      '@koa/router': 12.0.2
-      '@strapi/database': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)
-      '@strapi/logger': 5.31.3
-      '@strapi/permissions': 5.31.3
-      '@strapi/utils': 5.31.3
-      commander: 8.3.0
-      json-logic-js: 2.0.5
-      koa: 2.16.1
-      koa-body: 6.0.1
-      node-schedule: 2.1.1
-      typedoc: 0.25.10(typescript@5.4.4)
-      typedoc-github-wiki-theme: 1.1.0(typedoc-plugin-markdown@3.17.1(typedoc@0.25.10(typescript@5.9.3)))(typedoc@0.25.10(typescript@5.9.3))
-      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.10(typescript@5.9.3))
-      zod: 3.25.67
-    transitivePeerDependencies:
-      - '@types/node'
-      - better-sqlite3
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-      - typescript
 
   '@strapi/types@5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)':
     dependencies:
@@ -22807,6 +22789,15 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  remark@15.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remove-accents@0.5.0: {}
 
   remove-trailing-separator@1.1.0: {}
@@ -23930,14 +23921,6 @@ snapshots:
     dependencies:
       handlebars: 4.7.8
       typedoc: 0.25.10(typescript@5.9.3)
-
-  typedoc@0.25.10(typescript@5.4.4):
-    dependencies:
-      lunr: 2.3.9
-      marked: 4.3.0
-      minimatch: 9.0.5
-      shiki: 0.14.7
-      typescript: 5.4.4
 
   typedoc@0.25.10(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary
Adds the foundational MDX block parser infrastructure for the JSX imports pipeline (MDX → Strapi dynamic-zone blocks). Follows the outline discussed in the [RFC](https://github.com/interledger/interledger.org-v5/issues/89)

- Introduces `mdxBlockParser.ts` : AST-based parser using remark + remark-mdx with a pluggable component handler registry
- Introduces `jsxExtract.ts `: typed JSX attribute extractors (getStringAttr, getBooleanAttr, getStringArrayAttr) with strict validation
- Introduces `parserErrors.ts` :  MdxParserError class with 7 error codes for hard-fail on unsupported syntax
- Introduces `types.blocks.ts` :  Strapi REST API payload types for all block components
- Adds remark, remark-mdx, mdast-util-mdx-jsx dependencies to cms/package.json
- No behavior change to existing sync pipeline; this is scaffolding only

## Related Issue
Fixes INTORG-454

## Manual Test

- added new tests
pnpm --dir cms test:sync-mdx

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
