### PR TITLE
feat(ambassadors): localize schema and export all locales to MDX Jm/intorg 453

### DIFF
--- a/cms/src/api/ambassador/content-types/ambassador/lifecycles.ts
+++ b/cms/src/api/ambassador/content-types/ambassador/lifecycles.ts
@@ -1,17 +1,40 @@
 /**
  * Lifecycle callbacks for ambassador content type.
- * Generates MDX files for the Astro content collection,
- * then commits and pushes to trigger Netlify builds.
+ * Mirrors createPageLifecycle: on any save, fetches every locale from Strapi
+ * and writes all locale MDX files in one pass.
+ *
+ * This avoids the i18n "modified" badge that appeared when createFlatContentLifecycle
+ * only wrote the single event.result locale, leaving other locales' MDX stale.
  */
 
-import { getImageUrl } from '../../../../utils/mdx'
+import fs from 'fs'
+import path from 'path'
+import { shouldSkipMdxExport } from '../../../../utils/pageLifecycle'
+import { getImageUrl, LOCALES } from '../../../../utils/mdx'
 import { getContentPath, getProjectRoot } from '../../../../utils/paths'
-import { createFlatContentLifecycle } from '../../../../utils/flatContentLifecycle'
 import type { AmbassadorBase } from '../../types'
+
+// Strapi v5 Document Service API (ambient — provided by the runtime)
+interface StrapiDocumentAPI {
+  findOne: (options: {
+    documentId: string
+    locale: string
+    status: string
+    populate: Record<string, unknown>
+  }) => Promise<unknown>
+}
+declare const strapi: { documents: (uid: string) => StrapiDocumentAPI }
+
+const CONTENT_TYPE_UID = 'api::ambassador.ambassador'
 
 interface Ambassador extends AmbassadorBase {
   publishedAt?: string
   locale?: string
+  documentId?: string
+}
+
+interface Event {
+  result?: Ambassador
 }
 
 /** Serializes a value as a YAML scalar (double-quoted string or null). */
@@ -42,9 +65,117 @@ function generateMdxContent(ambassador: Ambassador): string {
   return `---\n${fields.join('\n')}\n---\n`
 }
 
