### PR TITLE
refactor(utils): convert create-excerpt to TypeScript - jon/intorg-445

### DIFF
--- a/src/utils/create-excerpt.ts
+++ b/src/utils/create-excerpt.ts
@@ -3,7 +3,7 @@ import MarkdownIt from 'markdown-it'
 
 const parser = new MarkdownIt()
 
-export const createExcerpt = (body) => {
+export const createExcerpt = (body: unknown): string => {
   const safeBody = typeof body === 'string' ? body : ''
   const html = parser.render(safeBody)
   const options = {


### PR DESCRIPTION
## Summary

Renames `create-excerpt.js` to `create-excerpt.ts` and adds a type annotation to the `body` parameter (`unknown` with a safe string guard) and an explicit `string` return type.

## Related Issue

Fixes INTORG-445

## Manual Test

No manual testing needed — logic is unchanged.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
