### PR TITLE
feat(404): add custom 404 page for static hosting jm/intorg-484-404page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -12,7 +12,9 @@ import FoundationPageLayout from '../layouts/FoundationPageLayout.astro'
   <main class="flex-1 flex items-center justify-center py-space-xl">
     <section class="text-center px-space-m">
       <h1 class="text-6xl font-semibold text-primary mb-space-s">404</h1>
-      <p class="text-lg text-[var(--sl-color-gray-2)] mb-space-m max-w-md mx-auto">
+      <p
+        class="text-lg text-[var(--sl-color-gray-2)] mb-space-m max-w-md mx-auto"
+      >
         The page you requested could not be found.
       </p>
       <a

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,26 @@
+---
+/**
+ * Custom 404 page for static hosting (Netlify serves 404.html).
+ */
+import FoundationPageLayout from '../layouts/FoundationPageLayout.astro'
+---
+
+<FoundationPageLayout
+  title="Page not found"
+  description="The page you requested could not be found."
+>
+  <main class="flex-1 flex items-center justify-center py-space-xl">
+    <section class="text-center px-space-m">
+      <h1 class="text-6xl font-semibold text-primary mb-space-s">404</h1>
+      <p class="text-lg text-[var(--sl-color-gray-2)] mb-space-m max-w-md mx-auto">
+        The page you requested could not be found.
+      </p>
+      <a
+        href="/"
+        class="inline-block text-primary font-medium underline hover:no-underline"
+      >
+        ← Back to home
+      </a>
+    </section>
+  </main>
+</FoundationPageLayout>


### PR DESCRIPTION
## Summary

Adds a custom `404.astro` page served as `404.html` for static hosting (Netlify). Displays a centered error message with a link back to the home page, using `FoundationPageLayout` to stay consistent with the rest of the site.

## Related Issue

Fixes INTORG-484

## Manual Test

Navigate to any non-existent URL on the site and verify the custom 404 page renders correctly.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
