### PR TITLE
feat(sync-mdx): detect Paragraph component on import, export as <Para…

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -29,6 +29,7 @@
     "jsesc": "^3.1.0",
     "marked": "^17.0.3",
     "mdast-util-mdx-jsx": "^3.2.0",
+    "mdast-util-to-markdown": "^2.1.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.2",

--- a/cms/package.json
+++ b/cms/package.json
@@ -28,9 +28,12 @@
     "is-html": "^3.2.0",
     "jsesc": "^3.1.0",
     "marked": "^17.0.3",
+    "mdast-util-mdx-jsx": "^3.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.2",
+    "remark": "^15.0.1",
+    "remark-mdx": "^3.1.1",
     "styled-components": "^6.1.19",
     "turndown": "^7.2.2",
     "zod": "^4.3.6"

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       marked:
         specifier: ^17.0.3
         version: 17.0.3
+      mdast-util-mdx-jsx:
+        specifier: ^3.2.0
+        version: 3.2.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -51,6 +54,12 @@ importers:
       react-router-dom:
         specifier: ^6.30.2
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark:
+        specifier: ^15.0.1
+        version: 15.0.1
+      remark-mdx:
+        specifier: ^3.1.1
+        version: 3.1.1
       styled-components:
         specifier: ^6.1.19
         version: 6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2663,6 +2672,11 @@ packages:
     peerDependencies:
       acorn: ^8.14.0
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
@@ -3701,6 +3715,9 @@ packages:
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -4921,6 +4938,9 @@ packages:
   mdast-util-mdx-jsx@3.2.0:
     resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
 
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
@@ -4973,11 +4993,29 @@ packages:
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
 
   micromark-factory-label@2.0.1:
     resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
 
   micromark-factory-space@2.0.1:
     resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
@@ -5008,6 +5046,9 @@ packages:
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
 
   micromark-util-html-tag-name@2.0.1:
     resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
@@ -5923,11 +5964,20 @@ packages:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
     engines: {node: '>= 0.10'}
 
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remark@15.0.1:
+    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
   remove-accents@0.5.0:
     resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
@@ -6708,6 +6758,9 @@ packages:
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
@@ -11156,6 +11209,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
@@ -11882,6 +11939,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -12256,6 +12317,11 @@ snapshots:
   estraverse@5.3.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
 
   estree-walker@3.0.3:
     dependencies:
@@ -13636,6 +13702,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -13721,6 +13797,57 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-factory-destination@2.0.1:
     dependencies:
       micromark-util-character: 2.1.1
@@ -13733,6 +13860,18 @@ snapshots:
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
 
   micromark-factory-space@2.0.1:
     dependencies:
@@ -13786,6 +13925,16 @@ snapshots:
 
   micromark-util-encode@2.0.1: {}
 
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
   micromark-util-html-tag-name@2.0.1: {}
 
   micromark-util-normalize-identifier@2.0.1:
@@ -13816,7 +13965,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -14782,6 +14931,13 @@ snapshots:
 
   relateurl@0.2.7: {}
 
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -14798,6 +14954,21 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remark@15.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remove-accents@0.5.0: {}
 
@@ -15622,6 +15793,10 @@ snapshots:
       crypto-random-string: 2.0.0
 
   unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
     dependencies:
       '@types/unist': 3.0.3
 

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       mdast-util-mdx-jsx:
         specifier: ^3.2.0
         version: 3.2.0
