### PR TITLE
ci: pipeline should source basrc for nvm to work

### DIFF
--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -183,6 +183,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          source ~/.bashrc
+
           nvm use 22
           PNPM_VERSION=10.27.0
           corepack enable


### PR DESCRIPTION
## Summary
The pipeline running on the self hosted runner should source bashrc otherwise nvm will not work correctly.

---
## Auto generated
This pull request makes a minor update to the staging merge workflow by ensuring the user's `.bashrc` is sourced before running subsequent commands. This helps guarantee that the environment is properly set up before proceeding with Node and package manager configuration.

* Sourced `.bashrc` at the start of the workflow step to ensure environment variables and settings are loaded.