### PR TITLE
fix(ci): remove manual PNPM_HOME override from rebuild step

### DIFF
--- a/.github/workflows/playground-merge.yml
+++ b/.github/workflows/playground-merge.yml
@@ -143,10 +143,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Add pnpm to PATH (not loaded from .bashrc in GitHub Actions)
-          export PNPM_HOME="/home/strapi/.local/share/pnpm"
-          export PATH="$PNPM_HOME:$PATH"
-
           cd /home/strapi/interledger.org-v5-playground
 
           # Ensure pull fails instead of creating merge commits

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -104,10 +104,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Add pnpm to PATH (not loaded from .bashrc in GitHub Actions)
-          export PNPM_HOME="/home/strapi/.local/share/pnpm"
-          export PATH="$PNPM_HOME:$PATH"
-
           cd /home/strapi/interledger.org-v5-staging
 
           # Ensure pull fails instead of creating merge commits


### PR DESCRIPTION

## Summary
pnpm/action-setup@v4 sets PNPM_HOME to the correct v10 install path. The manual export was overriding it with the old pnpm v9 path, causing pnpm to resolve from v9 instead of the version pinned via packageManager.


## Related Issue
<!-- Fixes INTORG-123 -->

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [ ] `pnpm run format`
- [ ] `pnpm run lint`

## PR Checklist

- [ ] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