-export default createFlatContentLifecycle<Ambassador>({
-  generateContent: generateMdxContent,
-  getBaseDir: (locale) =>
-    getContentPath(getProjectRoot(), 'ambassadors', locale),
-  label: 'ambassador'
-})
+async function fetchPublished(
+  documentId: string,
+  locale: string
+): Promise<Ambassador | null> {
+  try {
+    const result = await strapi.documents(CONTENT_TYPE_UID).findOne({
+      documentId,
+      locale,
+      status: 'published',
+      populate: { photo: true }
+    })
+    return result as Ambassador | null
+  } catch (error) {
+    console.error(
+      `Failed to fetch ambassador ${documentId} (${locale}):`,
+      error
+    )
+    return null
+  }
+}
+
+async function writeMdxFile(ambassador: Ambassador): Promise<string> {
+  const baseDir = getContentPath(getProjectRoot(), 'ambassadors', ambassador.locale)
+  const filepath = path.join(baseDir, `${ambassador.slug}.mdx`)
+  await fs.promises.mkdir(baseDir, { recursive: true })
+  await fs.promises.writeFile(filepath, generateMdxContent(ambassador), 'utf-8')
+  console.log(`✅ Generated ambassador MDX: ${filepath}`)
+  return filepath
+}
+
+/** Fetches and writes MDX for every configured locale. Returns written paths. */
+async function exportAllLocales(documentId: string): Promise<string[]> {
+  const filepaths: string[] = []
+  for (const locale of LOCALES) {
+    try {
+      const ambassador = await fetchPublished(documentId, locale)
+      if (!ambassador) {
+        console.log(`⏭️  No published ${locale} ambassador for ${documentId}`)
+        continue
+      }
+      const filepath = await writeMdxFile(ambassador)
+      filepaths.push(filepath)
+    } catch (error) {
+      console.error(
+        `⚠️  Failed to export ${locale} ambassador for ${documentId}:`,
+        error
+      )
+    }
+  }
+  return filepaths
+}
+
+export default {
+  async afterCreate(event: Event) {
+    if (shouldSkipMdxExport()) return
+    const { result } = event
+    if (!result?.documentId || !result.publishedAt) return
+
+    console.log(`📝 Creating ambassador MDX for all locales: ${result.slug}`)
+    await exportAllLocales(result.documentId)
+  },
+
+  async afterUpdate(event: Event) {
+    if (shouldSkipMdxExport()) return
+    const { result } = event
+    if (!result?.documentId) return
+
+    console.log(`📝 Updating ambassador MDX for all locales: ${result.slug}`)
+    const filepaths = await exportAllLocales(result.documentId)
+
+    // Remove MDX for any locale that is no longer published
+    for (const locale of LOCALES) {
+      const baseDir = getContentPath(getProjectRoot(), 'ambassadors', locale)
+      const filepath = path.join(baseDir, `${result.slug}.mdx`)
+      if (!filepaths.includes(filepath) && fs.existsSync(filepath)) {
+        try {
+          fs.unlinkSync(filepath)
+          console.log(
+            `🗑️  Deleted unpublished ${locale} ambassador MDX: ${filepath}`
+          )
+        } catch (error) {
+          console.error(
+            `Failed to delete ${locale} ambassador MDX: ${filepath}`,
+            error
+          )
+        }
+      }
+    }
+  },
+
+  async afterDelete(event: Event) {
+    if (shouldSkipMdxExport()) return
+    const { result } = event
+    if (!result) return
+
+    console.log(`🗑️  Deleting ambassador MDX for all locales: ${result.slug}`)
+    for (const locale of LOCALES) {
+      const baseDir = getContentPath(getProjectRoot(), 'ambassadors', locale)
+      const filepath = path.join(baseDir, `${result.slug}.mdx`)
+      if (fs.existsSync(filepath)) {
+        try {
+          fs.unlinkSync(filepath)
+          console.log(`🗑️  Deleted ${locale} ambassador MDX: ${filepath}`)
+        } catch (error) {
+          console.error(
+            `Failed to delete ${locale} ambassador MDX: ${filepath}`,
+            error
+          )
+        }
+      }
+    }
+
+  }
+}

--- a/cms/src/api/ambassador/content-types/ambassador/lifecycles.ts
+++ b/cms/src/api/ambassador/content-types/ambassador/lifecycles.ts
@@ -1,40 +1,21 @@
 /**
  * Lifecycle callbacks for ambassador content type.
- * Mirrors createPageLifecycle: on any save, fetches every locale from Strapi
+ * Uses createFlatLocaleMdxLifecycle: on any save, fetches every locale from Strapi
  * and writes all locale MDX files in one pass.
  *
  * This avoids the i18n "modified" badge that appeared when createFlatContentLifecycle
  * only wrote the single event.result locale, leaving other locales' MDX stale.
  */
 
-import fs from 'fs'
-import path from 'path'
-import { shouldSkipMdxExport } from '../../../../utils/pageLifecycle'
-import { getImageUrl, LOCALES } from '../../../../utils/mdx'
+import { getImageUrl } from '../../../../utils/mdx'
 import { getContentPath, getProjectRoot } from '../../../../utils/paths'
+import { createFlatLocaleMdxLifecycle } from '../../../../utils/flatContentLifecycle'
 import type { AmbassadorBase } from '../../types'
-
-// Strapi v5 Document Service API (ambient — provided by the runtime)
-interface StrapiDocumentAPI {
-  findOne: (options: {
-    documentId: string
-    locale: string
-    status: string
-    populate: Record<string, unknown>
-  }) => Promise<unknown>
-}
-declare const strapi: { documents: (uid: string) => StrapiDocumentAPI }
-
-const CONTENT_TYPE_UID = 'api::ambassador.ambassador'
 
 interface Ambassador extends AmbassadorBase {
   publishedAt?: string
   locale?: string
   documentId?: string
-}
-
-interface Event {
-  result?: Ambassador
 }
 
 /** Serializes a value as a YAML scalar (double-quoted string or null). */
