### PR TITLE
fix(cms): update git sync lifecycles

### DIFF
--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -185,6 +185,7 @@ export function buildBlogPayload(
     description: parsed.description,
     slug: parsed.slug,
     date: date.toISOString().split('T')[0],
+    pillar: parsed.pillar,
     publishedAt: date.toISOString(),
     content: mdx.content || ''
   }

--- a/cms/scripts/sync-navigation.ts
+++ b/cms/scripts/sync-navigation.ts
@@ -121,7 +121,8 @@ async function updateNavigation({
   }
 
   const headers: Record<string, string> = {
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
+    'x-skip-mdx-export': 'true' // Skip lifecycle git sync - sync script is import-only
   }
 
   if (token) {

--- a/cms/src/api/ambassador/content-types/ambassador/lifecycles.ts
+++ b/cms/src/api/ambassador/content-types/ambassador/lifecycles.ts
@@ -8,7 +8,8 @@
  */
 
 import { getImageUrl } from '../../../../utils/mdx'
-import { getContentPath, getProjectRoot } from '../../../../utils/paths'
+import { getContentPath } from '../../../../utils/paths'
+import { getTargetRepoRoot } from '../../../../utils/gitSync'
 import { createFlatLocaleMdxLifecycle } from '../../../../utils/flatContentLifecycle'
 import type { AmbassadorBase } from '../../types'
 
@@ -57,7 +58,7 @@ export default createFlatLocaleMdxLifecycle<Ambassador>({
   contentTypeUid: 'api::ambassador.ambassador',
   label: 'ambassador',
   getBaseDir: (locale) =>
-    getContentPath(getProjectRoot(), 'ambassadors', locale),
+    getContentPath(getTargetRepoRoot(), 'ambassadors', locale),
   generateContent: generateMdxContent,
   populate: { photo: true }
 })

--- a/cms/src/api/ambassador/content-types/ambassador/lifecycles.ts
+++ b/cms/src/api/ambassador/content-types/ambassador/lifecycles.ts
@@ -7,7 +7,7 @@
  * only wrote the single event.result locale, leaving other locales' MDX stale.
  */
 
-import { getImageUrl } from '../../../../utils/mdx'
+import { getImageUrl, yamlSingleQuoteScalar } from '../../../../utils/mdx'
 import { getContentPath } from '../../../../utils/paths'
 import { getTargetRepoRoot } from '../../../../utils/gitSync'
 import { createFlatLocaleMdxLifecycle } from '../../../../utils/flatContentLifecycle'
@@ -17,12 +17,6 @@ interface Ambassador extends AmbassadorBase {
   publishedAt?: string
   locale?: string
   documentId?: string
-}
-
-/** Serializes a value as a YAML scalar (double-quoted string or null). */
-function yamlValue(value: string | null | undefined): string {
-  if (value === null || value === undefined) return 'null'
-  return JSON.stringify(value)
 }
 
 function generateMdxContent(
@@ -37,18 +31,17 @@ function generateMdxContent(
       : undefined
   const isLocalized = locale !== undefined
 
+  const q = yamlSingleQuoteScalar
   const fields = [
-    `name: ${yamlValue(ambassador.name)}`,
-    `slug: ${yamlValue(ambassador.slug)}`,
-    `description: ${yamlValue(ambassador.description || '')}`,
-    `photo: ${yamlValue(photoUrl)}`,
-    `photoAlt: ${yamlValue(photoAlt)}`,
-    `linkedinUrl: ${yamlValue(ambassador.linkedinUrl ?? null)}`,
-    `grantReportUrl: ${yamlValue(ambassador.grantReportUrl ?? null)}`,
-    ...(isLocalized && englishSlug
-      ? [`localizes: ${yamlValue(englishSlug)}`]
-      : []),
-    ...(locale ? [`locale: ${yamlValue(locale)}`] : [])
+    `name: ${q(ambassador.name)}`,
+    `slug: ${q(ambassador.slug)}`,
+    `description: ${q(ambassador.description || '')}`,
+    `photo: ${q(photoUrl)}`,
+    `photoAlt: ${q(photoAlt)}`,
+    `linkedinUrl: ${q(ambassador.linkedinUrl ?? null)}`,
+    `grantReportUrl: ${q(ambassador.grantReportUrl ?? null)}`,
+    ...(isLocalized && englishSlug ? [`localizes: ${q(englishSlug)}`] : []),
+    ...(locale ? [`locale: ${q(locale)}`] : [])
   ]
 
   return `---\n${fields.join('\n')}\n---\n`

--- a/cms/src/serializers/blocks/ambassadors-grid.serializer.ts
+++ b/cms/src/serializers/blocks/ambassadors-grid.serializer.ts
@@ -14,6 +14,8 @@ export function serialize(block: {
 
   if (slugs.length === 0) return ''
 
-  const headingAttr = block.heading ? ` heading="${escDouble(block.heading)}"` : ''
+  const headingAttr = block.heading
+    ? ` heading="${escDouble(block.heading)}"`
+    : ''
   return `<AmbassadorGrid${headingAttr} slugs={[${slugs.join(',')}]} />`
 }

--- a/cms/src/serializers/blocks/ambassadors-grid.serializer.ts
+++ b/cms/src/serializers/blocks/ambassadors-grid.serializer.ts
@@ -1,7 +1,8 @@
 import jsesc from 'jsesc'
 import type { AmbassadorBase } from '../../api/ambassador/types'
 
-const esc = (v: string) => (v ? jsesc(v, { quotes: 'double' }) : '')
+const escDouble = (v: string) => (v ? jsesc(v, { quotes: 'double' }) : '')
+const escSingle = (v: string) => (v ? jsesc(v, { quotes: 'single' }) : '')
 
 export function serialize(block: {
   heading?: string
@@ -9,10 +10,10 @@ export function serialize(block: {
 }): string {
   const slugs = (block.ambassadors || [])
     .filter((amb) => amb?.slug)
-    .map((amb) => `"${esc(amb.slug)}"`)
+    .map((amb) => `'${escSingle(amb.slug)}'`)
 
   if (slugs.length === 0) return ''
 
-  const headingAttr = block.heading ? ` heading="${esc(block.heading)}"` : ''
+  const headingAttr = block.heading ? ` heading="${escDouble(block.heading)}"` : ''
   return `<AmbassadorGrid${headingAttr} slugs={[${slugs.join(',')}]} />`
 }

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { shouldSkipMdxExport } from './pageLifecycle'
-import { getProjectRoot } from './paths'
+import { scheduleGitSync, getTargetRepoRoot } from './gitSync'
 
 interface BlogResult {
   id: number
@@ -115,7 +115,7 @@ async function writeMDXFile({
 }: {
   outputPath: string
   post: BlogResult
-}) {
+}): Promise<string> {
   const filename = generateFilename({ date: post.date, slug: post.slug })
   const filepath = path.join(outputPath, filename)
   const mdxContent = generateBlogMDX(post)
@@ -124,6 +124,7 @@ async function writeMDXFile({
   await fs.promises.writeFile(filepath, mdxContent, 'utf-8')
 
   console.log(`✅ Generated Blog Post MDX file: ${filepath}`)
+  return filepath
 }
 
 async function deleteMDXFile({
@@ -132,13 +133,14 @@ async function deleteMDXFile({
 }: {
   outputPath: string
   post: BlogResult
-}) {
+}): Promise<string | null> {
   const filename = generateFilename({ date: post.date, slug: post.slug })
   const filepath = path.join(outputPath, filename)
 
   try {
     await fs.promises.unlink(filepath)
     console.log(`🗑️  Deleted MDX file: ${filepath}`)
+    return filepath
   } catch (error: unknown) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
       console.error(
@@ -147,11 +149,12 @@ async function deleteMDXFile({
       )
       throw error
     }
+    return null
   }
 }
 
 export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
-  const projectRoot = getProjectRoot()
+  const projectRoot = getTargetRepoRoot()
   const outputPath = path.join(projectRoot, outputDir)
 
   return {
@@ -159,20 +162,20 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
       if (shouldSkipMdxExport()) return
       const { result } = event
       if (!result || !result.publishedAt) return
-      console.log(
-        `📝 Creating ${event.model.singularName} MDX for: ${result.slug}`
-      )
+      const label = event.model.singularName
+      console.log(`📝 Creating ${label} MDX for: ${result.slug}`)
       await writeMDXFile({ outputPath, post: result })
+      scheduleGitSync(label)
     },
 
     async afterDelete(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
       const { result } = event
       if (!result || !result.publishedAt) return
-      console.log(
-        `📝 Deleting ${event.model.singularName} MDX for: ${result.slug}`
-      )
+      const label = event.model.singularName
+      console.log(`📝 Deleting ${label} MDX for: ${result.slug}`)
       await deleteMDXFile({ outputPath, post: result })
+      scheduleGitSync(label)
     }
   }
 }

--- a/cms/src/utils/flatContentLifecycle.ts
+++ b/cms/src/utils/flatContentLifecycle.ts
@@ -13,6 +13,7 @@ import {
   deleteLocaleMdxFiles,
   removeLocalizesFromLocaleFiles
 } from './localeMdxUtils'
+import { scheduleGitSync } from './gitSync'
 
 export interface FlatContentLifecycleConfig<
   T extends {
@@ -148,26 +149,30 @@ export function createFlatLocaleMdxLifecycle<
 
   return {
     async afterCreate(event: { result?: T }) {
-      if (shouldSkipMdxExport()) return
       const { result } = event
+      if (shouldSkipMdxExport()) return
       if (!result?.documentId || !result.publishedAt) return
 
       console.log(`📝 Creating ${label} MDX for all locales: ${result.slug}`)
       await exportAllLocales(result.documentId)
+      scheduleGitSync(label)
     },
 
     async afterDelete(event: { result?: T }) {
-      if (shouldSkipMdxExport()) return
       const { result } = event
-      if (!result) return
+      if (shouldSkipMdxExport()) return
+      if (!result?.documentId) return
 
       console.log(`🗑️  Deleting ${label} MDX for all locales: ${result.slug}`)
+
       removeLocalizesFromLocaleFiles(
         result.slug,
         (locale) => getBaseDir(locale),
         label
       )
       deleteLocaleMdxFiles((locale) => getFilePath(locale, result.slug), label)
+
+      scheduleGitSync(label)
     }
   }
 }

--- a/cms/src/utils/gitSync.ts
+++ b/cms/src/utils/gitSync.ts
@@ -2,44 +2,77 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { exec } from 'child_process'
+import { getProjectRoot } from './paths'
 
-function escapeForShell(str: string): string {
-  return str.replace(/'/g, "'\\''")
+const STAGE_CANDIDATES = [
+  'src/content/',
+  'src/data/',
+  'public/uploads'
+] as const
+const CONTENT_PATH_PREFIXES = ['src/content/', 'src/data/'] as const
+const DEBOUNCE_MS = 300
+
+interface GitStatusChange {
+  status: string
+  filepath: string
+}
+
+function shellEscape(value: string): string {
+  return value.replace(/'/g, "'\\''")
+}
+
+function shellQuote(value: string): string {
+  return `'${shellEscape(value)}'`
 }
 
 function expandHomeDir(filepath: string): string {
-  if (!filepath.startsWith('~/')) return filepath
-  return path.join(os.homedir(), filepath.slice(2))
-}
-
-export function getTargetRepoRoot(): string {
-  const configuredPath =
-    process.env.STRAPI_GIT_SYNC_REPO_PATH || '~/interledger.org-v5-staging'
-  return path.resolve(expandHomeDir(configuredPath))
-}
-
-export function resolveTargetRepoPath(targetPath: string): string {
-  const expandedPath = expandHomeDir(targetPath)
-
-  if (path.isAbsolute(expandedPath)) {
-    return path.resolve(expandedPath)
-  }
-
-  const normalizedRelativePath = expandedPath.replace(/^\/+/, '')
-  return path.join(getTargetRepoRoot(), normalizedRelativePath)
+  return filepath.startsWith('~/')
+    ? path.join(os.homedir(), filepath.slice(2))
+    : filepath
 }
 
 function execInRepo(command: string, cwd: string): Promise<string> {
   return new Promise((resolve, reject) => {
     exec(command, { cwd }, (error, stdout, stderr) => {
-      if (error) {
-        reject(new Error(stderr?.trim() || error.message))
-        return
-      }
-      resolve(stdout.trim())
+      if (error) reject(new Error(stderr?.trim() || error.message))
+      else resolve(stdout.trim())
     })
   })
 }
+
+function toGitPath(repoRoot: string, filepath: string): string | null {
+  const relative = path.isAbsolute(filepath)
+    ? path.relative(repoRoot, filepath)
+    : filepath
+  if (!relative || relative === '.') return null
+
+  // Ignore paths outside the target repository.
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    console.warn(`⚠️  Skipping out-of-repo path for git sync: ${filepath}`)
+    return null
+  }
+
+  return relative.replace(/\\/g, '/')
+}
+
+function quoteGitPaths(paths: string[]): string[] {
+  return [...new Set(paths)].map((value) => shellQuote(value))
+}
+
+// ── Repo resolution ──────────────────────────────────────────────────────────
+
+export function getTargetRepoRoot(): string {
+  const configured = process.env.STRAPI_GIT_SYNC_REPO_PATH
+  return configured ? path.resolve(expandHomeDir(configured)) : getProjectRoot()
+}
+
+export function resolveTargetRepoPath(targetPath: string): string {
+  const expanded = expandHomeDir(targetPath)
+  if (path.isAbsolute(expanded)) return path.resolve(expanded)
+  return path.join(getTargetRepoRoot(), expanded.replace(/^\/+/, ''))
+}
+
+// ── Startup validation ───────────────────────────────────────────────────────
 
 export async function validateGitSyncRepoOnStartup(): Promise<void> {
   if (process.env.STRAPI_DISABLE_GIT_SYNC === 'true') {
@@ -47,86 +80,236 @@ export async function validateGitSyncRepoOnStartup(): Promise<void> {
     return
   }
 
-  const targetRepoRoot = getTargetRepoRoot()
-  const gitDir = path.join(targetRepoRoot, '.git')
+  const repoRoot = getTargetRepoRoot()
 
-  if (!fs.existsSync(targetRepoRoot)) {
+  if (!fs.existsSync(repoRoot)) {
     throw new Error(
-      `Git sync repository path does not exist: ${targetRepoRoot}. ` +
-        'Set STRAPI_GIT_SYNC_REPO_PATH or create the staging clone.'
+      `Git sync repository path does not exist: ${repoRoot}. ` +
+        `Set STRAPI_GIT_SYNC_REPO_PATH or create the staging clone.`
     )
   }
 
-  if (!fs.existsSync(gitDir)) {
-    throw new Error(
-      `Git sync repository is not a git checkout: ${targetRepoRoot}`
-    )
+  if (!fs.existsSync(path.join(repoRoot, '.git'))) {
+    throw new Error(`Git sync repository is not a git checkout: ${repoRoot}`)
   }
 
-  const branch = await execInRepo(
-    'git rev-parse --abbrev-ref HEAD',
-    targetRepoRoot
-  )
-  if (branch !== 'staging') {
-    throw new Error(
-      `Git sync repository must be on "staging" branch, found "${branch}" at ${targetRepoRoot}`
-    )
-  }
-
+  const branch = await execInRepo('git rev-parse --abbrev-ref HEAD', repoRoot)
   console.log(
-    `✅ Git sync repository validated: ${targetRepoRoot} (branch: ${branch})`
+    `✅ Git sync repository validated: ${repoRoot} (branch: ${branch})`
   )
 }
 
-/**
- * Pulls latest changes, stages the filepath, commits, and pushes.
- * Resolves even on failure so Strapi saves content.
- */
-export async function gitCommitAndPush(
-  filepath: string,
+// ── Git status + commit message inference ───────────────────────────────────
+
+function parseGitStatusLine(line: string): GitStatusChange | null {
+  if (!line.trim()) return null
+
+  const status = line.slice(0, 2).trim()
+  // git status --porcelain: "XY PATH" (2-char status + space); slice(3) skips to path
+  const rawPath = line.slice(3).trimStart()
+  const filepath = rawPath.includes(' -> ')
+    ? (rawPath.split(' -> ').pop() ?? rawPath)
+    : rawPath
+
+  return {
+    status,
+    filepath
+  }
+}
+
+function isDeleted(status: string): boolean {
+  return status.includes('D')
+}
+
+function isAdded(status: string): boolean {
+  return status === '??' || status.includes('A')
+}
+
+function isModified(status: string): boolean {
+  return status.includes('M') || status.includes('R') || status.includes('C')
+}
+
+async function getGitStatus(cwd: string): Promise<GitStatusChange[]> {
+  try {
+    const output = await execInRepo('git status --porcelain', cwd)
+    if (!output) return []
+    return output
+      .split('\n')
+      .map(parseGitStatusLine)
+      .filter((change): change is GitStatusChange => Boolean(change))
+  } catch {
+    return []
+  }
+}
+
+function extractSlug(filepath: string): string {
+  const basename = path.basename(filepath, path.extname(filepath))
+  const dateMatch = basename.match(/^\d{4}-\d{2}-\d{2}-(.+)$/)
+  return dateMatch ? dateMatch[1] : basename
+}
+
+function inferCommitMessage(label: string, changes: GitStatusChange[]): string {
+  const contentChanges = changes.filter((c) =>
+    CONTENT_PATH_PREFIXES.some((prefix) => c.filepath.startsWith(prefix))
+  )
+
+  if (contentChanges.length === 0) return `${label}: sync`
+
+  const deleted = contentChanges.filter((c) => isDeleted(c.status))
+  const added = contentChanges.filter((c) => isAdded(c.status))
+  const modified = contentChanges.filter((c) => isModified(c.status))
+
+  if (contentChanges.length === 1) {
+    const [change] = contentChanges
+    const slug = extractSlug(change.filepath)
+    if (isDeleted(change.status)) return `${label}: delete ${slug}`
+    if (isModified(change.status)) return `${label}: update ${slug}`
+    return `${label}: create ${slug}`
+  }
+
+  const deletedSlugs = [...new Set(deleted.map((c) => extractSlug(c.filepath)))]
+  const addedSlugs = [...new Set(added.map((c) => extractSlug(c.filepath)))]
+
+  // Rename: 1 delete + 1 add with different slugs
+  if (deleted.length === 1 && added.length === 1 && modified.length === 0) {
+    if (deletedSlugs[0] !== addedSlugs[0]) {
+      return `${label}: rename ${deletedSlugs[0]} -> ${addedSlugs[0]}`
+    }
+  }
+
+  // Re-slug as update: 1 delete + 1 add with same slug
+  if (
+    deleted.length === 1 &&
+    added.length === 1 &&
+    deletedSlugs[0] === addedSlugs[0]
+  ) {
+    return `${label}: update ${deletedSlugs[0]}`
+  }
+
+  // Bulk summary
+  const parts: string[] = []
+  if (deleted.length > 0) parts.push(`${deleted.length} deleted`)
+  if (added.length > 0) parts.push(`${added.length} created`)
+  if (modified.length > 0) parts.push(`${modified.length} modified`)
+  return `${label}: sync (${parts.join(', ')})`
+}
+
+// ── Git operations ───────────────────────────────────────────────────────────
+
+function getStagePaths(repoRoot: string): string[] {
+  const stagePaths = STAGE_CANDIDATES.filter((p) =>
+    fs.existsSync(path.join(repoRoot, p))
+  )
+  return quoteGitPaths(stagePaths)
+}
+
+async function commitAndPush(
+  repoRoot: string,
+  addPaths: string[],
   message: string
 ): Promise<void> {
-  if (process.env.STRAPI_DISABLE_GIT_SYNC === 'true') {
-    console.log('⏭️  Git sync disabled via STRAPI_DISABLE_GIT_SYNC')
-    return
-  }
-
-  const projectRoot = getTargetRepoRoot()
-  const safeMessage = escapeForShell(message)
-
-  const relativeFilepath = path.isAbsolute(filepath)
-    ? path.relative(projectRoot, filepath)
-    : filepath
-  const safeFilepath = escapeForShell(relativeFilepath)
-
-  // Always include public/uploads if it exists so media changes are committed
-  const uploadsDir = path.join(projectRoot, 'public', 'uploads')
-  const addPaths = [safeFilepath]
-  if (fs.existsSync(uploadsDir)) {
-    const uploadsRelative = escapeForShell(
-      path.relative(projectRoot, uploadsDir)
-    )
-    addPaths.push(uploadsRelative)
-  }
+  const safeMessage = shellQuote(message)
+  const commands = [
+    `git add ${addPaths.join(' ')}`,
+    `git commit -m ${safeMessage}`,
+    'git pull --rebase',
+    'git push'
+  ].join(' && ')
 
   return new Promise((resolve) => {
-    const commands = [
-      `git add ${addPaths.map((p) => `'${p}'`).join(' ')}`,
-      `git commit -m '${safeMessage}'`,
-      'git pull --rebase',
-      'git push'
-    ].join(' && ')
-
-    exec(commands, { cwd: projectRoot }, (error, stdout, stderr) => {
+    exec(commands, { cwd: repoRoot }, (error, stdout, stderr) => {
       if (error) {
-        console.error(`⚠️  Git sync failed: ${error.message}`)
-        if (stderr) console.error(`stderr: ${stderr}`)
-        resolve()
-        return
+        const combined = `${stdout ?? ''}\n${stderr ?? ''}`
+        if (combined.includes('nothing to commit')) {
+          console.log(`[gitSync] Nothing to commit`)
+        } else {
+          console.error(`⚠️  Git sync failed: ${error.message}`)
+          if (stderr) console.error(`stderr: ${stderr}`)
+        }
+      } else {
+        console.log(`✅ Git sync complete: ${message}`)
+        if (stdout) console.log(stdout)
       }
-      console.log(`✅ Git sync complete: ${message}`)
-      if (stdout) console.log(stdout)
       resolve()
     })
   })
+}
+
+// ── Debounced sync ───────────────────────────────────────────────────────────
+
+let pendingSyncTimer: ReturnType<typeof setTimeout> | null = null
+
+async function flushGitSync(label: string): Promise<void> {
+  const repoRoot = getTargetRepoRoot()
+  const changes = await getGitStatus(repoRoot)
+
+  if (changes.length === 0) {
+    console.log(`[gitSync] No changes to commit`)
+    return
+  }
+
+  const stagePaths = getStagePaths(repoRoot)
+  if (stagePaths.length === 0) {
+    console.log(`[gitSync] No content directories to stage`)
+    return
+  }
+
+  const message = inferCommitMessage(label, changes)
+  console.log(`[gitSync] Inferred message: ${message}`)
+  await commitAndPush(repoRoot, stagePaths, message)
+}
+
+/**
+ * Schedule a debounced git sync. Multiple calls within {@link DEBOUNCE_MS}
+ * are coalesced into a single commit. The commit message is inferred from
+ * actual git status rather than the caller.
+ */
+export function scheduleGitSync(label: string): void {
+  if (process.env.STRAPI_DISABLE_GIT_SYNC === 'true') {
+    console.log('⏭️  Git sync scheduling skipped via STRAPI_DISABLE_GIT_SYNC')
+    return
+  }
+
+  if (pendingSyncTimer) clearTimeout(pendingSyncTimer)
+
+  pendingSyncTimer = setTimeout(() => {
+    pendingSyncTimer = null
+    flushGitSync(label).catch((err) =>
+      console.error(`[gitSync] Flush error:`, err)
+    )
+  }, DEBOUNCE_MS)
+}
+
+/**
+ * Commit specific files immediately with an explicit message.
+ * Use for cases like navigation updates where status inference isn't needed.
+ */
+export async function gitCommitAndPush(
+  filepath: string | string[],
+  message: string
+): Promise<void> {
+  if (process.env.STRAPI_DISABLE_GIT_SYNC === 'true') {
+    console.log('⏭️  Git sync commit skipped via STRAPI_DISABLE_GIT_SYNC')
+    return
+  }
+
+  const repoRoot = getTargetRepoRoot()
+  const rawPaths = Array.isArray(filepath) ? filepath : [filepath]
+  const normalizedPaths = rawPaths
+    .map((fp) => toGitPath(repoRoot, fp))
+    .filter((p): p is string => Boolean(p))
+
+  const uploadsDir = path.join(repoRoot, 'public', 'uploads')
+  if (fs.existsSync(uploadsDir)) {
+    const uploadsPath = toGitPath(repoRoot, uploadsDir)
+    if (uploadsPath) normalizedPaths.push(uploadsPath)
+  }
+
+  const paths = quoteGitPaths(normalizedPaths)
+  if (paths.length === 0) {
+    console.log('[gitSync] No valid paths to stage')
+    return
+  }
+
+  await commitAndPush(repoRoot, paths, message)
 }

--- a/cms/src/utils/mdx.ts
+++ b/cms/src/utils/mdx.ts
@@ -31,6 +31,17 @@ export function uidToLogLabel(uid: string): string {
 }
 
 /**
+ * Serializes a value as a YAML scalar: single-quoted string or 'null'.
+ * Escapes internal single quotes per YAML spec ('').
+ */
+export function yamlSingleQuoteScalar(
+  value: string | null | undefined
+): string {
+  if (value === null || value === undefined) return 'null'
+  return `'${String(value).replace(/'/g, "''")}'`
+}
+
+/**
  * Gets the resolved URL for a Strapi media field.
  * Pass `preferredFormat` to try a specific image format first (e.g. 'thumbnail'),
  * falling back to the original URL if that format is unavailable.

--- a/cms/src/utils/navigationLifecycle.ts
+++ b/cms/src/utils/navigationLifecycle.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { getProjectRoot } from './paths'
-import { gitCommitAndPush } from './gitSync'
+import { gitCommitAndPush, getTargetRepoRoot } from './gitSync'
 import { uidToLogLabel } from './mdx'
 
 // Strapi v5 Document API types
@@ -74,7 +73,7 @@ function writeNavigationFile(
   config: NavigationLifecycleConfig,
   data: NavigationData
 ): string {
-  const projectRoot = getProjectRoot()
+  const projectRoot = getTargetRepoRoot()
   const outputPath = path.join(projectRoot, config.outputPath)
   const outputDir = path.dirname(outputPath)
 
@@ -126,7 +125,7 @@ async function fetchPublishedNavigation(
 async function deleteNavigationFile(
   config: NavigationLifecycleConfig
 ): Promise<string | null> {
-  const projectRoot = getProjectRoot()
+  const projectRoot = getTargetRepoRoot()
   const outputPath = path.join(projectRoot, config.outputPath)
   try {
     if (fs.existsSync(outputPath)) {
@@ -159,7 +158,7 @@ export function createNavigationLifecycle(config: NavigationLifecycleConfig) {
       }
       const outputPath = writeNavigationFile(config, navigation)
       await gitCommitAndPush(
-        outputPath,
+        [outputPath],
         `${uidToLogLabel(config.contentTypeUid)}: update navigation`
       )
     },
@@ -169,7 +168,7 @@ export function createNavigationLifecycle(config: NavigationLifecycleConfig) {
       const deletedPath = await deleteNavigationFile(config)
       if (deletedPath) {
         await gitCommitAndPush(
-          deletedPath,
+          [deletedPath],
           `${uidToLogLabel(config.contentTypeUid)}: delete navigation`
         )
       }

--- a/cms/src/utils/navigationLifecycle.ts
+++ b/cms/src/utils/navigationLifecycle.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { gitCommitAndPush, getTargetRepoRoot } from './gitSync'
 import { uidToLogLabel } from './mdx'
+import { shouldSkipMdxExport } from './pageLifecycle'
 
 // Strapi v5 Document API types
 interface StrapiDocumentAPI {
@@ -148,6 +149,7 @@ async function deleteNavigationFile(
 export function createNavigationLifecycle(config: NavigationLifecycleConfig) {
   return {
     async afterCreate(_event: Event) {
+      if (shouldSkipMdxExport()) return
       console.log(`📝 Creating ${uidToLogLabel(config.contentTypeUid)} JSON`)
       const navigation = await fetchPublishedNavigation(config)
       if (!navigation) {
@@ -164,6 +166,7 @@ export function createNavigationLifecycle(config: NavigationLifecycleConfig) {
     },
 
     async afterDelete(_event: Event) {
+      if (shouldSkipMdxExport()) return
       console.log(`🗑️  Deleting ${uidToLogLabel(config.contentTypeUid)} JSON`)
       const deletedPath = await deleteNavigationFile(config)
       if (deletedPath) {

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -137,7 +137,7 @@ function generateMDX(
 
   const content = serializeContent(page.content)
 
-  return matter.stringify(content ? `\n${content}\n` : '\n', frontmatterData)
+  return matter.stringify(content ? `\n${content}\n` : '', frontmatterData)
 }
 
 async function writeMDXFile(

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -24,7 +24,7 @@ declare const strapi: {
 import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
-import { getProjectRoot, PATHS } from './paths'
+import { PATHS } from './paths'
 import { serializeContent } from '../serializers/blocks'
 import {
   LOCALES,
@@ -37,6 +37,7 @@ import {
   deleteLocaleMdxFiles,
   removeLocalizesFromLocaleFiles
 } from './localeMdxUtils'
+import { scheduleGitSync, getTargetRepoRoot } from './gitSync'
 
 interface PageData {
   id: number
@@ -95,7 +96,7 @@ export interface PageLifecycleConfig {
 }
 
 function getOutputDir(config: PageLifecycleConfig, locale: string): string {
-  const projectRoot = getProjectRoot()
+  const projectRoot = getTargetRepoRoot()
 
   if (locale === 'en') {
     return path.join(projectRoot, config.outputDir)
@@ -259,10 +260,10 @@ export function createPageLifecycle(config: PageLifecycleConfig) {
       if (!result) return
       if (shouldSkipMdxExport()) return
 
-      console.log(
-        `📝 Creating ${uidToLogLabel(config.contentTypeUid)} MDX for all locales: ${result.slug}`
-      )
+      const label = uidToLogLabel(config.contentTypeUid)
+      console.log(`📝 Creating ${label} MDX for all locales: ${result.slug}`)
       await exportAllLocales(config, result.documentId)
+      scheduleGitSync(label)
     },
 
     async afterDelete(event: Event) {
@@ -270,19 +271,21 @@ export function createPageLifecycle(config: PageLifecycleConfig) {
       if (!result) return
       if (shouldSkipMdxExport()) return
 
-      console.log(
-        `🗑️  Deleting ${uidToLogLabel(config.contentTypeUid)} MDX for all locales: ${result.slug}`
-      )
+      const label = uidToLogLabel(config.contentTypeUid)
+      console.log(`🗑️  Deleting ${label} MDX for all locales: ${result.slug}`)
+
       removeLocalizesFromLocaleFiles(
         result.slug,
         (locale) => getOutputDir(config, locale),
-        uidToLogLabel(config.contentTypeUid)
+        label
       )
       deleteLocaleMdxFiles(
         (locale) =>
           path.join(getOutputDir(config, locale), `${result.slug}.mdx`),
-        uidToLogLabel(config.contentTypeUid)
+        label
       )
+
+      scheduleGitSync(label)
     }
   }
 }

--- a/src/content/foundation-pages/page-for-ambassadors.mdx
+++ b/src/content/foundation-pages/page-for-ambassadors.mdx
@@ -1,0 +1,6 @@
+---
+slug: page-for-ambassadors
+title: Page for Ambassadors
+---
+
+<AmbassadorGrid heading="Test test test" slugs={['ed-ambassador-1']} />


### PR DESCRIPTION
## Summary
- Refactor CMS lifecycle handling to improve git sync behavior across blog, navigation, and page lifecycles.
- Add shared lifecycle utilities to reduce duplication and standardize sync flow.

## Related Issue
Fixes jon/intorg-331

## Manual Test
- Trigger create/update/delete in Strapi for pages, navigation, and blog posts.
- Verify MDX files are created/updated/removed in the repo as expected.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
