### PR TITLE
ci: better file change detection to trigger build

### DIFF
--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -190,7 +190,7 @@ jobs:
   sync-mdx-to-strapi:
     needs: [detect-changes, rebuild-strapi]
     if: |
-      always() &&
+      (needs.rebuild-strapi.result == 'success' || needs.rebuild-strapi.result == 'skipped') &&
       needs.detect-changes.outputs.content_changed == 'true'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -100,17 +100,46 @@ jobs:
                 changedFiles = (commit.data.files ?? []).map((file) => file.filename)
               }
             } else {
-              const files = await github.paginate(
-                github.rest.repos.compareCommitsWithBasehead,
-                {
+              core.info(`Comparing commits ${before}...${after} via GitHub API`)
+              try {
+                const response = await github.rest.repos.compareCommitsWithBasehead({
                   owner,
                   repo,
                   basehead: `${before}...${after}`,
                   per_page: 100
-                },
-                (response) => (response.data.files ?? []).map((file) => file.filename)
-              )
-              changedFiles = files
+                })
+                const compare = response.data
+                const files = compare.files ?? []
+
+                // The compare endpoint caps the files list; it is not truly paginated.
+                // If the response is truncated or reports too many files, fail safe by
+                // forcing a rebuild/sync instead of risking missing relevant changes.
+                const tooManyFilesFlag =
+                  typeof compare.too_many_files === 'boolean'
+                    ? compare.too_many_files
+                    : false
+                const filesLikelyTruncated = files.length >= 300
+
+                if (tooManyFilesFlag || filesLikelyTruncated) {
+                  core.warning(
+                    'GitHub compareCommitsWithBasehead response may be truncated due to too many changed files; ' +
+                      'treating CMS and content as changed to avoid missing updates.'
+                  )
+                  core.setOutput('cms_changed', 'true')
+                  core.setOutput('content_changed', 'true')
+                  return
+                }
+
+                changedFiles = files.map((file) => file.filename)
+              } catch (error) {
+                core.warning(
+                  `Failed to compare commits ${before}...${after}: ${error}`
+                )
+                // On API failure, err on the side of caution and assume relevant changes occurred.
+                core.setOutput('cms_changed', 'true')
+                core.setOutput('content_changed', 'true')
+                return
+              }
             }
 
             changedFiles = [...new Set(changedFiles)]
@@ -155,10 +184,11 @@ jobs:
           set -euo pipefail
 
           nvm use 22
+          PNPM_VERSION=10.27.0
           corepack enable
-          corepack prepare pnpm@10.27.0 --activate
+          corepack prepare pnpm@$PNPM_VERSION --activate
           pnpm --version
-          test "$(pnpm --version)" = "10.27.0"
+          test "$(pnpm --version)" = "$PNPM_VERSION"
 
           # Add pnpm to PATH (not loaded from .bashrc in GitHub Actions)
           export PNPM_HOME="/home/strapi/.local/share/pnpm"
