### PR TITLE
ci: slack notification to frontend team

### DIFF
--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -195,3 +195,28 @@ jobs:
           STRAPI_URL: ${{ secrets.STRAPI_URL }}
           STRAPI_API_TOKEN: ${{ secrets.STRAPI_API_TOKEN }}
         run: pnpm run sync:mdx
+
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs: [check-pr-merge, rebuild-strapi]
+    if: failure()
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v2.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "frontend-team",
+              "text": "❌ Pipeline failed in *${{ github.repository }}*",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "❌ *Pipeline Failed*\n*Repo:* ${{ github.repository }}\n*Branch:* ${{ github.ref_name }}\n*Workflow:* ${{ github.workflow }}\n*Author:* ${{ github.actor }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -198,11 +198,11 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [check-pr-merge, rebuild-strapi]
-    if: failure()
+    needs: [check-pr-merge, rebuild-strapi, sync-mdx-to-strapi]
+    if: ${{ always() && failure() }}
     steps:
       - name: Notify Slack on failure
-        uses: slackapi/slack-github-action@v2.1
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This pull request adds a Slack notification step to the GitHub Actions workflow for the staging environment. Now, if the pipeline fails after the `check-pr-merge` or `rebuild-strapi` jobs, a message will be sent to the frontend team's Slack channel with details about the failure.

**CI/CD Improvements:**

* Added a `notify-slack` job to `.github/workflows/staging-merge.yml` that triggers on pipeline failure and sends a detailed message to the `frontend-team` Slack channel using the `slackapi/slack-github-action`.