### PR TITLE
fix(ci): remove stray page-for-ambassadors

### DIFF
--- a/src/content/foundation-pages/page-for-ambassadors.mdx
+++ b/src/content/foundation-pages/page-for-ambassadors.mdx
@@ -1,6 +1,0 @@
----
-slug: page-for-ambassadors
-title: Page for Ambassadors
----
-
-<AmbassadorGrid heading="Test test test" slugs={['ed-ambassador-1']} />


### PR DESCRIPTION
## Summary
Removed the stray page which was trying to reference a non existing ambassador causing the parser to hard fail (as per the intended behaviour)

## Related Issue
<!-- Fixes INTORG-123 -->

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