@@ -201,12 +231,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -61,13 +61,44 @@ jobs:
             let changedFiles = []
 
             if (!before || before === zeroSha) {
-              core.info('No valid "before" SHA available; using head commit files as fallback')
-              const commit = await github.rest.repos.getCommit({
-                owner,
-                repo,
-                ref: after
-              })
-              changedFiles = (commit.data.files ?? []).map((file) => file.filename)
+              core.info('No valid "before" SHA available; using push payload commits to detect changes')
+
+              const payloadCommits = Array.isArray(context.payload.commits)
+                ? context.payload.commits
+                : []
+
+              if (payloadCommits.length > 0) {
+                const changedFilesSet = new Set()
+
+                for (const commit of payloadCommits) {
+                  for (const file of commit.added || []) {
+                    changedFilesSet.add(file)
+                  }
+                  for (const file of commit.modified || []) {
+                    changedFilesSet.add(file)
+                  }
+                  for (const file of commit.removed || []) {
+                    changedFilesSet.add(file)
+                  }
+                }
+
+                changedFiles = [...changedFilesSet]
+
+                if (changedFiles.length === 0) {
+                  core.info('Push payload commits found but produced no changed files; falling back to head commit files')
+                }
+              } else {
+                core.info('No commits found in push payload; falling back to head commit files')
+              }
+
+              if (changedFiles.length === 0) {
+                const commit = await github.rest.repos.getCommit({
+                  owner,
+                  repo,
+                  ref: after
+                })
+                changedFiles = (commit.data.files ?? []).map((file) => file.filename)
+              }
             } else {
               const files = await github.paginate(
                 github.rest.repos.compareCommitsWithBasehead,

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           script: |
             const contentPattern = /^src\/content\/(?:(?:foundation-pages|summit-pages|foundation-blog-posts|ambassadors)\/|[^/]+\/(?:foundation-pages|summit-pages|foundation-blog-posts|ambassadors)\/).+\.(md|mdx)$/
+            const zeroSha = '0000000000000000000000000000000000000000'
 
             if (context.eventName === 'workflow_dispatch') {
               core.info('Manual trigger - will rebuild CMS and sync content')
@@ -52,28 +53,52 @@ jobs:
               return
             }
 
-            const changedFiles = [...new Set(
-              (context.payload.commits ?? []).flatMap((commit) => [
-                ...(commit.added ?? []),
-                ...(commit.modified ?? []),
-                ...(commit.removed ?? [])
-              ])
-            )]
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const before = context.payload.before
+            const after = context.sha
 
-            const fallbackToAllChanged = changedFiles.length === 0
+            let changedFiles = []
 
-            if (fallbackToAllChanged) {
-              core.info(
-                'No changed files were available in the push payload; treating tracked areas as changed'
-              )
+            if (!before || before === zeroSha) {
+              core.info('No valid "before" SHA available; using head commit files as fallback')
+              const commit = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: after
+              })
+              changedFiles = (commit.data.files ?? []).map((file) => file.filename)
             } else {
-              core.info(`Detected ${changedFiles.length} changed file(s) from push payload`)
+              const files = await github.paginate(
+                github.rest.repos.compareCommitsWithBasehead,
+                {
+                  owner,
+                  repo,
+                  basehead: `${before}...${after}`,
+                  per_page: 100
+                },
+                (response) => (response.data.files ?? []).map((file) => file.filename)
+              )
+              changedFiles = files
+            }
+
+            changedFiles = [...new Set(changedFiles)]
+            core.info(`Detected ${changedFiles.length} changed file(s) via GitHub API`)
+
+            if (changedFiles.length === 0) {
+              core.info('Changed files list is empty')
+            } else {
+              core.startGroup('Changed files')
+              for (const file of changedFiles) {
+                core.info(file)
+              }
+              core.endGroup()
             }
 
             const cmsChanged =
-              fallbackToAllChanged || changedFiles.some((file) => file.startsWith('cms/'))
+              changedFiles.some((file) => file.startsWith('cms/'))
             const contentChanged =
-              fallbackToAllChanged || changedFiles.some((file) => contentPattern.test(file))
+              changedFiles.some((file) => contentPattern.test(file))
 
             if (cmsChanged) {
               core.info('CMS changes detected')
@@ -93,12 +118,6 @@ jobs:
     runs-on: strapi-vm
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
       - name: Rebuild Strapi CMS
         shell: bash
         run: |
@@ -145,10 +164,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '20'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -123,6 +123,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          nvm use 22
+          corepack enable
+          corepack prepare pnpm@10.27.0 --activate
+          pnpm --version
+          test "$(pnpm --version)" = "10.27.0"
+
           # Add pnpm to PATH (not loaded from .bashrc in GitHub Actions)
           export PNPM_HOME="/home/strapi/.local/share/pnpm"
           export PATH="$PNPM_HOME:$PATH"


### PR DESCRIPTION
- Pins node to 22 and pnpm to 10.27.0 for the build
- Now uses the changes api to better handle build triggers

---

## Summary
This pull request updates the `staging-merge.yml` GitHub Actions workflow to improve how changed files are detected and to update Node.js and pnpm versions for consistency and reliability. The most significant changes include a more robust method for determining changed files using the GitHub API, dropping some unnecessary setup steps, and updating tool versions.

**Workflow improvements:**

* Changed the logic for detecting changed files: Instead of relying solely on the push payload, the workflow now uses the GitHub API to compare commit SHAs and retrieve changed files, with a fallback for cases where the "before" SHA is missing or zero. This makes file detection more accurate and reliable.
* Improved logging: The workflow now logs the number of changed files detected and lists them in a group for better traceability during runs.

**Dependency and environment updates:**

* Updated the Node.js version from 22 to 20 and set pnpm to version 9 to ensure compatibility and stability.
* Removed unnecessary steps for checking out the repository and setting up pnpm in the Strapi CMS rebuild job, streamlining the workflow.

**Other technical improvements:**

* Introduced a `zeroSha` constant to handle edge cases when the "before" SHA is not available, ensuring the workflow doesn't fail in such scenarios.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