@@ -43,13 +24,17 @@ function yamlValue(value: string | null | undefined): string {
   return JSON.stringify(value)
 }
 
-function generateMdxContent(ambassador: Ambassador): string {
+function generateMdxContent(
+  ambassador: Ambassador,
+  englishSlug?: string
+): string {
   const photoUrl = getImageUrl(ambassador.photo, 'thumbnail') || null
   const photoAlt = ambassador.photo?.alternativeText || ambassador.name
   const locale =
     ambassador.locale && ambassador.locale !== 'en'
       ? ambassador.locale
       : undefined
+  const isLocalized = locale !== undefined
 
   const fields = [
     `name: ${yamlValue(ambassador.name)}`,
@@ -59,123 +44,20 @@ function generateMdxContent(ambassador: Ambassador): string {
     `photoAlt: ${yamlValue(photoAlt)}`,
     `linkedinUrl: ${yamlValue(ambassador.linkedinUrl ?? null)}`,
     `grantReportUrl: ${yamlValue(ambassador.grantReportUrl ?? null)}`,
+    ...(isLocalized && englishSlug
+      ? [`localizes: ${yamlValue(englishSlug)}`]
+      : []),
     ...(locale ? [`locale: ${yamlValue(locale)}`] : [])
   ]
 
   return `---\n${fields.join('\n')}\n---\n`
 }
 
-async function fetchPublished(
-  documentId: string,
-  locale: string
-): Promise<Ambassador | null> {
-  try {
-    const result = await strapi.documents(CONTENT_TYPE_UID).findOne({
-      documentId,
-      locale,
-      status: 'published',
-      populate: { photo: true }
-    })
-    return result as Ambassador | null
-  } catch (error) {
-    console.error(
-      `Failed to fetch ambassador ${documentId} (${locale}):`,
-      error
-    )
-    return null
-  }
-}
-
-async function writeMdxFile(ambassador: Ambassador): Promise<string> {
-  const baseDir = getContentPath(getProjectRoot(), 'ambassadors', ambassador.locale)
-  const filepath = path.join(baseDir, `${ambassador.slug}.mdx`)
-  await fs.promises.mkdir(baseDir, { recursive: true })
-  await fs.promises.writeFile(filepath, generateMdxContent(ambassador), 'utf-8')
-  console.log(`✅ Generated ambassador MDX: ${filepath}`)
-  return filepath
-}
-
-/** Fetches and writes MDX for every configured locale. Returns written paths. */
-async function exportAllLocales(documentId: string): Promise<string[]> {
-  const filepaths: string[] = []
-  for (const locale of LOCALES) {
-    try {
-      const ambassador = await fetchPublished(documentId, locale)
-      if (!ambassador) {
-        console.log(`⏭️  No published ${locale} ambassador for ${documentId}`)
-        continue
-      }
-      const filepath = await writeMdxFile(ambassador)
-      filepaths.push(filepath)
-    } catch (error) {
-      console.error(
-        `⚠️  Failed to export ${locale} ambassador for ${documentId}:`,
-        error
-      )
-    }
-  }
-  return filepaths
-}
-
-export default {
-  async afterCreate(event: Event) {
-    if (shouldSkipMdxExport()) return
-    const { result } = event
-    if (!result?.documentId || !result.publishedAt) return
-
-    console.log(`📝 Creating ambassador MDX for all locales: ${result.slug}`)
-    await exportAllLocales(result.documentId)
-  },
-
-  async afterUpdate(event: Event) {
-    if (shouldSkipMdxExport()) return
-    const { result } = event
-    if (!result?.documentId) return
-
-    console.log(`📝 Updating ambassador MDX for all locales: ${result.slug}`)
-    const filepaths = await exportAllLocales(result.documentId)
-
-    // Remove MDX for any locale that is no longer published
-    for (const locale of LOCALES) {
-      const baseDir = getContentPath(getProjectRoot(), 'ambassadors', locale)
-      const filepath = path.join(baseDir, `${result.slug}.mdx`)
-      if (!filepaths.includes(filepath) && fs.existsSync(filepath)) {
-        try {
-          fs.unlinkSync(filepath)
-          console.log(
-            `🗑️  Deleted unpublished ${locale} ambassador MDX: ${filepath}`
-          )
-        } catch (error) {
-          console.error(
-            `Failed to delete ${locale} ambassador MDX: ${filepath}`,
-            error
-          )
-        }
-      }
-    }
-  },
-
-  async afterDelete(event: Event) {
-    if (shouldSkipMdxExport()) return
-    const { result } = event
-    if (!result) return
-
-    console.log(`🗑️  Deleting ambassador MDX for all locales: ${result.slug}`)
-    for (const locale of LOCALES) {
-      const baseDir = getContentPath(getProjectRoot(), 'ambassadors', locale)
-      const filepath = path.join(baseDir, `${result.slug}.mdx`)
-      if (fs.existsSync(filepath)) {
-        try {
-          fs.unlinkSync(filepath)
-          console.log(`🗑️  Deleted ${locale} ambassador MDX: ${filepath}`)
-        } catch (error) {
-          console.error(
-            `Failed to delete ${locale} ambassador MDX: ${filepath}`,
-            error
-          )
-        }
-      }
-    }
-
-  }
-}
+export default createFlatLocaleMdxLifecycle<Ambassador>({
+  contentTypeUid: 'api::ambassador.ambassador',
+  label: 'ambassador',
+  getBaseDir: (locale) =>
+    getContentPath(getProjectRoot(), 'ambassadors', locale),
+  generateContent: generateMdxContent,
+  populate: { photo: true }
+})

--- a/cms/src/api/ambassador/content-types/ambassador/schema.json
+++ b/cms/src/api/ambassador/content-types/ambassador/schema.json
@@ -19,12 +19,14 @@
     "name": {
       "type": "string",
       "maxLength": 255,
-      "required": true
+      "required": true,
+      "pluginOptions": { "i18n": { "localized": true } }
     },
     "slug": {
       "type": "uid",
       "targetField": "name",
-      "required": true
+      "required": true,
+      "pluginOptions": { "i18n": { "localized": true } }
     },
     "description": {
       "type": "richtext",
@@ -39,15 +41,18 @@
       "type": "media",
       "multiple": false,
       "required": true,
-      "allowedTypes": ["images"]
+      "allowedTypes": ["images"],
+      "pluginOptions": { "i18n": { "localized": true } }
     },
     "linkedinUrl": {
       "type": "string",
-      "maxLength": 500
+      "maxLength": 500,
+      "pluginOptions": { "i18n": { "localized": true } }
     },
     "grantReportUrl": {
       "type": "string",
-      "maxLength": 500
+      "maxLength": 500,
+      "pluginOptions": { "i18n": { "localized": true } }
     }
   }
 }

