### PR TITLE
fix: types in serializer test file

### DIFF
--- a/cms/src/serializers/blocks/ambassador.serializer.test.ts
+++ b/cms/src/serializers/blocks/ambassador.serializer.test.ts
@@ -6,6 +6,7 @@ const baseAmbassador = {
   slug: 'alice-example',
   description: 'A great ambassador.',
   photo: {
+    id: 1,
     url: '/uploads/alice.jpg',
     alternativeText: 'Alice smiling'
   },
@@ -57,6 +58,7 @@ describe('ambassador serializer', () => {
       ambassador: {
         ...baseAmbassador,
         photo: {
+          id: 1,
           url: '/uploads/alice.jpg',
           alternativeText: 'Portrait of Alice'
         }
@@ -70,7 +72,7 @@ describe('ambassador serializer', () => {
     const result = serialize({
       ambassador: {
         ...baseAmbassador,
-        photo: { url: '/uploads/alice.jpg' }
+        photo: { id: 1, url: '/uploads/alice.jpg' }
       }
     })
 


### PR DESCRIPTION
## Summary
added the missing property for the ambassador type in serializer test file

## Related Issue
<!-- Fixes INTORG-123 -->

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
