### PR TITLE
fix(sync-mdx): include pillar field in blog payload jm/intorg-479-fix-foundationblog-import

### DIFF
--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -185,6 +185,7 @@ export function buildBlogPayload(
     description: parsed.description,
     slug: parsed.slug,
     date: date.toISOString().split('T')[0],
+    pillar: parsed.pillar,
     publishedAt: date.toISOString(),
     content: mdx.content || ''
   }


### PR DESCRIPTION
## Summary
- Include the `pillar` field in the blog payload during MDX sync to keep Strapi data consistent.

## Related Issue
Fixes jon/intorg-479

## Manual Test
- Run the MDX sync for a blog post with a `pillar` field.
- Confirm the `pillar` value is present in the Strapi payload.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)