### PR TITLE
chore: pin pnpm to v10.27.0 across repo and CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,12 +13,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
@@ -32,12 +30,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/playground-merge.yml
+++ b/.github/workflows/playground-merge.yml
@@ -132,10 +132,11 @@ jobs:
     runs-on: strapi-vm
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Rebuild Strapi CMS
         shell: bash
@@ -188,8 +189,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/playground-merge.yml
+++ b/.github/workflows/playground-merge.yml
@@ -132,6 +132,11 @@ jobs:
     runs-on: strapi-vm
 
     steps:
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Rebuild Strapi CMS
         shell: bash
         run: |
@@ -179,12 +184,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -132,10 +132,11 @@ jobs:
     runs-on: strapi-vm
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Rebuild Strapi CMS
         shell: bash
@@ -188,8 +189,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -132,6 +132,11 @@ jobs:
     runs-on: strapi-vm
 
     steps:
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Rebuild Strapi CMS
         shell: bash
         run: |
@@ -179,12 +184,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Install dependencies
         run: pnpm install

--- a/cms/package.json
+++ b/cms/package.json
@@ -2,6 +2,7 @@
   "name": "interledger-cms",
   "private": true,
   "version": "0.1.0",
+  "packageManager": "pnpm@10.27.0",
   "description": "Strapi CMS for Interledger developer portal",
   "scripts": {
     "develop": "ENV_PATH=../.env strapi develop",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "interledger-website",
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "pnpm@10.27.0",
   "scripts": {
     "start": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
## Summary

Pins pnpm to v10.27.0 across the repository and all CI workflows to resolve a native addon installation failure on the GCP VM.

**Root cause:** `better-sqlite3@12.6.2` (already on staging) failed to install on the VM with pnpm v9. pnpm v9 constructs an incorrect path for the `prebuild-install` binary when running native addon install scripts, dropping the `.pnpm/` store segment. pnpm v10 fixes this.

**Changes:**
- Added `"packageManager": "pnpm@10.27.0"` to root and `cms/package.json`  `pnpm/action-setup@v4` reads this automatically, and corepack enforces it locally
- Removed explicit `version:` from all `pnpm/action-setup@v4` steps in CI, the action reads the version from `packageManager` in `package.json` (specifying both causes a conflict error)
- Added `actions/checkout@v4` to the `rebuild-strapi` job in both merge workflows, required so `pnpm/action-setup` can find `package.json` on the runner (the job previously had no checkout step)
- Bumped `sync-mdx-to-strapi` job from Node 20 → Node 22 in both merge workflows (Node 22 is required by Astro 6, already updated in `lint.yml`)

## Related Issue

Unblocks the VM regression introduced by `better-sqlite3@12.6.2` on staging.

## Manual Test

After merging, trigger the staging-merge workflow manually and confirm `rebuild-strapi` completes without the `prebuild-install` path error.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `chore: pin pnpm to v10.27.0 across repo and CI workflows`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)