### PR TITLE
ci: any change to the cms folder should trigger a rebuild

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -111,7 +111,7 @@ The GitHub Actions workflow (`.github/workflows/lint.yml`) runs on every PR and 
 - **Branches**: `staging` is the preview environment, `main` is production.
 - **Strapi publishing**: Lifecycle hooks generate MDX and commit/push to `staging`.
 - **Netlify**: Auto-builds `staging` to preview and `main` to production.
-- **Self-hosted runner**: The `.github/workflows/staging-merge.yml` runs on push to `staging` via a self-hosted runner (`strapi-vm`). It automatically rebuilds Strapi CMS when `cms/` changes are detected, and syncs MDX to Strapi when `src/content/foundation-pages` or `src/content/summit-pages` MD/MDX changes are detected.
+- **Self-hosted runner**: The `.github/workflows/staging-merge.yml` runs on push to `staging` via a self-hosted runner (`strapi-vm`). It automatically rebuilds Strapi CMS when `cms/` changes are detected, and syncs MDX to Strapi when `.md` or `.mdx` files change in `src/content/foundation-pages`, `src/content/summit-pages`, `src/content/foundation-blog-posts`, or `src/content/ambassadors`, including localized mirrors under `src/content/<locale>/...`.
 - **Promotion**: Content moves from `staging` to `main` via PR approval.
 - **Preview drafts**: Drafts can be previewed via SSR without publishing.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -111,7 +111,7 @@ The GitHub Actions workflow (`.github/workflows/lint.yml`) runs on every PR and 
 - **Branches**: `staging` is the preview environment, `main` is production.
 - **Strapi publishing**: Lifecycle hooks generate MDX and commit/push to `staging`.
 - **Netlify**: Auto-builds `staging` to preview and `main` to production.
-- **Self-hosted runner**: The `.github/workflows/main-merge.yml` runs on push to `staging` via a self-hosted runner (`strapi-vm`). It automatically rebuilds Strapi CMS if cms/ directory changes are detected, using `bun install && bun run build`.
+- **Self-hosted runner**: The `.github/workflows/staging-merge.yml` runs on push to `staging` via a self-hosted runner (`strapi-vm`). It automatically rebuilds Strapi CMS when `cms/` changes are detected, and syncs MDX to Strapi when `src/content/foundation-pages` or `src/content/summit-pages` MD/MDX changes are detected.
 - **Promotion**: Content moves from `staging` to `main` via PR approval.
 - **Preview drafts**: Drafts can be previewed via SSR without publishing.
 
