### PR TITLE
refactor(nav): split Summit and Foundation headers into sub-components [INTORG-404]

### DIFF
--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -8,7 +8,18 @@ import {
   localizeRoute
 } from '@/utils'
 
+interface Props {
+  listClass?: string
+  itemClass?: string
+  linkClass?: string
+}
+
 const { routeLocale, currentSlug, currentBasePath } = Astro.locals
+const {
+  listClass = 'flex items-center p-0 list-none',
+  itemClass = "flex items-center after:mx-space-2xs after:opacity-80 after:text-primary-fallback after:content-['|'] last:after:content-none",
+  linkClass = 'block px-space-2xs py-space-s text-primary-fallback no-underline transition-colors duration-200 hover:text-primary data-[active=true]:underline data-[active=true]:decoration-2 data-[active=true]:underline-offset-[4px]'
+} = Astro.props as Props
 
 const entry = translationMap[currentSlug]
 function toDefaultSectionHref(locale: Locale, basePath: string): string {
@@ -26,13 +37,13 @@ const hrefs = Object.fromEntries(
 ) as Record<Locale, string>
 ---
 
-<ul class="flex items-center p-0 list-none">
+<ul class={listClass}>
   {
     switcherLocales.map((locale) => (
-      <li class="flex items-center after:mx-space-2xs after:opacity-80 after:text-primary-fallback after:content-['|'] last:after:content-none">
+      <li class={itemClass}>
         <a
           href={hrefs[locale]}
-          class="block px-space-2xs py-space-s text-primary-fallback no-underline transition-colors duration-200 hover:text-primary data-[active=true]:underline data-[active=true]:decoration-2 data-[active=true]:underline-offset-[4px]"
+          class={linkClass}
           data-active={routeLocale === locale ? 'true' : 'false'}
           hreflang={locale}
         >

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -19,7 +19,7 @@ const {
   listClass = 'flex items-center p-0 list-none',
   itemClass = "flex items-center after:mx-space-2xs after:opacity-80 after:text-primary-fallback after:content-['|'] last:after:content-none",
   linkClass = 'block px-space-2xs py-space-s text-primary-fallback no-underline transition-colors duration-200 hover:text-primary data-[active=true]:underline data-[active=true]:decoration-2 data-[active=true]:underline-offset-[4px]'
-} = Astro.props as Props
+} = Astro.props
 
 const entry = translationMap[currentSlug]
 function toDefaultSectionHref(locale: Locale, basePath: string): string {

--- a/src/components/pages/FoundationHeader.astro
+++ b/src/components/pages/FoundationHeader.astro
@@ -1,18 +1,19 @@
 ---
+/**
+ * Foundation site header.
+ * Composes navigation menu, action links, and mobile toggle.
+ */
 import FoundationLogo from '../logos/FoundationLogo.astro'
-import LanguageSwitcher from '@/components/LanguageSwitcher.astro'
-import {
-  HOME_CONTENT_SLUG,
-  type Locale,
-  translatePath,
-  useTranslations,
-  getNavigation
-} from '@/utils'
+import FoundationNavMenu from '../shared/foundation-header/FoundationNavMenu.astro'
+import FoundationNavActions from '../shared/foundation-header/FoundationNavActions.astro'
+import HamburgerButton from '../shared/HamburgerButton.astro'
+import foundationNavigation from '@/config/foundation-navigation.json'
+import type { MenuGroup, MenuItem } from '@/types/navigation'
 
-const { routeLocale } = Astro.locals
-const locale = (routeLocale ?? 'en') as Locale
-const { mainMenu, ctaButton } = getNavigation('foundation', locale)
-const t = useTranslations(routeLocale)
+const { mainMenu, ctaButton } = foundationNavigation as {
+  mainMenu: MenuGroup[]
+  ctaButton?: MenuItem
+}
 ---
 
 <header
@@ -20,267 +21,36 @@ const t = useTranslations(routeLocale)
   role="banner"
 >
   <nav
-    class="flex items-center justify-between xl:grid xl:grid-cols-[auto_1fr_auto] xl:gap-space-s max-[1059px]:h-[var(--site-header-height)]"
+    class="flex items-center justify-between min-[1060px]:grid min-[1060px]:grid-cols-[auto_1fr_auto] min-[1060px]:gap-space-s max-[1059px]:h-[var(--site-header-height)]"
     role="navigation"
     aria-labelledby="block-interledger-mainnavigation-menu"
     id="block-interledger-mainnavigation"
     data-nav
   >
     <h2 class="sr-only" id="block-interledger-mainnavigation-menu">
-      {t('nav.main')}
+      Main Navigation
     </h2>
     <a
-      href={translatePath('foundation-pages', routeLocale, HOME_CONTENT_SLUG)}
-      class="w-[11em] flex-none xl:col-start-1 xl:col-end-2 xl:z-[1]"
-      aria-label={t('aria.logo.foundation')}
+      href="/"
+      class="w-[11em] flex-none min-[1060px]:col-start-1 min-[1060px]:col-end-2 min-[1060px]:z-[1]"
+      aria-label="Interledger Foundation"
       data-umami-event="Site Nav - Logo"
     >
       <FoundationLogo class="text-black" />
     </a>
     <div
-      class="xl:col-start-2 xl:col-end-3 xl:flex xl:items-center xl:justify-center max-[1059px]:absolute max-[1059px]:right-0 max-[1059px]:top-[var(--site-header-height)] max-[1059px]:bg-white max-[1059px]:border-t max-[1059px]:border-gray-header max-[1059px]:transition-transform max-[1059px]:duration-slow max-[1059px]:will-change-transform max-[479px]:w-full min-[480px]:max-[1059px]:w-max min-[1060px]:relative min-[1060px]:transform-none min-[1060px]:top-0 min-[1060px]:right-0 min-[1060px]:bg-transparent min-[1060px]:border-0 data-[offscreen=true]:max-[1059px]:translate-x-full"
+      class="header-nav-wrapper header-nav-wrapper--foundation"
       data-nav-wrapper
       data-offscreen="true"
       id="siteNavLinks"
     >
-      <ul
-        class="list-none ps-0 justify-center xl:flex xl:items-center"
-        id="siteNavMenu"
-        data-nav-list
-      >
-        {
-          mainMenu.map((group) => (
-            <li class="group min-[1060px]:relative" data-menu-level="1">
-              <button
-                aria-expanded="false"
-                data-umami-event={`Site Nav - ${group.label}`}
-                class="peer block text-current whitespace-nowrap py-space-s px-space-2xs border-none bg-transparent transition-colors duration-200 hover:bg-gray-header max-[1059px]:px-space-s after:content-[url('/img/arrow-menu.svg')] after:inline-block after:w-[9px] after:ml-2 after:transition-transform after:duration-500 motion-reduce:after:transition-none group-hover:after:translate-y-[30%] group-hover:after:rotate-180 data-[open=true]:after:translate-y-[30%] data-[open=true]:after:rotate-180 data-[active=true]:underline data-[active=true]:decoration-current data-[active=true]:decoration-2 data-[active=true]:underline-offset-8"
-                data-submenu-button
-                data-open="false"
-              >
-                {group.label}
-              </button>
-              {group.items && group.items.length > 0 && (
-                <ul class="list-none ps-0 max-[1059px]:hidden max-[1059px]:ps-space-m min-[1060px]:absolute min-[1060px]:bg-white min-[1060px]:border-l-2 min-[1060px]:border-gray-header min-[1060px]:transition-opacity min-[1060px]:duration-fast min-[1060px]:invisible min-[1060px]:opacity-0 min-[1060px]:min-w-full min-[1060px]:top-[calc(1.4em+var(--spacing-space-s)*2)] min-[1060px]:shadow-[2px_3px_6px_-3px_hsla(0,0%,0%,0.06),-2px_3px_6px_-3px_hsla(0,0%,0%,0.06)] min-[1060px]:group-hover:visible min-[1060px]:group-hover:opacity-100 min-[1060px]:group-hover:w-max min-[1060px]:group-hover:left-0 min-[1060px]:peer-data-[open=true]:visible min-[1060px]:peer-data-[open=true]:opacity-100 min-[1060px]:peer-data-[open=true]:w-max min-[1060px]:peer-data-[open=true]:left-0 max-[1059px]:peer-data-[open=true]:block">
-                  {group.items.map((item) => (
-                    <li data-menu-level="2">
-                      <a
-                        href={item.href || '#'}
-                        data-umami-event={`Site Nav - ${item.label}`}
-                        class="block no-underline text-black hover:bg-gray-header max-[1059px]:py-space-s max-[1059px]:px-space-s min-[1060px]:py-space-2xs min-[1060px]:px-space-2xs data-[active=true]:underline data-[active=true]:decoration-current data-[active=true]:decoration-2 data-[active=true]:underline-offset-8"
-                        {...(item.openInNewTab
-                          ? { target: '_blank', rel: 'noopener noreferrer' }
-                          : {})}
-                      >
-                        {item.label}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </li>
-          ))
-        }
-      </ul>
+      <FoundationNavMenu menuGroups={mainMenu} />
     </div>
-    <div
-      class="flex items-center gap-space-s xl:col-start-3 xl:col-end-4 max-[1059px]:flex-col max-[1059px]:items-start max-[1059px]:px-space-s"
-    >
-      {
-        ctaButton && (
-          <a
-            class="self-center no-underline py-space-s hover:underline max-[1059px]:hover:bg-gray-header"
-            href={ctaButton.href || '#'}
-            data-umami-event={`Site Nav - ${ctaButton.label}`}
-            {...(ctaButton.openInNewTab
-              ? { target: '_blank', rel: 'noopener noreferrer' }
-              : {})}
-          >
-            {ctaButton.label}
-          </a>
-        )
-      }
-      <LanguageSwitcher />
-    </div>
-    <button
-      type="button"
-      class="min-[1060px]:hidden border-0 bg-transparent py-space-xs"
-      aria-controls="siteNavMenu"
-      aria-label={t('nav.toggle_menu')}
-      title={t('nav.toggle_menu')}
-      id="siteNavToggle"
-      data-nav-toggle
-    >
-      <div
-        id="menuIcon"
-        class="group relative h-[1em] w-[1.5em] cursor-pointer transition-[transform] duration-500 ease-in-out"
-        data-open="false"
-      >
-        <span
-          class="absolute left-0 block h-[4px] w-full rounded bg-current opacity-100 transition-[transform,top,width,left] duration-200 ease-in-out top-0 group-data-[open=true]:top-1/2 group-data-[open=true]:w-0 group-data-[open=true]:left-1/2"
-        ></span>
-        <span
-          class="absolute left-0 block h-[4px] w-full rounded bg-current opacity-100 transition-[transform,top,width,left] duration-200 ease-in-out top-1/2 group-data-[open=true]:rotate-45"
-        ></span>
-        <span
-          class="absolute left-0 block h-[4px] w-full rounded bg-current opacity-100 transition-[transform,top,width,left] duration-200 ease-in-out top-1/2 group-data-[open=true]:-rotate-45"
-        ></span>
-        <span
-          class="absolute left-0 block h-[4px] w-full rounded bg-current opacity-100 transition-[transform,top,width,left] duration-200 ease-in-out top-full group-data-[open=true]:top-1/2 group-data-[open=true]:w-0 group-data-[open=true]:left-1/2"
-        ></span>
-      </div>
-    </button>
+    <FoundationNavActions ctaButton={ctaButton} />
+    <HamburgerButton menuId="siteNavMenu" iconId="foundationMenuIcon" />
   </nav>
 </header>
 
 <script>
-  import { stripTrailingSlash } from '@/utils/client'
-
-  const siteLinksWrapper = document.querySelector('[data-nav-wrapper]')
-  const wideNavMinWidth = window.matchMedia('(min-width: 1060px)')
-  wideNavMinWidth.addEventListener('change', handleNavDisplayStyles)
-
-  const siteNavToggle = document.querySelector('[data-nav-toggle]')
-  const menuIcon = document.getElementById('menuIcon')
-
-  if (document.contains(siteNavToggle)) {
-    siteNavToggle?.addEventListener('click', handleMobileNavToggle, false)
-  }
-
-  function setOffscreenState(isOffscreen: boolean) {
-    if (siteLinksWrapper instanceof HTMLElement) {
-      siteLinksWrapper.dataset.offscreen = isOffscreen ? 'true' : 'false'
-    }
-  }
-
-  function setMenuIconOpenState(isOpen: boolean) {
-    if (menuIcon instanceof HTMLElement) {
-      menuIcon.dataset.open = isOpen ? 'true' : 'false'
-    }
-  }
-
-  function handleMobileNavToggle() {
-    const isCurrentlyOffscreen =
-      siteLinksWrapper instanceof HTMLElement &&
-      siteLinksWrapper.dataset.offscreen === 'true'
-    setOffscreenState(!isCurrentlyOffscreen)
-    setMenuIconOpenState(isCurrentlyOffscreen)
-  }
-
-  function handleNavDisplayStyles(event: MediaQueryListEvent) {
-    if (event.matches) {
-      setOffscreenState(false)
-      setMenuIconOpenState(false)
-    } else {
-      if (siteLinksWrapper) {
-        flashPrevention(siteLinksWrapper)
-      }
-      setOffscreenState(true)
-      setMenuIconOpenState(false)
-    }
-  }
-
-  function flashPrevention(element: Element) {
-    element.setAttribute('style', 'display:none')
-    setTimeout(() => {
-      element.removeAttribute('style')
-    }, 10)
-  }
-
-  // Site sub-navigation toggle
-  const siteNav = document.querySelector('[data-nav-list]') as HTMLInputElement
-
-  if (document.contains(siteNav)) {
-    const submenuButtons = document.querySelectorAll('[data-submenu-button]')
-
-    submenuButtons.forEach((submenuButton) => {
-      submenuButton.setAttribute('aria-expanded', 'false')
-      submenuButton.setAttribute('data-open', 'false')
-
-      submenuButton.addEventListener('click', function (event) {
-        const clickedSubmenuButton = event.target
-        const allSubmenuButtons = Array.from(submenuButtons)
-        const notClickedSubmenuButtons = allSubmenuButtons.filter(
-          function (otherSubmenuButton) {
-            return otherSubmenuButton !== clickedSubmenuButton
-          }
-        )
-        notClickedSubmenuButtons.forEach((button) => {
-          button.setAttribute('aria-expanded', 'false')
-          button.setAttribute('data-open', 'false')
-        })
-        if (clickedSubmenuButton instanceof HTMLElement) {
-          const isOpen =
-            clickedSubmenuButton?.getAttribute('aria-expanded') === 'true'
-          if (isOpen) {
-            clickedSubmenuButton?.setAttribute('aria-expanded', 'false')
-            clickedSubmenuButton?.setAttribute('data-open', 'false')
-          } else {
-            clickedSubmenuButton?.setAttribute('aria-expanded', 'true')
-            clickedSubmenuButton?.setAttribute('data-open', 'true')
-          }
-        }
-      })
-    })
-
-    siteNav?.addEventListener('keydown', function (event) {
-      if (event.key === 'Escape') {
-        resetSubMenus()
-      }
-    })
-
-    document.addEventListener('click', function (event) {
-      if (isClickOutside(event, submenuButtons)) {
-        resetSubMenus()
-      }
-    })
-
-    function resetSubMenus() {
-      submenuButtons.forEach((submenuButton) => {
-        submenuButton.setAttribute('aria-expanded', 'false')
-        submenuButton.setAttribute('data-open', 'false')
-      })
-    }
-  }
-
-  function isClickOutside(
-    event: MouseEvent,
-    nodeList: NodeListOf<Element>
-  ): boolean {
-    let clickedInsideTarget = false
-    const eventTarget = event.target as Element
-    Array.from(nodeList).forEach(function (element) {
-      if (element.contains(eventTarget)) {
-        clickedInsideTarget = true
-      }
-    })
-    return !clickedInsideTarget
-  }
-
-  // Site sub-navigation highlighting parent menu item
-  const devLinks = document.querySelectorAll(
-    "[data-menu-level='2'] a[href*='/developers']"
-  )
-  const currentPath = stripTrailingSlash(window.location.pathname)
-
-  const activeSections = ['/blog']
-  devLinks.forEach((devLink) => {
-    if (devLink instanceof HTMLAnchorElement) {
-      const linkPath = devLink.pathname
-      const isExactMatch = linkPath === currentPath
-
-      const isSectionMatch = activeSections.some(
-        (section) =>
-          currentPath.startsWith(section) && linkPath.startsWith(section)
-      )
-
-      if (isExactMatch || isSectionMatch) {
-        const parentMenu = devLink.closest("[data-menu-level='1']")
-        const parentMenuLink = parentMenu?.querySelector('button')
-
-        devLink.setAttribute('data-active', 'true')
-        parentMenuLink?.setAttribute('data-active', 'true')
-      }
-    }
-  })
+  import '../shared/foundation-header/foundation-header.ts'
 </script>

--- a/src/components/pages/FoundationHeader.astro
+++ b/src/components/pages/FoundationHeader.astro
@@ -7,13 +7,18 @@ import FoundationLogo from '../logos/FoundationLogo.astro'
 import FoundationNavMenu from '../shared/foundation-header/FoundationNavMenu.astro'
 import FoundationNavActions from '../shared/foundation-header/FoundationNavActions.astro'
 import HamburgerButton from '../shared/HamburgerButton.astro'
-import foundationNavigation from '@/config/foundation-navigation.json'
-import type { MenuGroup, MenuItem } from '@/types/navigation'
 
-const { mainMenu, ctaButton } = foundationNavigation as {
-  mainMenu: MenuGroup[]
-  ctaButton?: MenuItem
-}
+import {
+  translatePath,
+  HOME_CONTENT_SLUG,
+  useTranslations,
+  getNavigation
+} from '@/utils'
+
+const { routeLocale } = Astro.locals
+const t = useTranslations(routeLocale)
+
+const { mainMenu, ctaButton } = getNavigation('foundation', routeLocale)
 ---
 
 <header
@@ -28,12 +33,12 @@ const { mainMenu, ctaButton } = foundationNavigation as {
     data-nav
   >
     <h2 class="sr-only" id="block-interledger-mainnavigation-menu">
-      Main Navigation
+      {t('nav.main')}
     </h2>
     <a
-      href="/"
+      href={translatePath('foundation-pages', routeLocale, HOME_CONTENT_SLUG)}
       class="w-[11em] flex-none min-[1060px]:col-start-1 min-[1060px]:col-end-2 min-[1060px]:z-[1]"
-      aria-label="Interledger Foundation"
+      aria-label={t('aria.logo.foundation')}
       data-umami-event="Site Nav - Logo"
     >
       <FoundationLogo class="text-black" />

--- a/src/components/pages/SummitHeader.astro
+++ b/src/components/pages/SummitHeader.astro
@@ -1,44 +1,20 @@
 ---
+/**
+ * Summit site header.
+ * Composes navigation menu, action links, and mobile toggle.
+ */
 import FoundationLogo from '../logos/FoundationLogo.astro'
-import LanguageSwitcher from '@/components/LanguageSwitcher.astro'
-import {
-  HOME_CONTENT_SLUG,
-  type Locale,
-  translatePath,
-  useTranslations,
-  getNavigation
-} from '@/utils'
+import { ROUTE_BASES } from '@/utils/routes'
+import SummitNavMenu from '../shared/summit-header/SummitNavMenu.astro'
+import SummitNavActions from '../shared/summit-header/SummitNavActions.astro'
+import HamburgerButton from '../shared/HamburgerButton.astro'
+import summitNavigation from '@/config/summit-navigation.json'
+import type { MenuGroup, MenuItem } from '@/types/navigation'
 
-const { routeLocale } = Astro.locals
-const locale = (routeLocale ?? 'en') as Locale
-const { mainMenu, ctaButton } = getNavigation('summit', locale)
-const t = useTranslations(routeLocale)
-const summitHomePath = translatePath(
-  'summit-pages',
-  routeLocale,
-  HOME_CONTENT_SLUG
-)
-
-const navWrapperClass =
-  'xl:col-start-2 xl:col-end-3 xl:flex xl:items-center xl:justify-center max-[1059px]:absolute max-[1059px]:right-0 max-[1059px]:top-[var(--site-header-height)] max-[1059px]:bg-black max-[1059px]:border-t max-[1059px]:border-gray-header max-[1059px]:transition-transform max-[1059px]:duration-slow max-[1059px]:will-change-transform max-[479px]:w-full min-[480px]:max-[1059px]:w-max min-[1060px]:relative min-[1060px]:transform-none min-[1060px]:top-0 min-[1060px]:right-0 min-[1060px]:bg-transparent min-[1060px]:border-0 data-[offscreen=true]:max-[1059px]:translate-x-full'
-
-const navItemBase =
-  'block text-current whitespace-nowrap py-space-s px-space-2xs transition-colors duration-150 max-[1059px]:px-space-s'
-const navItemActive =
-  'hover:bg-[#444] data-[active=true]:underline data-[active=true]:decoration-current data-[active=true]:decoration-2 data-[active=true]:underline-offset-8'
-const topNavLinkClass = `${navItemBase} ${navItemActive}`
-const topNavButtonClass = `${navItemBase} border-none bg-transparent after:content-[url('/img/arrow-menu.svg')] after:inline-block after:w-[9px] after:ml-2 after:filter after:invert after:transition-transform after:duration-300 motion-reduce:after:transition-none group-hover:after:translate-y-[30%] group-hover:after:rotate-180 data-[open=true]:bg-[#444] data-[open=true]:after:translate-y-[30%] data-[open=true]:after:rotate-180 ${navItemActive} peer`
-
-const submenuClass =
-  'list-none ps-0 max-[1059px]:hidden max-[1059px]:ps-space-m min-[1060px]:absolute min-[1060px]:bg-black min-[1060px]:border-l-2 min-[1060px]:border-[#444] min-[1060px]:transition-opacity min-[1060px]:duration-fast min-[1060px]:invisible min-[1060px]:opacity-0 min-[1060px]:min-w-full min-[1060px]:top-[calc(1.4em+var(--spacing-space-s)*2)] min-[1060px]:shadow-[2px_3px_6px_-3px_hsla(0,0%,0%,0.3),-2px_3px_6px_-3px_hsla(0,0%,0%,0.3)] min-[1060px]:group-hover:visible min-[1060px]:group-hover:opacity-100 min-[1060px]:group-hover:w-max min-[1060px]:group-hover:left-0 min-[1060px]:peer-data-[open=true]:visible min-[1060px]:peer-data-[open=true]:opacity-100 min-[1060px]:peer-data-[open=true]:w-max min-[1060px]:peer-data-[open=true]:left-0 max-[1059px]:peer-data-[open=true]:block'
-
-const submenuItemBase =
-  'block no-underline text-white max-[1059px]:py-space-s max-[1059px]:px-space-s min-[1060px]:py-space-2xs min-[1060px]:px-space-2xs transition-colors duration-150'
-const submenuItemClass = `${submenuItemBase} ${navItemActive}`
-
-const rightNavBase =
-  'self-center py-space-s no-underline hover:underline transition-colors duration-150 max-[1059px]:hover:bg-[#444]'
-const rightNavLinkClass = `${rightNavBase} whitespace-nowrap max-[1059px]:hidden`
+const { mainMenu, ctaButton } = summitNavigation as {
+  mainMenu: MenuGroup[]
+  ctaButton?: MenuItem
+}
 ---
 
 <header
@@ -46,284 +22,36 @@ const rightNavLinkClass = `${rightNavBase} whitespace-nowrap max-[1059px]:hidden
   role="banner"
 >
   <nav
-    class="flex items-center justify-between xl:grid xl:grid-cols-[auto_1fr_auto] xl:gap-space-s max-[1059px]:h-[var(--site-header-height)]"
+    class="flex items-center justify-between min-[1060px]:grid min-[1060px]:grid-cols-[auto_1fr_auto] min-[1060px]:gap-space-s max-[1059px]:h-[var(--site-header-height)]"
     role="navigation"
     aria-labelledby="block-summit-navigation-menu"
     id="block-summit-navigation"
     data-nav
-    data-summit-home-path={summitHomePath}
   >
     <h2 class="sr-only" id="block-summit-navigation-menu">
-      {t('nav.summit')}
+      Summit Navigation
     </h2>
     <a
-      href={summitHomePath}
-      class="w-[11em] flex-none xl:col-start-1 xl:col-end-2 xl:z-[1]"
-      aria-label={t('aria.logo.summit')}
+      href={ROUTE_BASES['summit-pages']}
+      class="w-[11em] flex-none min-[1060px]:col-start-1 min-[1060px]:col-end-2 min-[1060px]:z-[1]"
+      aria-label="Interledger Summit"
       data-umami-event="Summit Nav - Logo"
     >
       <FoundationLogo class="text-white" />
     </a>
     <div
-      class={navWrapperClass}
+      class="header-nav-wrapper header-nav-wrapper--summit"
       data-nav-wrapper
       data-offscreen="true"
       id="summitNavLinks"
     >
-      <ul
-        class="list-none ps-0 justify-center xl:flex xl:items-center"
-        id="summitNavMenu"
-        data-nav-list
-      >
-        {
-          mainMenu.map((group) => (
-            <li class="group min-[1060px]:relative" data-menu-level="1">
-              {group.href ? (
-                <a
-                  href={group.href}
-                  data-umami-event={`Summit Nav - ${group.label}`}
-                  class={topNavLinkClass}
-                >
-                  {group.label}
-                </a>
-              ) : (
-                <>
-                  <button
-                    aria-expanded="false"
-                    data-umami-event={`Summit Nav - ${group.label}`}
-                    class={topNavButtonClass}
-                    data-submenu-button
-                    data-open="false"
-                  >
-                    {group.label}
-                  </button>
-                  {group.items && group.items.length > 0 && (
-                    <ul class={submenuClass}>
-                      {group.items.map((item) => (
-                        <li data-menu-level="2">
-                          <a
-                            href={item.href || '#'}
-                            data-umami-event={`Summit Nav - ${item.label}`}
-                            class={submenuItemClass}
-                            {...(item.openInNewTab
-                              ? { target: '_blank', rel: 'noopener noreferrer' }
-                              : {})}
-                          >
-                            {item.label}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </>
-              )}
-            </li>
-          ))
-        }
-      </ul>
+      <SummitNavMenu menuGroups={mainMenu} />
     </div>
-    <div
-      class="flex items-center gap-space-s xl:col-start-3 xl:col-end-4 max-[1059px]:flex-col max-[1059px]:items-start max-[1059px]:px-space-s"
-    >
-      <a
-        class={rightNavLinkClass}
-        href={ctaButton?.href || '/'}
-        data-umami-event={`Summit Nav - ${ctaButton?.label || 'Interledger Foundation'}`}
-        {...ctaButton?.openInNewTab
-          ? { target: '_blank', rel: 'noopener noreferrer' }
-          : {}}
-      >
-        {ctaButton?.label || 'Interledger Foundation'}
-      </a>
-      <LanguageSwitcher />
-    </div>
-    <button
-      type="button"
-      class="min-[1060px]:hidden border-0 bg-transparent py-space-xs"
-      aria-controls="summitNavMenu"
-      aria-label={t('nav.toggle_menu')}
-      title={t('nav.toggle_menu')}
-      id="summitNavToggle"
-      data-nav-toggle
-    >
-      <div
-        id="summitMenuIcon"
-        class="group relative h-[1em] w-[1.5em] cursor-pointer transition-[transform] duration-500 ease-in-out"
-        data-open="false"
-      >
-        <span
-          class="absolute left-0 block h-[4px] w-full rounded bg-current opacity-100 transition-[transform,top,width,left] duration-200 ease-in-out top-0 group-data-[open=true]:top-1/2 group-data-[open=true]:w-0 group-data-[open=true]:left-1/2"
-        ></span>
-        <span
-          class="absolute left-0 block h-[4px] w-full rounded bg-current opacity-100 transition-[transform,top,width,left] duration-200 ease-in-out top-1/2 group-data-[open=true]:rotate-45"
-        ></span>
-        <span
-          class="absolute left-0 block h-[4px] w-full rounded bg-current opacity-100 transition-[transform,top,width,left] duration-200 ease-in-out top-1/2 group-data-[open=true]:-rotate-45"
-        ></span>
-        <span
-          class="absolute left-0 block h-[4px] w-full rounded bg-current opacity-100 transition-[transform,top,width,left] duration-200 ease-in-out top-full group-data-[open=true]:top-1/2 group-data-[open=true]:w-0 group-data-[open=true]:left-1/2"
-        ></span>
-      </div>
-    </button>
+    <SummitNavActions ctaButton={ctaButton} />
+    <HamburgerButton menuId="summitNavMenu" iconId="summitMenuIcon" />
   </nav>
 </header>
 
 <script>
-  import { stripTrailingSlash } from '@/utils/client'
-
-  const summitLinksWrapper = document.querySelector('[data-nav-wrapper]')
-  const wideNavMinWidth = window.matchMedia('(min-width: 1060px)')
-  wideNavMinWidth.addEventListener('change', handleNavDisplayStyles)
-
-  const summitNavToggle = document.querySelector('[data-nav-toggle]')
-  const summitMenuIcon = document.getElementById('summitMenuIcon')
-
-  if (document.contains(summitNavToggle)) {
-    summitNavToggle?.addEventListener('click', handleMobileNavToggle, false)
-  }
-
-  function setOffscreenState(isOffscreen: boolean) {
-    if (summitLinksWrapper instanceof HTMLElement) {
-      summitLinksWrapper.dataset.offscreen = isOffscreen ? 'true' : 'false'
-    }
-  }
-
-  function setMenuIconOpenState(isOpen: boolean) {
-    if (summitMenuIcon instanceof HTMLElement) {
-      summitMenuIcon.dataset.open = isOpen ? 'true' : 'false'
-    }
-  }
-
-  function handleMobileNavToggle() {
-    const isCurrentlyOffscreen =
-      summitLinksWrapper instanceof HTMLElement &&
-      summitLinksWrapper.dataset.offscreen === 'true'
-    setOffscreenState(!isCurrentlyOffscreen)
-    setMenuIconOpenState(isCurrentlyOffscreen)
-  }
-
-  function handleNavDisplayStyles(event: MediaQueryListEvent) {
-    if (event.matches) {
-      setOffscreenState(false)
-      setMenuIconOpenState(false)
-    } else {
-      if (summitLinksWrapper) {
-        flashPrevention(summitLinksWrapper)
-      }
-      setOffscreenState(true)
-      setMenuIconOpenState(false)
-    }
-  }
-
-  function flashPrevention(element: Element) {
-    element.setAttribute('style', 'display:none')
-    setTimeout(() => {
-      element.removeAttribute('style')
-    }, 10)
-  }
-
-  // Summit sub-navigation toggle
-  const summitNav = document.querySelector(
-    '[data-nav-list]'
-  ) as HTMLInputElement
-
-  if (document.contains(summitNav)) {
-    const submenuButtons = document.querySelectorAll('[data-submenu-button]')
-
-    submenuButtons.forEach((submenuButton) => {
-      submenuButton.setAttribute('aria-expanded', 'false')
-      submenuButton.setAttribute('data-open', 'false')
-
-      submenuButton.addEventListener('click', function (event) {
-        const clickedSubmenuButton = event.target
-        const allSubmenuButtons = Array.from(submenuButtons)
-        const notClickedSubmenuButtons = allSubmenuButtons.filter(
-          function (otherSubmenuButton) {
-            return otherSubmenuButton !== clickedSubmenuButton
-          }
-        )
-        notClickedSubmenuButtons.forEach((button) => {
-          button.setAttribute('aria-expanded', 'false')
-          button.setAttribute('data-open', 'false')
-        })
-        if (clickedSubmenuButton instanceof HTMLElement) {
-          const isOpen =
-            clickedSubmenuButton?.getAttribute('aria-expanded') === 'true'
-          if (isOpen) {
-            clickedSubmenuButton?.setAttribute('aria-expanded', 'false')
-            clickedSubmenuButton?.setAttribute('data-open', 'false')
-          } else {
-            clickedSubmenuButton?.setAttribute('aria-expanded', 'true')
-            clickedSubmenuButton?.setAttribute('data-open', 'true')
-          }
-        }
-      })
-    })
-
-    summitNav?.addEventListener('keydown', function (event) {
-      if (event.key === 'Escape') {
-        resetSubMenus()
-      }
-    })
-
-    document.addEventListener('click', function (event) {
-      if (isClickOutside(event, submenuButtons)) {
-        resetSubMenus()
-      }
-    })
-
-    function resetSubMenus() {
-      submenuButtons.forEach((submenuButton) => {
-        submenuButton.setAttribute('aria-expanded', 'false')
-        submenuButton.setAttribute('data-open', 'false')
-      })
-    }
-  }
-
-  function isClickOutside(
-    event: MouseEvent,
-    nodeList: NodeListOf<Element>
-  ): boolean {
-    let clickedInsideTarget = false
-    const eventTarget = event.target as Element
-    Array.from(nodeList).forEach(function (element) {
-      if (element.contains(eventTarget)) {
-        clickedInsideTarget = true
-      }
-    })
-    return !clickedInsideTarget
-  }
-
-  // Mark active navigation links
-  const currentPath = window.location.pathname
-  const summitHomePath =
-    document
-      .querySelector('[data-nav]')
-      ?.getAttribute('data-summit-home-path') ?? '/summit'
-  const navLinks = document.querySelectorAll('[data-nav-list] a')
-
-  navLinks.forEach((link) => {
-    if (link instanceof HTMLAnchorElement) {
-      const linkPath = link.pathname
-      const normalizedCurrentPath = stripTrailingSlash(currentPath)
-      const normalizedLinkPath = stripTrailingSlash(linkPath)
-
-      // Check for exact match or if current path starts with link path (for subpages)
-      if (
-        normalizedCurrentPath === normalizedLinkPath ||
-        (normalizedLinkPath !== summitHomePath &&
-          normalizedCurrentPath.startsWith(normalizedLinkPath))
-      ) {
-        link.setAttribute('data-active', 'true')
-        link.setAttribute('aria-current', 'page')
-
-        // If it's a submenu item, also mark the parent button
-        const parentMenu = link.closest("[data-menu-level='1']")
-        const parentButton = parentMenu?.querySelector('button')
-        if (parentButton) {
-          parentButton.setAttribute('data-active', 'true')
-        }
-      }
-    }
-  })
+  import '../shared/summit-header/summit-header.ts'
 </script>

--- a/src/components/pages/SummitHeader.astro
+++ b/src/components/pages/SummitHeader.astro
@@ -4,17 +4,24 @@
  * Composes navigation menu, action links, and mobile toggle.
  */
 import FoundationLogo from '../logos/FoundationLogo.astro'
-import { ROUTE_BASES } from '@/utils/routes'
+import {
+  getNavigation,
+  useTranslations,
+  translatePath,
+  HOME_CONTENT_SLUG
+} from '@/utils'
 import SummitNavMenu from '../shared/summit-header/SummitNavMenu.astro'
 import SummitNavActions from '../shared/summit-header/SummitNavActions.astro'
 import HamburgerButton from '../shared/HamburgerButton.astro'
-import summitNavigation from '@/config/summit-navigation.json'
-import type { MenuGroup, MenuItem } from '@/types/navigation'
 
-const { mainMenu, ctaButton } = summitNavigation as {
-  mainMenu: MenuGroup[]
-  ctaButton?: MenuItem
-}
+const { routeLocale } = Astro.locals
+const { mainMenu, ctaButton } = getNavigation('summit', routeLocale)
+const t = useTranslations(routeLocale)
+const summitHomePath = translatePath(
+  'summit-pages',
+  routeLocale,
+  HOME_CONTENT_SLUG
+)
 ---
 
 <header
@@ -28,13 +35,11 @@ const { mainMenu, ctaButton } = summitNavigation as {
     id="block-summit-navigation"
     data-nav
   >
-    <h2 class="sr-only" id="block-summit-navigation-menu">
-      Summit Navigation
-    </h2>
+    <h2 class="sr-only" id="block-summit-navigation-menu">{t('nav.summit')}</h2>
     <a
-      href={ROUTE_BASES['summit-pages']}
+      href={summitHomePath}
       class="w-[11em] flex-none min-[1060px]:col-start-1 min-[1060px]:col-end-2 min-[1060px]:z-[1]"
-      aria-label="Interledger Summit"
+      aria-label={t('aria.logo.summit')}
       data-umami-event="Summit Nav - Logo"
     >
       <FoundationLogo class="text-white" />

--- a/src/components/shared/HamburgerButton.astro
+++ b/src/components/shared/HamburgerButton.astro
@@ -1,11 +1,14 @@
 ---
+import { useTranslations } from '@/utils'
+
 interface Props {
   menuId: string
   iconId: string
 }
 
 const { menuId, iconId } = Astro.props
-
+const { routeLocale } = Astro.locals
+const t = useTranslations(routeLocale)
 const barClass =
   'absolute left-0 block h-[4px] w-full rounded bg-current opacity-100 transition-[transform,top,width,left] duration-200 ease-in-out'
 ---
@@ -14,8 +17,8 @@ const barClass =
   type="button"
   class="min-[1060px]:hidden border-0 bg-transparent py-space-xs"
   aria-controls={menuId}
-  aria-label="Toggle Menu"
-  title="Toggle Menu"
+  aria-label={t('nav.toggle_menu')}
+  title={t('nav.toggle_menu')}
   data-nav-toggle
 >
   <div

--- a/src/components/shared/HamburgerButton.astro
+++ b/src/components/shared/HamburgerButton.astro
@@ -1,0 +1,41 @@
+---
+interface Props {
+  menuId: string
+  iconId: string
+}
+
+const { menuId, iconId } = Astro.props
+
+const barClass =
+  'absolute left-0 block h-[4px] w-full rounded bg-current opacity-100 transition-[transform,top,width,left] duration-200 ease-in-out'
+---
+
+<button
+  type="button"
+  class="min-[1060px]:hidden border-0 bg-transparent py-space-xs"
+  aria-controls={menuId}
+  aria-label="Toggle Menu"
+  title="Toggle Menu"
+  data-nav-toggle
+>
+  <div
+    id={iconId}
+    class="group relative h-[1em] w-[1.5em] cursor-pointer transition-[transform] duration-500 ease-in-out"
+    data-open="false"
+  >
+    <span
+      class:list={[
+        barClass,
+        'top-0 group-data-[open=true]:top-1/2 group-data-[open=true]:w-0 group-data-[open=true]:left-1/2'
+      ]}></span>
+    <span class:list={[barClass, 'top-1/2 group-data-[open=true]:rotate-45']}
+    ></span>
+    <span class:list={[barClass, 'top-1/2 group-data-[open=true]:-rotate-45']}
+    ></span>
+    <span
+      class:list={[
+        barClass,
+        'top-full group-data-[open=true]:top-1/2 group-data-[open=true]:w-0 group-data-[open=true]:left-1/2'
+      ]}></span>
+  </div>
+</button>

--- a/src/components/shared/foundation-header/FoundationNavActions.astro
+++ b/src/components/shared/foundation-header/FoundationNavActions.astro
@@ -9,7 +9,7 @@ interface Props {
 const { ctaButton } = Astro.props
 
 const ctaLinkClass =
-  'self-center no-underline py-space-s hover:underline max-[1059px]:hover:bg-gray-header'
+  'self-center no-underline py-space-s hover:underline max-[1059px]:hover:bg-gray-header max-[1059px]:hidden'
 
 const langItemClass =
   "flex items-center after:mx-space-2xs after:opacity-80 after:text-primary-fallback after:content-['|'] last:after:content-none"

--- a/src/components/shared/foundation-header/FoundationNavActions.astro
+++ b/src/components/shared/foundation-header/FoundationNavActions.astro
@@ -1,0 +1,39 @@
+---
+import type { MenuItem } from '@/types/navigation'
+import LanguageSwitcher from '@/components/LanguageSwitcher.astro'
+
+interface Props {
+  ctaButton?: MenuItem
+}
+
+const { ctaButton } = Astro.props
+
+const ctaLinkClass =
+  'self-center no-underline py-space-s hover:underline max-[1059px]:hover:bg-gray-header'
+
+const langItemClass =
+  "flex items-center after:mx-space-2xs after:opacity-80 after:text-primary-fallback after:content-['|'] last:after:content-none"
+
+const langLinkClass =
+  'block px-space-2xs py-space-s text-primary-fallback no-underline transition-colors duration-200 hover:text-primary data-[active=true]:underline data-[active=true]:decoration-2 data-[active=true]:underline-offset-[4px]'
+---
+
+<div
+  class="flex items-center gap-space-s min-[1060px]:col-start-3 min-[1060px]:col-end-4 max-[1059px]:flex-col max-[1059px]:items-start max-[1059px]:px-space-s"
+>
+  {
+    ctaButton && (
+      <a
+        class={ctaLinkClass}
+        href={ctaButton.href || '#'}
+        data-umami-event={`Site Nav - ${ctaButton.label}`}
+        {...(ctaButton.openInNewTab
+          ? { target: '_blank', rel: 'noopener noreferrer' }
+          : {})}
+      >
+        {ctaButton.label}
+      </a>
+    )
+  }
+  <LanguageSwitcher itemClass={langItemClass} linkClass={langLinkClass} />
+</div>

--- a/src/components/shared/foundation-header/FoundationNavMenu.astro
+++ b/src/components/shared/foundation-header/FoundationNavMenu.astro
@@ -1,0 +1,58 @@
+---
+import type { MenuGroup } from '@/types/navigation'
+
+interface Props {
+  menuGroups: MenuGroup[]
+}
+
+const { menuGroups } = Astro.props
+
+const navButtonClass =
+  "peer block text-current whitespace-nowrap py-space-s px-space-2xs border-none bg-transparent transition-colors duration-200 hover:bg-gray-header max-[1059px]:px-space-s after:content-[url('/img/arrow-menu.svg')] after:inline-block after:w-[9px] after:ml-2 after:transition-transform after:duration-500 motion-reduce:after:transition-none group-hover:after:translate-y-[30%] group-hover:after:rotate-180 data-[open=true]:after:translate-y-[30%] data-[open=true]:after:rotate-180 data-[active=true]:underline data-[active=true]:decoration-current data-[active=true]:decoration-2 data-[active=true]:underline-offset-8"
+
+const submenuClass =
+  'list-none ps-0 max-[1059px]:hidden max-[1059px]:ps-space-m min-[1060px]:absolute min-[1060px]:bg-white min-[1060px]:border-l-2 min-[1060px]:border-gray-header min-[1060px]:transition-opacity min-[1060px]:duration-fast min-[1060px]:invisible min-[1060px]:opacity-0 min-[1060px]:min-w-full min-[1060px]:top-[calc(1.4em+var(--spacing-space-s)*2)] min-[1060px]:shadow-[2px_3px_6px_-3px_hsla(0,0%,0%,0.06),-2px_3px_6px_-3px_hsla(0,0%,0%,0.06)] min-[1060px]:group-hover:visible min-[1060px]:group-hover:opacity-100 min-[1060px]:group-hover:w-max min-[1060px]:group-hover:left-0 min-[1060px]:peer-data-[open=true]:visible min-[1060px]:peer-data-[open=true]:opacity-100 min-[1060px]:peer-data-[open=true]:w-max min-[1060px]:peer-data-[open=true]:left-0 max-[1059px]:peer-data-[open=true]:block'
+
+const submenuItemClass =
+  'block no-underline text-black hover:bg-gray-header max-[1059px]:py-space-s max-[1059px]:px-space-s min-[1060px]:py-space-2xs min-[1060px]:px-space-2xs data-[active=true]:underline data-[active=true]:decoration-current data-[active=true]:decoration-2 data-[active=true]:underline-offset-8'
+---
+
+<ul
+  class="list-none ps-0 justify-center min-[1060px]:flex min-[1060px]:items-center"
+  id="siteNavMenu"
+  data-nav-list
+>
+  {
+    menuGroups.map((group) => (
+      <li class="group min-[1060px]:relative" data-menu-level="1">
+        <button
+          aria-expanded="false"
+          data-umami-event={`Site Nav - ${group.label}`}
+          class={navButtonClass}
+          data-submenu-button
+          data-open="false"
+        >
+          {group.label}
+        </button>
+        {group.items && group.items.length > 0 && (
+          <ul class={submenuClass}>
+            {group.items.map((item) => (
+              <li data-menu-level="2">
+                <a
+                  href={item.href || '#'}
+                  data-umami-event={`Site Nav - ${item.label}`}
+                  class={submenuItemClass}
+                  {...(item.openInNewTab
+                    ? { target: '_blank', rel: 'noopener noreferrer' }
+                    : {})}
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </li>
+    ))
+  }
+</ul>

--- a/src/components/shared/foundation-header/foundation-header.ts
+++ b/src/components/shared/foundation-header/foundation-header.ts
@@ -1,9 +1,10 @@
 import { initHeaderNav } from '@/scripts/header-nav'
 
-const rootSelector = '#block-interledger-mainnavigation'
+const navId = 'block-interledger-mainnavigation'
+const rootSelector = `#${navId}`
 const headerRoot = document.querySelector<HTMLElement>(rootSelector)
 if (headerRoot) {
-  initHeaderNav('foundationMenuIcon', rootSelector)
+  initHeaderNav(navId, 'foundationMenuIcon')
 
   // Mark active navigation links (Foundation-specific: developer links + blog section)
   const devLinks = headerRoot.querySelectorAll(

--- a/src/components/shared/foundation-header/foundation-header.ts
+++ b/src/components/shared/foundation-header/foundation-header.ts
@@ -1,0 +1,38 @@
+import { initHeaderNav } from '@/scripts/header-nav'
+
+const rootSelector = '#block-interledger-mainnavigation'
+const headerRoot = document.querySelector<HTMLElement>(rootSelector)
+if (headerRoot) {
+  initHeaderNav('foundationMenuIcon', rootSelector)
+
+  // Mark active navigation links (Foundation-specific: developer links + blog section)
+  const devLinks = headerRoot.querySelectorAll(
+    "[data-menu-level='2'] a[href*='/developers']"
+  )
+  let currentPath = window.location.pathname
+
+  if (currentPath.endsWith('/')) {
+    currentPath = currentPath.slice(0, -1)
+  }
+
+  const activeSections = ['/blog']
+  devLinks.forEach((devLink) => {
+    if (devLink instanceof HTMLAnchorElement) {
+      const linkPath = devLink.pathname
+      const isExactMatch = linkPath === currentPath
+
+      const isSectionMatch = activeSections.some(
+        (section) =>
+          currentPath.startsWith(section) && linkPath.startsWith(section)
+      )
+
+      if (isExactMatch || isSectionMatch) {
+        const parentMenu = devLink.closest("[data-menu-level='1']")
+        const parentMenuLink = parentMenu?.querySelector('button')
+
+        devLink.setAttribute('data-active', 'true')
+        parentMenuLink?.setAttribute('data-active', 'true')
+      }
+    }
+  })
+}

--- a/src/components/shared/summit-header/SummitNavActions.astro
+++ b/src/components/shared/summit-header/SummitNavActions.astro
@@ -9,8 +9,7 @@ interface Props {
 const { ctaButton } = Astro.props
 
 const rightNavBase =
-  'self-center py-space-s no-underline hover:underline transition-colors duration-150 max-[1059px]:hover:bg-[#444]'
-const rightNavLinkClass = `${rightNavBase} whitespace-nowrap max-[1059px]:hidden`
+  'self-center py-space-s no-underline hover:underline transition-colors duration-150 max-[1059px]:hover:bg-[#444] max-[1059px]:hidden'
 const ctaLinkClass = rightNavBase
 
 const langItemClass =
@@ -37,12 +36,5 @@ const langLinkClass =
       </a>
     )
   }
-  <a
-    href="/"
-    class={rightNavLinkClass}
-    data-umami-event="Summit Nav - Interledger Foundation"
-  >
-    Interledger Foundation
-  </a>
   <LanguageSwitcher itemClass={langItemClass} linkClass={langLinkClass} />
 </div>

--- a/src/components/shared/summit-header/SummitNavActions.astro
+++ b/src/components/shared/summit-header/SummitNavActions.astro
@@ -1,0 +1,48 @@
+---
+import type { MenuItem } from '@/types/navigation'
+import LanguageSwitcher from '@/components/LanguageSwitcher.astro'
+
+interface Props {
+  ctaButton?: MenuItem
+}
+
+const { ctaButton } = Astro.props
+
+const rightNavBase =
+  'self-center py-space-s no-underline hover:underline transition-colors duration-150 max-[1059px]:hover:bg-[#444]'
+const rightNavLinkClass = `${rightNavBase} whitespace-nowrap max-[1059px]:hidden`
+const ctaLinkClass = rightNavBase
+
+const langItemClass =
+  "flex items-center after:mx-space-2xs after:text-white/70 after:content-['|'] last:after:content-none"
+
+const langLinkClass =
+  'block px-space-2xs py-space-s text-white/80 no-underline transition-colors duration-200 hover:text-[hsl(180,100%,50%)] data-[active=true]:text-[hsl(180,100%,50%)] data-[active=true]:underline data-[active=true]:decoration-[hsl(180,100%,50%)] data-[active=true]:decoration-2 data-[active=true]:underline-offset-[4px]'
+---
+
+<div
+  class="flex items-center gap-space-s min-[1060px]:col-start-3 min-[1060px]:col-end-4 max-[1059px]:flex-col max-[1059px]:items-start max-[1059px]:px-space-s"
+>
+  {
+    ctaButton && (
+      <a
+        class={ctaLinkClass}
+        href={ctaButton.href || '#'}
+        data-umami-event={`Summit Nav - ${ctaButton.label}`}
+        {...(ctaButton.openInNewTab
+          ? { target: '_blank', rel: 'noopener noreferrer' }
+          : {})}
+      >
+        {ctaButton.label}
+      </a>
+    )
+  }
+  <a
+    href="/"
+    class={rightNavLinkClass}
+    data-umami-event="Summit Nav - Interledger Foundation"
+  >
+    Interledger Foundation
+  </a>
+  <LanguageSwitcher itemClass={langItemClass} linkClass={langLinkClass} />
+</div>

--- a/src/components/shared/summit-header/SummitNavMenu.astro
+++ b/src/components/shared/summit-header/SummitNavMenu.astro
@@ -1,0 +1,75 @@
+---
+import type { MenuGroup } from '@/types/navigation'
+
+interface Props {
+  menuGroups: MenuGroup[]
+}
+
+const { menuGroups } = Astro.props
+
+const navItemBase =
+  'block text-current whitespace-nowrap py-space-s px-space-2xs transition-colors duration-150 max-[1059px]:px-space-s'
+const navItemActive =
+  'hover:bg-[#444] data-[active=true]:underline data-[active=true]:decoration-current data-[active=true]:decoration-2 data-[active=true]:underline-offset-8'
+const topNavLinkClass = `${navItemBase} ${navItemActive}`
+const topNavButtonClass = `${navItemBase} border-none bg-transparent after:content-[url('/img/arrow-menu.svg')] after:inline-block after:w-[9px] after:ml-2 after:filter after:invert after:transition-transform after:duration-300 motion-reduce:after:transition-none group-hover:after:translate-y-[30%] group-hover:after:rotate-180 data-[open=true]:bg-[#444] data-[open=true]:after:translate-y-[30%] data-[open=true]:after:rotate-180 ${navItemActive} peer`
+
+const submenuClass =
+  'list-none ps-0 max-[1059px]:hidden max-[1059px]:ps-space-m min-[1060px]:absolute min-[1060px]:bg-black min-[1060px]:border-l-2 min-[1060px]:border-[#444] min-[1060px]:transition-opacity min-[1060px]:duration-fast min-[1060px]:invisible min-[1060px]:opacity-0 min-[1060px]:min-w-full min-[1060px]:top-[calc(1.4em+var(--spacing-space-s)*2)] min-[1060px]:shadow-[2px_3px_6px_-3px_hsla(0,0%,0%,0.3),-2px_3px_6px_-3px_hsla(0,0%,0%,0.3)] min-[1060px]:group-hover:visible min-[1060px]:group-hover:opacity-100 min-[1060px]:group-hover:w-max min-[1060px]:group-hover:left-0 min-[1060px]:peer-data-[open=true]:visible min-[1060px]:peer-data-[open=true]:opacity-100 min-[1060px]:peer-data-[open=true]:w-max min-[1060px]:peer-data-[open=true]:left-0 max-[1059px]:peer-data-[open=true]:block'
+
+const submenuItemBase =
+  'block no-underline text-white max-[1059px]:py-space-s max-[1059px]:px-space-s min-[1060px]:py-space-2xs min-[1060px]:px-space-2xs transition-colors duration-150'
+const submenuItemClass = `${submenuItemBase} ${navItemActive}`
+---
+
+<ul
+  class="list-none ps-0 justify-center min-[1060px]:flex min-[1060px]:items-center"
+  id="summitNavMenu"
+  data-nav-list
+>
+  {
+    menuGroups.map((group) => (
+      <li class="group min-[1060px]:relative" data-menu-level="1">
+        {group.href ? (
+          <a
+            href={group.href}
+            data-umami-event={`Summit Nav - ${group.label}`}
+            class={topNavLinkClass}
+          >
+            {group.label}
+          </a>
+        ) : (
+          <>
+            <button
+              aria-expanded="false"
+              data-umami-event={`Summit Nav - ${group.label}`}
+              class={topNavButtonClass}
+              data-submenu-button
+              data-open="false"
+            >
+              {group.label}
+            </button>
+            {group.items && group.items.length > 0 && (
+              <ul class={submenuClass}>
+                {group.items.map((item) => (
+                  <li data-menu-level="2">
+                    <a
+                      href={item.href || '#'}
+                      data-umami-event={`Summit Nav - ${item.label}`}
+                      class={submenuItemClass}
+                      {...(item.openInNewTab
+                        ? { target: '_blank', rel: 'noopener noreferrer' }
+                        : {})}
+                    >
+                      {item.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </li>
+    ))
+  }
+</ul>

--- a/src/components/shared/summit-header/summit-header.ts
+++ b/src/components/shared/summit-header/summit-header.ts
@@ -1,9 +1,10 @@
 import { initHeaderNav } from '@/scripts/header-nav'
 
-const rootSelector = '#block-summit-navigation'
+const navId = 'block-summit-navigation'
+const rootSelector = `#${navId}`
 const headerRoot = document.querySelector<HTMLElement>(rootSelector)
 if (headerRoot) {
-  initHeaderNav('summitMenuIcon', rootSelector)
+  initHeaderNav(navId, 'summitMenuIcon')
 
   // Mark active navigation links (Summit-specific)
   const currentPath = window.location.pathname

--- a/src/components/shared/summit-header/summit-header.ts
+++ b/src/components/shared/summit-header/summit-header.ts
@@ -1,0 +1,34 @@
+import { initHeaderNav } from '@/scripts/header-nav'
+
+const rootSelector = '#block-summit-navigation'
+const headerRoot = document.querySelector<HTMLElement>(rootSelector)
+if (headerRoot) {
+  initHeaderNav('summitMenuIcon', rootSelector)
+
+  // Mark active navigation links (Summit-specific)
+  const currentPath = window.location.pathname
+  const navLinks = headerRoot.querySelectorAll('[data-nav-list] a')
+
+  navLinks.forEach((link) => {
+    if (link instanceof HTMLAnchorElement) {
+      const normalizedCurrentPath = currentPath.replace(/\/$/, '')
+      const normalizedLinkPath = link.pathname.replace(/\/$/, '')
+
+      const isExactMatch = normalizedCurrentPath === normalizedLinkPath
+      const isSubpageMatch =
+        normalizedLinkPath !== '/summit' &&
+        normalizedCurrentPath.startsWith(normalizedLinkPath)
+
+      if (isExactMatch || isSubpageMatch) {
+        link.setAttribute('data-active', 'true')
+        link.setAttribute('aria-current', 'page')
+
+        const parentMenu = link.closest("[data-menu-level='1']")
+        const parentButton = parentMenu?.querySelector('button')
+        if (parentButton) {
+          parentButton.setAttribute('data-active', 'true')
+        }
+      }
+    }
+  })
+}

--- a/src/scripts/header-nav.ts
+++ b/src/scripts/header-nav.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared header navigation behavior.
+ * Used by both Summit and Foundation headers.
+ */
+
+/** Sets up mobile nav toggle, responsive breakpoint handling, and submenu behavior. */
+export function initHeaderNav(iconId: string, rootSelector: string) {
+  const root = document.querySelector<HTMLElement>(rootSelector)
+  if (!root) return
+
+  const linksWrapper = root.querySelector<HTMLElement>('[data-nav-wrapper]')
+  const menuIcon = root.querySelector<HTMLElement>(`#${iconId}`)
+  const navToggle = root.querySelector<HTMLElement>('[data-nav-toggle]')
+
+  function setOffscreenState(isOffscreen: boolean) {
+    if (linksWrapper instanceof HTMLElement) {
+      linksWrapper.dataset.offscreen = isOffscreen ? 'true' : 'false'
+    }
+  }
+
+  function setMenuIconOpenState(isOpen: boolean) {
+    if (menuIcon instanceof HTMLElement) {
+      menuIcon.dataset.open = isOpen ? 'true' : 'false'
+    }
+  }
+
+  function handleMobileNavToggle() {
+    const isCurrentlyOffscreen =
+      linksWrapper instanceof HTMLElement &&
+      linksWrapper.dataset.offscreen === 'true'
+    setOffscreenState(!isCurrentlyOffscreen)
+    setMenuIconOpenState(isCurrentlyOffscreen)
+  }
+
+  function handleNavDisplayStyles(event: MediaQueryListEvent) {
+    if (event.matches) {
+      setOffscreenState(false)
+      setMenuIconOpenState(false)
+    } else {
+      if (linksWrapper) {
+        suppressTransitionFlash(linksWrapper)
+      }
+      setOffscreenState(true)
+      setMenuIconOpenState(false)
+    }
+  }
+
+  const wideNavMinWidth = window.matchMedia('(min-width: 1060px)')
+  wideNavMinWidth.addEventListener('change', handleNavDisplayStyles)
+
+  if (navToggle) {
+    navToggle.addEventListener('click', handleMobileNavToggle, false)
+  }
+
+  initSubmenuToggle(root)
+}
+
+function suppressTransitionFlash(element: HTMLElement) {
+  const previousTransition = element.style.transition
+
+  element.style.transition = 'none'
+  // Force style recalculation so the transition suppression is applied.
+  void element.offsetHeight
+
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      if (previousTransition) {
+        element.style.transition = previousTransition
+      } else {
+        element.style.removeProperty('transition')
+      }
+    })
+  })
+}
+
+function isClickOutside(
+  event: MouseEvent,
+  nodeList: NodeListOf<Element>
+): boolean {
+  const eventTarget = event.target as Element
+  return !Array.from(nodeList).some((element) => element.contains(eventTarget))
+}
+
+/** Sets up submenu button toggling, Escape key, and click-outside closing. */
+function initSubmenuToggle(root: HTMLElement) {
+  const navList = root.querySelector<HTMLElement>('[data-nav-list]')
+
+  if (!navList || !document.contains(navList)) return
+
+  const submenuButtons = root.querySelectorAll<HTMLElement>(
+    '[data-submenu-button]'
+  )
+
+  submenuButtons.forEach((submenuButton) => {
+    submenuButton.setAttribute('aria-expanded', 'false')
+    submenuButton.setAttribute('data-open', 'false')
+
+    submenuButton.addEventListener('click', function (event) {
+      const clickedButton = event.currentTarget as HTMLElement
+      const otherButtons = Array.from(submenuButtons).filter(
+        (btn) => btn !== clickedButton
+      )
+
+      otherButtons.forEach((btn) => {
+        btn.setAttribute('aria-expanded', 'false')
+        btn.setAttribute('data-open', 'false')
+      })
+
+      const isOpen = clickedButton.getAttribute('aria-expanded') === 'true'
+      clickedButton.setAttribute('aria-expanded', isOpen ? 'false' : 'true')
+      clickedButton.setAttribute('data-open', isOpen ? 'false' : 'true')
+    })
+  })
+
+  navList.addEventListener('keydown', function (event) {
+    if (event.key === 'Escape') {
+      resetSubMenus()
+    }
+  })
+
+  document.addEventListener('click', function (event) {
+    if (isClickOutside(event, submenuButtons)) {
+      resetSubMenus()
+    }
+  })
+
+  function resetSubMenus() {
+    submenuButtons.forEach((btn) => {
+      btn.setAttribute('aria-expanded', 'false')
+      btn.setAttribute('data-open', 'false')
+    })
+  }
+}

--- a/src/scripts/header-nav.ts
+++ b/src/scripts/header-nav.ts
@@ -1,15 +1,18 @@
 /**
  * Shared header navigation behavior.
  * Used by both Summit and Foundation headers.
+ *
+ * All DOM queries are scoped to the nav root identified by `navId`,
+ * so multiple headers on the same page won't interfere with each other.
  */
 
 /** Sets up mobile nav toggle, responsive breakpoint handling, and submenu behavior. */
-export function initHeaderNav(iconId: string, rootSelector: string) {
-  const root = document.querySelector<HTMLElement>(rootSelector)
+export function initHeaderNav(navId: string, iconId: string) {
+  const root = document.getElementById(navId)
   if (!root) return
 
   const linksWrapper = root.querySelector<HTMLElement>('[data-nav-wrapper]')
-  const menuIcon = root.querySelector<HTMLElement>(`#${iconId}`)
+  const menuIcon = document.getElementById(iconId)
   const navToggle = root.querySelector<HTMLElement>('[data-nav-toggle]')
 
   function setOffscreenState(isOffscreen: boolean) {
@@ -38,7 +41,7 @@ export function initHeaderNav(iconId: string, rootSelector: string) {
       setMenuIconOpenState(false)
     } else {
       if (linksWrapper) {
-        suppressTransitionFlash(linksWrapper)
+        flashPrevention(linksWrapper)
       }
       setOffscreenState(true)
       setMenuIconOpenState(false)
@@ -55,22 +58,11 @@ export function initHeaderNav(iconId: string, rootSelector: string) {
   initSubmenuToggle(root)
 }
 
-function suppressTransitionFlash(element: HTMLElement) {
-  const previousTransition = element.style.transition
-
-  element.style.transition = 'none'
-  // Force style recalculation so the transition suppression is applied.
-  void element.offsetHeight
-
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      if (previousTransition) {
-        element.style.transition = previousTransition
-      } else {
-        element.style.removeProperty('transition')
-      }
-    })
-  })
+function flashPrevention(element: Element) {
+  element.setAttribute('style', 'display:none')
+  setTimeout(() => {
+    element.removeAttribute('style')
+  }, 10)
 }
 
 function isClickOutside(
@@ -85,7 +77,7 @@ function isClickOutside(
 function initSubmenuToggle(root: HTMLElement) {
   const navList = root.querySelector<HTMLElement>('[data-nav-list]')
 
-  if (!navList || !document.contains(navList)) return
+  if (!navList) return
 
   const submenuButtons = root.querySelectorAll<HTMLElement>(
     '[data-submenu-button]'

--- a/src/styles/components/navigation.css
+++ b/src/styles/components/navigation.css
@@ -9,4 +9,68 @@
     color: var(--color-primary);
     text-decoration-line: none;
   }
+
+  /* Shared responsive wrapper used by Foundation/Summit header menus. */
+  .header-nav-wrapper {
+    will-change: transform;
+  }
+
+  @media (min-width: 1060px) {
+    .header-nav-wrapper {
+      grid-column-start: 2;
+      grid-column-end: 3;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
+
+  @media (max-width: 1059px) {
+    .header-nav-wrapper {
+      position: absolute;
+      right: 0;
+      top: var(--site-header-height);
+      border-top-width: 1px;
+      border-top-style: solid;
+      transition-property: transform;
+      transition-duration: var(--duration-slow);
+    }
+
+    .header-nav-wrapper[data-offscreen='true'] {
+      transform: translateX(100%);
+    }
+  }
+
+  @media (max-width: 479px) {
+    .header-nav-wrapper {
+      width: 100%;
+    }
+  }
+
+  @media (min-width: 480px) and (max-width: 1059px) {
+    .header-nav-wrapper {
+      width: max-content;
+    }
+  }
+
+  @media (min-width: 1060px) {
+    .header-nav-wrapper {
+      position: relative;
+      top: 0;
+      right: 0;
+      transform: none;
+      background: transparent;
+      border-width: 0;
+    }
+  }
+
+  .header-nav-wrapper--foundation {
+    background: white;
+    border-top-color: var(--color-gray-header);
+  }
+
+  .header-nav-wrapper--summit {
+    background: black;
+    border-top-color: var(--color-gray-header);
+  }
 }

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -9,3 +9,8 @@ export interface MenuGroup {
   href?: string
   items?: MenuItem[]
 }
+
+export interface NavigationData {
+  mainMenu: MenuGroup[]
+  ctaButton?: MenuItem
+}

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,11 @@
+export interface MenuItem {
+  label: string
+  href?: string
+  openInNewTab?: boolean
+}
+
+export interface MenuGroup {
+  label: string
+  href?: string
+  items?: MenuItem[]
+}

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -4,23 +4,7 @@ import foundationEn from '@/config/foundation-navigation.json'
 import foundationEs from '@/config/foundation-navigation.es.json'
 import summitEn from '@/config/summit-navigation.json'
 import summitEs from '@/config/summit-navigation.es.json'
-
-interface MenuItem {
-  label: string
-  href?: string
-  openInNewTab?: boolean
-}
-
-interface MenuGroup {
-  label: string
-  href?: string
-  items?: MenuItem[]
-}
-
-interface NavigationData {
-  mainMenu: MenuGroup[]
-  ctaButton?: MenuItem
-}
+import type { NavigationData } from '@/types/navigation'
 
 const navigationMap: Record<string, Record<string, NavigationData>> = {
   foundation: {


### PR DESCRIPTION
## Summary

- Split `SummitHeader.astro` (379 lines) and `FoundationHeader.astro` (333 lines) into focused sub-components with co-located styles
- Extract shared navigation behavior (mobile toggle, submenu toggle, keyboard/click-outside handling) into `src/scripts/header-nav.ts`
- Move shared `HamburgerButton` to `src/components/shared/` and shared `MenuItem`/`MenuGroup` types to `src/types/navigation.ts`
- Each header is now a slim orchestrator (~60 lines) composing `NavMenu`, `NavActions`, `HamburgerButton`, and a site-specific script

## Related Issue

INTORG-404

## Manual Test

- [ ] Verify Summit header navigation works (desktop + mobile toggle, submenus, active link highlighting)
- [ ] Verify Foundation header navigation works (desktop + mobile toggle, submenus, developer link highlighting)
- [ ] Test keyboard navigation (Escape closes submenus)
- [ ] Test responsive breakpoint at 1060px transitions cleanly

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)