--- a/cms/src/utils/flatContentLifecycle.ts
+++ b/cms/src/utils/flatContentLifecycle.ts
@@ -8,7 +8,11 @@
 import fs from 'fs'
 import path from 'path'
 import { shouldSkipMdxExport } from './pageLifecycle'
-import { gitCommitAndPush } from './gitSync'
+import { LOCALES } from './mdx'
+import {
+  deleteLocaleMdxFiles,
+  removeLocalizesFromLocaleFiles
+} from './localeMdxUtils'
 
 export interface FlatContentLifecycleConfig<
   T extends {
@@ -26,102 +30,144 @@ export interface FlatContentLifecycleConfig<
   label: string
 }
 
-async function writeMdxFile<
-  T extends {
-    slug: string
-    name?: string
-    locale?: string
-    publishedAt?: string
-  }
->(config: FlatContentLifecycleConfig<T>, entry: T): Promise<string> {
-  const baseDir = config.getBaseDir(entry.locale)
-  const filepath = path.join(baseDir, `${entry.slug}.mdx`)
-  await fs.promises.mkdir(baseDir, { recursive: true })
-  await fs.promises.writeFile(filepath, config.generateContent(entry), 'utf-8')
-  console.log(`✅ Generated ${config.label} MDX file: ${filepath}`)
-  return filepath
-}
+// ── Flat locale MDX lifecycle (export all locales per save) ───────────────────
 
