### PR TITLE
feat(seo): add per-page meta title, description, image, and canonical… jon/intorg-446

### DIFF
--- a/src/layouts/SummitPageLayout.astro
+++ b/src/layouts/SummitPageLayout.astro
@@ -11,16 +11,20 @@ interface Props {
   title: string
   description?: string
   gradient?: string
+  ogImageUrl?: string
+  canonicalURL?: string
 }
 
-const { title, description, gradient = 'option1' } = Astro.props
+const { title, description, gradient = 'option1', ogImageUrl, canonicalURL } =
+  Astro.props
 ---
 
 <BaseLayout
   title={title}
   titleSuffix="Interledger Summit"
   description={description}
-  ogImageUrl="/img/og-summit.png"
+  ogImageUrl={ogImageUrl ?? '/img/og-summit.png'}
+  canonicalURL={canonicalURL}
   theme="dark"
   bodyClass="flex min-h-full min-w-[360px] flex-col overflow-x-hidden bg-fixed bg-no-repeat font-titillium text-step-0 text-white"
   bodyStyle={`--gradient:var(--${gradient}); background-image: var(--gradient);`}

--- a/src/layouts/SummitPageLayout.astro
+++ b/src/layouts/SummitPageLayout.astro
@@ -15,8 +15,13 @@ interface Props {
   canonicalURL?: string
 }
 
-const { title, description, gradient = 'option1', ogImageUrl, canonicalURL } =
-  Astro.props
+const {
+  title,
+  description,
+  gradient = 'option1',
+  ogImageUrl,
+  canonicalURL
+} = Astro.props
 ---
 
 <BaseLayout

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -32,8 +32,7 @@ if (mdxPage) {
 }
 
 const title = mdxData?.metaTitle || mdxData?.title || slug
-const description =
-  mdxData?.metaDescription || mdxData?.description || null
+const description = mdxData?.metaDescription || mdxData?.description || null
 const ogImageUrl = mdxData?.metaImage || undefined
 const canonicalURL = mdxData?.canonicalUrl || undefined
 const mdxHeroTitle = mdxData?.heroTitle || mdxData?.title || ''

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -31,15 +31,23 @@ if (mdxPage) {
   mdxData = mdxPage.data
 }
 
-const title = mdxData?.title || slug
-const description = mdxData?.description || null
+const title = mdxData?.metaTitle || mdxData?.title || slug
+const description =
+  mdxData?.metaDescription || mdxData?.description || null
+const ogImageUrl = mdxData?.metaImage || undefined
+const canonicalURL = mdxData?.canonicalUrl || undefined
 const mdxHeroTitle = mdxData?.heroTitle || mdxData?.title || ''
 const mdxHeroDescription = mdxData?.heroDescription || ''
 const isNotFound = !MdxContent
 if (isNotFound) Astro.response.status = 404
 ---
 