+      mdast-util-to-markdown:
+        specifier: ^2.1.2
+        version: 2.1.2
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1840,66 +1843,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -15906,7 +15922,7 @@ snapshots:
   vite-node@2.1.9(@types/node@22.19.11)(terser@5.46.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
       vite: 5.4.21(@types/node@22.19.11)(terser@5.46.0)
@@ -15951,7 +15967,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.3.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 1.1.2

--- a/cms/scripts/sync-mdx/COMPONENT_IMPORT_TEMPLATE.md
+++ b/cms/scripts/sync-mdx/COMPONENT_IMPORT_TEMPLATE.md
@@ -112,7 +112,7 @@ Use the helpers in `jsxExtract.ts` — do NOT read AST node attributes directly:
 | `getStringAttr(node, 'name')`                     | String props    | `title="Hello"`                                      |
 | `getStringAttr(node, 'name', { required: true })` | Required string | Throws if missing                                    |
 | `getBooleanAttr(node, 'name')`                    | Boolean props   | `showLinks`, `showLinks={true}`, `showLinks={false}` |
-| `getStringArrayAttr(node, 'name')`                | String arrays   | `slugs={["a","b"]}` or `slugs={['a','b']}`           |
+| `getStringArrayAttr(node, 'name')`                | String arrays   | `slugs={["a","b"]}` (double-quoted only)             |
 
 All extractors throw `MdxParserError` with the right error code on bad input. They handle single and double quotes in arrays.
 

--- a/cms/scripts/sync-mdx/COMPONENT_IMPORT_TEMPLATE.md
+++ b/cms/scripts/sync-mdx/COMPONENT_IMPORT_TEMPLATE.md
@@ -1,0 +1,176 @@
+# Adding a New Component to the MDX Import Pipeline
+
+This guide walks you through wiring up a new JSX component so the MDX → Strapi sync pipeline can parse it into the correct dynamic-zone block payload.
+
+Use the Ambassador handler (`ambassadorHandler.ts`) as the reference implementation.
+
+## Files You Will Touch
+
+| File                                         | What to do                                                                             |
+| -------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `cms/src/components/blocks/<name>.json`      | Strapi component schema must exist first                                               |
+| `cms/scripts/sync-mdx/types.blocks.ts`       | Add a payload interface + include it in `ParsedBlock` union                            |
+| `cms/scripts/sync-mdx/<name>Handler.ts`      | Handler function + registration                                                        |
+| `cms/scripts/sync-mdx/<name>Handler.test.ts` | Tests for the handler                                                                  |
+| `cms/scripts/sync-mdx/config.ts`             | Side-effect import if handler self-registers (usually just `import './<name>Handler'`) |
+
+## Step-by-Step
+
+### 1. Define the block payload type
+
+In `types.blocks.ts`, add an interface that describes the **Strapi REST API body** (not the schema type). Every block must extend `StrapiBlockBase` and set `__component`.
+
+```ts
+export interface MyWidgetBlock extends StrapiBlockBase {
+  __component: 'blocks.my-widget'
+  title: string
+  description?: string
+}
+```
+
+Add it to the `ParsedBlock` union at the bottom of the file.
+
+### 2. Write the handler (TDD — red first)
+
+Create `<name>Handler.test.ts`. Import `parseMdxToBlocks` and write a test that parses your component's JSX and asserts the expected block output:
+
+```ts
+import './myWidgetHandler' // side-effect: registers handler
+import { parseMdxToBlocks, type ParserContext } from './mdxBlockParser'
+
+const ctx: ParserContext = { locale: 'en' }
+
+it('parses <MyWidget title="Hello" />', async () => {
+  const blocks = await parseMdxToBlocks('<MyWidget title="Hello" />', ctx)
+  expect(blocks).toEqual([{ __component: 'blocks.my-widget', title: 'Hello' }])
+})
+```
+
+Run it — it should fail with `UNSUPPORTED_COMPONENT` because no handler is registered yet. That's the RED phase.
+
+### 3. Implement the handler
+
+Create `<name>Handler.ts`:
+
+```ts
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
+import type { ParsedBlock, MyWidgetBlock } from './types.blocks'
+import { getStringAttr } from './jsxExtract'
+import { registerComponentHandler, type ParserContext } from './mdxBlockParser'
+
+async function handleMyWidget(
+  node: MdxJsxFlowElement,
+  _ctx: ParserContext
+): Promise<ParsedBlock[]> {
+  const title = getStringAttr(node, 'title', { required: true })
+  const description = getStringAttr(node, 'description')
+
+  const block: MyWidgetBlock = {
+    __component: 'blocks.my-widget',
+    title
+  }
+  if (description !== undefined) {
+    block.description = description
+  }
+  return [block]
+}
+
+// Self-register on import
+registerComponentHandler('MyWidget', handleMyWidget)
+```
+
+Run tests — they should go GREEN.
+
+### 4. Wire the handler into the pipeline
+
+In `config.ts`, add the side-effect import so the handler is registered before any sync runs:
+
+```ts
+import './<name>Handler'
+```
+
+This goes next to the existing `import './ambassadorHandler'` line. That's all that's needed — `buildParsedPagePayload` already passes the parser context through.
+
+**How registration works:** `COMPONENT_HANDLERS` in `mdxBlockParser.ts` is a module-level singleton — Node's module cache guarantees only one instance exists per process. When your handler module calls `registerComponentHandler('MyWidget', handleMyWidget)` at the top level, importing the module is enough to populate the registry. The bare `import './<name>Handler'` in `config.ts` triggers this side-effect before any parsing runs. No explicit init call or factory setup needed.
+
+### 5. Write the full test suite
+
+Cover at minimum:
+
+- [x] Happy path with all required props
+- [x] Optional props present vs absent
+- [x] Missing required prop → `MISSING_REQUIRED_PROP`
+- [x] Dynamic expression in prop → `DYNAMIC_EXPRESSION`
+- [x] Mixed content (your component + markdown) → blocks in document order
+
+## Attribute Extractors
+
+Use the helpers in `jsxExtract.ts` — do NOT read AST node attributes directly:
+
+| Helper                                            | Use for         | Example JSX                                          |
+| ------------------------------------------------- | --------------- | ---------------------------------------------------- |
+| `getStringAttr(node, 'name')`                     | String props    | `title="Hello"`                                      |
+| `getStringAttr(node, 'name', { required: true })` | Required string | Throws if missing                                    |
+| `getBooleanAttr(node, 'name')`                    | Boolean props   | `showLinks`, `showLinks={true}`, `showLinks={false}` |
+| `getStringArrayAttr(node, 'name')`                | String arrays   | `slugs={["a","b"]}` or `slugs={['a','b']}`           |
+
+All extractors throw `MdxParserError` with the right error code on bad input. They handle single and double quotes in arrays.
+
+## Relation Fields (Gotcha: Strapi v5 Connect Syntax)
+
+If your component has a relation field (e.g. linking to another content type), you **must** wrap the resolved documentId in Strapi v5's `connect` syntax.
+
+**Correct**:
+
+```ts
+ambassador: {
+  connect: [{ documentId: 'abc123' }]
+}
+```
+
+For arrays of relations:
+
+```ts
+ambassadors: {
+  connect: [{ documentId: 'abc' }, { documentId: 'def' }]
+}
+```
+
+Use `ctx.resolveRelation!(apiId, slug)` to resolve slugs to document IDs. The resolver handles locale fallback automatically.
+
+```ts
+const { documentId } = await ctx.resolveRelation!('ambassadors', slug)
+const block = {
+  __component: 'blocks.ambassador',
+  ambassador: { connect: [{ documentId }] }
+}
+```
+
+## Error Handling
+
+The parser is **strict by design**. Do not silently skip or default on bad input.
+
+- Missing required props → throw `MISSING_REQUIRED_PROP`
+- Dynamic expressions → throw `DYNAMIC_EXPRESSION`
+- Unresolved relation slugs → throw `UNRESOLVED_RELATION`
+- Unknown components → throw `UNSUPPORTED_COMPONENT` (handled by the core parser, not your handler)
+
+`buildPagePayload` in `mdxTransformer.ts` catches `MdxParserError` and re-throws with the file slug prepended for easier debugging.
+
+## Testing Utilities
+
+- `parseMdxToBlocks(mdxBody, ctx)` — end-to-end: MDX string → block array. Use this for handler integration tests.
+- `createMdxFile({ slug, frontmatter, content })` — from `test-utils.ts`, creates an `MDXFile` object for `buildPagePayload` tests.
+- For resolver tests, create a mock: `async (_apiId, slug) => ({ documentId: \`doc-\${slug}\` })`
+
+## Checklist Before Opening PR
+
+- [ ] Block type added to `types.blocks.ts` and included in `ParsedBlock` union
+- [ ] Handler created and self-registers via `registerComponentHandler()`
+- [ ] Side-effect import added in `config.ts`
+- [ ] All attribute extraction uses `jsxExtract.ts` helpers (no raw AST access)
+- [ ] Relation fields use `{ connect: [...] }` syntax
+- [ ] Optional fields omitted from payload when `undefined` (don't send `undefined` — let Strapi schema defaults apply)
+- [ ] Tests cover: happy path, optional props, missing required, dynamic expression, mixed content
+- [ ] `pnpm --dir cms test:sync-mdx` all green
+- [ ] `pnpm --dir cms run sync:mdx:dry-run` no new errors

--- a/cms/scripts/sync-mdx/ambassadorHandler.test.ts
+++ b/cms/scripts/sync-mdx/ambassadorHandler.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+import { parseMdxToBlocks, type ParserContext } from './mdxBlockParser'
+import type { StrapiClient } from './strapiClient'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal mock StrapiClient with a controllable findBySlug. */
+function createMockStrapi(
+  entries: Record<string, { documentId: string; locale: string }>
+): StrapiClient {
+  return {
+    findBySlug: vi.fn(
+      async (
+        _apiId: string,
+        slug: string,
+        locale?: string
+      ): Promise<{ documentId: string; slug: string } | undefined> => {
+        const key = `${locale}:${slug}`
+        const entry = entries[key]
+        return entry ? { documentId: entry.documentId, slug } : undefined
+      }
+    ),
+    // Unused methods — stub to satisfy the interface
+    request: vi.fn(),
+    getAllEntries: vi.fn(),
+    findUploadByUrl: vi.fn(),
+    createLocalization: vi.fn(),
+    updateLocalization: vi.fn(),
+    createEntry: vi.fn(),
+    updateEntry: vi.fn(),
+    deleteEntry: vi.fn(),
+    deleteLocalization: vi.fn()
+  } as unknown as StrapiClient
+}
+
+// ---------------------------------------------------------------------------
+// createRelationResolver
+// ---------------------------------------------------------------------------
+
+describe('createRelationResolver', () => {
+  let createRelationResolver: typeof import('./ambassadorHandler').createRelationResolver
+
+  beforeEach(async () => {
+    const mod = await import('./ambassadorHandler')
+    createRelationResolver = mod.createRelationResolver
+  })
+
+  it('resolves slug in the target locale', async () => {
+    const strapi = createMockStrapi({
+      'es:alice': { documentId: 'doc-es-alice', locale: 'es' }
+    })
+    const resolve = createRelationResolver(strapi, 'es')
+
+    const result = await resolve('ambassadors', 'alice')
+
+    expect(result).toEqual({ documentId: 'doc-es-alice' })
+    expect(strapi.findBySlug).toHaveBeenCalledWith('ambassadors', 'alice', 'es')
+  })
+
+  it('falls back to en when not found in target locale', async () => {
+    const strapi = createMockStrapi({
+      'en:alice': { documentId: 'doc-en-alice', locale: 'en' }
+    })
+    const resolve = createRelationResolver(strapi, 'es')
+
+    const result = await resolve('ambassadors', 'alice')
+
+    expect(result).toEqual({ documentId: 'doc-en-alice' })
+    expect(strapi.findBySlug).toHaveBeenCalledWith('ambassadors', 'alice', 'es')
+    expect(strapi.findBySlug).toHaveBeenCalledWith('ambassadors', 'alice', 'en')
+  })
+
+  it('throws UNRESOLVED_RELATION when not found in any locale', async () => {
+    const strapi = createMockStrapi({})
+    const resolve = createRelationResolver(strapi, 'es')
+
+    await expect(resolve('ambassadors', 'ghost')).rejects.toThrow(
+      MdxParserError
+    )
+    await expect(resolve('ambassadors', 'ghost')).rejects.toMatchObject({
+      code: ParserErrorCode.UNRESOLVED_RELATION
+    })
+  })
+
+  it('does not fall back when locale is already en', async () => {
+    const strapi = createMockStrapi({})
+    const resolve = createRelationResolver(strapi, 'en')
+
+    await expect(resolve('ambassadors', 'ghost')).rejects.toThrow(
+      MdxParserError
+    )
+    // Should only call once (no fallback to same locale)
+    expect(strapi.findBySlug).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers for handler tests
+// ---------------------------------------------------------------------------
+
+/** Mock resolver that returns a predictable documentId from the slug. */
+function mockResolver(
+  knownSlugs: Record<string, string> = {}
+): (apiId: string, slug: string) => Promise<{ documentId: string }> {
+  return async (_apiId: string, slug: string) => {
+    const docId = knownSlugs[slug]
+    if (!docId) {
+      throw new MdxParserError({
+        code: ParserErrorCode.UNRESOLVED_RELATION,
+        message: `Slug "${slug}" not found.`
+      })
+    }
+    return { documentId: docId }
+  }
+}
+
+function ctxWith(slugs: Record<string, string>, locale = 'en'): ParserContext {
+  return { locale, resolveRelation: mockResolver(slugs) }
+}
+
+// ---------------------------------------------------------------------------
+// Ambassador handler (via parseMdxToBlocks)
+// ---------------------------------------------------------------------------
+
+// Import side-effects: registers Ambassador + AmbassadorGrid handlers
+import './ambassadorHandler'
+
+describe('Ambassador handler', () => {
+  it('parses <Ambassador slug="alice" /> into AmbassadorBlock', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<Ambassador slug="alice" />',
+      ctxWith({ alice: 'doc-alice' })
+    )
+
+    expect(blocks).toEqual([
+      {
+        __component: 'blocks.ambassador',
+        ambassador: { connect: [{ documentId: 'doc-alice' }] }
+      }
+    ])
+  })
+
+  it('parses showLinks={false}', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<Ambassador slug="alice" showLinks={false} />',
+      ctxWith({ alice: 'doc-alice' })
+    )
+
+    expect(blocks[0]).toMatchObject({ showLinks: false })
+  })
+
+  it('parses showLinks={true}', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<Ambassador slug="alice" showLinks={true} />',
+      ctxWith({ alice: 'doc-alice' })
+    )
+
+    expect(blocks[0]).toMatchObject({ showLinks: true })
+  })
+
+  it('parses valueless showLinks as true', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<Ambassador slug="alice" showLinks />',
+      ctxWith({ alice: 'doc-alice' })
+    )
+
+    expect(blocks[0]).toMatchObject({ showLinks: true })
+  })
+
+  it('omits showLinks when not specified', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<Ambassador slug="alice" />',
+      ctxWith({ alice: 'doc-alice' })
+    )
+
+    expect(blocks[0]).not.toHaveProperty('showLinks')
+  })
+
+  it('throws MISSING_REQUIRED_PROP when slug is missing', async () => {
+    await expect(
+      parseMdxToBlocks('<Ambassador />', ctxWith({}))
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.MISSING_REQUIRED_PROP
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AmbassadorGrid handler (via parseMdxToBlocks)
+// ---------------------------------------------------------------------------
+
+describe('AmbassadorGrid handler', () => {
+  it('parses <AmbassadorGrid> with heading and slugs', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<AmbassadorGrid heading="Our Team" slugs={["alice","bob"]} />',
+      ctxWith({ alice: 'doc-alice', bob: 'doc-bob' })
+    )
+
+    expect(blocks).toEqual([
+      {
+        __component: 'blocks.ambassadors-grid',
+        heading: 'Our Team',
+        ambassadors: {
+          connect: [{ documentId: 'doc-alice' }, { documentId: 'doc-bob' }]
+        }
+      }
+    ])
+  })
+
+  it('preserves slug order in resolved ambassadors', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<AmbassadorGrid slugs={["bob","alice"]} />',
+      ctxWith({ alice: 'doc-alice', bob: 'doc-bob' })
+    )
+
+    expect(blocks[0]).toMatchObject({
+      ambassadors: {
+        connect: [{ documentId: 'doc-bob' }, { documentId: 'doc-alice' }]
+      }
+    })
+  })
+
+  it('heading is optional', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<AmbassadorGrid slugs={["alice"]} />',
+      ctxWith({ alice: 'doc-alice' })
+    )
+
+    expect(blocks[0]).not.toHaveProperty('heading')
+  })
+
+  it('throws MISSING_REQUIRED_PROP when slugs is missing', async () => {
+    await expect(
+      parseMdxToBlocks('<AmbassadorGrid heading="Team" />', ctxWith({}))
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.MISSING_REQUIRED_PROP
+    })
+  })
+
+  it('throws UNRESOLVED_RELATION when any slug is unresolved', async () => {
+    await expect(
+      parseMdxToBlocks(
+        '<AmbassadorGrid slugs={["alice","ghost"]} />',
+        ctxWith({ alice: 'doc-alice' })
+      )
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.UNRESOLVED_RELATION
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: mixed markdown + JSX
+// ---------------------------------------------------------------------------
+
+describe('mixed markdown and JSX content', () => {
+  it('produces blocks in document order', async () => {
+    const mdx = [
+      'Here are our ambassadors:',
+      '',
+      '<Ambassador slug="alice" />',
+      '',
+      'More text below.'
+    ].join('\n')
+
+    const blocks = await parseMdxToBlocks(mdx, ctxWith({ alice: 'doc-alice' }))
+
+    expect(blocks).toHaveLength(3)
+    expect(blocks[0]).toEqual({
+      __component: 'blocks.paragraph',
+      content: 'Here are our ambassadors:'
+    })
+    expect(blocks[1]).toEqual({
+      __component: 'blocks.ambassador',
+      ambassador: { connect: [{ documentId: 'doc-alice' }] }
+    })
+    expect(blocks[2]).toEqual({
+      __component: 'blocks.paragraph',
+      content: 'More text below.'
+    })
+  })
+})

--- a/cms/scripts/sync-mdx/ambassadorHandler.ts
+++ b/cms/scripts/sync-mdx/ambassadorHandler.ts
@@ -1,0 +1,115 @@
+/**
+ * Ambassador + AmbassadorGrid component handlers for the MDX block parser.
+ *
+ * Handles:
+ * - <Ambassador slug="..." showLinks={true|false} />
+ * - <AmbassadorGrid heading="..." slugs={["a","b"]} />
+ *
+ * Both handlers resolve ambassador slugs to Strapi document IDs
+ * via the generic `resolveRelation` function on ParserContext.
+ */
+
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
+import type { StrapiClient } from './strapiClient'
+import type {
+  ParsedBlock,
+  AmbassadorBlock,
+  AmbassadorsGridBlock
+} from './types.blocks'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+import { getStringAttr, getBooleanAttr, getStringArrayAttr } from './jsxExtract'
+import { registerComponentHandler, type ParserContext } from './mdxBlockParser'
+
+// ---------------------------------------------------------------------------
+// Relation resolver factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a relation resolver with locale-first + `en` fallback.
+ *
+ * Resolution order:
+ * 1. Target locale (e.g. `fr`)
+ * 2. Fallback to `en` (when target !== 'en')
+ * 3. Throw UNRESOLVED_RELATION if neither found
+ *
+ * The returned function matches the `resolveRelation` signature on
+ * ParserContext so it can be plugged in directly.
+ */
+export function createRelationResolver(
+  strapi: StrapiClient,
+  locale: string
+): (apiId: string, slug: string) => Promise<{ documentId: string }> {
+  return async (apiId: string, slug: string) => {
+    const entry = await strapi.findBySlug(apiId, slug, locale)
+    if (entry) return { documentId: entry.documentId }
+
+    if (locale !== 'en') {
+      const fallback = await strapi.findBySlug(apiId, slug, 'en')
+      if (fallback) return { documentId: fallback.documentId }
+    }
+
+    throw new MdxParserError({
+      code: ParserErrorCode.UNRESOLVED_RELATION,
+      message: `Slug "${slug}" could not be resolved for "${apiId}" in locale "${locale}" or "en".`
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ambassador handler
+// ---------------------------------------------------------------------------
+
+async function handleAmbassador(
+  node: MdxJsxFlowElement,
+  ctx: ParserContext
+): Promise<ParsedBlock[]> {
+  const slug = getStringAttr(node, 'slug', { required: true })
+  const showLinks = getBooleanAttr(node, 'showLinks')
+
+  const { documentId } = await ctx.resolveRelation!('ambassadors', slug)
+
+  const block: AmbassadorBlock = {
+    __component: 'blocks.ambassador',
+    ambassador: { connect: [{ documentId }] }
+  }
+
+  if (showLinks !== undefined) {
+    block.showLinks = showLinks
+  }
+
+  return [block]
+}
+
+// ---------------------------------------------------------------------------
+// AmbassadorGrid handler
+// ---------------------------------------------------------------------------
+
+async function handleAmbassadorGrid(
+  node: MdxJsxFlowElement,
+  ctx: ParserContext
+): Promise<ParsedBlock[]> {
+  const heading = getStringAttr(node, 'heading')
+  const slugs = getStringArrayAttr(node, 'slugs', { required: true })
+
+  const resolved = await Promise.all(
+    slugs.map((slug) => ctx.resolveRelation!('ambassadors', slug))
+  )
+
+  const block: AmbassadorsGridBlock = {
+    __component: 'blocks.ambassadors-grid',
+    ambassadors: { connect: resolved }
+  }
+
+  if (heading !== undefined) {
+    block.heading = heading
+  }
+
+  return [block]
+}
+
+// ---------------------------------------------------------------------------
+// Registration (runs on import)
+// ---------------------------------------------------------------------------
+
+registerComponentHandler('Ambassador', handleAmbassador)
+registerComponentHandler('AmbassadorGrid', handleAmbassadorGrid)

--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -12,6 +12,9 @@ import {
   foundationPageFrontmatterSchema,
   summitPageFrontmatterSchema
 } from './siteSchemas'
+// Side-effect import: registers Ambassador + AmbassadorGrid handlers
+import './ambassadorHandler'
+import { createRelationResolver } from './ambassadorHandler'
 
 /**
  * Minimal schema interface for frontmatter validation.
@@ -45,21 +48,45 @@ export interface ContentTypes {
   ambassadors: ContentTypeConfig
 }
 
+/** Build a page payload with the MDX block parser wired in. */
+function buildParsedPagePayload(
+  schema: FrontmatterSchema,
+  mdx: MDXFile,
+  strapi: StrapiClient,
+  existing: StrapiEntry | null
+) {
+  const locale = mdx.locale || 'en'
+  return buildPagePayload(schema, mdx, existing, {
+    locale,
+    resolveRelation: createRelationResolver(strapi, locale)
+  })
+}
+
 export function buildContentTypes(projectRoot: string): ContentTypes {
   return {
     'foundation-pages': {
       dir: getContentPath(projectRoot, 'foundationPages'),
       apiId: 'foundation-pages',
       schema: foundationPageFrontmatterSchema,
-      buildPayload: async (mdx, _strapi, existing) =>
-        buildPagePayload(foundationPageFrontmatterSchema, mdx, existing)
+      buildPayload: (mdx, strapi, existing) =>
+        buildParsedPagePayload(
+          foundationPageFrontmatterSchema,
+          mdx,
+          strapi,
+          existing
+        )
     },
     'summit-pages': {
       dir: getContentPath(projectRoot, 'summitPages'),
       apiId: 'summit-pages',
       schema: summitPageFrontmatterSchema,
-      buildPayload: async (mdx, _strapi, existing) =>
-        buildPagePayload(summitPageFrontmatterSchema, mdx, existing)
+      buildPayload: (mdx, strapi, existing) =>
+        buildParsedPagePayload(
+          summitPageFrontmatterSchema,
+          mdx,
+          strapi,
+          existing
+        )
     },
     'foundation-blog-posts': {
       dir: getContentPath(projectRoot, 'blog'),

--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -12,8 +12,9 @@ import {
   foundationPageFrontmatterSchema,
   summitPageFrontmatterSchema
 } from './siteSchemas'
-// Side-effect import: registers Ambassador + AmbassadorGrid handlers
+// Side-effect import: registers Ambassador + AmbassadorGrid + Paragraph handlers
 import './ambassadorHandler'
+import './paragraphHandler'
 import { createRelationResolver } from './ambassadorHandler'
 
 /**

--- a/cms/scripts/sync-mdx/jsxExtract.test.ts
+++ b/cms/scripts/sync-mdx/jsxExtract.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkMdx from 'remark-mdx'
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
+import type { Root } from 'mdast'
+
+import { getStringAttr, getBooleanAttr, getStringArrayAttr } from './jsxExtract'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+// ---------------------------------------------------------------------------
+// Helper: parse MDX snippet and extract the first JSX flow element
+// ---------------------------------------------------------------------------
+
+function parseJsx(mdx: string): MdxJsxFlowElement {
+  const tree = unified().use(remarkParse).use(remarkMdx).parse(mdx) as Root
+  const node = tree.children.find((n) => n.type === 'mdxJsxFlowElement')
+  if (!node) throw new Error('No JSX flow element found in snippet')
+  return node as MdxJsxFlowElement
+}
+
+// ---------------------------------------------------------------------------
+// getStringAttr
+// ---------------------------------------------------------------------------
+
+describe('getStringAttr', () => {
+  it('extracts a string literal attribute', () => {
+    const node = parseJsx('<Foo bar="hello" />')
+    expect(getStringAttr(node, 'bar')).toBe('hello')
+  })
+
+  it('returns undefined for missing optional attribute', () => {
+    const node = parseJsx('<Foo />')
+    expect(getStringAttr(node, 'bar')).toBeUndefined()
+  })
+
+  it('throws MISSING_REQUIRED_PROP for missing required attribute', () => {
+    const node = parseJsx('<Foo />')
+    expect(() => getStringAttr(node, 'bar', { required: true })).toThrow(
+      MdxParserError
+    )
+    expect(() => getStringAttr(node, 'bar', { required: true })).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.MISSING_REQUIRED_PROP,
+        prop: 'bar'
+      })
+    )
+  })
+
+  it('throws DYNAMIC_EXPRESSION for expression values', () => {
+    const node = parseJsx('<Foo bar={someVar} />')
+    expect(() => getStringAttr(node, 'bar')).toThrow(MdxParserError)
+    expect(() => getStringAttr(node, 'bar')).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION
+      })
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getBooleanAttr
+// ---------------------------------------------------------------------------
+
+describe('getBooleanAttr', () => {
+  it('returns true for valueless attribute (<Foo bar />)', () => {
+    const node = parseJsx('<Foo bar />')
+    expect(getBooleanAttr(node, 'bar')).toBe(true)
+  })
+
+  it('returns true for expression {true}', () => {
+    const node = parseJsx('<Foo bar={true} />')
+    expect(getBooleanAttr(node, 'bar')).toBe(true)
+  })
+
+  it('returns false for expression {false}', () => {
+    const node = parseJsx('<Foo bar={false} />')
+    expect(getBooleanAttr(node, 'bar')).toBe(false)
+  })
+
+  it('returns undefined for missing attribute', () => {
+    const node = parseJsx('<Foo />')
+    expect(getBooleanAttr(node, 'bar')).toBeUndefined()
+  })
+
+  it('throws DYNAMIC_EXPRESSION for non-boolean expression', () => {
+    const node = parseJsx('<Foo bar={someVar} />')
+    expect(() => getBooleanAttr(node, 'bar')).toThrow(MdxParserError)
+    expect(() => getBooleanAttr(node, 'bar')).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION
+      })
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getStringArrayAttr
+// ---------------------------------------------------------------------------
+
+describe('getStringArrayAttr', () => {
+  it('extracts a static string array', () => {
+    const node = parseJsx('<Foo items={["a","b","c"]} />')
+    expect(getStringArrayAttr(node, 'items')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns undefined for missing optional attribute', () => {
+    const node = parseJsx('<Foo />')
+    expect(getStringArrayAttr(node, 'items')).toBeUndefined()
+  })
+
+  it('throws MISSING_REQUIRED_PROP for missing required attribute', () => {
+    const node = parseJsx('<Foo />')
+    expect(() => getStringArrayAttr(node, 'items', { required: true })).toThrow(
+      MdxParserError
+    )
+    expect(() => getStringArrayAttr(node, 'items', { required: true })).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.MISSING_REQUIRED_PROP
+      })
+    )
+  })
+
+  it('throws INVALID_PROP_VALUE for plain string attribute', () => {
+    const node = parseJsx('<Foo items="not-an-array" />')
+    expect(() => getStringArrayAttr(node, 'items')).toThrow(MdxParserError)
+    expect(() => getStringArrayAttr(node, 'items')).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.INVALID_PROP_VALUE
+      })
+    )
+  })
+
+  it('throws DYNAMIC_EXPRESSION for non-static expression', () => {
+    const node = parseJsx('<Foo items={someVar} />')
+    expect(() => getStringArrayAttr(node, 'items')).toThrow(MdxParserError)
+    expect(() => getStringArrayAttr(node, 'items')).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION
+      })
+    )
+  })
+})

--- a/cms/scripts/sync-mdx/jsxExtract.test.ts
+++ b/cms/scripts/sync-mdx/jsxExtract.test.ts
@@ -99,8 +99,13 @@ describe('getBooleanAttr', () => {
 // ---------------------------------------------------------------------------
 
 describe('getStringArrayAttr', () => {
-  it('extracts a static string array', () => {
+  it('extracts a static string array with double quotes', () => {
     const node = parseJsx('<Foo items={["a","b","c"]} />')
+    expect(getStringArrayAttr(node, 'items')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('extracts a static string array with single quotes', () => {
+    const node = parseJsx("<Foo items={['a','b','c']} />")
     expect(getStringArrayAttr(node, 'items')).toEqual(['a', 'b', 'c'])
   })
 

--- a/cms/scripts/sync-mdx/jsxExtract.test.ts
+++ b/cms/scripts/sync-mdx/jsxExtract.test.ts
@@ -104,9 +104,19 @@ describe('getStringArrayAttr', () => {
     expect(getStringArrayAttr(node, 'items')).toEqual(['a', 'b', 'c'])
   })
 
-  it('extracts a static string array with single quotes', () => {
-    const node = parseJsx("<Foo items={['a','b','c']} />")
-    expect(getStringArrayAttr(node, 'items')).toEqual(['a', 'b', 'c'])
+  it('extracts array with apostrophes in slugs (double-quoted, no escaping needed)', () => {
+    const node = parseJsx('<Foo items={["it\'s-a-slug","other"]} />')
+    expect(getStringArrayAttr(node, 'items')).toEqual(["it's-a-slug", 'other'])
+  })
+
+  it('throws DYNAMIC_EXPRESSION for single-quoted array (not supported)', () => {
+    const node = parseJsx("<Foo items={['a','b']} />")
+    expect(() => getStringArrayAttr(node, 'items')).toThrow(MdxParserError)
+    expect(() => getStringArrayAttr(node, 'items')).toThrow(
+      expect.objectContaining({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION
+      })
+    )
   })
 
   it('returns undefined for missing optional attribute', () => {

--- a/cms/scripts/sync-mdx/jsxExtract.ts
+++ b/cms/scripts/sync-mdx/jsxExtract.ts
@@ -234,33 +234,28 @@ export function getStringArrayAttr(
 
   const raw = attr.value.value.trim()
 
-  // Try JSON parse – handles ["a", "b", "c"]
-  try {
-    const parsed: unknown = JSON.parse(raw)
-    if (
-      Array.isArray(parsed) &&
-      parsed.every((item) => typeof item === 'string')
-    ) {
-      return parsed as string[]
+  // Try JSON parse first (double-quoted strings), then normalize
+  // single quotes to double quotes for JS-style arrays like ['a','b'].
+  for (const candidate of [raw, raw.replace(/'/g, '"')]) {
+    try {
+      const parsed: unknown = JSON.parse(candidate)
+      if (
+        Array.isArray(parsed) &&
+        parsed.every((item) => typeof item === 'string')
+      ) {
+        return parsed as string[]
+      }
+    } catch {
+      // Try next candidate
     }
-    throw new MdxParserError({
-      code: ParserErrorCode.INVALID_PROP_VALUE,
-      message: `Prop "${name}" must be an array of strings, got ${typeof parsed}.`,
-      component: node.name ?? undefined,
-      prop: name,
-      line: node.position?.start.line,
-      column: node.position?.start.column
-    })
-  } catch (err) {
-    if (err instanceof MdxParserError) throw err
-
-    throw new MdxParserError({
-      code: ParserErrorCode.DYNAMIC_EXPRESSION,
-      message: `Prop "${name}" contains a dynamic expression that cannot be statically evaluated.`,
-      component: node.name ?? undefined,
-      prop: name,
-      line: node.position?.start.line,
-      column: node.position?.start.column
-    })
   }
+
+  throw new MdxParserError({
+    code: ParserErrorCode.DYNAMIC_EXPRESSION,
+    message: `Prop "${name}" contains a dynamic expression that cannot be statically evaluated.`,
+    component: node.name ?? undefined,
+    prop: name,
+    line: node.position?.start.line,
+    column: node.position?.start.column
+  })
 }

--- a/cms/scripts/sync-mdx/jsxExtract.ts
+++ b/cms/scripts/sync-mdx/jsxExtract.ts
@@ -1,0 +1,266 @@
+/**
+ * JSX attribute extraction utilities for MDX AST nodes.
+ *
+ * Provides safe, typed accessors for reading props from
+ * `mdast-util-mdx-jsx` JSX element nodes. All accessors
+ * throw `MdxParserError` on unexpected shapes so callers
+ * get strict, actionable failures.
+ */
+
+import type { MdxJsxFlowElement, MdxJsxAttribute } from 'mdast-util-mdx-jsx'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find a JSX attribute by name on an MDX JSX element.
+ * Returns `undefined` when the attribute is absent.
+ */
+function findAttr(
+  node: MdxJsxFlowElement,
+  name: string
+): MdxJsxAttribute | undefined {
+  return node.attributes.find(
+    (attr): attr is MdxJsxAttribute =>
+      attr.type === 'mdxJsxAttribute' && attr.name === name
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a string attribute value.
+ *
+ * @example
+ * ```ts
+ * // <Ambassador slug="caroline-sinders" />
+ * getStringAttr(node, 'slug')                        // → "caroline-sinders"
+ * getStringAttr(node, 'bio')                          // → undefined
+ * getStringAttr(node, 'slug', { required: true })     // → "caroline-sinders"
+ * getStringAttr(node, 'bio', { required: true })      // → throws MISSING_REQUIRED_PROP
+ * // <Ambassador slug={dynamicVar} />
+ * getStringAttr(node, 'slug')                         // → throws DYNAMIC_EXPRESSION
+ * ```
+ *
+ * @param node - JSX AST node
+ * @param name - Attribute name
+ * @param opts.required - When true, throws if the attribute is missing
+ * @returns The string value, or `undefined` if absent and not required
+ */
+export function getStringAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts: { required: true }
+): string
+export function getStringAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts?: { required?: false }
+): string | undefined
+export function getStringAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts: { required?: boolean } = {}
+): string | undefined {
+  const attr = findAttr(node, name)
+
+  if (!attr) {
+    if (opts.required) {
+      throw new MdxParserError({
+        code: ParserErrorCode.MISSING_REQUIRED_PROP,
+        message: `Required prop "${name}" is missing.`,
+        component: node.name ?? undefined,
+        prop: name,
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
+    return undefined
+  }
+
+  // String literal: <Foo bar="baz" />
+  if (typeof attr.value === 'string') {
+    return attr.value
+  }
+
+  // Expression container: <Foo bar={"baz"} /> or <Foo bar={`baz`} />
+  if (
+    attr.value &&
+    typeof attr.value === 'object' &&
+    attr.value.type === 'mdxJsxAttributeValueExpression'
+  ) {
+    throw new MdxParserError({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION,
+      message: `Prop "${name}" must be a static string, not an expression.`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+
+  if (opts.required) {
+    throw new MdxParserError({
+      code: ParserErrorCode.INVALID_PROP_VALUE,
+      message: `Prop "${name}" has an unexpected value shape.`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+
+  return undefined
+}
+
+/**
+ * Extract a boolean attribute value.
+ *
+ * @example
+ * ```ts
+ * // <Ambassador showLinks />           → true  (valueless)
+ * // <Ambassador showLinks={true} />    → true
+ * // <Ambassador showLinks={false} />   → false
+ * // <Ambassador />                     → undefined (absent)
+ * // <Ambassador showLinks={someVar} /> → throws DYNAMIC_EXPRESSION
+ * getBooleanAttr(node, 'showLinks')
+ * ```
+ *
+ * @returns The boolean value, or `undefined` if absent
+ */
+export function getBooleanAttr(
+  node: MdxJsxFlowElement,
+  name: string
+): boolean | undefined {
+  const attr = findAttr(node, name)
+  if (!attr) return undefined
+
+  // Valueless: <Foo showLinks /> → true
+  if (attr.value === null || attr.value === undefined) {
+    return true
+  }
+
+  // String "true" / "false" (rare but valid in some MDX)
+  if (attr.value === 'true') return true
+  if (attr.value === 'false') return false
+
+  // Expression: <Foo bar={true} /> or <Foo bar={false} />
+  if (
+    typeof attr.value === 'object' &&
+    attr.value.type === 'mdxJsxAttributeValueExpression'
+  ) {
+    const raw = attr.value.value.trim()
+    if (raw === 'true') return true
+    if (raw === 'false') return false
+
+    throw new MdxParserError({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION,
+      message: `Prop "${name}" must be a static boolean (true/false), got "${raw}".`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+
+  return undefined
+}
+
+/**
+ * Extract a string-array attribute from a JSX expression.
+ *
+ * Only static JSON arrays are supported. Dynamic expressions throw.
+ *
+ * @example
+ * ```ts
+ * // <AmbassadorGrid slugs={["caroline-sinders","alex-smith"]} />
+ * getStringArrayAttr(node, 'slugs')  // → ["caroline-sinders", "alex-smith"]
+ * // <AmbassadorGrid slugs={myArray} />
+ * getStringArrayAttr(node, 'slugs')  // → throws DYNAMIC_EXPRESSION
+ * ```
+ *
+ * @returns The string array, or `undefined` if absent
+ */
+export function getStringArrayAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts: { required: true }
+): string[]
+export function getStringArrayAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts?: { required?: false }
+): string[] | undefined
+export function getStringArrayAttr(
+  node: MdxJsxFlowElement,
+  name: string,
+  opts: { required?: boolean } = {}
+): string[] | undefined {
+  const attr = findAttr(node, name)
+
+  if (!attr) {
+    if (opts.required) {
+      throw new MdxParserError({
+        code: ParserErrorCode.MISSING_REQUIRED_PROP,
+        message: `Required prop "${name}" is missing.`,
+        component: node.name ?? undefined,
+        prop: name,
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
+    return undefined
+  }
+
+  // Must be an expression: slugs={["a","b"]}
+  if (
+    !attr.value ||
+    typeof attr.value !== 'object' ||
+    attr.value.type !== 'mdxJsxAttributeValueExpression'
+  ) {
+    throw new MdxParserError({
+      code: ParserErrorCode.INVALID_PROP_VALUE,
+      message: `Prop "${name}" must be a JSX expression array (e.g. {["a","b"]}).`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+
+  const raw = attr.value.value.trim()
+
+  // Try JSON parse – handles ["a", "b", "c"]
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((item) => typeof item === 'string')
+    ) {
+      return parsed as string[]
+    }
+    throw new MdxParserError({
+      code: ParserErrorCode.INVALID_PROP_VALUE,
+      message: `Prop "${name}" must be an array of strings, got ${typeof parsed}.`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  } catch (err) {
+    if (err instanceof MdxParserError) throw err
+
+    throw new MdxParserError({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION,
+      message: `Prop "${name}" contains a dynamic expression that cannot be statically evaluated.`,
+      component: node.name ?? undefined,
+      prop: name,
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+}

--- a/cms/scripts/sync-mdx/jsxExtract.ts
+++ b/cms/scripts/sync-mdx/jsxExtract.ts
@@ -234,25 +234,21 @@ export function getStringArrayAttr(
 
   const raw = attr.value.value.trim()
 
-  // Try JSON parse first (double-quoted strings), then normalize
-  // single quotes to double quotes for JS-style arrays like ['a','b'].
-  for (const candidate of [raw, raw.replace(/'/g, '"')]) {
-    try {
-      const parsed: unknown = JSON.parse(candidate)
-      if (
-        Array.isArray(parsed) &&
-        parsed.every((item) => typeof item === 'string')
-      ) {
-        return parsed as string[]
-      }
-    } catch {
-      // Try next candidate
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((item) => typeof item === 'string')
+    ) {
+      return parsed as string[]
     }
+  } catch {
+    // JSON.parse failed — may be single-quoted array or dynamic expression
   }
 
   throw new MdxParserError({
     code: ParserErrorCode.DYNAMIC_EXPRESSION,
-    message: `Prop "${name}" contains a dynamic expression that cannot be statically evaluated.`,
+    message: `Prop "${name}" must be a JSON array with double-quoted strings (e.g. {["a","b"]}). Single-quoted arrays are not supported.`,
     component: node.name ?? undefined,
     prop: name,
     line: node.position?.start.line,

--- a/cms/scripts/sync-mdx/mdxBlockParser.test.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.test.ts
@@ -93,6 +93,31 @@ describe('parseMdxToBlocks', () => {
       code: ParserErrorCode.UNSUPPORTED_COMPONENT
     })
   })
+
+  // --- Markdown node fallback ---
+
+  it('converts markdown nodes to paragraph blocks', async () => {
+    const blocks = await parseMdxToBlocks('## Hello\n\nSome text here.', ctx)
+
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0]).toEqual({
+      __component: 'blocks.paragraph',
+      content: '## Hello'
+    })
+    expect(blocks[1]).toEqual({
+      __component: 'blocks.paragraph',
+      content: 'Some text here.'
+    })
+  })
+
+  it('skips whitespace-only markdown nodes', async () => {
+    // A thematic break (---) produces a node with no textual content,
+    // but it still has non-whitespace source so it should be kept
+    const blocks = await parseMdxToBlocks('Hello\n\n---\n\nWorld', ctx)
+
+    expect(blocks.length).toBeGreaterThanOrEqual(2)
+    expect(blocks.every((b) => b.__component === 'blocks.paragraph')).toBe(true)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/cms/scripts/sync-mdx/mdxBlockParser.test.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import './paragraphHandler'
 import { parseMdxToBlocks, getRegisteredComponents } from './mdxBlockParser'
 import { MdxParserError, ParserErrorCode } from './parserErrors'
 
@@ -117,6 +118,66 @@ describe('parseMdxToBlocks', () => {
 
     expect(blocks.length).toBeGreaterThanOrEqual(2)
     expect(blocks.every((b) => b.__component === 'blocks.paragraph')).toBe(true)
+  })
+
+  it('parses <Paragraph> with children to blocks.paragraph', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<Paragraph>\n\n## Hello\n\nSome text here.\n\n</Paragraph>',
+      ctx
+    )
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toEqual({
+      __component: 'blocks.paragraph',
+      content: '## Hello\n\nSome text here.'
+    })
+  })
+
+  it('parses <Paragraph content="..." /> to blocks.paragraph', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<Paragraph content="Inline content" />',
+      ctx
+    )
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toEqual({
+      __component: 'blocks.paragraph',
+      content: 'Inline content'
+    })
+  })
+
+  it('parses <Paragraph alignment="center"> to blocks.paragraph with alignment', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<Paragraph alignment="center">\n\nCentered text.\n\n</Paragraph>',
+      ctx
+    )
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toEqual({
+      __component: 'blocks.paragraph',
+      content: 'Centered text.',
+      alignment: 'center'
+    })
+  })
+
+  it('throws INVALID_PROP_VALUE for empty <Paragraph></Paragraph>', async () => {
+    await expect(
+      parseMdxToBlocks('<Paragraph></Paragraph>', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.INVALID_PROP_VALUE,
+      component: 'Paragraph',
+      prop: 'content'
+    })
+  })
+
+  it('throws INVALID_PROP_VALUE for <Paragraph content="" />', async () => {
+    await expect(
+      parseMdxToBlocks('<Paragraph content="" />', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.INVALID_PROP_VALUE,
+      component: 'Paragraph',
+      prop: 'content'
+    })
   })
 })
 

--- a/cms/scripts/sync-mdx/mdxBlockParser.test.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { parseMdxToBlocks, getRegisteredComponents } from './mdxBlockParser'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+// ---------------------------------------------------------------------------
+// parseMdxToBlocks
+// ---------------------------------------------------------------------------
+
+describe('parseMdxToBlocks', () => {
+  const ctx = { locale: 'en' }
+
+  it('returns empty array for empty body', async () => {
+    expect(await parseMdxToBlocks('', ctx)).toEqual([])
+  })
+
+  it('returns empty array for whitespace-only body', async () => {
+    expect(await parseMdxToBlocks('   \n\n  ', ctx)).toEqual([])
+  })
+
+  it('throws MdxParserError for malformed MDX', async () => {
+    // Unclosed JSX tag that remark-mdx cannot parse
+    await expect(parseMdxToBlocks('<Broken attr={>', ctx)).rejects.toThrow(
+      MdxParserError
+    )
+
+    await expect(
+      parseMdxToBlocks('<Broken attr={>', ctx)
+    ).rejects.toMatchObject({ code: ParserErrorCode.MDX_PARSE_ERROR })
+  })
+
+  it('throws UNSUPPORTED_COMPONENT for unregistered JSX', async () => {
+    await expect(
+      parseMdxToBlocks('<UnknownWidget foo="bar" />', ctx)
+    ).rejects.toThrow(MdxParserError)
+
+    await expect(
+      parseMdxToBlocks('<UnknownWidget foo="bar" />', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.UNSUPPORTED_COMPONENT,
+      component: 'UnknownWidget'
+    })
+  })
+
+  it('throws DYNAMIC_EXPRESSION for bare top-level expressions', async () => {
+    // {someVariable} becomes mdxFlowExpression in the AST
+    await expect(parseMdxToBlocks('{someVariable}', ctx)).rejects.toThrow(
+      MdxParserError
+    )
+
+    await expect(parseMdxToBlocks('{someVariable}', ctx)).rejects.toMatchObject(
+      {
+        code: ParserErrorCode.DYNAMIC_EXPRESSION
+      }
+    )
+  })
+
+  it('throws DYNAMIC_EXPRESSION for arrow function expressions', async () => {
+    await expect(
+      parseMdxToBlocks('{() => doSomething()}', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION
+    })
+  })
+
+  it('throws DYNAMIC_EXPRESSION for import statements', async () => {
+    await expect(
+      parseMdxToBlocks('import { foo } from "bar"', ctx)
+    ).rejects.toThrow(MdxParserError)
+
+    await expect(
+      parseMdxToBlocks('import { foo } from "bar"', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION
+    })
+  })
+
+  it('throws DYNAMIC_EXPRESSION for export statements', async () => {
+    await expect(
+      parseMdxToBlocks('export const x = 1', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.DYNAMIC_EXPRESSION
+    })
+  })
+
+  it('throws UNSUPPORTED_COMPONENT for JSX fragments', async () => {
+    await expect(parseMdxToBlocks('<>\n  content\n</>', ctx)).rejects.toThrow(
+      MdxParserError
+    )
+
+    await expect(
+      parseMdxToBlocks('<>\n  content\n</>', ctx)
+    ).rejects.toMatchObject({
+      code: ParserErrorCode.UNSUPPORTED_COMPONENT
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getRegisteredComponents
+// ---------------------------------------------------------------------------
+
+describe('getRegisteredComponents', () => {
+  it('returns an array', () => {
+    const names = getRegisteredComponents()
+    expect(Array.isArray(names)).toBe(true)
+  })
+})

--- a/cms/scripts/sync-mdx/mdxBlockParser.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.ts
@@ -1,0 +1,199 @@
+/**
+ * MDX Block Parser
+ *
+ * Parses MDX body content into an ordered array of Strapi dynamic-zone
+ * block payloads using remark + remark-mdx AST walking.
+ *
+ * Entry point: `parseMdxToBlocks()`
+ *
+ * Design:
+ * - AST-first: parse once, walk once, map each node to a block handler.
+ * - Strict: unsupported JSX, dynamic expressions, and missing required
+ *   props produce hard errors via `MdxParserError`.
+ * - Extensible: component handlers are registered in `COMPONENT_HANDLERS`
+ *   and new components only need a handler function + type entry.
+ */
+
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkMdx from 'remark-mdx'
+import type { Root } from 'mdast'
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
+
+import type { ParsedBlock } from './types.blocks'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for a single JSX component.
+ *
+ * Receives the AST node and an opaque context (for relation resolution
+ * etc.) and returns one or more block payloads.
+ *
+ * Handlers are async to support relation lookups (e.g. ambassador slug
+ * resolution).
+ */
+export type ComponentHandler = (
+  node: MdxJsxFlowElement,
+  ctx: ParserContext
+) => Promise<ParsedBlock[]>
+
+/**
+ * Context passed to component handlers during parsing.
+ *
+ * Contains the services handlers may need (e.g. relation resolver).
+ */
+export interface ParserContext {
+  /** Locale of the MDX file being parsed. */
+  locale: string
+}
+
+// ---------------------------------------------------------------------------
+// Handler registry
+// ---------------------------------------------------------------------------
+
+/** Map of JSX component name → handler function. */
+const COMPONENT_HANDLERS: Record<string, ComponentHandler> = {}
+
+// ---------------------------------------------------------------------------
+// Core parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an MDX body string into an ordered array of Strapi dynamic-zone
+ * block payloads.
+ *
+ * @example
+ * ```ts
+ * // Given MDX body:
+ * //   <Ambassador slug="caroline-sinders" showLinks={false} />
+ * //   <AmbassadorGrid heading="Our Team" slugs={["alice","bob"]} />
+ * //
+ * // Returns (once handlers are registered):
+ * // [
+ * //   { __component: 'blocks.ambassador', ambassador: { documentId: '...' }, showLinks: false },
+ * //   { __component: 'blocks.ambassadors-grid', heading: 'Our Team', ambassadors: [...] }
+ * // ]
+ *
+ * const blocks = await parseMdxToBlocks(mdxBody, { locale: 'en' })
+ * ```
+ *
+ * @param mdxBody - Raw MDX body content (no frontmatter)
+ * @param ctx - Parser context (locale, services, etc.)
+ * @returns Ordered array of block payloads ready for Strapi import
+ *
+ * @throws {MdxParserError} on unsupported JSX, bad props, parse errors
+ */
+export async function parseMdxToBlocks(
+  mdxBody: string,
+  ctx: ParserContext
+): Promise<ParsedBlock[]> {
+  if (!mdxBody.trim()) return []
+
+  // Parse MDX into AST.
+  // unified() creates the processing pipeline that remark plugins attach to.
+  // remarkParse adds markdown parsing, remarkMdx extends it with JSX syntax
+  // support (<Component />, {expressions}). The .parse() call produces the
+  // AST without running any transforms.
+  let tree: Root
+  try {
+    tree = unified().use(remarkParse).use(remarkMdx).parse(mdxBody)
+  } catch (err) {
+    throw new MdxParserError({
+      code: ParserErrorCode.MDX_PARSE_ERROR,
+      message: `Failed to parse MDX: ${err instanceof Error ? err.message : String(err)}`
+    })
+  }
+
+  const blocks: ParsedBlock[] = []
+
+  // Walk top-level AST nodes
+  for (const node of tree.children) {
+    if (node.type === 'mdxJsxFlowElement') {
+      const jsxNode = node as MdxJsxFlowElement
+      const componentName = jsxNode.name
+
+      if (!componentName) {
+        throw new MdxParserError({
+          code: ParserErrorCode.UNSUPPORTED_COMPONENT,
+          message:
+            'Encountered a JSX fragment (<>...</>). Fragments are not supported.',
+          line: jsxNode.position?.start.line,
+          column: jsxNode.position?.start.column
+        })
+      }
+
+      const handler = COMPONENT_HANDLERS[componentName]
+      if (!handler) {
+        throw new MdxParserError({
+          code: ParserErrorCode.UNSUPPORTED_COMPONENT,
+          message: `Unsupported JSX component "${componentName}".`,
+          component: componentName,
+          line: jsxNode.position?.start.line,
+          column: jsxNode.position?.start.column
+        })
+      }
+
+      const result = await handler(jsxNode, ctx)
+      blocks.push(...result)
+    }
+    // Bare expressions like {someVar} or {() => fn()} are not allowed.
+    if (
+      node.type === 'mdxFlowExpression' ||
+      node.type === 'mdxTextExpression'
+    ) {
+      const expr = node as { value?: string; position?: Root['position'] }
+      throw new MdxParserError({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION,
+        message: `Top-level expression "{${expr.value ?? '...'}}" is not supported.`,
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
+
+    // ESM import/export statements are not allowed — MDX content in this
+    // pipeline is converted to Strapi blocks, not executed as JS modules.
+    if (node.type === 'mdxjsEsm') {
+      const esm = node as { value?: string; position?: Root['position'] }
+      throw new MdxParserError({
+        code: ParserErrorCode.DYNAMIC_EXPRESSION,
+        message: `Import/export statements are not supported: "${esm.value ?? '...'}"`,
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
+
+    // Markdown nodes (paragraph, heading, etc.) are handled by the
+    // Paragraph handler once registered. Until then, they pass through
+    // unmatched — the caller (buildPagePayload) only invokes the parser
+    // when JSX components are present in the body.
+  }
+
+  return blocks
+}
+
+// ---------------------------------------------------------------------------
+// Handler registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a component handler. Called by individual handler modules
+ * during their initialization.
+ */
+export function registerComponentHandler(
+  name: string,
+  handler: ComponentHandler
+): void {
+  COMPONENT_HANDLERS[name] = handler
+}
+
+/**
+ * Get a read-only snapshot of registered handler names.
+ * Useful for testing and diagnostics.
+ */
+export function getRegisteredComponents(): string[] {
+  return Object.keys(COMPONENT_HANDLERS)
+}

--- a/cms/scripts/sync-mdx/mdxBlockParser.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.ts
@@ -66,7 +66,17 @@ export interface ParserContext {
 // Handler registry
 // ---------------------------------------------------------------------------
 
-/** Map of JSX component name → handler function. */
+/**
+ * Singleton handler registry: JSX component name → handler function.
+ *
+ * This is a module-level object — Node's module cache guarantees only one
+ * instance exists per process. Handler modules (e.g. ambassadorHandler.ts)
+ * call `registerComponentHandler()` at the top level, so importing the
+ * module is enough to populate this map (side-effect registration).
+ *
+ * The pipeline triggers registration via bare imports in config.ts:
+ *   import './ambassadorHandler'  // populates COMPONENT_HANDLERS['Ambassador']
+ */
 const COMPONENT_HANDLERS: Record<string, ComponentHandler> = {}
 
 // ---------------------------------------------------------------------------
@@ -206,8 +216,11 @@ export async function parseMdxToBlocks(
 // ---------------------------------------------------------------------------
 
 /**
- * Register a component handler. Called by individual handler modules
- * during their initialization.
+ * Register a component handler into the singleton registry.
+ *
+ * Called at the top level of handler modules so that importing the module
+ * is enough to make the handler available to `parseMdxToBlocks()`.
+ * Node's module cache ensures each handler is registered exactly once.
  */
 export function registerComponentHandler(
   name: string,

--- a/cms/scripts/sync-mdx/mdxBlockParser.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.ts
@@ -49,6 +49,17 @@ export type ComponentHandler = (
 export interface ParserContext {
   /** Locale of the MDX file being parsed. */
   locale: string
+  /**
+   * Resolve a relation slug to a Strapi document ID.
+   * Provided by the caller for handlers that reference other content types.
+   *
+   * @param apiId - Strapi API identifier (e.g. 'ambassadors')
+   * @param slug  - Content slug to look up
+   */
+  resolveRelation?: (
+    apiId: string,
+    slug: string
+  ) => Promise<{ documentId: string }>
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +150,9 @@ export async function parseMdxToBlocks(
 
       const result = await handler(jsxNode, ctx)
       blocks.push(...result)
+      // Skip to next node — don't let handled JSX fall through to
+      // the markdown fallback which would double-emit the source text.
+      continue
     }
     // Bare expressions like {someVar} or {() => fn()} are not allowed.
     if (
@@ -166,10 +180,22 @@ export async function parseMdxToBlocks(
       })
     }
 
-    // Markdown nodes (paragraph, heading, etc.) are handled by the
-    // Paragraph handler once registered. Until then, they pass through
-    // unmatched — the caller (buildPagePayload) only invokes the parser
-    // when JSX components are present in the body.
+    // Markdown nodes (paragraph, heading, thematic break, etc.) —
+    // extract source text and wrap as a paragraph block. Will be
+    // replaced by a dedicated Paragraph component handler.
+    if (
+      node.position &&
+      node.position.start.offset != null &&
+      node.position.end.offset != null
+    ) {
+      const raw = mdxBody.slice(
+        node.position.start.offset,
+        node.position.end.offset
+      )
+      if (raw.trim()) {
+        blocks.push({ __component: 'blocks.paragraph' as const, content: raw })
+      }
+    }
   }
 
   return blocks

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -97,25 +97,25 @@ describe('getEntryField', () => {
 // Handles validation, hero section logic, and content block creation.
 describe('buildPagePayload', () => {
   describe('error handling', () => {
-    it('throws when frontmatter fails validation', () => {
+    it('throws when frontmatter fails validation', async () => {
       const mdx = createMdxFile({
         slug: 'test'
       })
 
-      expect(() =>
+      await expect(
         buildPagePayload(foundationPageFrontmatterSchema, mdx, null)
-      ).toThrow()
+      ).rejects.toThrow()
     })
   })
 
   describe('base payload fields', () => {
-    it('includes title from frontmatter', () => {
+    it('includes title from frontmatter', async () => {
       const mdx = createMdxFile({
         slug: 'about',
         frontmatter: { title: 'About Us' }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -124,13 +124,13 @@ describe('buildPagePayload', () => {
       expect(payload.title).toBe('About Us')
     })
 
-    it('includes slug from mdx file', () => {
+    it('includes slug from mdx file', async () => {
       const mdx = createMdxFile({
         slug: 'about-page',
         frontmatter: { title: 'About' }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -139,13 +139,13 @@ describe('buildPagePayload', () => {
       expect(payload.slug).toBe('about-page')
     })
 
-    it('includes publishedAt timestamp', () => {
+    it('includes publishedAt timestamp', async () => {
       const mdx = createMdxFile({
         slug: 'test',
         frontmatter: { title: 'Test' }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -155,7 +155,7 @@ describe('buildPagePayload', () => {
       expect(typeof payload.publishedAt).toBe('string')
     })
 
-    it('accepts optional schema fields (description, heroImage, sections)', () => {
+    it('accepts optional schema fields (description, heroImage, sections)', async () => {
       const mdx = createMdxFile({
         slug: 'about',
         frontmatter: {
@@ -173,7 +173,7 @@ describe('buildPagePayload', () => {
         }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -187,7 +187,7 @@ describe('buildPagePayload', () => {
   // Hero section can come from MDX frontmatter OR be preserved from existing Strapi entry.
   // This lets us update title/content without losing hero images set in Strapi admin.
   describe('hero fallback logic', () => {
-    it('uses frontmatter heroTitle and heroDescription when provided', () => {
+    it('uses frontmatter heroTitle and heroDescription when provided', async () => {
       const mdx = createMdxFile({
         slug: 'about',
         frontmatter: {
@@ -197,7 +197,7 @@ describe('buildPagePayload', () => {
         }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -210,7 +210,7 @@ describe('buildPagePayload', () => {
     })
 
     // If only description is provided, use the page title as hero title
-    it('uses title as hero title when heroTitle not provided but heroDescription is', () => {
+    it('uses title as hero title when heroTitle not provided but heroDescription is', async () => {
       const mdx = createMdxFile({
         slug: 'about',
         frontmatter: {
@@ -219,7 +219,7 @@ describe('buildPagePayload', () => {
         }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -231,7 +231,7 @@ describe('buildPagePayload', () => {
       })
     })
 
-    it('uses empty description when heroTitle provided but heroDescription is not', () => {
+    it('uses empty description when heroTitle provided but heroDescription is not', async () => {
       const mdx = createMdxFile({
         slug: 'about',
         frontmatter: {
@@ -240,7 +240,7 @@ describe('buildPagePayload', () => {
         }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -254,7 +254,7 @@ describe('buildPagePayload', () => {
 
     // Key feature: if MDX doesn't have hero fields, keep whatever's in Strapi.
     // This preserves hero images uploaded via Strapi admin UI.
-    it('preserves existing hero when no hero fields in frontmatter', () => {
+    it('preserves existing hero when no hero fields in frontmatter', async () => {
       const existingEntry: StrapiEntry = {
         documentId: '1',
         slug: 'about',
@@ -265,7 +265,7 @@ describe('buildPagePayload', () => {
         frontmatter: { title: 'About' }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         existingEntry
@@ -278,13 +278,13 @@ describe('buildPagePayload', () => {
     })
 
     // No hero in MDX + no existing entry = no hero in payload
-    it('does not include hero when no frontmatter hero and no existing entry', () => {
+    it('does not include hero when no frontmatter hero and no existing entry', async () => {
       const mdx = createMdxFile({
         slug: 'about',
         frontmatter: { title: 'About' }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -294,7 +294,7 @@ describe('buildPagePayload', () => {
     })
 
     // MDX hero fields take precedence over Strapi — intentional override
-    it('overrides existing hero when frontmatter has hero fields', () => {
+    it('overrides existing hero when frontmatter has hero fields', async () => {
       const existingEntry: StrapiEntry = {
         documentId: '1',
         slug: 'about',
@@ -309,7 +309,7 @@ describe('buildPagePayload', () => {
         }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         existingEntry
@@ -324,14 +324,14 @@ describe('buildPagePayload', () => {
 
   // Content is stored as a paragraph block component. Empty content preserves existing.
   describe('content block handling', () => {
-    it('creates content block with markdown when mdx has body', () => {
+    it('creates content block with markdown when mdx has body', async () => {
       const mdx = createMdxFile({
         slug: 'about',
         frontmatter: { title: 'About' },
         content: '## Heading\n\nParagraph text'
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -346,7 +346,7 @@ describe('buildPagePayload', () => {
     })
 
     // Same fallback logic as hero — empty MDX body preserves Strapi content
-    it('preserves existing content when mdx body is empty', () => {
+    it('preserves existing content when mdx body is empty', async () => {
       const existingEntry: StrapiEntry = {
         documentId: '1',
         slug: 'about',
@@ -357,7 +357,7 @@ describe('buildPagePayload', () => {
         frontmatter: { title: 'About' }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         existingEntry
@@ -369,7 +369,7 @@ describe('buildPagePayload', () => {
     })
 
     // Whitespace-only should be treated as empty
-    it('preserves existing content when mdx body is whitespace only', () => {
+    it('preserves existing content when mdx body is whitespace only', async () => {
       const existingEntry: StrapiEntry = {
         documentId: '1',
         slug: 'about',
@@ -381,7 +381,7 @@ describe('buildPagePayload', () => {
         content: '   \n\n   '
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         existingEntry
@@ -392,13 +392,13 @@ describe('buildPagePayload', () => {
       ])
     })
 
-    it('does not include content when no mdx body and no existing entry', () => {
+    it('does not include content when no mdx body and no existing entry', async () => {
       const mdx = createMdxFile({
         slug: 'about',
         frontmatter: { title: 'About' }
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -407,7 +407,7 @@ describe('buildPagePayload', () => {
       expect(payload.content).toBeUndefined()
     })
 
-    it('overrides existing content when mdx has body', () => {
+    it('overrides existing content when mdx has body', async () => {
       const existingEntry: StrapiEntry = {
         documentId: '1',
         slug: 'about',
@@ -419,7 +419,7 @@ describe('buildPagePayload', () => {
         content: 'New content'
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         existingEntry
@@ -430,14 +430,14 @@ describe('buildPagePayload', () => {
       ])
     })
 
-    it('handles content with null existing entry', () => {
+    it('handles content with null existing entry', async () => {
       const mdx = createMdxFile({
         slug: 'about',
         frontmatter: { title: 'About' },
         content: undefined
       })
 
-      const payload = buildPagePayload(
+      const payload = await buildPagePayload(
         foundationPageFrontmatterSchema,
         mdx,
         null
@@ -448,20 +448,80 @@ describe('buildPagePayload', () => {
   })
 
   describe('summit-pages content type', () => {
-    it('processes summit-pages same as foundation-pages', () => {
+    it('processes summit-pages same as foundation-pages', async () => {
       const mdx = createMdxFile({
         slug: 'schedule',
         frontmatter: { title: 'Schedule' },
         content: 'Summit content'
       })
 
-      const payload = buildPagePayload(summitPageFrontmatterSchema, mdx, null)
+      const payload = await buildPagePayload(
+        summitPageFrontmatterSchema,
+        mdx,
+        null
+      )
 
       expect(payload.title).toBe('Schedule')
       expect(payload.slug).toBe('schedule')
       expect(payload.content).toEqual([
         { __component: 'blocks.paragraph', content: 'Summit content' }
       ])
+    })
+  })
+
+  // Parser integration: when parserCtx is provided, MDX body is parsed into
+  // structured blocks instead of a single paragraph.
+  describe('parser integration', () => {
+    it('parses JSX into structured blocks when parserCtx is provided', async () => {
+      // Import handler side-effects to register Ambassador
+      await import('./ambassadorHandler')
+
+      const parserCtx = {
+        locale: 'en',
+        resolveRelation: async (_apiId: string, slug: string) => ({
+          documentId: `doc-${slug}`
+        })
+      }
+
+      const mdx = createMdxFile({
+        slug: 'ambassadors-page',
+        frontmatter: { title: 'Ambassadors' },
+        content: '<Ambassador slug="alice" showLinks={false} />'
+      })
+
+      const payload = await buildPagePayload(
+        foundationPageFrontmatterSchema,
+        mdx,
+        null,
+        parserCtx
+      )
+
+      expect(payload.content).toEqual([
+        {
+          __component: 'blocks.ambassador',
+          ambassador: { connect: [{ documentId: 'doc-alice' }] },
+          showLinks: false
+        }
+      ])
+    })
+
+    it('re-throws parser errors with file slug context', async () => {
+      await import('./ambassadorHandler')
+
+      const parserCtx = {
+        locale: 'en',
+        resolveRelation: async () => ({ documentId: 'doc-x' })
+      }
+
+      const mdx = createMdxFile({
+        slug: 'bad-page',
+        frontmatter: { title: 'Bad' },
+        content: '<UnknownWidget />'
+      })
+
+      await expect(
+        buildPagePayload(foundationPageFrontmatterSchema, mdx, null, parserCtx)
+      ).rejects.toThrow(/bad-page/)
     })
   })
 })

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -14,6 +14,8 @@
 import type { MDXFile } from './mdxTypes'
 import type { StrapiClient, StrapiEntry } from './strapiClient'
 import type { FrontmatterSchema } from './config'
+import { parseMdxToBlocks, type ParserContext } from './mdxBlockParser'
+import { MdxParserError } from './parserErrors'
 
 /**
  * Extracts a field value from a Strapi entry.
@@ -40,13 +42,16 @@ export function getEntryField(entry: StrapiEntry | null, key: string): unknown {
  * @param schema - Zod schema to validate/parse the frontmatter
  * @param mdx - MDX file data with frontmatter and content
  * @param existingEntry - Existing Strapi entry (optional, for updates)
+ * @param parserCtx - When provided, MDX body is parsed into structured blocks
+ *   via `parseMdxToBlocks`. Without it, the body is stored as a single paragraph.
  * @returns Strapi payload object
  */
-export function buildPagePayload(
+export async function buildPagePayload(
   schema: FrontmatterSchema,
   mdx: MDXFile,
-  existingEntry: StrapiEntry | null = null
-): Record<string, unknown> {
+  existingEntry: StrapiEntry | null = null,
+  parserCtx?: ParserContext
+): Promise<Record<string, unknown>> {
   // Validate frontmatter against schema (throws if invalid)
   const parsed = schema.parse({
     ...mdx.frontmatter,
@@ -76,17 +81,36 @@ export function buildPagePayload(
   }
 
   // Handle content import
-  // Import MDX content as markdown (preserve original format, no HTML conversion)
   const mdxBody = (mdx.content || '').trim()
   if (mdxBody.length > 0) {
-    // Store markdown content in a Strapi paragraph block component
-    // Strapi's richtext field can accept markdown and will handle rendering
-    data.content = [
-      {
-        __component: 'blocks.paragraph',
-        content: mdx.content
+    if (parserCtx) {
+      // Parse MDX body into structured dynamic-zone blocks.
+      // Parser errors (unsupported JSX, missing props, unresolved relations)
+      // are intentional hard failures — re-thrown with file context.
+      try {
+        data.content = await parseMdxToBlocks(mdxBody, parserCtx)
+      } catch (err) {
+        if (err instanceof MdxParserError) {
+          throw new MdxParserError({
+            code: err.code,
+            message: `[${mdx.slug}] ${err.message}`,
+            component: err.component,
+            prop: err.prop,
+            line: err.line,
+            column: err.column
+          })
+        }
+        throw err
       }
-    ]
+    } else {
+      // Fallback: store entire body as a single paragraph block
+      data.content = [
+        {
+          __component: 'blocks.paragraph',
+          content: mdx.content
+        }
+      ]
+    }
   } else {
     // Preserve existing content if MDX file has no body
     const existingContent = getEntryField(existingEntry, 'content')

--- a/cms/scripts/sync-mdx/paragraphHandler.ts
+++ b/cms/scripts/sync-mdx/paragraphHandler.ts
@@ -1,0 +1,68 @@
+/**
+ * Paragraph component handler for the MDX block parser.
+ *
+ * Handles:
+ * - <Paragraph>markdown content</Paragraph>
+ * - <Paragraph content="markdown string" />
+ *
+ * Maps to Strapi blocks.paragraph.
+ */
+
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
+import { toMarkdown } from 'mdast-util-to-markdown'
+import type { Root } from 'mdast'
+import type { ParsedBlock, ParagraphBlock } from './types.blocks'
+import { getStringAttr } from './jsxExtract'
+import { registerComponentHandler, type ParserContext } from './mdxBlockParser'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+async function handleParagraph(
+  node: MdxJsxFlowElement,
+  _ctx: ParserContext
+): Promise<ParsedBlock[]> {
+  // Prefer content prop if present: <Paragraph content="..." />
+  const contentAttr = getStringAttr(node, 'content')
+
+  let content: string
+  if (contentAttr !== undefined) {
+    content = contentAttr
+  } else {
+    // Otherwise extract from children: <Paragraph>...children...</Paragraph>
+    const children = node.children
+    content =
+      children && children.length > 0
+        ? toMarkdown({ type: 'root', children } as Root).trim()
+        : ''
+  }
+
+  if (!content) {
+    throw new MdxParserError({
+      code: ParserErrorCode.INVALID_PROP_VALUE,
+      message:
+        'Paragraph requires non-empty content. Strapi blocks.paragraph has content as required.',
+      component: 'Paragraph',
+      prop: 'content',
+      line: node.position?.start.line,
+      column: node.position?.start.column
+    })
+  }
+
+  return [buildParagraphBlock(node, content)]
+}
+
+function buildParagraphBlock(
+  node: MdxJsxFlowElement,
+  content: string
+): ParagraphBlock {
+  const alignment = getStringAttr(node, 'alignment')
+  const block: ParagraphBlock = {
+    __component: 'blocks.paragraph',
+    content
+  }
+  if (alignment === 'center' || alignment === 'right') {
+    block.alignment = alignment
+  }
+  return block
+}
+
+registerComponentHandler('Paragraph', handleParagraph)

--- a/cms/scripts/sync-mdx/parserErrors.test.ts
+++ b/cms/scripts/sync-mdx/parserErrors.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+describe('MdxParserError', () => {
+  it('sets code, message, and component', () => {
+    const err = new MdxParserError({
+      code: ParserErrorCode.MISSING_REQUIRED_PROP,
+      message: 'Required prop "slug" is missing.',
+      component: 'Ambassador',
+      prop: 'slug'
+    })
+
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(MdxParserError)
+    expect(err.name).toBe('MdxParserError')
+    expect(err.code).toBe(ParserErrorCode.MISSING_REQUIRED_PROP)
+    expect(err.component).toBe('Ambassador')
+    expect(err.prop).toBe('slug')
+    expect(err.message).toContain('Ambassador')
+    expect(err.message).toContain('slug')
+  })
+
+  it('includes line/column in message when provided', () => {
+    const err = new MdxParserError({
+      code: ParserErrorCode.UNSUPPORTED_COMPONENT,
+      message: 'Unsupported JSX component "Foo".',
+      component: 'Foo',
+      line: 5,
+      column: 3
+    })
+
+    expect(err.line).toBe(5)
+    expect(err.column).toBe(3)
+    expect(err.message).toContain('line 5:3')
+  })
+
+  it('omits location from message when line is not provided', () => {
+    const err = new MdxParserError({
+      code: ParserErrorCode.MDX_PARSE_ERROR,
+      message: 'Failed to parse MDX.'
+    })
+
+    expect(err.line).toBeUndefined()
+    expect(err.message).not.toContain('line')
+    expect(err.message).toContain('[parser]')
+  })
+
+  it('exposes all error codes', () => {
+    expect(ParserErrorCode.UNSUPPORTED_COMPONENT).toBe('UNSUPPORTED_COMPONENT')
+    expect(ParserErrorCode.MISSING_REQUIRED_PROP).toBe('MISSING_REQUIRED_PROP')
+    expect(ParserErrorCode.INVALID_PROP_VALUE).toBe('INVALID_PROP_VALUE')
+    expect(ParserErrorCode.DYNAMIC_EXPRESSION).toBe('DYNAMIC_EXPRESSION')
+    expect(ParserErrorCode.MDX_PARSE_ERROR).toBe('MDX_PARSE_ERROR')
+    expect(ParserErrorCode.UNRESOLVED_RELATION).toBe('UNRESOLVED_RELATION')
+    expect(ParserErrorCode.CONFLICTING_PROPS).toBe('CONFLICTING_PROPS')
+  })
+})

--- a/cms/scripts/sync-mdx/parserErrors.ts
+++ b/cms/scripts/sync-mdx/parserErrors.ts
@@ -1,0 +1,84 @@
+/**
+ * Strict error model for the MDX block parser.
+ *
+ * The parser fails loudly on unsupported syntax rather than silently
+ * dropping content. Every error carries enough context (component name,
+ * position, reason) for the caller to produce actionable diagnostics.
+ */
+
+// ---------------------------------------------------------------------------
+// Error codes
+// ---------------------------------------------------------------------------
+
+export const ParserErrorCode = {
+  /** JSX component not in the supported handler registry. */
+  UNSUPPORTED_COMPONENT: 'UNSUPPORTED_COMPONENT',
+
+  /** A required prop is missing from a JSX element. */
+  MISSING_REQUIRED_PROP: 'MISSING_REQUIRED_PROP',
+
+  /** A prop value has an unexpected type or format. */
+  INVALID_PROP_VALUE: 'INVALID_PROP_VALUE',
+
+  /** A JSX expression (`{...}`) could not be statically evaluated. */
+  DYNAMIC_EXPRESSION: 'DYNAMIC_EXPRESSION',
+
+  /** MDX AST could not be parsed by remark + remark-mdx. */
+  MDX_PARSE_ERROR: 'MDX_PARSE_ERROR',
+
+  /** Relation slug could not be resolved to a Strapi document ID. */
+  UNRESOLVED_RELATION: 'UNRESOLVED_RELATION',
+
+  /** Conflicting props (e.g. both children and content on Paragraph). */
+  CONFLICTING_PROPS: 'CONFLICTING_PROPS'
+} as const
+
+export type ParserErrorCode =
+  (typeof ParserErrorCode)[keyof typeof ParserErrorCode]
+
+// ---------------------------------------------------------------------------
+// Error class
+// ---------------------------------------------------------------------------
+
+export interface ParserErrorContext {
+  /** Error classification. */
+  code: ParserErrorCode
+  /** Human-readable explanation. */
+  message: string
+  /** JSX component name (e.g. "Ambassador"), if applicable. */
+  component?: string
+  /** Prop name that caused the error, if applicable. */
+  prop?: string
+  /** 1-based line number in the source MDX, if available. */
+  line?: number
+  /** 1-based column number in the source MDX, if available. */
+  column?: number
+}
+
+/**
+ * Thrown by the MDX block parser on any irrecoverable issue.
+ *
+ * Callers should catch this at the pipeline boundary and surface
+ * the structured context for debugging.
+ */
+export class MdxParserError extends Error {
+  public readonly code: ParserErrorCode
+  public readonly component?: string
+  public readonly prop?: string
+  public readonly line?: number
+  public readonly column?: number
+
+  constructor(ctx: ParserErrorContext) {
+    const location =
+      ctx.line != null ? ` (line ${ctx.line}:${ctx.column ?? 0})` : ''
+    const prefix = ctx.component ? `[${ctx.component}]` : '[parser]'
+    super(`${prefix}${location} ${ctx.message}`)
+
+    this.name = 'MdxParserError'
+    this.code = ctx.code
+    this.component = ctx.component
+    this.prop = ctx.prop
+    this.line = ctx.line
+    this.column = ctx.column
+  }
+}

--- a/cms/scripts/sync-mdx/types.blocks.ts
+++ b/cms/scripts/sync-mdx/types.blocks.ts
@@ -1,0 +1,81 @@
+/**
+ * Block type definitions for MDX ↔ Strapi dynamic zone import.
+ *
+ * These types represent the Strapi REST API payload shapes produced by
+ * the MDX block parser — NOT the Strapi schema types (those live in
+ * cms/types/generated/components.d.ts and use Schema.Attribute.*).
+ *
+ * Each type maps to a Strapi component schema under
+ * cms/src/components/blocks/ but describes the JSON body sent to the
+ * Strapi REST API during import.
+ *
+ */
+
+// ---------------------------------------------------------------------------
+// Shared
+// ---------------------------------------------------------------------------
+
+/** Discriminator present on every Strapi dynamic-zone block payload. */
+export interface StrapiBlockBase {
+  __component: string
+}
+
+// ---------------------------------------------------------------------------
+// Block Payloads
+// ---------------------------------------------------------------------------
+
+/** blocks.paragraph – rich text content block. */
+export interface ParagraphBlock extends StrapiBlockBase {
+  __component: 'blocks.paragraph'
+  content: string
+  alignment?: 'left' | 'center' | 'right'
+}
+
+/**
+ * blocks.ambassador – single ambassador relation block.
+ *
+ * The `ambassador` field holds a Strapi relation connect payload
+ * (documentId resolved from slug at parse time).
+ */
+export interface AmbassadorBlock extends StrapiBlockBase {
+  __component: 'blocks.ambassador'
+  ambassador: { documentId: string }
+  showLinks?: boolean
+}
+
+/**
+ * blocks.ambassadors-grid – ordered grid of ambassador relations.
+ *
+ * `ambassadors` is an array of relation connect payloads whose order
+ * must match the input slug order.
+ */
+export interface AmbassadorsGridBlock extends StrapiBlockBase {
+  __component: 'blocks.ambassadors-grid'
+  heading?: string
+  ambassadors: Array<{ documentId: string }>
+}
+
+/** blocks.blockquote – styled quote with optional attribution. */
+export interface BlockquoteBlock extends StrapiBlockBase {
+  __component: 'blocks.blockquote'
+  quote: string
+  source?: string
+}
+
+/** blocks.callout-text – highlighted text block. */
+export interface CalloutTextBlock extends StrapiBlockBase {
+  __component: 'blocks.callout-text'
+  content: string
+}
+
+// ---------------------------------------------------------------------------
+// Union
+// ---------------------------------------------------------------------------
+
+/** Any block the parser can produce. */
+export type ParsedBlock =
+  | ParagraphBlock
+  | AmbassadorBlock
+  | AmbassadorsGridBlock
+  | BlockquoteBlock
+  | CalloutTextBlock

--- a/cms/scripts/sync-mdx/types.blocks.ts
+++ b/cms/scripts/sync-mdx/types.blocks.ts
@@ -34,25 +34,25 @@ export interface ParagraphBlock extends StrapiBlockBase {
 /**
  * blocks.ambassador – single ambassador relation block.
  *
- * The `ambassador` field holds a Strapi relation connect payload
- * (documentId resolved from slug at parse time).
+ * The `ambassador` field uses Strapi v5's `connect` syntax for
+ * relations inside dynamic zone components.
  */
 export interface AmbassadorBlock extends StrapiBlockBase {
   __component: 'blocks.ambassador'
-  ambassador: { documentId: string }
+  ambassador: { connect: Array<{ documentId: string }> }
   showLinks?: boolean
 }
 
 /**
  * blocks.ambassadors-grid – ordered grid of ambassador relations.
  *
- * `ambassadors` is an array of relation connect payloads whose order
+ * `ambassadors` uses Strapi v5's `connect` syntax. Order of entries
  * must match the input slug order.
  */
 export interface AmbassadorsGridBlock extends StrapiBlockBase {
   __component: 'blocks.ambassadors-grid'
   heading?: string
-  ambassadors: Array<{ documentId: string }>
+  ambassadors: { connect: Array<{ documentId: string }> }
 }
 
 /** blocks.blockquote – styled quote with optional attribution. */

--- a/cms/src/serializers/blocks/paragraph.serializer.ts
+++ b/cms/src/serializers/blocks/paragraph.serializer.ts
@@ -11,8 +11,9 @@ export function serialize(block: {
     ? htmlToMarkdown(block.content)
     : block.content
 
-  if (block.alignment && block.alignment !== 'left') {
-    return `<div class="text-${block.alignment}">\n\n${content}\n\n</div>`
-  }
-  return content
+  const alignmentAttr =
+    block.alignment && block.alignment !== 'left'
+      ? ` alignment="${block.alignment}"`
+      : ''
+  return `<Paragraph${alignmentAttr}>\n\n${content}\n\n</Paragraph>`
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       mdast-util-mdx-jsx:
         specifier: ^3.2.0
         version: 3.2.0
+      mdast-util-to-markdown:
+        specifier: ^2.1.2
+        version: 2.1.2
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1768,155 +1771,183 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2347,36 +2378,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.6':
     resolution: {integrity: sha512-byAiBZ1t3tXQvc8dMD/eoyE7lTXYorhn+6uVW5AC+JGI1KtJC/LvDche5cfUE+qiefH+Ybq0bUCJU0aB1cSHUA==}
@@ -3029,66 +3066,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -3438,24 +3488,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.11':
     resolution: {integrity: sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.11':
     resolution: {integrity: sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.11':
     resolution: {integrity: sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.11':
     resolution: {integrity: sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==}
@@ -3535,24 +3589,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
     resolution: {integrity: sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
     resolution: {integrity: sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.0':
     resolution: {integrity: sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.0':
     resolution: {integrity: sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw==}
@@ -7518,24 +7576,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       marked:
         specifier: ^17.0.3
         version: 17.0.3
+      mdast-util-mdx-jsx:
+        specifier: ^3.2.0
+        version: 3.2.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -153,6 +156,12 @@ importers:
       react-router-dom:
         specifier: ^6.30.2
         version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark:
+        specifier: ^15.0.1
+        version: 15.0.1
+      remark-mdx:
+        specifier: ^3.1.1
+        version: 3.1.1
       styled-components:
         specifier: ^6.1.19
         version: 6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9271,6 +9280,9 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  remark@15.0.1:
+    resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
+
   remove-accents@0.5.0:
     resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
 
@@ -14534,7 +14546,7 @@ snapshots:
       '@strapi/design-system': 2.0.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(@strapi/icons@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/permissions': 5.31.3
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.31.3
       '@strapi/utils': 5.31.3
       '@testing-library/dom': 10.1.0
@@ -14731,7 +14743,7 @@ snapshots:
       '@strapi/database': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)
       '@strapi/design-system': 2.0.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(@strapi/icons@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/utils': 5.31.3
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
@@ -14832,7 +14844,7 @@ snapshots:
       '@strapi/generators': 5.31.3(@types/node@22.19.11)
       '@strapi/logger': 5.31.3
       '@strapi/permissions': 5.31.3
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.31.3
       '@strapi/utils': 5.31.3
       '@vercel/stega': 0.1.2
@@ -15362,7 +15374,7 @@ snapshots:
       '@strapi/openapi': 5.31.3
       '@strapi/permissions': 5.31.3
       '@strapi/review-workflows': 5.31.3(681caf389605bd5fac823ee0158edb2f)
-      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)
+      '@strapi/types': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)
       '@strapi/typescript-utils': 5.31.3
       '@strapi/upload': 5.31.3(c76dd935e99411c3ec50b97509689cc7)
       '@strapi/utils': 5.31.3
@@ -15465,36 +15477,6 @@ snapshots:
       - webpack-cli
       - webpack-dev-server
       - webpack-plugin-serve
-
-  '@strapi/types@5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.4.4)':
-    dependencies:
-      '@casl/ability': 6.5.0
-      '@koa/cors': 5.0.0
-      '@koa/router': 12.0.2
-      '@strapi/database': 5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)
-      '@strapi/logger': 5.31.3
-      '@strapi/permissions': 5.31.3
-      '@strapi/utils': 5.31.3
-      commander: 8.3.0
-      json-logic-js: 2.0.5
-      koa: 2.16.1
-      koa-body: 6.0.1
-      node-schedule: 2.1.1
-      typedoc: 0.25.10(typescript@5.4.4)
-      typedoc-github-wiki-theme: 1.1.0(typedoc-plugin-markdown@3.17.1(typedoc@0.25.10(typescript@5.9.3)))(typedoc@0.25.10(typescript@5.9.3))
-      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.10(typescript@5.9.3))
-      zod: 3.25.67
-    transitivePeerDependencies:
-      - '@types/node'
-      - better-sqlite3
-      - mysql
-      - mysql2
-      - pg
-      - pg-native
-      - sqlite3
-      - supports-color
-      - tedious
-      - typescript
 
   '@strapi/types@5.31.3(@types/node@22.19.11)(better-sqlite3@11.5.0)(typescript@5.9.3)':
     dependencies:
@@ -22807,6 +22789,15 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  remark@15.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remove-accents@0.5.0: {}
 
   remove-trailing-separator@1.1.0: {}
@@ -23930,14 +23921,6 @@ snapshots:
     dependencies:
       handlebars: 4.7.8
       typedoc: 0.25.10(typescript@5.9.3)
-
-  typedoc@0.25.10(typescript@5.4.4):
-    dependencies:
-      lunr: 2.3.9
-      marked: 4.3.0
-      minimatch: 9.0.5
-      shiki: 0.14.7
-      typescript: 5.4.4
 
   typedoc@0.25.10(typescript@5.9.3):
     dependencies:

--- a/src/components/blocks/Paragraph.astro
+++ b/src/components/blocks/Paragraph.astro
@@ -2,19 +2,17 @@
 import MarkdownIt from 'markdown-it'
 
 interface Props {
-  content: string
+  content?: string
   alignment?: 'left' | 'center' | 'right'
 }
 
 const { content, alignment = 'left' } = Astro.props
 
-// Convert markdown to HTML
 const md = new MarkdownIt({
   html: true,
   linkify: true,
   typographer: true
 })
-const htmlContent = md.render(content || '')
 
 const alignmentClass =
   alignment === 'center'
@@ -22,9 +20,18 @@ const alignmentClass =
     : alignment === 'right'
       ? 'text-right'
       : ''
+
+const wrapperClass = `mx-auto max-w-narrow ${alignmentClass} [&_p]:mb-space-s [&_p]:leading-relaxed [&_a]:text-primary [&_a]:underline [&_a:hover]:no-underline [&_h2]:mt-space-l [&_h2]:mb-space-s [&_h2]:text-[1.75rem] [&_h2]:font-semibold [&_h2]:text-primary [&_h3]:mt-space-m [&_h3]:mb-space-xs [&_h3]:text-[1.25rem] [&_h3]:font-semibold [&_ul]:mb-space-s [&_ul]:ps-space-m [&_ol]:mb-space-s [&_ol]:ps-space-m [&_li]:mb-space-xs`
+
+const hasContent = content != null && content !== ''
 ---
 
-<div
-  class={`mx-auto max-w-narrow ${alignmentClass} [&_p]:mb-space-s [&_p]:leading-relaxed [&_a]:text-primary [&_a]:underline [&_a:hover]:no-underline [&_h2]:mt-space-l [&_h2]:mb-space-s [&_h2]:text-[1.75rem] [&_h2]:font-semibold [&_h2]:text-primary [&_h3]:mt-space-m [&_h3]:mb-space-xs [&_h3]:text-[1.25rem] [&_h3]:font-semibold [&_ul]:mb-space-s [&_ul]:ps-space-m [&_ol]:mb-space-s [&_ol]:ps-space-m [&_li]:mb-space-xs`}
-  set:html={htmlContent}
-/>
+{
+  hasContent ? (
+    <div class={wrapperClass} set:html={md.render(content)} />
+  ) : (
+    <div class={wrapperClass}>
+      <slot />
+    </div>
+  )
+}

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -11,6 +11,7 @@ import Ambassador from '../components/ambassadors/Ambassador.astro'
 import AmbassadorGrid from '../components/ambassadors/AmbassadorGrid.astro'
 import Blockquote from '../components/blockquote/Blockquote.astro'
 import CalloutText from '../components/callout/CalloutText.astro'
+import Paragraph from '../components/blocks/Paragraph.astro'
 
 export async function getStaticPaths() {
   return getPagePaths('foundation-pages', { excludeSlug: 'home' })
@@ -79,7 +80,8 @@ if (isNotFound) Astro.response.status = 404
                     Ambassador,
                     AmbassadorGrid,
                     Blockquote,
-                    CalloutText
+                    CalloutText,
+                    Paragraph
                   }}
                 />
               </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content'
 import FoundationPageLayout from '../layouts/FoundationPageLayout.astro'
+import Paragraph from '../components/blocks/Paragraph.astro'
 
 const pages = await getCollection('foundation-pages')
 const homePage = pages.find((page) => page.data.slug === 'home')
@@ -37,7 +38,7 @@ const { title, heroTitle, heroDescription } = homePage.data
         <div
           class="mx-auto max-w-narrow [&_h2]:mt-space-l [&_h2]:mb-space-s [&_h2]:text-[1.75rem] [&_h2]:font-semibold [&_h2]:text-primary [&_h3]:mt-space-m [&_h3]:mb-space-xs [&_h3]:text-[1.25rem] [&_h3]:font-semibold [&_p]:mb-space-s [&_p]:leading-[1.6] [&_ul]:mb-space-s [&_ul]:ps-space-m [&_li]:mb-space-xs [&_a]:text-primary [&_a]:underline [&_a:hover]:no-underline [&_.cta-group]:my-space-m [&_.cta-group]:flex [&_.cta-group]:flex-wrap [&_.cta-group]:gap-space-s [&_.cta-group_a]:rounded-pill [&_.cta-group_a]:bg-primary [&_.cta-group_a]:px-space-s [&_.cta-group_a]:py-space-xs [&_.cta-group_a]:text-white [&_.cta-group_a]:no-underline [&_.cta-group_a:hover]:opacity-90"
         >
-          <Content />
+          <Content components={{ Paragraph }} />
         </div>
       </div>
     </section>

--- a/src/pages/summit/[...page].astro
+++ b/src/pages/summit/[...page].astro
@@ -4,6 +4,7 @@ import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
 import { getPagePaths } from '@/utils/static-paths'
 import AmbassadorGrid from '@/components/ambassadors/AmbassadorGrid.astro'
 import Blockquote from '@/components/blockquote/Blockquote.astro'
+import Paragraph from '@/components/blocks/Paragraph.astro'
 
 export async function getStaticPaths() {
   return getPagePaths('summit-pages')
@@ -75,7 +76,9 @@ if (isNotFound) Astro.response.status = 404
           <section class="py-space-xl">
             <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
               <div class="mx-auto max-w-narrow [&_h2]:mt-space-l [&_h2]:mb-space-s [&_h2]:text-[1.75rem] [&_h2]:font-semibold [&_h3]:mt-space-m [&_h3]:mb-space-xs [&_h3]:text-[1.25rem] [&_h3]:font-semibold [&_p]:mb-space-s [&_p]:leading-[1.6] [&_ul]:mb-space-s [&_ul]:ps-space-m [&_li]:mb-space-xs [&_a]:underline [&_a:hover]:no-underline">
-                <MdxContent components={{ AmbassadorGrid, Blockquote }} />
+                <MdxContent
+                  components={{ AmbassadorGrid, Blockquote, Paragraph }}
+                />
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary
<!-- What changed and why -->

- **Import (MDX → Strapi)**: Added `paragraphHandler.ts` to detect `<Paragraph>` in MDX and map it to Strapi `blocks.paragraph`. Supports both `<Paragraph>markdown content</Paragraph>` (children) and `<Paragraph content="..." />` (prop).
- **Export (Strapi → MDX)**: Updated `paragraph.serializer.ts` to wrap paragraph block content in `<Paragraph>...</Paragraph>` when exporting to MDX, matching the format used in foundation pages.

## Related Issue
<!-- Fixes INTORG-123 -->

Fixes INTORG-457

## Manual Test
<!-- Reviewer steps (only if needed) -->

1. Run `pnpm run sync:mdx:dry-run` from `cms/` — foundation pages with `<Paragraph>` should parse without errors.
2. In Strapi, edit a foundation page with paragraph blocks and save — exported MDX should wrap content in `<Paragraph>...</Paragraph>`.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
