### PR TITLE
chore(foundation-blog): add Strapi lifecycle file to create / update / delete mdx in Astro

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -111,9 +111,11 @@ When content is published or updated in Strapi:
 
 **File Naming**
 
-MDX files are named using the slug: `{slug}.mdx`
+- MDX files for **pages** (e.g., foundation pages, summit pages) are named using the slug: `{slug}.mdx` <br/>
+  Example: If the slug is `interledger-launches-new-platform`, the file will be: `interledger-launches-new-platform.mdx`
 
-Example: If slug is `interledger-launches-new-platform`, the file will be `interledger-launches-new-platform.mdx`
+- MDX files for **blog posts** use a date-prefixed format: `yyyy-mm-dd-{slug}.mdx`<br/>
+  Example: `2025-01-15-interledger-launches-new-platform.mdx`
 
 **Git Commits**
 
@@ -132,6 +134,7 @@ Example: If slug is `interledger-launches-new-platform`, the file will be `inter
 - Scans MDX files in
   - `src/content/foundation-pages`
   - `src/content/summit-pages`
+  - `src/content/foundation-blog-posts`
 - Creates, updates, and deletes Strapi entries to match the MDX file system
 - Supports localized content matching
 - Supports `dry-run` mode to preview changes
@@ -196,6 +199,7 @@ The workflow in `.github/workflows/staging-merge.yml` automatically syncs MDX fi
 - `src/content/foundation-pages/*.mdx` → `foundation-pages` (API ID)
 - `src/content/summit-pages/*.mdx` → `summit-pages` (API ID)
 - `src/content/ambassadors/*.mdx` → `ambassadors` (API ID)
+- `src/content/foundation-blog-posts/*mdx` → `foundation-blog-posts` (API ID)
 
 These mappings are configured in: `scripts/sync-mdx/config.ts`
 

--- a/cms/src/api/foundation-blog-post/content-types/foundation-blog-post/lifecycles.ts
+++ b/cms/src/api/foundation-blog-post/content-types/foundation-blog-post/lifecycles.ts
@@ -1,0 +1,9 @@
+import { createBlogLifecycle } from '../../../../utils/blogLifecycle'
+// import { PATHS } from '../../../../utils/paths'
+
+export default createBlogLifecycle()
+// {
+//   contentTypeUid: 'api::foundation-blog-post.foundation-blog-post',
+//   outputDir: `${PATHS.CONTENT_ROOT}/${PATHS.CONTENT.blog}`,
+//   localizedOutputDir: PATHS.CONTENT.blog
+// }

--- a/cms/src/api/foundation-blog-post/content-types/foundation-blog-post/lifecycles.ts
+++ b/cms/src/api/foundation-blog-post/content-types/foundation-blog-post/lifecycles.ts
@@ -1,9 +1,6 @@
 import { createBlogLifecycle } from '../../../../utils/blogLifecycle'
-// import { PATHS } from '../../../../utils/paths'
+import { PATHS } from '../../../../utils/paths'
 
-export default createBlogLifecycle()
-// {
-//   contentTypeUid: 'api::foundation-blog-post.foundation-blog-post',
-//   outputDir: `${PATHS.CONTENT_ROOT}/${PATHS.CONTENT.blog}`,
-//   localizedOutputDir: PATHS.CONTENT.blog
-// }
+export default createBlogLifecycle({
+  outputDir: `${PATHS.CONTENT_ROOT}/${PATHS.CONTENT.blog}`
+})

--- a/cms/src/api/foundation-blog-post/content-types/foundation-blog-post/schema.json
+++ b/cms/src/api/foundation-blog-post/content-types/foundation-blog-post/schema.json
@@ -85,14 +85,6 @@
         "images"
       ]
     },
-    "authors": {
-      "type": "string",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
-    },
     "description": {
       "type": "text",
       "pluginOptions": {

--- a/cms/src/components/shared/article-bio.json
+++ b/cms/src/components/shared/article-bio.json
@@ -5,6 +5,9 @@
   },
   "options": {},
   "attributes": {
+    "author": {
+      "type": "string"
+    },
     "profileBio": {
       "type": "customField",
       "customField": "plugin::ckeditor5.CKEditor",

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -158,7 +158,6 @@ async function configureFieldLabels(strapi: StrapiInstance) {
       pillar: 'Pillar',
       featureImage: 'Feature Image',
       thumbnailImage: 'Article Thumbnail',
-      authors: 'Byline',
       content: 'Content',
       articleBio: 'Article Bio',
       tags: 'Tags',

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -33,7 +33,7 @@ interface BlogResult {
     profileImage?: { url: string }
   }[]
   tags?: { tagValue: string }[]
-  localizations: []
+  localizations: string[]
 }
 
 interface BlogEvent {
@@ -47,7 +47,7 @@ function yamlSingleQuote(value: string): string {
 }
 const q = yamlSingleQuote
 
-function generateFilename({ date, slug }): string {
+function generateFilename({ date, slug }:{date: string, slug: string}): string {
   const prefix = date ? `${date}-` : ''
   return `${prefix}${slug}.mdx`
 }
@@ -108,7 +108,7 @@ async function writeMDXFile({
   const filename = generateFilename({ date: post.date, slug: post.slug })
   const filepath = path.join(outputPath, filename)
   const mdxContent = generateBlogMDX(post)
-
+  
   await fs.promises.writeFile(filepath, mdxContent, 'utf-8')
 
   console.log(`✅ Generated Blog Post MDX file: ${filepath}`)
@@ -127,17 +127,19 @@ async function deleteMDXFile({
   try {
     await fs.promises.unlink(filepath)
     console.log(`🗑️  Deleted MDX file: ${filepath}`)
-  } catch (err) {
-    if (err.code !== 'ENOENT') {
-      console.error(`❌ Failed to delete Blog Post MDX file: ${filepath}`, err)
-      throw err
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.error(`❌ Failed to delete Blog Post MDX file: ${filepath}`, error)
+      throw error
     }
   }
 }
 
-export function createBlogLifecycle({ outputDir }) {
+export async function createBlogLifecycle({ outputDir }) {
   const projectRoot = getProjectRoot()
   const outputPath = path.join(projectRoot, outputDir)
+  await fs.promises.mkdir(outputPath, { recursive: true })
+
   return {
     async afterCreate(event: BlogEvent) {
       if (shouldSkipMdxExport()) return

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -61,16 +61,20 @@ function generateFilename({
 function generateBlogMDX(post: BlogResult) {
   const articleBios =
     post.articleBio?.length > 0
-      ? `articleBios:${post.articleBio.map((bio) => {
-          const articleBio = [
-            `\n  - author: ${bio.author}`,
-            bio.profileBio ? `\n    text: ${q(bio.profileBio)}` : null,
-            bio.profileImage ? `\n    image: ${q(bio.profileImage.url)}` : null
-          ]
-            .filter(Boolean)
-            .join('')
-          return articleBio
-        })}`
+      ? `articleBios:${post.articleBio
+          .map((bio) => {
+            const articleBio = [
+              `\n  - author: ${bio.author}`,
+              bio.profileBio ? `\n    text: ${q(bio.profileBio)}` : null,
+              bio.profileImage
+                ? `\n    image: ${q(bio.profileImage.url)}`
+                : null
+            ]
+              .filter(Boolean)
+              .join('')
+            return articleBio
+          })
+          .join('')}`
       : null
 
   const frontmatterLines = [

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -1,0 +1,34 @@
+import { shouldSkipMdxExport } from './pageLifecycle'
+import { uidToLogLabel } from './mdx'
+
+export function createBlogLifecycle() {
+  return {
+    async afterCreate(event: Event) {
+      if (shouldSkipMdxExport()) return
+      const { result } = event
+      if (!result) return
+      console.log('EVENT: ', event)
+      console.log(
+        `📝 Creating ${uidToLogLabel(event.model.uid)} MDX for: ${result.slug}`
+      )
+    },
+
+    async afterUpdate(event: Event) {
+      if (shouldSkipMdxExport()) return
+      const { result } = event
+      if (!result) return
+      console.log(
+        `📝 Updating ${uidToLogLabel(event.model.uid)} MDX for: ${result.slug}`
+      )
+    },
+
+    async afterDelete(event: Event) {
+      if (shouldSkipMdxExport()) return
+      const { result } = event
+      if (!result) return
+      console.log(
+        `📝 Deleting ${uidToLogLabel(event.model.uid)} MDX for: ${result.slug}`
+      )
+    }
+  }
+}

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -40,7 +40,6 @@ interface BlogEvent {
   model: { singularName: string }
   result: BlogResult
 }
-//TODO: use documentID, not ID - each entry has draft and published with same documentID, but differents IDs
 //TODO: git
 
 function generateFilename({ date, slug }): string {
@@ -85,15 +84,20 @@ function generateBlogMDX(post: BlogResult) {
   ].filter(Boolean) as string[]
 
   const frontmatter = frontmatterLines.join('\n')
-  const content = post.content ?? '' //TODO CKEditor format to markdown
+  const content = post.content ?? ''
 
   return `---\n${frontmatter}\n---\n\n${content}\n`
 }
-async function writeMDXFile(outputDir: string, post: BlogResult) {
-  const projectRoot = getProjectRoot()
+
+async function writeMDXFile({
+  outputPath,
+  post
+}: {
+  outputPath: string
+  post: BlogResult
+}) {
   const filename = generateFilename({ date: post.date, slug: post.slug })
-  const filepath = path.join(projectRoot, outputDir, filename)
-  console.log('FILEPATH: ', filepath)
+  const filepath = path.join(outputPath, filename)
   const mdxContent = generateBlogMDX(post)
 
   await fs.promises.writeFile(filepath, mdxContent, 'utf-8')
@@ -101,15 +105,30 @@ async function writeMDXFile(outputDir: string, post: BlogResult) {
   console.log(`✅ Generated Blog Post MDX file: ${filepath}`)
 }
 
-function updateMDXFile() {
-  //TODO
-}
+async function deleteMDXFile({
+  outputPath,
+  post
+}: {
+  outputPath: string
+  post: BlogResult
+}) {
+  const filename = generateFilename({ date: post.date, slug: post.slug })
+  const filepath = path.join(outputPath, filename)
 
-function deleteMDXFile() {
-  //TODO
+  try {
+    await fs.promises.unlink(filepath)
+    console.log(`🗑️  Deleted MDX file: ${filepath}`)
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.error(`❌ Failed to delete MDX file: ${filepath}`, err)
+      throw err
+    }
+  }
 }
 
 export function createBlogLifecycle({ outputDir }) {
+  const projectRoot = getProjectRoot()
+  const outputPath = path.join(projectRoot, outputDir)
   return {
     async afterCreate(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
@@ -118,33 +137,17 @@ export function createBlogLifecycle({ outputDir }) {
       console.log(
         `📝 Creating ${event.model.singularName} MDX for: ${result.slug}`
       )
-      writeMDXFile(outputDir, result)
-    },
-
-    async afterUpdate(event: BlogEvent) {
-      if (shouldSkipMdxExport()) return
-      const { result } = event
-      if (!result) return
-      if (result.publishedAt) {
-        updateMDXFile()
-      } else {
-        deleteMDXFile()
-      }
-
-      console.log(
-        `📝 Updating ${event.model.singularName} MDX for: ${result.slug}`
-      )
+      await writeMDXFile({ outputPath, post: result })
     },
 
     async afterDelete(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
       const { result } = event
-      if (!result) return
-      deleteMDXFile()
-
+      if (!result || !result.publishedAt) return
       console.log(
         `📝 Deleting ${event.model.singularName} MDX for: ${result.slug}`
       )
+      await deleteMDXFile({ outputPath, post: result })
     }
   }
 }

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -42,6 +42,11 @@ interface BlogEvent {
 }
 //TODO: git
 
+function yamlSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "''").replace(/\r\n/g, '\n')}'`
+}
+const q = yamlSingleQuote
+
 function generateFilename({ date, slug }): string {
   const prefix = date ? `${date}-` : ''
   return `${prefix}${slug}.mdx`
@@ -53,8 +58,8 @@ function generateBlogMDX(post: BlogResult) {
       ? `articleBios:${post.articleBio.map((bio) => {
           const articleBio = [
             `\n  - author: ${bio.author}`,
-            bio.profileBio ? `\n    text: '${bio.profileBio}'` : null,
-            bio.profileImage ? `\n    image: '${bio.profileImage.url}'` : null
+            bio.profileBio ? `\n    text: ${q(bio.profileBio)}` : null,
+            bio.profileImage ? `\n    image: ${q(bio.profileImage.url)}` : null
           ]
             .filter(Boolean)
             .join('')
@@ -63,24 +68,28 @@ function generateBlogMDX(post: BlogResult) {
       : null
 
   const frontmatterLines = [
-    `title: '${post.title}'`,
-    `description: '${post.description}'`,
+    `title: ${q(post.title)}`,
+    `description: ${q(post.description)}`,
     `date: ${post.date}`,
     `slug: ${post.slug}`,
-    `pillar: '${post.pillar}'`,
-    post.featureImage ? `featureImage: '${post.featureImage.url}'` : null,
+    `pillar: ${q(post.pillar)}`,
+    post.featureImage?.url ? `featureImage: ${q(post.featureImage.url)}` : null,
     post.featureImage?.alternativeText
-      ? `featureImageAlt: '${post.featureImage.alternativeText}'`
+      ? `featureImageAlt: ${q(post.featureImage.alternativeText)}`
       : null,
-    post.thumbnailImage ? `thumbnailImage: '${post.thumbnailImage.url}'` : null,
+    post.thumbnailImage?.url
+      ? `thumbnailImage: ${q(post.thumbnailImage.url)}`
+      : null,
     post.thumbnailImage?.alternativeText
-      ? `thumbnailImageAlt: '${post.thumbnailImage.alternativeText}'`
+      ? `thumbnailImageAlt: ${q(post.thumbnailImage.alternativeText)}`
       : null,
     articleBios,
-    post.tags.length > 0
-      ? `tags: ${post.tags.map((tag) => `\n  - ${tag.tagValue}`).join('')}`
+    post.tags
+      ? post.tags.length === 0
+        ? `tags: []`
+        : `tags: ${post.tags.map((tag) => `\n  - ${tag.tagValue}`).join('')}`
       : null,
-    post.language ? `locale: ${post.language}` : null
+    post.language ? `locale: ${q(post.language)}` : null
   ].filter(Boolean) as string[]
 
   const frontmatter = frontmatterLines.join('\n')
@@ -120,7 +129,7 @@ async function deleteMDXFile({
     console.log(`🗑️  Deleted MDX file: ${filepath}`)
   } catch (err) {
     if (err.code !== 'ENOENT') {
-      console.error(`❌ Failed to delete MDX file: ${filepath}`, err)
+      console.error(`❌ Failed to delete Blog Post MDX file: ${filepath}`, err)
       throw err
     }
   }

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -47,7 +47,13 @@ function yamlSingleQuote(value: string): string {
 }
 const q = yamlSingleQuote
 
-function generateFilename({ date, slug }:{date: string, slug: string}): string {
+function generateFilename({
+  date,
+  slug
+}: {
+  date: string
+  slug: string
+}): string {
   const prefix = date ? `${date}-` : ''
   return `${prefix}${slug}.mdx`
 }
@@ -108,7 +114,7 @@ async function writeMDXFile({
   const filename = generateFilename({ date: post.date, slug: post.slug })
   const filepath = path.join(outputPath, filename)
   const mdxContent = generateBlogMDX(post)
-  
+
   await fs.promises.writeFile(filepath, mdxContent, 'utf-8')
 
   console.log(`✅ Generated Blog Post MDX file: ${filepath}`)
@@ -129,7 +135,10 @@ async function deleteMDXFile({
     console.log(`🗑️  Deleted MDX file: ${filepath}`)
   } catch (error: unknown) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-      console.error(`❌ Failed to delete Blog Post MDX file: ${filepath}`, error)
+      console.error(
+        `❌ Failed to delete Blog Post MDX file: ${filepath}`,
+        error
+      )
       throw error
     }
   }

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -115,6 +115,7 @@ async function writeMDXFile({
   const filepath = path.join(outputPath, filename)
   const mdxContent = generateBlogMDX(post)
 
+  await fs.promises.mkdir(outputPath, { recursive: true })
   await fs.promises.writeFile(filepath, mdxContent, 'utf-8')
 
   console.log(`✅ Generated Blog Post MDX file: ${filepath}`)
@@ -144,10 +145,9 @@ async function deleteMDXFile({
   }
 }
 
-export async function createBlogLifecycle({ outputDir }) {
+export function createBlogLifecycle({ outputDir }) {
   const projectRoot = getProjectRoot()
   const outputPath = path.join(projectRoot, outputDir)
-  await fs.promises.mkdir(outputPath, { recursive: true })
 
   return {
     async afterCreate(event: BlogEvent) {

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -16,7 +16,6 @@ interface BlogResult {
   publishedAt?: Date
   locale: string
   pillar: 'vision' | 'mission' | 'tech' | 'values'
-  authors?: string
   language?: 'en' | 'es'
   featureImage?: {
     name: string
@@ -28,7 +27,11 @@ interface BlogResult {
     alternativeText?: string
     url: string
   }
-  articleBio?: { profileBio: string; profileImage: string }[]
+  articleBio?: {
+    author: string
+    profileBio?: string
+    profileImage?: { url: string }
+  }[]
   tags?: { tagValue: string }[]
   localizations: []
 }
@@ -46,7 +49,20 @@ function generateFilename({ date, slug }): string {
 }
 
 function generateBlogMDX(post: BlogResult) {
-  console.log('POST: ', post)
+  const articleBios =
+    post.articleBio?.length > 0
+      ? `articleBios:${post.articleBio.map((bio) => {
+          const articleBio = [
+            `\n  - author: ${bio.author}`,
+            bio.profileBio ? `\n    text: '${bio.profileBio}'` : null,
+            bio.profileImage ? `\n    image: '${bio.profileImage.url}'` : null
+          ]
+            .filter(Boolean)
+            .join('')
+          return articleBio
+        })}`
+      : null
+
   const frontmatterLines = [
     `title: '${post.title}'`,
     `description: '${post.description}'`,
@@ -61,13 +77,7 @@ function generateBlogMDX(post: BlogResult) {
     post.thumbnailImage?.alternativeText
       ? `thumbnailImageAlt: '${post.thumbnailImage.alternativeText}'`
       : null,
-    post.authors ? `authors: ${post.authors[0]}` : null, //TODO - group together author + articleBio
-    post.articleBio.length > 0
-      ? `bioTexts: '${post.articleBio[0].profileBio}'`
-      : null,
-    post.articleBio.length > 0
-      ? `bioImages: '${post.articleBio[0].profileImage}'`
-      : null,
+    articleBios,
     post.tags.length > 0
       ? `tags: ${post.tags.map((tag) => `\n  - ${tag.tagValue}`).join('')}`
       : null,

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -40,10 +40,9 @@ interface BlogEvent {
   model: { singularName: string }
   result: BlogResult
 }
-//TODO: git
 
 function yamlSingleQuote(value: string): string {
-  return `'${value.replace(/'/g, "''").replace(/\r\n/g, '\n')}'`
+  return `${value.replace(/'/g, "''").replace(/\r\n/g, '\n')}`
 }
 const q = yamlSingleQuote
 
@@ -64,10 +63,10 @@ function generateBlogMDX(post: BlogResult) {
       ? `articleBios:${post.articleBio
           .map((bio) => {
             const articleBio = [
-              `\n  - author: ${bio.author}`,
-              bio.profileBio ? `\n    text: ${q(bio.profileBio)}` : null,
+              `\n  - author: ${q(bio.author)}`,
+              bio.profileBio ? `\n    text: '${q(bio.profileBio)}'` : null,
               bio.profileImage
-                ? `\n    image: ${q(bio.profileImage.url)}`
+                ? `\n    image: '${q(bio.profileImage.url)}'`
                 : null
             ]
               .filter(Boolean)
@@ -78,26 +77,28 @@ function generateBlogMDX(post: BlogResult) {
       : null
 
   const frontmatterLines = [
-    `title: ${q(post.title)}`,
-    `description: ${q(post.description)}`,
+    `title: '${q(post.title)}'`,
+    `description: '${q(post.description)}'`,
     `date: ${post.date}`,
     `slug: ${post.slug}`,
-    `pillar: ${q(post.pillar)}`,
-    post.featureImage?.url ? `featureImage: ${q(post.featureImage.url)}` : null,
+    `pillar: '${q(post.pillar)}'`,
+    post.featureImage?.url
+      ? `featureImage: '${q(post.featureImage.url)}'`
+      : null,
     post.featureImage?.alternativeText
-      ? `featureImageAlt: ${q(post.featureImage.alternativeText)}`
+      ? `featureImageAlt: '${q(post.featureImage.alternativeText)}'`
       : null,
     post.thumbnailImage?.url
-      ? `thumbnailImage: ${q(post.thumbnailImage.url)}`
+      ? `thumbnailImage: '${q(post.thumbnailImage.url)}'`
       : null,
     post.thumbnailImage?.alternativeText
-      ? `thumbnailImageAlt: ${q(post.thumbnailImage.alternativeText)}`
+      ? `thumbnailImageAlt: '${q(post.thumbnailImage.alternativeText)}'`
       : null,
     articleBios,
     post.tags
       ? post.tags.length === 0
         ? `tags: []`
-        : `tags: ${post.tags.map((tag) => `\n  - ${tag.tagValue}`).join('')}`
+        : `tags: ${post.tags.map((tag) => `\n  - ${q(tag.tagValue)}`).join('')}`
       : null,
     post.language ? `locale: ${q(post.language)}` : null
   ].filter(Boolean) as string[]
@@ -149,7 +150,7 @@ async function deleteMDXFile({
   }
 }
 
-export function createBlogLifecycle({ outputDir }) {
+export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
   const projectRoot = getProjectRoot()
   const outputPath = path.join(projectRoot, outputDir)
 

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -1,33 +1,59 @@
 import { shouldSkipMdxExport } from './pageLifecycle'
-import { uidToLogLabel } from './mdx'
+
+interface BlogResult {
+  id: number,
+  documentId: string,
+  title: string,
+  description: string,
+  slug: string,
+  date: string,
+  content: string,
+  createdAt: string,
+  updatedAt: string,
+  publishedAt?: Date,
+  locale: string,
+  pillar: 'vision' | 'mission' |'tech' | 'values',
+  authors?: string,
+  language?: 'en' | 'es',
+  featureImage: null,
+  thumbnailImage: null,
+  articleBio?: string[],
+  tags?: string[],
+  localizations: []
+}
+
+interface BlogEvent {
+  model: { singularName: string},
+  result: BlogResult
+}
 
 export function createBlogLifecycle() {
   return {
-    async afterCreate(event: Event) {
+    async afterCreate(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
       const { result } = event
       if (!result) return
       console.log('EVENT: ', event)
       console.log(
-        `📝 Creating ${uidToLogLabel(event.model.uid)} MDX for: ${result.slug}`
+        `📝 Creating ${event.model.singularName} MDX for: ${result.slug}`
       )
     },
 
-    async afterUpdate(event: Event) {
+    async afterUpdate(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
       const { result } = event
       if (!result) return
       console.log(
-        `📝 Updating ${uidToLogLabel(event.model.uid)} MDX for: ${result.slug}`
+        `📝 Updating ${event.model.singularName} MDX for: ${result.slug}`
       )
     },
 
-    async afterDelete(event: Event) {
+    async afterDelete(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
       const { result } = event
       if (!result) return
       console.log(
-        `📝 Deleting ${uidToLogLabel(event.model.uid)} MDX for: ${result.slug}`
+        `📝 Deleting ${event.model.singularName} MDX for: ${result.slug}`
       )
     }
   }

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -1,48 +1,126 @@
+import fs from 'fs'
+import path from 'path'
 import { shouldSkipMdxExport } from './pageLifecycle'
+import { getProjectRoot } from './paths'
 
 interface BlogResult {
-  id: number,
-  documentId: string,
-  title: string,
-  description: string,
-  slug: string,
-  date: string,
-  content: string,
-  createdAt: string,
-  updatedAt: string,
-  publishedAt?: Date,
-  locale: string,
-  pillar: 'vision' | 'mission' |'tech' | 'values',
-  authors?: string,
-  language?: 'en' | 'es',
-  featureImage: null,
-  thumbnailImage: null,
-  articleBio?: string[],
-  tags?: string[],
+  id: number
+  documentId: string
+  title: string
+  description: string
+  slug: string
+  date: string
+  content: string
+  createdAt: Date
+  updatedAt: Date
+  publishedAt?: Date
+  locale: string
+  pillar: 'vision' | 'mission' | 'tech' | 'values'
+  authors?: string
+  language?: 'en' | 'es'
+  featureImage?: {
+    name: string
+    alternativeText?: string
+    url: string
+  }
+  thumbnailImage?: {
+    name: string
+    alternativeText?: string
+    url: string
+  }
+  articleBio?: { profileBio: string; profileImage: string }[]
+  tags?: { tagValue: string }[]
   localizations: []
 }
 
 interface BlogEvent {
-  model: { singularName: string},
+  model: { singularName: string }
   result: BlogResult
 }
+//TODO: use documentID, not ID - each entry has draft and published with same documentID, but differents IDs
+//TODO: git
 
-export function createBlogLifecycle() {
+function generateFilename({ date, slug }): string {
+  const prefix = date ? `${date}-` : ''
+  return `${prefix}${slug}.mdx`
+}
+
+function generateBlogMDX(post: BlogResult) {
+  console.log('POST: ', post)
+  const frontmatterLines = [
+    `title: '${post.title}'`,
+    `description: '${post.description}'`,
+    `date: ${post.date}`,
+    `slug: ${post.slug}`,
+    `pillar: '${post.pillar}'`,
+    post.featureImage ? `featureImage: '${post.featureImage.url}'` : null,
+    post.featureImage?.alternativeText
+      ? `featureImageAlt: '${post.featureImage.alternativeText}'`
+      : null,
+    post.thumbnailImage ? `thumbnailImage: '${post.thumbnailImage.url}'` : null,
+    post.thumbnailImage?.alternativeText
+      ? `thumbnailImageAlt: '${post.thumbnailImage.alternativeText}'`
+      : null,
+    post.authors ? `authors: ${post.authors[0]}` : null, //TODO - group together author + articleBio
+    post.articleBio.length > 0
+      ? `bioTexts: '${post.articleBio[0].profileBio}'`
+      : null,
+    post.articleBio.length > 0
+      ? `bioImages: '${post.articleBio[0].profileImage}'`
+      : null,
+    post.tags.length > 0
+      ? `tags: ${post.tags.map((tag) => `\n  - ${tag.tagValue}`).join('')}`
+      : null,
+    post.language ? `locale: ${post.language}` : null
+  ].filter(Boolean) as string[]
+
+  const frontmatter = frontmatterLines.join('\n')
+  const content = post.content ?? '' //TODO CKEditor format to markdown
+
+  return `---\n${frontmatter}\n---\n\n${content}\n`
+}
+async function writeMDXFile(outputDir: string, post: BlogResult) {
+  const projectRoot = getProjectRoot()
+  const filename = generateFilename({ date: post.date, slug: post.slug })
+  const filepath = path.join(projectRoot, outputDir, filename)
+  console.log('FILEPATH: ', filepath)
+  const mdxContent = generateBlogMDX(post)
+
+  await fs.promises.writeFile(filepath, mdxContent, 'utf-8')
+
+  console.log(`✅ Generated Blog Post MDX file: ${filepath}`)
+}
+
+function updateMDXFile() {
+  //TODO
+}
+
+function deleteMDXFile() {
+  //TODO
+}
+
+export function createBlogLifecycle({ outputDir }) {
   return {
     async afterCreate(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
       const { result } = event
-      if (!result) return
-      console.log('EVENT: ', event)
+      if (!result || !result.publishedAt) return
       console.log(
         `📝 Creating ${event.model.singularName} MDX for: ${result.slug}`
       )
+      writeMDXFile(outputDir, result)
     },
 
     async afterUpdate(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
       const { result } = event
       if (!result) return
+      if (result.publishedAt) {
+        updateMDXFile()
+      } else {
+        deleteMDXFile()
+      }
+
       console.log(
         `📝 Updating ${event.model.singularName} MDX for: ${result.slug}`
       )
@@ -52,6 +130,8 @@ export function createBlogLifecycle() {
       if (shouldSkipMdxExport()) return
       const { result } = event
       if (!result) return
+      deleteMDXFile()
+
       console.log(
         `📝 Deleting ${event.model.singularName} MDX for: ${result.slug}`
       )

--- a/cms/types/generated/components.d.ts
+++ b/cms/types/generated/components.d.ts
@@ -489,6 +489,7 @@ export interface SharedArticleBio extends Struct.ComponentSchema {
     displayName: 'Article Bio'
   }
   attributes: {
+    author: Schema.Attribute.String
     profileBio: Schema.Attribute.RichText &
       Schema.Attribute.CustomField<
         'plugin::ckeditor5.CKEditor',

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -508,12 +508,6 @@ export interface ApiFoundationBlogPostFoundationBlogPost
           localized: true
         }
       }>
-    authors: Schema.Attribute.String &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true
-        }
-      }>
     content: Schema.Attribute.RichText &
       Schema.Attribute.Required &
       Schema.Attribute.CustomField<

--- a/src/content/foundation-blog-posts/2023-10-04-ad-filtering-dev-summit-23-web-monetization-100-ad-filter.mdx
+++ b/src/content/foundation-blog-posts/2023-10-04-ad-filtering-dev-summit-23-web-monetization-100-ad-filter.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/ad-filter.jpg'
 featureImageAlt: "Sabine Schaller speaking on stage at the Ad Filtering Dev Summit '23"
 thumbnailImage: '/img/foundation-blog/ad-filter_thumbnail.jpg'
 thumbnailImageAlt: "Sabine Schaller speaking on stage at the Ad Filtering Dev Summit '23"
-authors:
-  - Sabine Schaller
-bioTexts:
-  - 'Sabine has always been interested in Data Ownership and the Internet of Value. She works on specifying and implementing open standards like the Interledger Protocol (ILP), Open Payments, and Web Monetization to allow for a Web where content can be paid for with hard currency instead of data.'
-bioImages:
-  - '/img/foundation-blog/authors/sabine.jpg'
+articleBios:
+  - author: Sabine Schaller
+    text: 'Sabine has always been interested in Data Ownership and the Internet of Value. She works on specifying and implementing open standards like the Interledger Protocol (ILP), Open Payments, and Web Monetization to allow for a Web where content can be paid for with hard currency instead of data.'
+    image: '/img/foundation-blog/authors/sabine.jpg'
 tags:
   - Community & Events
   - Interledger Technology

--- a/src/content/foundation-blog-posts/2023-11-30-unleashing-real-time-potential-streaming-payments.mdx
+++ b/src/content/foundation-blog-posts/2023-11-30-unleashing-real-time-potential-streaming-payments.mdx
@@ -8,8 +8,8 @@ featureImage: '/img/foundation-blog/paystreme.jpg'
 featureImageAlt: 'The Paystreme team'
 thumbnailImage: '/img/foundation-blog/paystreme-thumbnail.jpg'
 thumbnailImageAlt: 'The Paystreme team'
-authors:
-  - Magic Unicorn
+articleBios:
+  - author: Magic Unicorn
 tags:
   - Interledger Technology
   - Announcements

--- a/src/content/foundation-blog-posts/2024-02-01-introducing-2024-digital-money-blog-series.mdx
+++ b/src/content/foundation-blog-posts/2024-02-01-introducing-2024-digital-money-blog-series.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money.jpg'
 featureImageAlt: 'Julaire Hall on stage at Interledger Summit'
 thumbnailImage: '/img/foundation-blog/digital-money_thumbnail.jpg'
 thumbnailImageAlt: 'Julaire Hall on stage at Interledger Summit'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-02-20-future-banking-and-payments-digital.mdx
+++ b/src/content/foundation-blog-posts/2024-02-20-future-banking-and-payments-digital.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-02-28-mobile-money-ecosystem-africa.mdx
+++ b/src/content/foundation-blog-posts/2024-02-28-mobile-money-ecosystem-africa.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-03-14-mobile-money-ecosystem-asia-pacific.mdx
+++ b/src/content/foundation-blog-posts/2024-03-14-mobile-money-ecosystem-asia-pacific.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-04-02-mobile-money-ecosystem-latin-america-and-caribbean.mdx
+++ b/src/content/foundation-blog-posts/2024-04-02-mobile-money-ecosystem-latin-america-and-caribbean.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-04-10-mobile-money-ecosystem-europe.mdx
+++ b/src/content/foundation-blog-posts/2024-04-10-mobile-money-ecosystem-europe.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-04-24-mobile-money-ecosystem-north-america.mdx
+++ b/src/content/foundation-blog-posts/2024-04-24-mobile-money-ecosystem-north-america.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-05-08-digital-financial-inclusion-igniting-sustainable-development-goals.mdx
+++ b/src/content/foundation-blog-posts/2024-05-08-digital-financial-inclusion-igniting-sustainable-development-goals.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-05-29-interledger-campus.mdx
+++ b/src/content/foundation-blog-posts/2024-05-29-interledger-campus.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/campus.jpg'
 featureImageAlt: 'Bowie State students at the 2023 Interledger Summit'
 thumbnailImage: '/img/foundation-blog/campus_thumbnail.jpg'
 thumbnailImageAlt: 'Bowie State students at the 2023 Interledger Summit'
-authors:
-  - Briana Marbury
-bioTexts:
-  - 'Briana Marbury is the President & CEO of the Interledger Foundation (ILF), a nonprofit organization committed to expanding digital financial inclusion to vulnerable populations.'
-bioImages:
-  - '/img/foundation-blog/authors/briana.jpg'
+articleBios:
+  - author: Briana Marbury
+    text: 'Briana Marbury is the President & CEO of the Interledger Foundation (ILF), a nonprofit organization committed to expanding digital financial inclusion to vulnerable populations.'
+    image: '/img/foundation-blog/authors/briana.jpg'
 tags:
   - Grants & Grantee Insights
 ---

--- a/src/content/foundation-blog-posts/2024-06-21-harnessing-future-insights-global-technology-retreat-digital-trust-and-inclusion.mdx
+++ b/src/content/foundation-blog-posts/2024-06-21-harnessing-future-insights-global-technology-retreat-digital-trust-and-inclusion.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/gtr.jpg'
 featureImageAlt: 'Global Technology Retreat 2024 by WEF'
 thumbnailImage: '/img/foundation-blog/gtr_thumbnail.jpg'
 thumbnailImageAlt: 'Global Technology Retreat 2024 by WEF'
-authors:
-  - Vineel R. Pindi
-bioTexts:
-  - 'Vineel has spent the last 12 years in community building and user engagement across Technology and Creator ecosystems. With a background in Community Strategy and Advocacy, he helped build global programs, campaigns, and events.'
-bioImages:
-  - '/img/foundation-blog/authors/vineel.jpg'
+articleBios:
+  - author: Vineel R. Pindi
+    text: 'Vineel has spent the last 12 years in community building and user engagement across Technology and Creator ecosystems. With a background in Community Strategy and Advocacy, he helped build global programs, campaigns, and events.'
+    image: '/img/foundation-blog/authors/vineel.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-06-26-bridging-digital-divide-improve-underserved-and-unbanked-financial-lives.mdx
+++ b/src/content/foundation-blog-posts/2024-06-26-bridging-digital-divide-improve-underserved-and-unbanked-financial-lives.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-06-27-hack-uct-2024-highlights-and-achievements-our-student-bootcamp-and-hackathon.mdx
+++ b/src/content/foundation-blog-posts/2024-06-27-hack-uct-2024-highlights-and-achievements-our-student-bootcamp-and-hackathon.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/uct-hackathon.jpg'
 featureImageAlt: 'Hack @ UCT 2024'
 thumbnailImage: '/img/foundation-blog/uct-hackathon_thumbnail.jpg'
 thumbnailImageAlt: 'Hack @ UCT 2024'
-authors:
-  - Sabine Schaller
-bioTexts:
-  - 'Sabine has always been interested in Data Ownership and the Internet of Value. She works on specifying and implementing open standards like the Interledger Protocol (ILP), Open Payments, and Web Monetization to allow for a Web where content can be paid for with hard currency instead of data.'
-bioImages:
-  - '/img/foundation-blog/authors/sabine.jpg'
+articleBios:
+  - author: Sabine Schaller
+    text: 'Sabine has always been interested in Data Ownership and the Internet of Value. She works on specifying and implementing open standards like the Interledger Protocol (ILP), Open Payments, and Web Monetization to allow for a Web where content can be paid for with hard currency instead of data.'
+    image: '/img/foundation-blog/authors/sabine.jpg'
 tags:
   - Community & Events
 ---

--- a/src/content/foundation-blog-posts/2024-09-20-collaborative-work-week-peoples-clearinghouse.mdx
+++ b/src/content/foundation-blog-posts/2024-09-20-collaborative-work-week-peoples-clearinghouse.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/pch-ww-feature.jpg'
 featureImageAlt: 'A group photo during the visit to the mezcal distillery'
 thumbnailImage: '/img/foundation-blog/pch-ww-thumbnail.jpeg'
 thumbnailImageAlt: 'A group photo during the visit to the mezcal distillery'
-authors:
-  - Max Kurapov
-bioTexts:
-  - 'As a software developer at the Interledger Foundation, Max builds open source tools and APIs that provide developers & institutions access to the Interledger network. Before joining the Foundation, Max spent 5 years working at startups: one of which a Fintech company, where he was one of the leads on the card payments processing team.'
-bioImages:
-  - '/img/foundation-blog/authors/max.jpg'
+articleBios:
+  - author: Max Kurapov
+    text: 'As a software developer at the Interledger Foundation, Max builds open source tools and APIs that provide developers & institutions access to the Interledger network. Before joining the Foundation, Max spent 5 years working at startups: one of which a Fintech company, where he was one of the leads on the card payments processing team.'
+    image: '/img/foundation-blog/authors/max.jpg'
 tags:
   - Community & Events
 ---

--- a/src/content/foundation-blog-posts/2024-09-24-interledger-foundation-partners-waag-and-here-support.mdx
+++ b/src/content/foundation-blog-posts/2024-09-24-interledger-foundation-partners-waag-and-here-support.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/blog-image.png'
 featureImageAlt: 'interledger foundation and wag and here to support '
 thumbnailImage: '/img/foundation-blog/blog-thumbnail.png'
 thumbnailImageAlt: 'logos'
-authors:
-  - Chiara Ostrin
-bioTexts:
-  - 'Chiara Ostrin is a dedicated member of the marketing and communications team at Interledger Foundation. With a bachelor’s degree in Industrial-Organizational Psychology and a strong background in project management and marketing, Chiara combines her passion for storytelling and social impact to raise awareness about global digital financial inclusion and the transformative potential of the Interledger Protocol.'
-bioImages:
-  - '/img/foundation-blog/authors/chiara.jpg'
+articleBios:
+  - author: Chiara Ostrin
+    text: 'Chiara Ostrin is a dedicated member of the marketing and communications team at Interledger Foundation. With a bachelor’s degree in Industrial-Organizational Psychology and a strong background in project management and marketing, Chiara combines her passion for storytelling and social impact to raise awareness about global digital financial inclusion and the transformative potential of the Interledger Protocol.'
+    image: '/img/foundation-blog/authors/chiara.jpg'
 tags:
   - Grants & Grantee Insights
 ---

--- a/src/content/foundation-blog-posts/2024-10-03-financial-inclusion-20-financial-cooperatives-enabling-inclusivity.mdx
+++ b/src/content/foundation-blog-posts/2024-10-03-financial-inclusion-20-financial-cooperatives-enabling-inclusivity.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2024-10-24-introducing-parliamentarian-track-interledger-summit-2024.mdx
+++ b/src/content/foundation-blog-posts/2024-10-24-introducing-parliamentarian-track-interledger-summit-2024.mdx
@@ -8,8 +8,8 @@ featureImage: '/img/foundation-blog/2024-summit.svg'
 featureImageAlt: ''
 thumbnailImage: '/img/foundation-blog/2024-summit_thumbnail.svg'
 thumbnailImageAlt: ''
-authors:
-  - Ayden Férdeline, Interledger Research Fellow and Hon. Neema Lugangira, Member of Parliament, Tanzania
+articleBios:
+  - author: Ayden Férdeline, Interledger Research Fellow and Hon. Neema Lugangira, Member of Parliament, Tanzania
 tags:
   - Community & Events
   - Thought Leadership

--- a/src/content/foundation-blog-posts/2024-11-11-hacktoberfest-2024-celebrating-open-source-and-community-impact-interledger.mdx
+++ b/src/content/foundation-blog-posts/2024-11-11-hacktoberfest-2024-celebrating-open-source-and-community-impact-interledger.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/hacktoberfest.png'
 featureImageAlt: 'A group photo of Hacktoberfest participants at a CodeWave Hub event'
 thumbnailImage: '/img/foundation-blog/hacktoberfest-thumbnail.png'
 thumbnailImageAlt: 'A group photo of Hacktoberfest participants at a CodeWave Hub event'
-authors:
-  - Vineel Reddy
-bioTexts:
-  - 'Vineel has spent the last 12 years in community building and user engagement across Technology and Creator ecosystems. With a background in Community Strategy and Advocacy, he helped build global programs, campaigns, and events.'
-bioImages:
-  - '/img/foundation-blog/authors/vineel.jpg'
+articleBios:
+  - author: Vineel R. Pindi
+    text: 'Vineel has spent the last 12 years in community building and user engagement across Technology and Creator ecosystems. With a background in Community Strategy and Advocacy, he helped build global programs, campaigns, and events.'
+    image: '/img/foundation-blog/authors/vineel.jpg'
 tags:
   - Community & Events
 ---

--- a/src/content/foundation-blog-posts/2024-11-26-highlights-afrilabs-2024.mdx
+++ b/src/content/foundation-blog-posts/2024-11-26-highlights-afrilabs-2024.mdx
@@ -8,15 +8,13 @@ featureImage: '/img/foundation-blog/afrilabs-feature.jpg'
 featureImageAlt: 'Interledger team members standing at their booth at the AfriLabs gathering'
 thumbnailImage: '/img/foundation-blog/afrilabs-thumbnail.jpg'
 thumbnailImageAlt: 'Interledger team members standing at their booth at the AfriLabs gathering'
-authors:
-  - Sarah Jones
-  - Tšeli Thabane
-bioTexts:
-  - 'Sarah is a frontend developer at the Interledger Foundation, passionate about design, UX, and accessibility. She has worked on Rafiki, which packages up Interledger and Open Payments functionality, and contributed to a Web Monetization WordPress plugin.'
-  - 'Tšeli’s career spans software development, management, and entrepreneurship in South Africa. She has experience delivering proprietary software for banks and retailers, and now focuses on open-source solutions and standards to deliver impactful projects in different parts of the world.'
-bioImages:
-  - '/img/foundation-blog/authors/sarah.jpg'
-  - '/img/foundation-blog/authors/tseli.jpg'
+articleBios:
+  - author: Sarah Jones
+    text: 'Sarah is a frontend developer at the Interledger Foundation, passionate about design, UX, and accessibility. She has worked on Rafiki, which packages up Interledger and Open Payments functionality, and contributed to a Web Monetization WordPress plugin.'
+    image: '/img/foundation-blog/authors/sarah.jpg'
+  - author: Tšeli Thabane
+    text: 'Tšeli’s career spans software development, management, and entrepreneurship in South Africa. She has experience delivering proprietary software for banks and retailers, and now focuses on open-source solutions and standards to deliver impactful projects in different parts of the world.'
+    image: '/img/foundation-blog/authors/tseli.jpg'
 tags:
   - Community & Events
 ---

--- a/src/content/foundation-blog-posts/2025-02-11-case-digital-currencies-unlocking-future-interoperable-digital-financial-systems.mdx
+++ b/src/content/foundation-blog-posts/2025-02-11-case-digital-currencies-unlocking-future-interoperable-digital-financial-systems.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2025-03-23-are-financial-rights-human-rights.mdx
+++ b/src/content/foundation-blog-posts/2025-03-23-are-financial-rights-human-rights.mdx
@@ -8,8 +8,8 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Ayden Férdeline
+articleBios:
+  - author: Ayden Férdeline
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2025-03-24-announcing-interledger-foundations-web-monetization-extension-beta-release.mdx
+++ b/src/content/foundation-blog-posts/2025-03-24-announcing-interledger-foundations-web-monetization-extension-beta-release.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/wm-launch-feature.svg'
 featureImageAlt: ''
 thumbnailImage: '/img/foundation-blog/WM-release-thumbnail.png'
 thumbnailImageAlt: 'Web Monetization Beta Launch'
-authors:
-  - Rabeb Othmani
-bioTexts:
-  - 'Rabeb is an accomplished technologist and product leader with 15 years of experience in the tech industry. Rabeb has excelled in crafting product strategies, managing cross-functional teams, and delivering innovative solutions that solve real-world problems. Rabeb is an advocate for diversity and inclusion in the tech industry. She works towards empowering and promoting others.'
-bioImages:
-  - '/img/foundation-blog/authors/rabeb.jpg'
+articleBios:
+  - author: Rabeb Othmani
+    text: 'Rabeb is an accomplished technologist and product leader with 15 years of experience in the tech industry. Rabeb has excelled in crafting product strategies, managing cross-functional teams, and delivering innovative solutions that solve real-world problems. Rabeb is an advocate for diversity and inclusion in the tech industry. She works towards empowering and promoting others.'
+    image: '/img/foundation-blog/authors/rabeb.jpg'
 tags:
   - Announcements
 ---

--- a/src/content/foundation-blog-posts/2025-04-01-introducing-2025-interledger-foundation-ambassadors-cohort.mdx
+++ b/src/content/foundation-blog-posts/2025-04-01-introducing-2025-interledger-foundation-ambassadors-cohort.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/ambassador-feature-image.png'
 featureImageAlt: 'Activate and empower communities'
 thumbnailImage: '/img/foundation-blog/ambassador-blog-thumbnail.png'
 thumbnailImageAlt: 'Activate and empower communities'
-authors:
-  - Lawil Karama
-bioTexts:
-  - 'Lawil is a multidisciplinary artist using her practice to explore multiple themes of human awareness. She brings her perspective to work with global communities at the Interledger Foundation as a Programs Officer, supporting individuals grow through open payments.'
-bioImages:
-  - '/img/foundation-blog/authors/lawil.jpg'
+articleBios:
+  - author: Lawil Karama
+    text: 'Lawil is a multidisciplinary artist using her practice to explore multiple themes of human awareness. She brings her perspective to work with global communities at the Interledger Foundation as a Programs Officer, supporting individuals grow through open payments.'
+    image: '/img/foundation-blog/authors/lawil.jpg'
 tags:
   - Announcements
   - Community & Events

--- a/src/content/foundation-blog-posts/2025-04-08-grantee-report-quarterly-roundup.mdx
+++ b/src/content/foundation-blog-posts/2025-04-08-grantee-report-quarterly-roundup.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/grantee-roundup.png'
 featureImageAlt: 'Grantee Report - The Roundup'
 thumbnailImage: '/img/foundation-blog/grantee-roundup-thumbnail.png'
 thumbnailImageAlt: 'Grantee Report - The Roundup'
-authors:
-  - Ayesha Ware
-bioTexts:
-  - 'As Awardee Support for Grant for the Web, Ayesha onboards awardees, shares important project information, and is the liaison between awardees, the GftW program team and partners.'
-bioImages:
-  - '/img/foundation-blog/authors/ayesha.jpg'
+articleBios:
+  - author: Ayesha Ware
+    text: 'As Awardee Support for Grant for the Web, Ayesha onboards awardees, shares important project information, and is the liaison between awardees, the GftW program team and partners.'
+    image: '/img/foundation-blog/authors/ayesha.jpg'
 tags:
   - Grants & Grantee Insights
 ---

--- a/src/content/foundation-blog-posts/2025-04-29-exploring-community-based-identification-systems.mdx
+++ b/src/content/foundation-blog-posts/2025-04-29-exploring-community-based-identification-systems.mdx
@@ -8,8 +8,8 @@ featureImage: '/img/foundation-blog/id-systems_header.jpg'
 featureImageAlt: 'Lady with microphone on stage at Interledger Summit'
 thumbnailImage: '/img/foundation-blog/id-systems_thumbnail.jpg'
 thumbnailImageAlt: 'Lady speaking into microphone while on stage'
-authors:
-  - Jeremiah Lee and Ayden Férdeline
+articleBios:
+  - author: Jeremiah Lee and Ayden Férdeline
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2025-06-04-reflections-2025-payments-canada-summit.mdx
+++ b/src/content/foundation-blog-posts/2025-06-04-reflections-2025-payments-canada-summit.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/payments-canada-group-photo.png'
 featureImageAlt: 'A group photo of participants who took part in a panel discussion convened by the Interledger Foundation at the 2025 Payments Canada Summit. The group stands together, smiling, in front of a summit-branded backdrop.'
 thumbnailImage: '/img/foundation-blog/canada-summit-thumbnail.png'
 thumbnailImageAlt: 'Thumbnail image showing speakers from the 2025 Payments Canada Summit'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Community & Events
 ---

--- a/src/content/foundation-blog-posts/2025-06-05-interledger-summit-workshop-week.mdx
+++ b/src/content/foundation-blog-posts/2025-06-05-interledger-summit-workshop-week.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/mexico-summit-banner.jpg'
 featureImageAlt: 'Banner image of a lively street scene in rural Mexico, with people in traditional costumes and masks dancing. A young man stands in the center playing a guitar, surrounded by colorful celebration.'
 thumbnailImage: '/img/foundation-blog/mexico-summit-thumbnail.jpg'
 thumbnailImageAlt: 'Thumbnail image of a festive street in rural Mexico, showing people in traditional costumes and masks dancing, with a young man playing guitar in the center.'
-authors:
-  - Vineel R. Pindi
-bioTexts:
-  - 'Vineel has spent the last 12 years in community building and user engagement across Technology and Creator ecosystems. With a background in Community Strategy and Advocacy, he helped build global programs, campaigns, and events.'
-bioImages:
-  - '/img/foundation-blog/authors/vineel.jpg'
+articleBios:
+  - author: Vineel R. Pindi
+    text: 'Vineel has spent the last 12 years in community building and user engagement across Technology and Creator ecosystems. With a background in Community Strategy and Advocacy, he helped build global programs, campaigns, and events.'
+    image: '/img/foundation-blog/authors/vineel.jpg'
 tags:
   - Community & Events
 ---

--- a/src/content/foundation-blog-posts/2025-06-13-making-money-move-julaire-halls-mission-financial-inclusion.mdx
+++ b/src/content/foundation-blog-posts/2025-06-13-making-money-move-julaire-halls-mission-financial-inclusion.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/julaire-summit-.jpg'
 featureImageAlt: 'Julaire Hall speaking at the Interledger Summit'
 thumbnailImage: '/img/foundation-blog/julaire-summit-square.jpg'
 thumbnailImageAlt: 'Julaire Hall speaking at the Interledger Summit'
-authors:
-  - Julaire Hall
-bioTexts:
-  - 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
-bioImages:
-  - '/img/foundation-blog/authors/julaire.jpg'
+articleBios:
+  - author: Julaire Hall
+    text: 'Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector.'
+    image: '/img/foundation-blog/authors/julaire.jpg'
 tags:
   - Thought Leadership
   - Interledger Technology

--- a/src/content/foundation-blog-posts/2025-07-15-july-2025-quarterly-roundup.mdx
+++ b/src/content/foundation-blog-posts/2025-07-15-july-2025-quarterly-roundup.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/grantee-roundup.png'
 featureImageAlt: 'Grantee Report - The Roundup'
 thumbnailImage: '/img/foundation-blog/grantee-roundup-thumbnail.png'
 thumbnailImageAlt: 'Grantee Report - The Roundup'
-authors:
-  - Ayesha Ware
-bioTexts:
-  - 'As Awardee Support for Grant for the Web, Ayesha onboards awardees, shares important project information, and is the liaison between awardees, the GftW program team and partners.'
-bioImages:
-  - '/img/foundation-blog/authors/ayesha.jpg'
+articleBios:
+  - author: Ayesha Ware
+    text: 'As Awardee Support for Grant for the Web, Ayesha onboards awardees, shares important project information, and is the liaison between awardees, the GftW program team and partners.'
+    image: '/img/foundation-blog/authors/ayesha.jpg'
 tags:
   - Grants & Grantee Insights
 ---

--- a/src/content/foundation-blog-posts/2025-07-15-reflections-un-open-source-week-2025.mdx
+++ b/src/content/foundation-blog-posts/2025-07-15-reflections-un-open-source-week-2025.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/un-open-source-banner.jpg'
 featureImageAlt: 'Participants at UN Open Source Week seated at tables with laptops and microphones inside a conference room at United Nations Headquarters in New York City.'
 thumbnailImage: '/img/foundation-blog/un-open-source-thumbnail.jpg'
 thumbnailImageAlt: 'Thumbnail that shows participants at UN Open Source Week seated at tables with laptops and microphones inside a conference room at United Nations Headquarters in New York City.'
-authors:
-  - Vineel R. Pindi
-bioTexts:
-  - 'Vineel has spent the last 12 years in community building and user engagement across Technology and Creator ecosystems. With a background in Community Strategy and Advocacy, he helped build global programs, campaigns, and events.'
-bioImages:
-  - '/img/foundation-blog/authors/vineel.jpg'
+articleBios:
+  - author: Vineel R. Pindi
+    text: 'Vineel has spent the last 12 years in community building and user engagement across Technology and Creator ecosystems. With a background in Community Strategy and Advocacy, he helped build global programs, campaigns, and events.'
+    image: '/img/foundation-blog/authors/vineel.jpg'
 tags:
   - Community & Events
   - Thought Leadership

--- a/src/content/foundation-blog-posts/2025-08-05-interledger-internet-governance-forum-2025.mdx
+++ b/src/content/foundation-blog-posts/2025-08-05-interledger-internet-governance-forum-2025.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/governance-forum-2025.jpg'
 featureImageAlt: 'Three participants seated at tables with microphones, engaged in discussion during the Internet Governance Forum; Ayden Ferdeline is among them.'
 thumbnailImage: '/img/foundation-blog/governance-forum-2025-thumbnail.jpg'
 thumbnailImageAlt: 'Internet Governance Forum 2025 thumbnail'
-authors:
-  - Ayden Férdeline
-bioTexts:
-  - 'Ayden Férdeline is Lead, Public Policy and Government Affairs at the Interledger Foundation, where he advances digital financial inclusion by advocating for equitable access to digital public infrastructure. He ensures the Foundation’s perspective is well represented within intergovernmental and multistakeholder fora, and is the point of contact for policymakers, lawmakers, and regulators.'
-bioImages:
-  - '/img/foundation-blog/authors/ayden-ferdeline.jpg'
+articleBios:
+  - author: Ayden Férdeline
+    text: 'Ayden Férdeline is Lead, Public Policy and Government Affairs at the Interledger Foundation, where he advances digital financial inclusion by advocating for equitable access to digital public infrastructure. He ensures the Foundation’s perspective is well represented within intergovernmental and multistakeholder fora, and is the point of contact for policymakers, lawmakers, and regulators.'
+    image: '/img/foundation-blog/authors/ayden-ferdeline.jpg'
 tags:
   - Community & Events
   - Thought Leadership

--- a/src/content/foundation-blog-posts/2025-09-04-multiple-sides-friction-good-bad-and-how-use-it.mdx
+++ b/src/content/foundation-blog-posts/2025-09-04-multiple-sides-friction-good-bad-and-how-use-it.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/digital-money-blog.svg'
 featureImageAlt: 'Digital Money Blog Series'
 thumbnailImage: '/img/foundation-blog/digital-money-blog-thumbnail.svg'
 thumbnailImageAlt: 'Digital Money Blog Series'
-authors:
-  - Caroline Sinders
-bioTexts:
-  - "Caroline Sinders is an Interledger Foundation Ambassador and an award winning critical designer, researcher, and artist. They’re the co-founder and executive director human rights research and technology lab, Convocation Research + Design. They’ve worked with the United Nations, Tate Exchange at the Tate Modern, the United Nations, Ars Electronica’s AI Lab, The Information Commissioner's Office, the Harvard Kennedy School and others."
-bioImages:
-  - '/img/foundation-blog/authors/caroline-sinders.jpg'
+articleBios:
+  - author: Caroline Sinders
+    text: "Caroline Sinders is an Interledger Foundation Ambassador and an award winning critical designer, researcher, and artist. They’re the co-founder and executive director human rights research and technology lab, Convocation Research + Design. They’ve worked with the United Nations, Tate Exchange at the Tate Modern, the United Nations, Ars Electronica’s AI Lab, The Information Commissioner's Office, the Harvard Kennedy School and others."
+    image: '/img/foundation-blog/authors/caroline-sinders.jpg'
 tags:
   - Thought Leadership
 ---

--- a/src/content/foundation-blog-posts/2025-09-11-work-weeks-2025-building-future-financial-interoperability-heart-transylvania.mdx
+++ b/src/content/foundation-blog-posts/2025-09-11-work-weeks-2025-building-future-financial-interoperability-heart-transylvania.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/ilf-workweek-banner.jpg'
 featureImageAlt: 'Group photo of the Rafiki team at the July 2025 work week.'
 thumbnailImage: '/img/foundation-blog/ilf-workweek-thumbnail.jpg'
 thumbnailImageAlt: 'Group photo of the Web Monetization team at the May 2025 work week'
-authors:
-  - Marian Villa, Developer Advocate | Interledger Foundation
-bioTexts:
-  - 'Marian Villa is a Devrel at Interledger and Fellow of the Royal Academy of Engineering in London, mentor for Google Launchpad, member of the Google Developers Experts program in Web Development, and a global ambassador for Women Techmakers. She is part of the Interledger Foundation team, strengthening relationships with developers.'
-bioImages:
-  - '/img/foundation-blog/authors/marian-villa.jpg'
+articleBios:
+  - author: Marian Villa
+    text: 'Marian Villa is a Devrel at Interledger and Fellow of the Royal Academy of Engineering in London, mentor for Google Launchpad, member of the Google Developers Experts program in Web Development, and a global ambassador for Women Techmakers. She is part of the Interledger Foundation team, strengthening relationships with developers.'
+    image: '/img/foundation-blog/authors/marian-villa.jpg'
 tags:
   - Interledger Technology
   - Community & Events

--- a/src/content/foundation-blog-posts/2025-11-20-mexico-joins-interledger-network.mdx
+++ b/src/content/foundation-blog-posts/2025-11-20-mexico-joins-interledger-network.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/mexico-hackathons-banner.png'
 featureImageAlt: 'Mexico Student Hackathon'
 thumbnailImage: '/img/foundation-blog/mexico-hackathons-thumbnail.png'
 thumbnailImageAlt: 'Mexico Student Hackathon'
-authors:
-  - Marian Villa
-bioTexts:
-  - 'Marian Villa is a Devrel at Interledger and Fellow of the Royal Academy of Engineering in London, mentor for Google Launchpad, member of the Google Developers Experts program in Web Development, and a global ambassador for Women Techmakers. She is part of the Interledger Foundation team, strengthening relationships with developers.'
-bioImages:
-  - '/img/foundation-blog/authors/marian-villa.jpg'
+articleBios:
+  - author: Marian Villa
+    text: 'Marian Villa is a Devrel at Interledger and Fellow of the Royal Academy of Engineering in London, mentor for Google Launchpad, member of the Google Developers Experts program in Web Development, and a global ambassador for Women Techmakers. She is part of the Interledger Foundation team, strengthening relationships with developers.'
+    image: '/img/foundation-blog/authors/marian-villa.jpg'
 tags:
   - Interledger Technology
   - Community & Events

--- a/src/content/foundation-blog-posts/2025-11-21-turning-headlines-backyard-conversations-lessons-2025-ofn-conference.mdx
+++ b/src/content/foundation-blog-posts/2025-11-21-turning-headlines-backyard-conversations-lessons-2025-ofn-conference.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/ofn-banner.jpeg'
 featureImageAlt: 'Speaker at the OFN Conference'
 thumbnailImage: '/img/foundation-blog/ofn-thumbnail.JPG'
 thumbnailImageAlt: 'Speaker at the OFN Conference'
-authors:
-  - Casey Ariel Dike’, Founder & CEO of Blaze Group, Contractor for the Interledger Foundation
-bioTexts:
-  - 'Casey Ariel Dike’ is the Founder and CEO of Blaze Group®, a finance innovation studio offering tools and frameworks that help overlooked communities own, protect, and scale their economic power. With a background in global corporate banking, Casey now focuses on reshaping capital access through financial education, fintech literacy, and equitable product design. She serves as a Strategic Lead for the Interledger Foundation, expanding their reach across financial institutions, colleges, and fintech communities concentrated in underbanked regions.'
-bioImages:
-  - '/img/foundation-blog/authors/casey-ariel-dike.jpeg'
+articleBios:
+  - author: Casey Ariel Dike’, Founder & CEO of Blaze Group, Contractor for the Interledger Foundation
+    text: 'Casey Ariel Dike’ is the Founder and CEO of Blaze Group®, a finance innovation studio offering tools and frameworks that help overlooked communities own, protect, and scale their economic power. With a background in global corporate banking, Casey now focuses on reshaping capital access through financial education, fintech literacy, and equitable product design. She serves as a Strategic Lead for the Interledger Foundation, expanding their reach across financial institutions, colleges, and fintech communities concentrated in underbanked regions.'
+    image: '/img/foundation-blog/authors/casey-ariel-dike.jpeg'
 tags:
   - Community & Events
 ---

--- a/src/content/foundation-blog-posts/2026-01-07-shanghai-flip-phones-and-robots-interledger-engineering-adventure.mdx
+++ b/src/content/foundation-blog-posts/2026-01-07-shanghai-flip-phones-and-robots-interledger-engineering-adventure.mdx
@@ -8,12 +8,10 @@ featureImage: '/img/foundation-blog/shanghai-banner.jpg'
 featureImageAlt: 'Shanghai skyline with the Oriental Pearl Tower and several modern high-rise buildings under a clear blue sky.'
 thumbnailImage: '/img/foundation-blog/shanghai-thumbnail.jpg'
 thumbnailImageAlt: 'Shanghai skyline with the Oriental Pearl Tower and several modern high-rise buildings under a clear blue sky.'
-authors:
-  - Timea Nagy
-bioTexts:
-  - 'Timea has been a software developer for many years, mainly passionate about developing frontend and user experience. She has been part of the interesting world of Interledger since the end of 2022. Together with her team, she has built the Interledger Tesnet testing network, in order to help people better understand the possibilities of Open Payments. Her passion is travelling, discovering as much as possible about this wonderful world we live in. Her flex is that she has travelled to all 7 continents.'
-bioImages:
-  - '/img/foundation-blog/authors/timea.jpg'
+articleBios:
+  - author: Timea Nagy
+    text: 'Timea has been a software developer for many years, mainly passionate about developing frontend and user experience. She has been part of the interesting world of Interledger since the end of 2022. Together with her team, she has built the Interledger Tesnet testing network, in order to help people better understand the possibilities of Open Payments. Her passion is travelling, discovering as much as possible about this wonderful world we live in. Her flex is that she has travelled to all 7 continents.'
+    image: '/img/foundation-blog/authors/timea.jpg'
 tags:
   - Community & Events
 ---

--- a/src/layouts/FoundationBlogLayout.astro
+++ b/src/layouts/FoundationBlogLayout.astro
@@ -71,9 +71,10 @@ const longDate = dateObj.toDateString().substring(4)
         {longDate}
       </time>
       {
-        frontmatter.authors && frontmatter.authors.length > 0 && (
+        frontmatter.articleBios && frontmatter.articleBios.length > 0 && (
           <address class="text-step-0 mb-space-s">
-            Written by {frontmatter.authors.join(', ')}
+            Written by{' '}
+            {frontmatter.articleBios.map((bio) => bio.author).join(', ')}
           </address>
         )
       }

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -21,14 +21,17 @@ const { Content } = await render(entry)
   <Content />
   <CommunityLinksFoundation />
   {
-    entry.data.bioTexts &&
-      entry.data.bioTexts.map((bioText, i) => (
-        <ArticleBio
-          text={bioText}
-          imageUrl={entry.data.bioImages?.[i]}
-          imageAlt={entry.data.authors?.[i] ?? ''}
-        />
-      ))
+    entry.data.articleBios &&
+      entry.data.articleBios.map((bio) => {
+        if (!bio.text) return
+        return (
+          <ArticleBio
+            text={bio.text}
+            imageUrl={bio.image}
+            imageAlt={bio.author}
+          />
+        )
+      })
   }
   {entry.data.tags?.length > 0 && <ArticleTags tags={entry.data.tags} />}
 </FoundationBlogLayout>

--- a/src/schemas/content.ts
+++ b/src/schemas/content.ts
@@ -37,6 +37,12 @@ export type DevelopersBlogFrontmatterType = z.infer<
   typeof developersBlogFrontmatterSchema
 >
 
+const ArticleBioSchema = z.object({
+  author: z.string(),
+  text: z.string().optional(),
+  image: z.string().optional()
+})
+
 export const foundationBlogFrontmatterSchema = z.object({
   title: z.string().min(1, 'title is required'),
   description: z.string().min(1, 'description is required'),
@@ -47,9 +53,7 @@ export const foundationBlogFrontmatterSchema = z.object({
   featureImageAlt: z.string().optional(),
   thumbnailImage: z.string().optional(),
   thumbnailImageAlt: z.string().optional(),
-  authors: z.array(z.string()).optional().default([]),
-  bioTexts: z.array(z.string()).optional(),
-  bioImages: z.array(z.string()).optional(),
+  articleBios: z.array(ArticleBioSchema).optional().default([]),
   tags: z.array(z.enum(foundationTags)).default([]),
   localizes: z.string().optional(),
   locale: z.string().optional()


### PR DESCRIPTION
## Summary
This PR 
- adds a Strapi lifecycle file to automatically create, update, and delete corresponding MDX files when blog articles are created, updated, or removed in the Strapi Admin UI.
- refactors author bio data: groups `author`, `bioText` and `bioImage` into articleBios object array
- updates frontmatter to match new `articleBios` structure (37 articles updated)

**Pushing to git will be part of a different PR** 

Note: Currently, images added to blog posts are uploaded to /public/uploads/, and three additional versions are generated automatically: thumbnail, small, and medium. This PR does not modify this behavior.


## Related Issue
Create Foundation blog template on Strapi + Astro - [INTORG-301](https://linear.app/interledger/issue/INTORG-301/create-foundation-blog-template-on-strapi-astro)

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