-<FoundationPageLayout title={title} description={description}>
+<FoundationPageLayout
+  title={title}
+  description={description}
+  ogImageUrl={ogImageUrl}
+  canonicalURL={canonicalURL}
+>
   <main class="pb-space-l">
     {
       isNotFound ? (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,8 +11,15 @@ if (!homePage) {
 }
 
 const { Content } = await render(homePage)
-const { title, metaTitle, metaDescription, metaImage, canonicalUrl, heroTitle, heroDescription } =
-  homePage.data
+const {
+  title,
+  metaTitle,
+  metaDescription,
+  metaImage,
+  canonicalUrl,
+  heroTitle,
+  heroDescription
+} = homePage.data
 const pageTitle = metaTitle || title || 'Interledger Foundation'
 const pageDescription = metaDescription || undefined
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,10 +11,18 @@ if (!homePage) {
 }
 
 const { Content } = await render(homePage)
-const { title, heroTitle, heroDescription } = homePage.data
+const { title, metaTitle, metaDescription, metaImage, canonicalUrl, heroTitle, heroDescription } =
+  homePage.data
+const pageTitle = metaTitle || title || 'Interledger Foundation'
+const pageDescription = metaDescription || undefined
 ---
 
-<FoundationPageLayout title={title || 'Interledger Foundation'}>
+<FoundationPageLayout
+  title={pageTitle}
+  description={pageDescription}
+  ogImageUrl={metaImage}
+  canonicalURL={canonicalUrl}
+>
   <main class="pb-space-l">
     <section
       class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[50vh] py-space-xl text-white flex items-center"

--- a/src/pages/summit/[...page].astro
+++ b/src/pages/summit/[...page].astro
@@ -30,8 +30,7 @@ const pageTitle = slug
   .join(' ')
 
 const title = mdxData?.metaTitle || mdxData?.title || pageTitle
-const description =
-  mdxData?.metaDescription || mdxData?.description || null
+const description = mdxData?.metaDescription || mdxData?.description || null
 const ogImageUrl = mdxData?.metaImage || undefined
 const canonicalURL = mdxData?.canonicalUrl || undefined
 const mdxHeroTitle = mdxData?.heroTitle || mdxData?.title || ''

--- a/src/pages/summit/[...page].astro
+++ b/src/pages/summit/[...page].astro
@@ -29,8 +29,11 @@ const pageTitle = slug
   .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
   .join(' ')
 
-const title = mdxData?.title || pageTitle
-const description = mdxData?.description || null
+const title = mdxData?.metaTitle || mdxData?.title || pageTitle
+const description =
+  mdxData?.metaDescription || mdxData?.description || null
+const ogImageUrl = mdxData?.metaImage || undefined
+const canonicalURL = mdxData?.canonicalUrl || undefined
 const mdxHeroTitle = mdxData?.heroTitle || mdxData?.title || ''
 const mdxHeroDescription = mdxData?.heroDescription || ''
 const gradient = mdxData?.gradient || 'option1'
@@ -38,7 +41,13 @@ const isNotFound = !MdxContent
 if (isNotFound) Astro.response.status = 404
 ---
 
-<SummitPageLayout title={title} description={description} gradient={gradient}>
+<SummitPageLayout
+  title={title}
+  description={description}
+  gradient={gradient}
+  ogImageUrl={ogImageUrl}
+  canonicalURL={canonicalURL}
+>
   <main
     class="relative z-0 pb-space-l before:content-[''] before:fixed before:inset-0 before:-z-10 before:bg-[url('/img/bg-swirl.svg')] before:bg-repeat before:bg-[length:100%] before:opacity-25 before:blur-[150px] before:transform before:translate-x-0 before:translate-y-0"
   >

--- a/src/schemas/content.ts
+++ b/src/schemas/content.ts
@@ -70,6 +70,10 @@ export const foundationPageFrontmatterSchema = z.object({
   heroTitle: z.string().optional(),
   heroDescription: z.string().optional(),
   heroImage: z.string().optional(),
+  metaTitle: z.string().optional(),
+  metaDescription: z.string().optional(),
+  metaImage: z.string().optional(),
+  canonicalUrl: z.string().optional(),
   sections: z
     .array(
       z.object({
@@ -97,6 +101,10 @@ export const summitPageFrontmatterSchema = z.object({
   heroTitle: z.string().optional(),
   heroDescription: z.string().optional(),
   heroImage: z.string().optional(),
+  metaTitle: z.string().optional(),
+  metaDescription: z.string().optional(),
+  metaImage: z.string().optional(),
+  canonicalUrl: z.string().optional(),
   sections: z
     .array(
       z.object({


### PR DESCRIPTION
## Summary

Adds optional `metaTitle`, `metaDescription`, `metaImage`, and `canonicalUrl` frontmatter fields to foundation and summit pages, overriding defaults when set.

## Related Issue

Fixes INTORG-446

## Manual Test

Add any meta field to a page's frontmatter and verify it appears in the rendered `<head>`.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