@@ -147,7 +147,7 @@ pnpm run build    # Production build
 ```
 
 **Production builds** (self-hosted runner on `staging` push):
-- Uses `bun install && bun run build` via `.github/workflows/main-merge.yml`
+- Uses `pnpm install && pnpm run build` via `.github/workflows/staging-merge.yml`
 - Includes `NODE_OPTIONS="--max-old-space-size=4096"` to handle OOM errors during build
 - Automatically restarts the `strapi.service` after rebuild
 

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -1,7 +1,7 @@
 name: Staging Merge Workflow
 
 on:
-  # Run when PRs are merged to staging
+  # Run on pushes to staging
   # WARNING: Do not trigger on pull_request events. We do not want forks to run code on our self-hosted runner,
   # and pull_request events run for forks. This workflow should only run on push to staging.
   push:
@@ -17,10 +17,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  check-pr-merge:
+  detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      is_merged_pr: ${{ steps.pr_merge_check.outputs.merged_pr }}
       cms_changed: ${{ steps.detect_changes.outputs.cms_changed }}
       content_changed: ${{ steps.detect_changes.outputs.content_changed }}
     
@@ -44,56 +43,8 @@ jobs:
           fi
           echo "✓ Manual trigger validated on staging branch"
 
-      - name: Check if push is from merged PR
-        id: pr_merge_check
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Skip PR check for manual dispatch
-            if (context.eventName === 'workflow_dispatch') {
-              core.setOutput('merged_pr', 'manual')
-              core.notice('Manually triggered workflow; PR check skipped.')
-              return
-            }
-
-            const owner = context.repo.owner
-            const repo = context.repo.repo
-            const sha = context.sha
-
-            // Check via API for associated PRs merged into staging
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner,
-              repo,
-              commit_sha: sha,
-              per_page: 100
-            })
-
-            const mergedPRIntoStaging = prs.some((pr) =>
-              pr.merged_at && pr.base && pr.base.ref === 'staging'
-            )
-
-            // Also check commit message for merge commit pattern
-            const { data: commit } = await github.rest.repos.getCommit({
-              owner,
-              repo,
-              ref: sha
-            })
-            
-            const isMergeCommit = commit.commit.message.match(/^Merge pull request #(\d+)/) &&
-              commit.parents.length > 1
-
-            const mergedIntoStaging = mergedPRIntoStaging || isMergeCommit
-
-            core.setOutput('merged_pr', mergedIntoStaging ? 'true' : 'false')
-            if (!mergedIntoStaging) {
-              core.notice('No merged PR into staging found for this commit; workflow steps will be skipped.')
-            } else {
-              core.notice('Merged PR detected into staging.')
-            }
-
       - name: Detect changed paths
         id: detect_changes
-        if: steps.pr_merge_check.outputs.merged_pr != 'false'
         shell: bash
         run: |
           set -euo pipefail
@@ -125,10 +76,9 @@ jobs:
           echo "content_changed=$content_changed" >> "$GITHUB_OUTPUT"
 
   rebuild-strapi:
-    needs: check-pr-merge
+    needs: detect-changes
     if: |
-      (needs.check-pr-merge.outputs.is_merged_pr == 'true' && needs.check-pr-merge.outputs.cms_changed == 'true') ||
-      needs.check-pr-merge.outputs.is_merged_pr == 'manual'
+      needs.detect-changes.outputs.cms_changed == 'true'
     runs-on: strapi-vm
 
     steps:
@@ -165,11 +115,10 @@ jobs:
           sudo systemctl status strapi.service
 
   sync-mdx-to-strapi:
-    needs: [check-pr-merge, rebuild-strapi]
+    needs: [detect-changes, rebuild-strapi]
     if: |
       always() &&
-      ((needs.check-pr-merge.outputs.is_merged_pr == 'true' && needs.check-pr-merge.outputs.content_changed == 'true') ||
-      needs.check-pr-merge.outputs.is_merged_pr == 'manual')
+      needs.detect-changes.outputs.content_changed == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -198,7 +147,7 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [check-pr-merge, rebuild-strapi, sync-mdx-to-strapi]
+    needs: [detect-changes, rebuild-strapi, sync-mdx-to-strapi]
     if: ${{ always() && failure() }}
     steps:
       - name: Notify Slack on failure

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -1,4 +1,4 @@
-name: Staging Merge Workflow
+name: Staging Push Workflow
 
 on:
   # Run on pushes to staging
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   # Ensure only one instance of this workflow runs at a time to avoid conflicts
-  group: staging-merge
+  group: staging-push
   cancel-in-progress: false
 
 jobs:
@@ -24,11 +24,6 @@ jobs:
       content_changed: ${{ steps.detect_changes.outputs.content_changed }}
     
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Validate manual trigger is on staging branch
         if: github.event_name == 'workflow_dispatch'
         shell: bash
@@ -45,35 +40,51 @@ jobs:
 
       - name: Detect changed paths
         id: detect_changes
-        shell: bash
-        run: |
-          set -euo pipefail
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const contentPattern = /^src\/content\/(?:(?:foundation-pages|summit-pages|foundation-blog-posts|ambassadors)\/|[^/]+\/(?:foundation-pages|summit-pages|foundation-blog-posts|ambassadors)\/).+\.(md|mdx)$/
 
-          cms_changed=false
-          content_changed=false
+            if (context.eventName === 'workflow_dispatch') {
+              core.info('Manual trigger - will rebuild CMS and sync content')
+              core.setOutput('cms_changed', 'true')
+              core.setOutput('content_changed', 'true')
+              return
+            }
 
-          # For manual dispatch, always rebuild CMS and sync content
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "Manual trigger - will rebuild CMS and sync content"
-            cms_changed=true
-            content_changed=true
-          else
-            # Check what changed in this push
-            changed_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}")
-            
-            if echo "$changed_files" | grep -q '^cms/'; then
-              cms_changed=true
-              echo "CMS changes detected"
-            fi
-            
-            if echo "$changed_files" | grep -qE '^src/content/(foundation-pages|summit-pages)/.*\.(md|mdx)$'; then
-              content_changed=true
-              echo "Content changes detected"
-            fi
-          fi
+            const changedFiles = [...new Set(
+              (context.payload.commits ?? []).flatMap((commit) => [
+                ...(commit.added ?? []),
+                ...(commit.modified ?? []),
+                ...(commit.removed ?? [])
+              ])
+            )]
 
-          echo "cms_changed=$cms_changed" >> "$GITHUB_OUTPUT"
-          echo "content_changed=$content_changed" >> "$GITHUB_OUTPUT"
+            const fallbackToAllChanged = changedFiles.length === 0
+
+            if (fallbackToAllChanged) {
+              core.info(
+                'No changed files were available in the push payload; treating tracked areas as changed'
+              )
+            } else {
+              core.info(`Detected ${changedFiles.length} changed file(s) from push payload`)
+            }
+
+            const cmsChanged =
+              fallbackToAllChanged || changedFiles.some((file) => file.startsWith('cms/'))
+            const contentChanged =
+              fallbackToAllChanged || changedFiles.some((file) => contentPattern.test(file))
+
+            if (cmsChanged) {
+              core.info('CMS changes detected')
+            }
+
+            if (contentChanged) {
+              core.info('Content changes detected')
+            }
+
+            core.setOutput('cms_changed', String(cmsChanged))
+            core.setOutput('content_changed', String(contentChanged))
 
   rebuild-strapi:
     needs: detect-changes

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ For more information on Strapi lifecycles, synchronization scripts and preview f
   - Serves the live staging website (deployed via Netlify).
   - Serves the Strapi Admin interface (running on the GCP VM).
   - Any push to `staging` that modifies files in `/cms` triggers a rebuild of the Strapi Admin panel on the GCP VM.
-  - Any push to `staging` that modifies MD/MDX files in `src/content/foundation-pages` or `src/content/summit-pages` triggers `sync:mdx`, which updates Strapi content from Astro files.
+  - Any push to `staging` that modifies `.md` or `.mdx` files in `src/content/foundation-pages`, `src/content/summit-pages`, `src/content/foundation-blog-posts`, or `src/content/ambassadors` also triggers `sync:mdx`, including their localized mirrors under `src/content/<locale>/...`.
 
 ### Hosting Architecture
 

--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ For more information on Strapi lifecycles, synchronization scripts and preview f
 - **`staging`**:
   - Serves the live staging website (deployed via Netlify).
   - Serves the Strapi Admin interface (running on the GCP VM).
-  - Every merge to `staging` that contains changes **outside the `/cms` folder** triggers the GCP VM to pull the latest changes and execute the `sync:mdx` script, which updates the Strapi database based on the Astro `.mdx` files.
-  - Any merge to `staging` that modifies files in the `/cms` folder triggers a rebuild of Strapi Admin panel.
+  - Any push to `staging` that modifies files in `/cms` triggers a rebuild of the Strapi Admin panel on the GCP VM.
+  - Any push to `staging` that modifies MD/MDX files in `src/content/foundation-pages` or `src/content/summit-pages` triggers `sync:mdx`, which updates Strapi content from Astro files.
 
 ### Hosting Architecture
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -127,7 +127,7 @@ When content is published or updated in Strapi:
 
 - This allows Astro content (blog posts, events, navigation, etc.) to remain the source of truth while keeping the Strapi database synchronized.
 
-- Every merge to `staging` that contains changes **outside the `/cms` directory** triggers the GCP VM to pull the latest changes and execute the `sync:mdx` script, which updates the Strapi database based on the Astro `.mdx` files.
+- On pushes to `staging`, changes in `src/content/foundation-pages` or `src/content/summit-pages` trigger the `sync:mdx` workflow job, which updates the Strapi database based on Astro files.
 
 **Features**
 
@@ -138,7 +138,7 @@ When content is published or updated in Strapi:
 - Creates, updates, and deletes Strapi entries to match the MDX file system
 - Supports localized content matching
 - Supports `dry-run` mode to preview changes
-- Automatically runs on merges to the `staging` branch
+- Automatically runs on pushes to `staging` when supported content paths change
 
 **Setup**
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -127,14 +127,16 @@ When content is published or updated in Strapi:
 
 - This allows Astro content (blog posts, events, navigation, etc.) to remain the source of truth while keeping the Strapi database synchronized.
 
-- On pushes to `staging`, changes in `src/content/foundation-pages` or `src/content/summit-pages` trigger the `sync:mdx` workflow job, which updates the Strapi database based on Astro files.
+- On pushes to `staging`, changes to `.md` or `.mdx` files in `src/content/foundation-pages`, `src/content/summit-pages`, `src/content/foundation-blog-posts`, or `src/content/ambassadors` trigger the `sync:mdx` workflow job, including localized files under `src/content/<locale>/...`.
 
 **Features**
 
 - Scans MDX files in
+  - `src/content/ambassadors`
   - `src/content/foundation-pages`
   - `src/content/summit-pages`
   - `src/content/foundation-blog-posts`
+- Also scans localized content under `src/content/<locale>/...` for those same content roots
 - Creates, updates, and deletes Strapi entries to match the MDX file system
 - Supports localized content matching
 - Supports `dry-run` mode to preview changes


### PR DESCRIPTION
## Summary
This pull request updates the documentation and GitHub Actions workflow to clarify and simplify how content and Strapi synchronization are triggered on the `staging` branch. The workflow now runs on all pushes to `staging` (not just merged PRs), and the logic for detecting relevant changes and triggering jobs has been streamlined. Documentation has been updated to reflect these changes and to clarify which files trigger which actions.

**Workflow and automation updates:**

* The `.github/workflows/staging-merge.yml` workflow now runs on every push to `staging` instead of only on merged pull requests, and the logic for detecting changes in `cms/` and content directories has been simplified by removing the merged PR detection step. [[1]](diffhunk://#diff-d14c2cc43db6867786c018837d7e0b036b27fd351a9eed3de6c571dda756dd6bL4-R4) [[2]](diffhunk://#diff-d14c2cc43db6867786c018837d7e0b036b27fd351a9eed3de6c571dda756dd6bL20-L23) [[3]](diffhunk://#diff-d14c2cc43db6867786c018837d7e0b036b27fd351a9eed3de6c571dda756dd6bL47-L96)
* The jobs for rebuilding Strapi and syncing MDX to Strapi now depend directly on the output of the change detection step, triggering only when relevant files are changed, and no longer check for merged PRs. [[1]](diffhunk://#diff-d14c2cc43db6867786c018837d7e0b036b27fd351a9eed3de6c571dda756dd6bL128-R81) [[2]](diffhunk://#diff-d14c2cc43db6867786c018837d7e0b036b27fd351a9eed3de6c571dda756dd6bL168-R121) [[3]](diffhunk://#diff-d14c2cc43db6867786c018837d7e0b036b27fd351a9eed3de6c571dda756dd6bL201-R150)

**Documentation updates:**

* Updated `.github/copilot-instructions.md` to describe the new workflow behavior, including the new triggers for rebuilding Strapi and syncing MDX, and the use of `pnpm` instead of `bun` for production builds. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L114-R114) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L150-R150)
* Clarified in both `README.md` and `cms/README.md` that pushes to `staging` (not just merges) trigger Strapi rebuilds and MDX syncs, and specified the exact content paths that trigger these actions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L294-R295) [[2]](diffhunk://#diff-ebc23392422666023e1931bd89aeba76fe47f409b13196baedffaeff3b04b58bL130-R130) [[3]](diffhunk://#diff-ebc23392422666023e1931bd89aeba76fe47f409b13196baedffaeff3b04b58bL141-R141)

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)