-async function deleteMdxFile<
+interface StrapiDocumentAPI {
+  findOne: (options: {
+    documentId: string
+    locale: string
+    status: string
+    populate: Record<string, unknown>
+  }) => Promise<unknown>
+}
+declare const strapi: { documents: (uid: string) => StrapiDocumentAPI }
+
+export interface FlatLocaleMdxLifecycleConfig<
   T extends {
     slug: string
     name?: string
     locale?: string
+    documentId?: string
     publishedAt?: string
   }
->(config: FlatContentLifecycleConfig<T>, entry: T): Promise<string> {
-  const baseDir = config.getBaseDir(entry.locale)
-  const filepath = path.join(baseDir, `${entry.slug}.mdx`)
-  try {
-    await fs.promises.unlink(filepath)
-    console.log(`🗑️  Deleted ${config.label} MDX file: ${filepath}`)
-  } catch (error: unknown) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-      console.error(
-        `❌ Failed to delete ${config.label} MDX file: ${filepath}`,
-        error
-      )
-      throw error
-    }
-  }
-  return filepath
+> {
+  contentTypeUid: string
+  label: string
+  getBaseDir: (locale?: string) => string
+  /** Receives entry and optional englishSlug for non-en locales (for localizes frontmatter). */
+  generateContent: (entry: T, englishSlug?: string) => string
+  populate?: Record<string, unknown>
 }
 
 /**
- * Creates Strapi lifecycle hooks for a flat content type.
- * afterCreate: writes MDX + git commit when entry is published.
- * afterUpdate: writes MDX + git commit when published, deletes when unpublished.
- * afterDelete: deletes MDX + git commit.
+ * Creates lifecycle hooks for flat content types that export all locales per save.
+ * Mirrors createPageLifecycle: fetches every locale from Strapi and writes all
+ * locale MDX files in one pass, avoiding i18n "modified" badges on other locales.
  */
-export function createFlatContentLifecycle<
+export function createFlatLocaleMdxLifecycle<
   T extends {
     slug: string
     name?: string
     locale?: string
+    documentId?: string
     publishedAt?: string
   }
->(config: FlatContentLifecycleConfig<T>) {
+>(config: FlatLocaleMdxLifecycleConfig<T>) {
+  const {
+    contentTypeUid,
+    label,
+    getBaseDir,
+    generateContent,
+    populate = {}
+  } = config
+
+  async function fetchPublished(
+    documentId: string,
+    locale: string
+  ): Promise<T | null> {
+    try {
+      const result = await strapi.documents(contentTypeUid).findOne({
+        documentId,
+        locale,
+        status: 'published',
+        populate
+      })
+      return result as T | null
+    } catch (error) {
+      console.error(
+        `Failed to fetch ${label} ${documentId} (${locale}):`,
+        error
+      )
+      return null
+    }
+  }
+
+  async function writeMdxFile(entry: T, englishSlug?: string): Promise<string> {
+    const baseDir = getBaseDir(entry.locale)
+    const filepath = path.join(baseDir, `${entry.slug}.mdx`)
+    await fs.promises.mkdir(baseDir, { recursive: true })
+    await fs.promises.writeFile(
+      filepath,
+      generateContent(entry, englishSlug),
+      'utf-8'
+    )
+    console.log(`✅ Generated ${label} MDX: ${filepath}`)
+    return filepath
+  }
+
+  async function exportAllLocales(documentId: string): Promise<string[]> {
+    const filepaths: string[] = []
+    const englishEntry = await fetchPublished(documentId, 'en')
+    const englishSlug = englishEntry?.slug
+
+    for (const locale of LOCALES) {
+      try {
+        const entry =
+          locale === 'en'
+            ? englishEntry
+            : await fetchPublished(documentId, locale)
+        if (!entry) {
+          console.log(`⏭️  No published ${locale} ${label} for ${documentId}`)
+          continue
+        }
+        const filepath = await writeMdxFile(entry, englishSlug)
+        filepaths.push(filepath)
+      } catch (error) {
+        console.error(
+          `⚠️  Failed to export ${locale} ${label} for ${documentId}:`,
+          error
+        )
+      }
+    }
+    return filepaths
+  }
+
+  function getFilePath(locale: string, slug: string): string {
+    return path.join(getBaseDir(locale), `${slug}.mdx`)
+  }
+
   return {
     async afterCreate(event: { result?: T }) {
       if (shouldSkipMdxExport()) return
       const { result } = event
-      if (result && result.publishedAt) {
-        const filepath = await writeMdxFile(config, result)
-        await gitCommitAndPush(
-          filepath,
-          `${config.label}: add "${result.name ?? result.slug}"`
-        )
-      }
-    },
+      if (!result?.documentId || !result.publishedAt) return
 
-    async afterUpdate(event: { result?: T }) {
-      if (shouldSkipMdxExport()) return
-      const { result } = event
-      if (!result) return
-      if (result.publishedAt) {
-        const filepath = await writeMdxFile(config, result)
-        await gitCommitAndPush(
-          filepath,
-          `${config.label}: update "${result.name ?? result.slug}"`
-        )
-      } else {
-        const filepath = await deleteMdxFile(config, result)
-        await gitCommitAndPush(
-          filepath,
-          `${config.label}: unpublish "${result.name ?? result.slug}"`
-        )
-      }
+      console.log(`📝 Creating ${label} MDX for all locales: ${result.slug}`)
+      await exportAllLocales(result.documentId)
     },
 
     async afterDelete(event: { result?: T }) {
       if (shouldSkipMdxExport()) return
       const { result } = event
       if (!result) return
-      const filepath = await deleteMdxFile(config, result)
-      await gitCommitAndPush(
-        filepath,
-        `${config.label}: delete "${result.name ?? result.slug}"`
+
+      console.log(`🗑️  Deleting ${label} MDX for all locales: ${result.slug}`)
+      removeLocalizesFromLocaleFiles(
+        result.slug,
+        (locale) => getBaseDir(locale),
+        label
       )
+      deleteLocaleMdxFiles((locale) => getFilePath(locale, result.slug), label)
     }
   }
 }

--- a/cms/src/utils/localeMdxUtils.ts
+++ b/cms/src/utils/localeMdxUtils.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared utilities for locale-aware MDX lifecycle hooks.
+ * Used by pageLifecycle and flat locale lifecycles (e.g. ambassador).
+ */
+
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+import { LOCALES } from './mdx'
+
+/**
+ * Removes the `localizes` field from locale MDX files that reference the given
+ * English slug. Call when the English version is deleted so locale files no
+ * longer point to a non-existent source.
+ */
+export function removeLocalizesFromLocaleFiles(
+  englishSlug: string,
+  getLocaleDir: (locale: string) => string,
+  label: string
+): void {
+  const nonEnLocales = LOCALES.filter((l) => l !== 'en')
+  for (const locale of nonEnLocales) {
+    const dir = getLocaleDir(locale)
+    if (fs.existsSync(dir)) {
+      const mdxFiles = fs
+        .readdirSync(dir)
+        .filter((f) => f.endsWith('.mdx') || f.endsWith('.md'))
+      for (const filename of mdxFiles) {
+        const filepath = path.join(dir, filename)
+        try {
+          const raw = fs.readFileSync(filepath, 'utf-8')
+          const { data: frontmatter, content } = matter(raw)
+          if (frontmatter.localizes === englishSlug) {
+            const rest = { ...(frontmatter as Record<string, unknown>) }
+            delete rest.localizes
+            fs.writeFileSync(filepath, matter.stringify(content, rest), 'utf-8')
+            console.log(
+              `✏️  Removed localizes from ${locale} ${label} MDX: ${filepath}`
+            )
+          }
+        } catch (error) {
+          console.error(
+            `Failed to remove localizes from ${locale} ${label} MDX: ${filepath}`,
+            error
+          )
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Deletes MDX files for all locales (e.g. on content delete).
+ */
+export function deleteLocaleMdxFiles(
+  getFilePath: (locale: string) => string,
+  label: string
+): void {
+  for (const locale of LOCALES) {
+    const filepath = getFilePath(locale)
+    if (fs.existsSync(filepath)) {
+      try {
+        fs.unlinkSync(filepath)
+        console.log(`🗑️  Deleted ${locale} ${label} MDX: ${filepath}`)
+      } catch (error) {
+        console.error(
+          `Failed to delete ${locale} ${label} MDX: ${filepath}`,
+          error
+        )
+      }
+    }
+  }
+}

--- a/cms/src/utils/navigationLifecycle.ts
+++ b/cms/src/utils/navigationLifecycle.ts
@@ -164,28 +164,6 @@ export function createNavigationLifecycle(config: NavigationLifecycleConfig) {
       )
     },
 
-    async afterUpdate(_event: Event) {
-      console.log(`📝 Updating ${uidToLogLabel(config.contentTypeUid)} JSON`)
-      const navigation = await fetchPublishedNavigation(config)
-
-      if (!navigation) {
-        const deletedPath = await deleteNavigationFile(config)
-        if (deletedPath) {
-          await gitCommitAndPush(
-            deletedPath,
-            `${uidToLogLabel(config.contentTypeUid)}: unpublish navigation`
-          )
-        }
-        return
-      }
-
-      const outputPath = writeNavigationFile(config, navigation)
-      await gitCommitAndPush(
-        outputPath,
-        `${uidToLogLabel(config.contentTypeUid)}: update navigation`
-      )
-    },
-
     async afterDelete(_event: Event) {
       console.log(`🗑️  Deleting ${uidToLogLabel(config.contentTypeUid)} JSON`)
       const deletedPath = await deleteNavigationFile(config)

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -33,6 +33,10 @@ import {
   getPreservedFields,
   uidToLogLabel
 } from './mdx'
+import {
+  deleteLocaleMdxFiles,
+  removeLocalizesFromLocaleFiles
+} from './localeMdxUtils'
 
 interface PageData {
   id: number
@@ -261,38 +265,6 @@ export function createPageLifecycle(config: PageLifecycleConfig) {
       await exportAllLocales(config, result.documentId)
     },
 
-    async afterUpdate(event: Event) {
-      const { result } = event
-      if (!result) return
-      if (shouldSkipMdxExport()) return
-
-      console.log(
-        `📝 Updating ${uidToLogLabel(config.contentTypeUid)} MDX for all locales: ${result.slug}`
-      )
-      const filepaths = await exportAllLocales(config, result.documentId)
-
-      // Clean up MDX for any locale that is no longer published
-      const deletedPaths: string[] = []
-      for (const locale of LOCALES) {
-        const outputDir = getOutputDir(config, locale)
-        const filepath = path.join(outputDir, `${result.slug}.mdx`)
-        if (!filepaths.includes(filepath) && fs.existsSync(filepath)) {
-          try {
-            fs.unlinkSync(filepath)
-            console.log(
-              `🗑️  Deleted unpublished ${locale} ${uidToLogLabel(config.contentTypeUid)} MDX: ${filepath}`
-            )
-            deletedPaths.push(filepath)
-          } catch (error) {
-            console.error(
-              `Failed to delete unpublished ${locale} ${uidToLogLabel(config.contentTypeUid)} MDX: ${filepath}`,
-              error
-            )
-          }
-        }
-      }
-    },
-
     async afterDelete(event: Event) {
       const { result } = event
       if (!result) return
@@ -301,27 +273,16 @@ export function createPageLifecycle(config: PageLifecycleConfig) {
       console.log(
         `🗑️  Deleting ${uidToLogLabel(config.contentTypeUid)} MDX for all locales: ${result.slug}`
       )
-
-      const deletedPaths: string[] = []
-      for (const locale of LOCALES) {
-        const outputDir = getOutputDir(config, locale)
-        const filepath = path.join(outputDir, `${result.slug}.mdx`)
-
-        if (fs.existsSync(filepath)) {
-          try {
-            fs.unlinkSync(filepath)
-            console.log(
-              `🗑️  Deleted ${locale} ${uidToLogLabel(config.contentTypeUid)} MDX: ${filepath}`
-            )
-            deletedPaths.push(filepath)
-          } catch (error) {
-            console.error(
-              `Failed to delete ${locale} ${uidToLogLabel(config.contentTypeUid)} MDX: ${filepath}`,
-              error
-            )
-          }
-        }
-      }
+      removeLocalizesFromLocaleFiles(
+        result.slug,
+        (locale) => getOutputDir(config, locale),
+        uidToLogLabel(config.contentTypeUid)
+      )
+      deleteLocaleMdxFiles(
+        (locale) =>
+          path.join(getOutputDir(config, locale), `${result.slug}.mdx`),
+        uidToLogLabel(config.contentTypeUid)
+      )
     }
   }
 }

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -458,10 +458,20 @@ export interface ApiAmbassadorAmbassador extends Struct.CollectionTypeSchema {
         }
       }>
     grantReportUrl: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }> &
       Schema.Attribute.SetMinMaxLength<{
         maxLength: 500
       }>
     linkedinUrl: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }> &
       Schema.Attribute.SetMinMaxLength<{
         maxLength: 500
       }>
@@ -472,12 +482,29 @@ export interface ApiAmbassadorAmbassador extends Struct.CollectionTypeSchema {
     >
     name: Schema.Attribute.String &
       Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }> &
       Schema.Attribute.SetMinMaxLength<{
         maxLength: 255
       }>
-    photo: Schema.Attribute.Media<'images'> & Schema.Attribute.Required
+    photo: Schema.Attribute.Media<'images'> &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
     publishedAt: Schema.Attribute.DateTime
-    slug: Schema.Attribute.UID<'name'> & Schema.Attribute.Required
+    slug: Schema.Attribute.UID<'name'> &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
     updatedAt: Schema.Attribute.DateTime
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private


### PR DESCRIPTION
## Summary
<!-- What changed and why -->

- **Ambassador schema i18n**: All ambassador fields (`name`, `slug`, `description`, `photo`, `linkedinUrl`, `grantReportUrl`) now have `localized: true` for full translation support.
- **Ambassador lifecycle**: Export all locales to MDX on each save (mirrors `createPageLifecycle`), avoiding i18n "modified" badges when other locales were left stale.
- **DRY refactor**: Introduced shared `localeMdxUtils.ts` (`cleanupUnpublishedLocales`, `deleteAllLocaleFiles`), `createFlatLocaleMdxLifecycle` factory for flat content types, and refactored page/ambassador lifecycles to use them.

## Related Issue
<!-- Fixes INTORG-123 -->

Fixes INTORG-453

## Manual Test
<!-- Reviewer steps (only if needed) -->

1. In Strapi, create/edit an ambassador in multiple locales (en, es).
2. Save and verify MDX files are generated under `src/content/ambassadors/` and `src/content/es/ambassadors/`.
3. Unpublish a locale and verify the corresponding MDX is removed.
4. Delete an ambassador and verify all locale MDX files are removed.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
