### PR TITLE
chore: store Sessionize data as JSON files

### DIFF
--- a/src/data/sessionize/2022-speakers.json
+++ b/src/data/sessionize/2022-speakers.json
@@ -1,0 +1,660 @@
+[
+  {
+    "id": "69f97e3e-d0c7-4fe3-9373-7cbcd223c6c8",
+    "firstName": "Adrian",
+    "lastName": "Hope-Bailie",
+    "fullName": "Adrian Hope-Bailie",
+    "bio": "Adrian is a co-inventor of the Interledger protocol stack and the Open Payments standards and payment pointers. He is a co-founder of Fynbos where he is building the first account that will issue payment pointers and support Open Payments.",
+    "tagLine": "Founder at Fynbos",
+    "profilePicture": "https://sessionize.com/image/9835-400o400o1-SR3MvKEACLnP4hSvrmn8Py.png",
+    "sessions": [
+      {
+        "id": 383792,
+        "name": "Payment pointers - the universal payment instrument"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "b403c048-01ab-4dfa-8a2e-312751966eb3",
+    "firstName": "Amanda",
+    "lastName": "Figueroa",
+    "fullName": "Amanda Figueroa",
+    "bio": "Amanda Figueora is Curationist’s Community Director. She is based in Boston and was raised at the US-Mexico border. Amanda’s finishing her PhD in American Studies at Harvard and has fifteen years of experience in public programs, content management, and web design. At Curationist, Amanda leads in building awareness, engagement, and encouraging connections between large arts-based institutions and underserved and grassroots cultural heritage communities. The goal is to bring together these different types of stakeholders to inform the future of Curationist.",
+    "tagLine": "Community Directior, Curationist",
+    "profilePicture": "https://sessionize.com/image/0938-400o400o1-4RHuGxYdr6sUHjSeCCYHEg.jpg",
+    "sessions": [
+      {
+        "id": 369807,
+        "name": "Open Knowledge and Web Monetization GAP Analysis"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "ea1a7e8e-53b1-4178-850d-c9e5c331d492",
+    "firstName": "Andrés",
+    "lastName": "Arauz",
+    "fullName": "Andrés Arauz",
+    "bio": "Former central banker and policymaker, PhD in crossborder payment systems.",
+    "tagLine": "The People's Clearinghouse, CEO",
+    "profilePicture": "https://sessionize.com/image/2d71-400o400o1-JAhsagT9rwpLApp1vctj2z.jpg",
+    "sessions": [
+      {
+        "id": 384019,
+        "name": "Central Bank RTGS and ILP implementation: Mexico's SPEI and the People's Clearinghouse"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "2d15432a-4cdb-43ff-a339-a4108822482d",
+    "firstName": "Andrew",
+    "lastName": "Mangle",
+    "fullName": "Andrew Mangle",
+    "bio": "Dr. Mangle is an Assistant Professor in Management Information Systems at Maryland's oldest HBCU Bowie State University.  ",
+    "tagLine": "Assistant Professor - Bowie State University",
+    "profilePicture": "https://sessionize.com/image/a7f2-400o400o1-3e3a6859-c3b0-4228-bf96-7998003f09d4.jpg",
+    "sessions": [
+      {
+        "id": 373702,
+        "name": "Including GenZ in Digital Affairs: Bowie State University Share-Out"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "619c6703-1d3c-443e-a176-46c7e66a8b23",
+    "firstName": "Arunjay",
+    "lastName": "Katakam",
+    "fullName": "Arunjay Katakam",
+    "bio": "Arunjay Katakam is a former EY consultant who has co-founded three startups, one of which eventually sold to Twitter. He works with the likes of the United Nations Capital Development Fund, the GSMA and the Bill & Melinda Gates Foundation to increase financial inclusion through mobile money payments and digital public infrastructure. \r\nArunjay mentored over 20 inclusive fintech startups with DFS Lab and was a venture builder with Catalyst Fund. He diligently advocates for a zero-fee customer payment model in his book, The Power of Micro Money Transfers.",
+    "tagLine": "Digital Finance Advisor, Migration and Remittances, UNCDF",
+    "profilePicture": "https://sessionize.com/image/00b0-400o400o1-saTDG4MgcyXTNYgqbr8XSD.jpg",
+    "sessions": [
+      {
+        "id": 389267,
+        "name": "An Open Regulated Global Payment Inter-Network"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "27429f38-3846-488f-9e53-58837c0b6842",
+    "firstName": "Ayden",
+    "lastName": "Férdeline",
+    "fullName": "Ayden Férdeline",
+    "bio": "Ayden Férdeline is a public interest technologist who has worked directly with activists, academics, civil society organizations, lawmakers and industry to support responsible technological innovation with a focus on social impact. He is inspired by the potential of the decentralized web and is passionate about cultivating an empowered community of civic minded stakeholders who share a meaningful and actionable commodority to make Web3 work for more people than Web 2.0 did. He previously represented European civil society organizations on ICANN’s GNSO Council, the body which makes binding policy for generic top-level domain names like .COM and .ORG, and was a technology policy fellow with the Mozilla Foundation. He now hosts the Internet governance history podcast POWER PLAYS – generously supported by Grant for the Web – and independently researches how Internet governance processes can be made more inclusive, for organizations like the National Democratic Institute and the National Endowment for Democracy. Based in Berlin, he is an alumnus of the London School of Economics.  ",
+    "tagLine": "Public Interest Technologist",
+    "profilePicture": "https://sessionize.com/image/0050-400o400o1-NkTkL7fUWbJHuUThxMdJvL.jpg",
+    "sessions": [
+      {
+        "id": 383892,
+        "name": "Can web monetization protocols bring about a fairer digital future?"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "213fae9a-c3ba-44de-8fa8-ab1062a95818",
+    "firstName": "Benjamin",
+    "lastName": "Bellamy",
+    "fullName": "Benjamin Bellamy",
+    "bio": "Benjamin Bellamy is an engineer and entrepreneur.\r\nFor the past twenty years he has led technical and entrepreneurial projects in various industries such as publishing, book distribution, online media, television and e-commerce.\r\nHe is a furious open-source advocate, a podcast lover, and an active contributor to the PodcastIndex community.\r\nBenjamin is the founder and CEO of Ad Aures, a company dedicated to creating fair and sustainable ecosystems for the podcasting industry. In 2020, Ad Aures released Castopod, the first full-fledged open-source podcast hosting solution supporting Web Monetization.",
+    "tagLine": "CEO at Ad Aures",
+    "profilePicture": "https://sessionize.com/image/e562-400o400o1-7z8UQdbBanvVaPS4jZtM3w.jpg",
+    "sessions": [
+      {
+        "id": 383803,
+        "name": "Podcasters, unlock your true creative potential with Web Monetization"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "60ca230a-ed4a-492b-b423-f4fbd279c871",
+    "firstName": "Briana",
+    "lastName": "Marbury",
+    "fullName": "Briana Marbury",
+    "bio": "Briana is passionate about promoting open payments and financial interoperability solutions for the world's population that need it most.  As Executive Director of the Interledger Foundation, her goal is to expand the public’s awareness of the Interledger Protocol's immense potential to improve lives.",
+    "tagLine": "Executive Director, Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/0a57-400o400o1-MMHNmkn9QaterKfaf6qpW1.png",
+    "sessions": [
+      {
+        "id": 370173,
+        "name": "State of Interledger"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "8c31891a-1b90-41c9-9419-cb79cdd7494e",
+    "firstName": "Chris",
+    "lastName": "Lawrence",
+    "fullName": "Chris Lawrence",
+    "bio": null,
+    "tagLine": null,
+    "profilePicture": "https://sessionize.com/image/fce0-400o400o1-0095eaf2-329e-4ba4-8ad1-7c500a4414c4.jpg",
+    "sessions": [
+      {
+        "id": 373822,
+        "name": "Life After the Grant : Let’s talk sustainability!"
+      },
+      {
+        "id": 373825,
+        "name": "Community Building for Innovation and Sustainability"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "4b689e03-a280-47f6-b763-d62a103b042a",
+    "firstName": "Christina",
+    "lastName": "Kinney",
+    "fullName": "Christina Kinney",
+    "bio": "Spent 10+ years in the payments & fintech industry across the globe; served as COO of cross-border payments platform Reach; Founded the Global Retail Insights Network; Stanford University graduate. ",
+    "tagLine": "Co-Founder, SumAssembly: Better Payments for Everyone",
+    "profilePicture": "https://sessionize.com/image/8a24-400o400o1-31dc5b6a-ebbb-4dec-8669-4b4a15036138.jpg",
+    "sessions": [
+      {
+        "id": 369753,
+        "name": "Get Paid. For Real. Right Now."
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "9816f454-6b5a-4ba7-b6b2-444176513cfb",
+    "firstName": "David",
+    "lastName": "Benoit",
+    "fullName": "David Benoit",
+    "bio": "20+ year technology leader and mentor with 11+ years in payments, FX, and market data. Invited expert to the W3C Web Payments Working Group. Extensive experience building reliable, scalable services for mission critical applications.",
+    "tagLine": "Founder, SumAssembly: Better Payouts for Everyone",
+    "profilePicture": "https://sessionize.com/image/bf40-400o400o1-nTXNNqiJLvv2FDqiAYvwSk.jpg",
+    "sessions": [
+      {
+        "id": 369753,
+        "name": "Get Paid. For Real. Right Now."
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "9ba11e2e-9aa7-4b7b-80e8-ba22562b90d0",
+    "firstName": "Ellen",
+    "lastName": "Magallanes",
+    "fullName": "Ellen Magallanes",
+    "bio": "Ellen Magallanes a dual-qualified US-Australian attorney, Secretary at the Internet Law and Policy Foundry, and Senior Counsel at the Wikimedia Foundation. Privacy law, like all the best rabbit holes, was something she fell into and never looked back. Now she furthers her interest in privacy with tech law advocacy in both of her homes: Australia and the US. She is currently based in the San Francisco Bay Area.",
+    "tagLine": "Senior Counsel, Wikimedia Foundation",
+    "profilePicture": "https://sessionize.com/image/c70f-400o400o1-YnEPEbv4qy3PnrEBRZQj9Z.jpg",
+    "sessions": [
+      {
+        "id": 383892,
+        "name": "Can web monetization protocols bring about a fairer digital future?"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "42d693ee-0efe-46fe-ac5c-c18349128166",
+    "firstName": "Erica",
+    "lastName": "Hargreave",
+    "fullName": "Erica Hargreave",
+    "bio": "I craft stories and engage communities through different mediums. To what goal, you ask?  Simply put, to create laughter and smiles, spark the imagination, provoke thought, improve cultural understanding, and to educate.",
+    "tagLine": "Dreaming of an internet full of whimsy, stories of social good & honest journalism, crafted by diverse voices, thanks to the possibilities that Interledger presents for financial inclusion & equity.",
+    "profilePicture": "https://sessionize.com/image/5798-400o400o1-E6SJMUs3eANun3SDnnkn8r.jpg",
+    "sessions": [
+      {
+        "id": 373822,
+        "name": "Life After the Grant : Let’s talk sustainability!"
+      },
+      {
+        "id": 373825,
+        "name": "Community Building for Innovation and Sustainability"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "59dd02ef-66e9-41ec-9335-e2d226665ea1",
+    "firstName": "Erin",
+    "lastName": "Brown",
+    "fullName": "Erin Brown",
+    "bio": "Erin Brown is the Team Leader for the Management Performance Strengthening Team in the Management Bureau’s Office of Management Policy, Budget and Operational Performance.  Before that she launched USAID’s new Diversity, Equity, Inclusion, and Accessibility (DEIA) agenda as the Agency’s Acting Chief DEIA Officer in the Office of the Administrator, including development of its 2021 DEIA Strategic Plan and an Equity Action Plan that highlights the Agency’s key actions to address equity across its programs and partnerships.  A strategy and organizational transformation subject matter expert with 23 years of experience in the public and private sectors, Ms. Brown joined the United States Agency for International Development in 2012 as a Franklin Fellow after 13 years in the private sector where she led medium and large-scale strategic planning, business process improvement, and organizational change management initiatives for defense and civilian government agencies.  Prior to joining USAID, Ms. Brown was a Senior Principal at the Hay Group, a global management consulting firm, where she led the Building Effective Organizations Practice in the Federal Sector. \r\n\r\nA two-time Gears of Government award-winner at USAID, Ms. Brown helped establish a new Safeguarding Unit to help protect recipients of USAID assistance from sexual exploitation and abuse, and launched a new Organizational Health Index to gauge the strength of USAID’s internal operations and mission readiness.  Ms. Brown has also been a dedicated champion for diversity, equity, and inclusion at USAID since joining the Agency, as proven by her service as a collateral duty Equal Employment Opportunity (EEO) Counselor and four years as Chapter President of the USAID Chapter of Blacks in Government (BIG).\r\n\r\nShe holds a bachelor of arts (BA) degree in Political Science from the Loyola University of New Orleans, a master’s degree in public policy (MPP) from the University of Chicago and a master of arts (MA) in organizational sciences from The George Washington University. \r\n\r\n\r\n",
+    "tagLine": "United States Agency for International Development, Former Acting Chief Diversity Officer",
+    "profilePicture": "https://sessionize.com/image/c06c-400o400o1-nv5dQQydeGDphfMZAKidmg.jpg",
+    "sessions": [
+      {
+        "id": 393412,
+        "name": "The 5Ps of Diversity, Equity, and Inclusion (DEI)"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "b0a14d9b-376a-48e2-9a43-75ee8855c9f4",
+    "firstName": "Jake ",
+    "lastName": "Kendall",
+    "fullName": "Jake Kendall",
+    "bio": null,
+    "tagLine": null,
+    "profilePicture": "https://sessionize.com/image/8433-400o400o1-3r2HcFhJGixa2hv8nWEbLQ.svg",
+    "sessions": [
+      {
+        "id": 373700,
+        "name": "DFS Lab work in Sub-Saharan Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "30b3c3bc-2196-4f86-be96-4578358d8818",
+    "firstName": "Joran",
+    "lastName": "Greef",
+    "fullName": "Joran Greef",
+    "bio": "Joran bumped into Coil (and the idea of Interledger) in 2020 on a soccer field in Cape Town. This led to analysis of the Mojaloop payments switch, and the idea for “an accounting database” called TigerBeetle to move the performance needle by three orders of magnitude, as part of providing infrastructure for Interledger and Rafiki. TigerBeetle, Inc. was spun out of Coil as a startup in August 2022.",
+    "tagLine": "Founder & CEO of TigerBeetle",
+    "profilePicture": "https://sessionize.com/image/33b0-400o400o1-7aYQNuj27gu3KEj8usK9dH.jpg",
+    "sessions": [
+      {
+        "id": 385579,
+        "name": "TigerBeetle, a Financial Accounting Database for Interledger"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "e485ce69-cfcc-49d4-8d31-dda1c45a362d",
+    "firstName": "Juan francisco",
+    "lastName": "Manzano garcia",
+    "fullName": "Juan francisco Manzano garcia",
+    "bio": "Software developer for the last 26 years, specialized in BAAS, core banking, digital wallets, and payment systems. With a strong interest in microfinance and socially conscious tech projects.",
+    "tagLine": "The People's Clearinghouse, Tech Partner",
+    "profilePicture": "https://sessionize.com/image/ce4c-400o400o1-D1uZpk2XhyMEYr2yA9DAp3.jpg",
+    "sessions": [
+      {
+        "id": 384019,
+        "name": "Central Bank RTGS and ILP implementation: Mexico's SPEI and the People's Clearinghouse"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "ceea3685-37aa-4cf0-bf1c-9527930f2232",
+    "firstName": "Julaire",
+    "lastName": "Hall",
+    "fullName": "Julaire Hall",
+    "bio": "To be done...",
+    "tagLine": "Program Outreach Manager - Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/b1c9-400o400o1-BPpS53MhqrSXKnunM3uM6B.jpg",
+    "sessions": [
+      {
+        "id": 373702,
+        "name": "Including GenZ in Digital Affairs: Bowie State University Share-Out"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "c9e6ec6a-09b1-4802-8adb-3a85d6651ec0",
+    "firstName": "Karl",
+    "lastName": "Carter",
+    "fullName": "Karl Carter",
+    "bio": "Karl Carter is Founder and CEO of Snake Nation. Karl is a passionate entrepreneur, with 20 + years expertise in social change, entertainment, innovation, creative, marketing/media platforms and strategic growth. He leads a team of dedicated creators, technologists, producers, strategists, influencers and project managers in 7 countries that are galvanized by Snake Nation’s mission to impact the lives of millions of diverse creators and coders globally.  \r\nSnake Nation is a mission driven culture, content and technology company, HQ in Atlanta, GA and Cape Town, South Africa.  Snake Nation has successfully established partnerships with major innovation hubs in Atlanta and  South Africa.  in 2018, Karl lead Snake Nation to establish its first wholly owned live/work/ launch property in Cape Town, South Africa.  Snake Nation empowers young Multicultural Millennial (M2) creators and coders to enter the global Creative Economy on their own terms and build sustainable careers.  The Snake Nation network encompasses People, Platforms and Places- Snake Nation College Societies, Digital platform and Social Studios to live, work and create throughout Africa and America.  \r\nKarl’s experience in brand and movement building is longstanding and is consistently innovative. From truth.com, the most successful youth social change campaign ever, to Current TV the first user generated TV network, to Master of the Mix, the first DJ competition reality show. Airing on a BET and Vh1 for three seasons, it generated millions of views and over 500 million PR impressions.  \r\nKarl has done award winning work for truth®, P&G, Current TV, Verizon, Nissan, Smirnoff and Guinness. He was awarded the first ever Ad Color Innovator award by a distinguished panel of leaders in the advertising and media industry.  He and his team’s work on Current TV garnered a Best New Network Launch from TV Week, Al Gore Guerrilla Marketer of the Year and an Emmy Award for Best Interactive Television Service. Their work on the Truth team won numerous awards and was recognized by Ad Age as the top 15 campaigns of the 21st century.  \r\nKarl is a GWU School of Business Alum and Goldman Sachs 10kSB Graduate. He is passionate about helping young people and social causes through media and marketing.  Karl's commitment to global youth culture, social change and media innovation make him a force in multiple areas. In 2018,  Karl was awarded the World Award for United Nations Sustainable Development Goals Achievement.  \r\nKarl has been interviewed multiple times regarding the creative economy, space making and technology for millennials and youth. \r\nIn 2021, Snake Nation was awarded induction into the World Wide Web consortium  as an awardee of Grand for the Web inclusion grant. Snake Nation’s purpose will be to influence the governing body for internet standards toward  a more diverse, inclusive  and equitable internet economy for everyone. \r\nKarl currently resides in Atlanta, GA and Cape Town South Africa with his wife and two daughters. His driving forces are the love of his family and the love of community, culture, technology and creativity.\r\n",
+    "tagLine": "Karl Carter, tech visionary, CEO and founder of  Snake Nation.",
+    "profilePicture": "https://sessionize.com/image/5cf1-400o400o1-MQREyDiY3vsCKB8fgRrhTH.png",
+    "sessions": [
+      {
+        "id": 383809,
+        "name": "Web Monetization & Creative Culture"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "01fa1826-488a-4034-b76e-5be85cd84a3f",
+    "firstName": "Lawil",
+    "lastName": "Karama",
+    "fullName": "Lawil Karama",
+    "bio": "- ",
+    "tagLine": "hi there ",
+    "profilePicture": "https://sessionize.com/image/c5a2-400o400o1-TqkTZX8HuDDXnBELpsGso6.jpg",
+    "sessions": [
+      {
+        "id": 373822,
+        "name": "Life After the Grant : Let’s talk sustainability!"
+      },
+      {
+        "id": 373825,
+        "name": "Community Building for Innovation and Sustainability"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "19463a94-4746-4eb6-8003-11aacd94ba0f",
+    "firstName": "Matt",
+    "lastName": "Mankins",
+    "fullName": "Matt Mankins",
+    "bio": "Matt Mankins is a recent Mozilla Fellow, researcher, inventor, and entrepreneur with degrees from the MIT Media Laboratory and the University of Miami. \r\n\r\nMankins is currently studying the economics of creativity which builds on his work in industry. Previously Mankins served as the CTO of Fast Company and Director of Monetization for Condé Nast.  He is co-founder of numerous companies, including Vert, SMTP.com, In-a-Moon and has recently started Lorem Labs to commercialize a new web reward system called Kudos.\r\n\r\nMankins formerly owned the Lorem Ipsum Bookstore in Cambridge, Massachusetts, which has won several awards, including the Boston Phoenix's 2005 award for \"Best Bookstore Trying to Save the World\".",
+    "tagLine": "Founder, Lorem Labs",
+    "profilePicture": "https://sessionize.com/image/8bd4-400o400o1-REkPbGYNnpVFPdkoapRh98.jpg",
+    "sessions": [
+      {
+        "id": 383990,
+        "name": "Monetization Patterns: Jump-start your paywall with the Monet Pattern Library"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "e94ceef0-e969-4034-82f5-0f6a39ae26d1",
+    "firstName": "Michael",
+    "lastName": "Richards",
+    "fullName": "Michael Richards",
+    "bio": "Michael Richards is the rapporteur of the Mojaloop Change Control Board, chair of the Mojaloop Design Authority and Mojaloop’s representative on the ISO 20022 standards group. He is deeply involved in the definition of extensions to Mojaloop functionality. These currently focus on improvements to the settlement process, on support for currency conversion and on opening Mojaloop schemes to cross-border payments.\r\n",
+    "tagLine": "Financial Services Principal at ModusBox",
+    "profilePicture": "https://sessionize.com/image/efdd-400o400o1-Y36A8WcU7JGNBmiViQAsfT.jpg",
+    "sessions": [
+      {
+        "id": 383527,
+        "name": "Making Digital Payments Affordable and Simple for Everyone, Everywhere"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "c9e83da7-c881-4eed-8e59-01beb295b8f8",
+    "firstName": "Néstor",
+    "lastName": "Campos",
+    "fullName": "Néstor Campos",
+    "bio": "Néstor has more than 12 years of experience, from software development to efficient artificial intelligence models. Now working in Web3 and financial inclusion in Techgethr (https://techgethr.com/) and PeerPay (https://peerpayapp.com/)",
+    "tagLine": "Microsoft MVP - Alibaba Cloud MVP - AWS Community Builder.",
+    "profilePicture": "https://sessionize.com/image/1afa-400o400o1-K9ny7zKuPHbdy3iFCmdh6x.png",
+    "sessions": [
+      {
+        "id": 368493,
+        "name": "The value of Interledger Protocol in Latin America now and in the future"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "996c2e33-414c-448e-938f-ea987b311373",
+    "firstName": "Nic",
+    "lastName": "Wistreich",
+    "fullName": "Nic Wistreich",
+    "bio": "Co-founded Netribution.co.uk in 1999 to help indie filmmakers get online. Co-author of the Film Finance Handbook (fundyourfilm.com), web designer for non-profits, CiviCRM community member & occasional filmmaker.",
+    "tagLine": "Author, Rervenue Sharing Language",
+    "profilePicture": "https://sessionize.com/image/625c-400o400o1-U6eC4agMLt6qCsb9YpYBFm.jpg",
+    "sessions": [
+      {
+        "id": 384007,
+        "name": "Revenue Sharing Language (RSL): a human and machine-readable syntax for profit-sharing and royalties"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "a922404b-f903-47cf-954f-770d29bed360",
+    "firstName": "Paula",
+    "lastName": "Hunter",
+    "fullName": "Paula Hunter",
+    "bio": "Paula Hunter is the Executive Director of the Mojaloop Foundation – a charitable nonprofit organization focused on extending the financial inclusion efforts of the Mojaloop open source software project. She leads the organization’s strategic planning and direction; grant, membership and strategic partnership development; and evangelism for the organization and its mission. Ms. Hunter is an open source and technology leader with nearly two decades of executive director-level experience managing industry advocacy groups, open source organizations, and standards associations. ",
+    "tagLine": "Executive Director, Mojaloop Foundation",
+    "profilePicture": "https://sessionize.com/image/3b3c-400o400o1-3f03c95c-16b3-4b8e-a197-e14891425746.jpg",
+    "sessions": [
+      {
+        "id": 383527,
+        "name": "Making Digital Payments Affordable and Simple for Everyone, Everywhere"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "9bd85c6e-88b7-4d06-b8c8-0458dc200746",
+    "firstName": "Roberto",
+    "lastName": "Valdovinos",
+    "fullName": "Roberto Valdovinos",
+    "bio": "B.A. and M.A. in Logic and Philosophy (Pantheon-Sorbonne University), M.Phil. in Comparative Studies (Columbia University). Directed the Institute of Mexicans Abroad in the Mexican Government. Works with migrants and marginalized communities in social justice and financial inclusion projects.",
+    "tagLine": "The People's Clearinghouse, CFO",
+    "profilePicture": "https://sessionize.com/image/ece9-400o400o1-WsqWT97aFSuE5KMCpxxrGx.png",
+    "sessions": [
+      {
+        "id": 384019,
+        "name": "Central Bank RTGS and ILP implementation: Mexico's SPEI and the People's Clearinghouse"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "79191886-f727-428b-b584-0eabb4e9587a",
+    "firstName": "Sabine",
+    "lastName": "Schaller",
+    "fullName": "Sabine Schaller",
+    "bio": "Sabine has always been interested in Data Ownership and the Internet of Value. She works on the specification and implementation of open standards like the Interledger Protocol, Open Payments, and Web Monetization to allow for a Web where content can be paid for with hard currency instead of data.\r\nPrior to joining Coil, Sabine co-founded Registree, a privacy-preserving recruitment platform. She holds a degree in Statistics and Mathematical Finance.",
+    "tagLine": "R&D Lead @ Coil",
+    "profilePicture": "https://sessionize.com/image/0dfc-400o400o1-KMFiRGeu27GC7A1QzKNya.jpg",
+    "sessions": [
+      {
+        "id": 383066,
+        "name": "Meet your new friend - Rafiki."
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "959a4893-5d5e-4540-be3c-9584185a3e23",
+    "firstName": "Sharon",
+    "lastName": "Wang",
+    "fullName": "Sharon Wang",
+    "bio": "Hey! I'm a big fan of open source and building community, and try to regularly find opportunities to get involved. When I'm not getting lost in my browser tabs, I enjoy spending time outdoors, bouldering and doing aerial silks.",
+    "tagLine": "software development + community building",
+    "profilePicture": "https://sessionize.com/image/fe3a-400o400o1-4ByDKZjXgc4YxNghryKDnw.jpg",
+    "sessions": [
+      {
+        "id": 374390,
+        "name": "Broadening Financial Inclusion…what does that mean?"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "9348bc41-12c2-4f51-9ee0-f611108e9936",
+    "firstName": "Stefan",
+    "lastName": "Thomas",
+    "fullName": "Stefan Thomas",
+    "bio": "Open-source developer and distributed systems advocate. Currently working to create a better business model for the Web.",
+    "tagLine": null,
+    "profilePicture": "https://sessionize.com/image/6b95-400o400o1-UDemA45zrMevPpgyYYNwFA.jpg",
+    "sessions": [
+      {
+        "id": 390999,
+        "name": "Introducing Dassie: An Interledger Peer-to-peer Network"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "7481c61c-4cb9-45c9-b4ba-44d077496927",
+    "firstName": "Todd",
+    "lastName": "W",
+    "fullName": "Todd W",
+    "bio": "Todd Weaver is a visionary entrepreneur having already challenged Big Media and Big Tech and is happy to be involved challenging Big Finance.",
+    "tagLine": "Founder @ Purism",
+    "profilePicture": "https://sessionize.com/image/041d-400o400o1-R62CuuXQaBXPMpDo1yF5Zr.jpg",
+    "sessions": [
+      {
+        "id": 395414,
+        "name": "An Interlude of Interfacing with Interledger"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "405070c5-a46c-4f12-9b68-5b1ed17e98a1",
+    "firstName": "Uchi",
+    "lastName": "Uchibeke",
+    "fullName": "Uchi Uchibeke",
+    "bio": "Developer, and Founder",
+    "tagLine": "DevRel, Coil. Founder Chimoney",
+    "profilePicture": "https://sessionize.com/image/dbdd-400o400o1-224a67ea-9a82-462c-bd6d-246ec4424151.jpg",
+    "sessions": [
+      {
+        "id": 374219,
+        "name": "Chimoney:  Financial Inclusion, Accessibility, and Monetization"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "3a71dfe5-a936-40b8-853b-46d1652952fe",
+    "firstName": "Xiaoji",
+    "lastName": "Song",
+    "fullName": "Xiaoji Song",
+    "bio": "Xiaoji Song (she/they) is an artist, (interdisciplinary) researcher, and creative practitioner based in Berlin. Growing up in China and trained in Europe, I work on socially relevant and community-specific experiences, often with the local networks, NGOs, and local cultural and political institutions, mediated by texts, images, games, and performances. My projects have appeared in local or international media or cultural platforms in China (PRC), the UK, Germany, the Netherlands, and Bulgaria, to name a few: Worldwide FM, Sofia Art Week, Design Indaba, Goethe Institute Bulgaria, etc.) Working in the liminal spaces of political theory, practice, and art, Xiaoji Song’s research interests include techno-politics, networked social movement, border practices, and the performative aspect of political memory. I am now in a residency at Trust Berlin with two other artists/researchers working on modding practice in the gaming community as well as involved in a collective project on a fictional system of speculative emotional future supported by Light Art Space and Callie’s in Berlin. I am in the study group for the AI Anarchies Project at the German Academy of Art (ADK) and am also an alumna of the Open Set Lab research residency and the University of the Underground research program. Currently, I am finishing my master’s in global communication focusing on political communication of border technology at the University of Erfurt while working as a research assistant for the Humboldt University of Berlin.",
+    "tagLine": "Artist and Interdisciplinary researcher ",
+    "profilePicture": "https://sessionize.com/image/8cc7-400o400o1-KBYLpKTMU3b2xjrwJF8dZT.png",
+    "sessions": [
+      {
+        "id": 383892,
+        "name": "Can web monetization protocols bring about a fairer digital future?"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "18b0324d-30b3-4bc3-975d-474182063ee8",
+    "firstName": "Yassine",
+    "lastName": "Doghri",
+    "fullName": "Yassine Doghri",
+    "bio": "Passionate software engineer with skills ranging from systems architecture and web development to UI / UX design. Open-source contributor and advocate: I've built Castopod and working on making it better!",
+    "tagLine": "Systems Architect at Ad Aures",
+    "profilePicture": null,
+    "sessions": [
+      {
+        "id": 383803,
+        "name": "Podcasters, unlock your true creative potential with Web Monetization"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  },
+  {
+    "id": "2baf70da-a2f6-4b5c-ab1c-1e89c6a4c7fa",
+    "firstName": "Yotam",
+    "lastName": "Liel",
+    "fullName": "Yotam Liel",
+    "bio": "Yotam Liel is a PhD candidate and a lecturer at Tel Aviv University. His research interests focus on studying human behavior in digital environments, ranging from online content consumption to Human-AI interaction and conformity to algorithmic advice. His research has won several awards. Prior to his PhD studies, he worked as a product manager and head of digital in several start-up companies.",
+    "tagLine": "Tel Aviv University, Research Scientist",
+    "profilePicture": "https://sessionize.com/image/01ff-400o400o1-EPiqqDSDnxNveK4NmPF5KR.jpg",
+    "sessions": [
+      {
+        "id": 382765,
+        "name": "Sharing Funds - Sharing Values? - Web Monetization as a catalyst for social change"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [],
+    "categories": []
+  }
+]

--- a/src/data/sessionize/2022-talks.json
+++ b/src/data/sessionize/2022-talks.json
@@ -1,0 +1,657 @@
+[
+  {
+    "groupId": null,
+    "groupName": "All",
+    "sessions": [
+      {
+        "questionAnswers": [],
+        "id": "370173",
+        "title": "State of Interledger",
+        "description": "We'll take a look back at the origins of the Interledger Protocol, where the ecosystem is today, and the illuminous future we're looking forward to.",
+        "startsAt": "2022-11-12T09:45:00",
+        "endsAt": "2022-11-12T10:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "60ca230a-ed4a-492b-b423-f4fbd279c871",
+            "name": "Briana Marbury"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "383066",
+        "title": "Meet your new friend - Rafiki.",
+        "description": "Rafiki is a software package that bundles Interledger infrastructure with the powerful accounting database Tigerbeetle and the Open Payments APIs to send money programmatically. \r\nAnd that is just what first meets the eye. Rafiki has a bunch of hidden qualities, which this session will formally introduce and show off during a live demo. \r\n",
+        "startsAt": "2022-11-12T10:15:00",
+        "endsAt": "2022-11-12T11:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "79191886-f727-428b-b584-0eabb4e9587a",
+            "name": "Sabine Schaller"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "385579",
+        "title": "TigerBeetle, a Financial Accounting Database for Interledger",
+        "description": "How Interledger gave rise to TigerBeetle, the open source distributed database for mission critical safety and performance.",
+        "startsAt": "2022-11-12T11:15:00",
+        "endsAt": "2022-11-12T11:45:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "30b3c3bc-2196-4f86-be96-4578358d8818",
+            "name": "Joran Greef"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "390999",
+        "title": "Introducing Dassie: An Interledger Peer-to-peer Network",
+        "description": "For the past several years, Interledger has been used very effectively among a small group of early adopters. However, it wasn't possible for many developers to gain access to the network due to the difficulty of peering with an existing participant.\r\n\r\nIn this talk, Stefan announces Dassie, a new open-source project which combines Interledger and peer-to-peer technology to dramatically lower the barrier to entry for developers looking to experiment with or build on ILP.",
+        "startsAt": "2022-11-12T11:45:00",
+        "endsAt": "2022-11-12T12:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "9348bc41-12c2-4f51-9ee0-f611108e9936",
+            "name": "Stefan Thomas"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": "https://www.youtube.com/watch?v=Whp4RfW3K_U",
+        "recordingUrl": "https://www.youtube.com/watch?v=FRVkkWTb5V8",
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "374390",
+        "title": "Broadening Financial Inclusion…what does that mean?",
+        "description": "What does Financial Inclusion mean? What does addressing economic disadvantage look like for people with different focus areas, communities, and geographical locations?\r\n\r\nThis panel will discuss considerations, barriers and progress around expanding Financial Inclusion, bringing together perspectives from various backgrounds.",
+        "startsAt": "2022-11-12T13:30:00",
+        "endsAt": "2022-11-12T14:10:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "959a4893-5d5e-4540-be3c-9584185a3e23",
+            "name": "Sharon Wang"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "369807",
+        "title": "Open Knowledge and Web Monetization GAP Analysis",
+        "description": "The Open Knowledge community is built by people all over the world, contributing their time, knowledge, and expertise to platforms like Curationist and Wikipedia. Although these platforms are and should be free to access, paying Open Knowledge contributors for their work would help develop the overall Open movement by further incentivizing and supporting the people who make it run. \r\n\r\nIn this working session, participants will collaborate on a GAP analysis of the Open Knowledge movement to determine if current web monetization practices and strategies could help meet the need to support contributors, and what steps could be taken. The session will result in the creation of a one-page document detailing the points raised in the analysis that can be shared widely within both the web monetization and Open Knowledge communities.",
+        "startsAt": "2022-11-12T13:30:00",
+        "endsAt": "2022-11-12T14:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "b403c048-01ab-4dfa-8a2e-312751966eb3",
+            "name": "Amanda Figueroa"
+          }
+        ],
+        "categories": [],
+        "roomId": 27380,
+        "room": "Breakout Room",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "395414",
+        "title": "An Interlude of Interfacing with Interledger",
+        "description": "A journey of implementing Interledger as the default payment protocol.",
+        "startsAt": "2022-11-12T14:10:00",
+        "endsAt": "2022-11-12T14:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "7481c61c-4cb9-45c9-b4ba-44d077496927",
+            "name": "Todd W"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "382765",
+        "title": "Sharing Funds - Sharing Values? - Web Monetization as a catalyst for social change",
+        "description": "What are the effects of online content monetization models on users' behavior and content consumption choices? Does users' awareness that their browsing time actively funds creators make them become more socially aware consumers? And how might Web Monetization help grassroots initiatives and activists who struggle with “converting” users from clicks to monetary support for their content and causes? In the past few months, we conducted several behavioral studies to examine these questions (and a few more) as part of a research project supported by Grant for the Web. Our project—informed by theories from cognitive and social psychology and studies on the role of online civic engagement in the last decade—investigates if joining web monetization initiatives and actively supporting web monetized content affects the pattern of users' online activism. The session will focus on presenting the studies and sharing the results and the lessons we learned. Our findings so far show that people are, in fact, mindful of the values and beliefs of the creators and outlets of the content they consume. We also learned that people see online content consumption as a means to support causes and creators they care for and that increased awareness of the monetization of online content affects people's willingness to consume content associated with societal and ideological causes.",
+        "startsAt": "2022-11-12T14:40:00",
+        "endsAt": "2022-11-12T15:05:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "2baf70da-a2f6-4b5c-ab1c-1e89c6a4c7fa",
+            "name": "Yotam Liel"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "373822",
+        "title": "Life After the Grant : Let’s talk sustainability!",
+        "description": "Grant funding is great. It can kickstart projects and innovation, creating a lifeline for startups, but it can't sustain a project forever. Join us in exploring the post-grant challenges and possible solutions and pathways to sustainability. In the process, we will look to examples from projects in the Interledger and Creative Equity Communities that are at different stages of crafting their sustainable pathways.",
+        "startsAt": "2022-11-12T14:40:00",
+        "endsAt": "2022-11-12T15:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "8c31891a-1b90-41c9-9419-cb79cdd7494e",
+            "name": "Chris Lawrence"
+          },
+          {
+            "id": "01fa1826-488a-4034-b76e-5be85cd84a3f",
+            "name": "Lawil Karama"
+          },
+          {
+            "id": "42d693ee-0efe-46fe-ac5c-c18349128166",
+            "name": "Erica Hargreave"
+          }
+        ],
+        "categories": [],
+        "roomId": 27380,
+        "room": "Breakout Room",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "374219",
+        "title": "Chimoney:  Financial Inclusion, Accessibility, and Monetization",
+        "description": "Chimoney is working towards a more equitable and creative global society through an open payments network that connects and benefits each human, regardless of identity, geography, or income.\r\n\r\nPayment systems are fragmented and with new ledgers and protocols, interoperability and utility are non-existent.\r\n\r\nIn this session, Uchi will talk about interoperability between offline and decentralized payment systems and how Chimoney is unleashing utility and increasing financial inclusion by enabling people with crypto to spend it on Mobile money like Mpesa, Airtime, and more global options that enhance financial inclusion. He will highlight how developers use Chimoney's API to win their payout gateway and unlock the full potential of the payment chain.\r\n\r\nUchi will guide the summit participants to interact with the Chimoney platform by sending out Chimoney for participants to redeem and have the Chi experience. And share opportunities for integrating with Interledger wallets so that anyone with funds in their interledger-enabled wallet can spend them on real-world products and services.\r\n",
+        "startsAt": "2022-11-12T15:05:00",
+        "endsAt": "2022-11-12T15:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "405070c5-a46c-4f12-9b68-5b1ed17e98a1",
+            "name": "Uchi Uchibeke"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "383990",
+        "title": "Monetization Patterns: Jump-start your paywall with the Monet Pattern Library",
+        "description": "Building user experiences for premium content involves design patterns that may be unfamiliar to web developers. This session introduces one pattern library, Monet, to help developers build paywalls and premium experiences that open for Web Monetization users. ",
+        "startsAt": "2022-11-12T16:00:00",
+        "endsAt": "2022-11-12T16:20:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "19463a94-4746-4eb6-8003-11aacd94ba0f",
+            "name": "Matt Mankins"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "373825",
+        "title": "Community Building for Innovation and Sustainability",
+        "description": "If you build it, go forth and seek your community, and engage that community, then they will come. Community building is not a field of dreams, at least not in the way of the movie. It takes work and a welcoming, open approach to encourage innovation and invite your community to adopt the space as their own, experimenting with what is possible beyond what you’ve thought of. There is an art to it that takes more than just advertising dollars. Join us as we explore the fine art of community building, pitfalls to avoid, and approaches to consider.",
+        "startsAt": "2022-11-12T16:00:00",
+        "endsAt": "2022-11-12T17:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "8c31891a-1b90-41c9-9419-cb79cdd7494e",
+            "name": "Chris Lawrence"
+          },
+          {
+            "id": "01fa1826-488a-4034-b76e-5be85cd84a3f",
+            "name": "Lawil Karama"
+          },
+          {
+            "id": "42d693ee-0efe-46fe-ac5c-c18349128166",
+            "name": "Erica Hargreave"
+          }
+        ],
+        "categories": [],
+        "roomId": 27380,
+        "room": "Breakout Room",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "383803",
+        "title": "Podcasters, unlock your true creative potential with Web Monetization",
+        "description": "Podcasting is booming all over the world, but only a minority of podcasts are monetized.\r\n\r\nPodcasters who want to make money are facing a cruel dilemma:\r\n- Draw away their audience by erecting a paywall.\r\n- Expose themselves to censorship by partnering with brands or closed distribution platforms.\r\n\r\nThanks to decentralized protocols, Interledger and Web Monetization allow podcasters to sell content, not their soul.\r\n\r\nDuring this showcase, we will show you how to set up a podcast with Web Monetization and Castopod, an open-source podcast hosting platform. You will see that podcasting is the perfect candidate for time-based pricing.",
+        "startsAt": "2022-11-12T16:20:00",
+        "endsAt": "2022-11-12T16:40:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "213fae9a-c3ba-44de-8fa8-ab1062a95818",
+            "name": "Benjamin Bellamy"
+          },
+          {
+            "id": "18b0324d-30b3-4bc3-975d-474182063ee8",
+            "name": "Yassine Doghri"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "369753",
+        "title": "Get Paid. For Real. Right Now.",
+        "description": "We're connecting ILP to your bank account, and more.  This talk will expose the details of our project, and how we're connecting to ILP.  We will talk about how ILP enables instant payments anywhere, which is almost unknown in the payments industry.",
+        "startsAt": "2022-11-12T16:40:00",
+        "endsAt": "2022-11-12T17:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "9816f454-6b5a-4ba7-b6b2-444176513cfb",
+            "name": "David Benoit"
+          },
+          {
+            "id": "4b689e03-a280-47f6-b763-d62a103b042a",
+            "name": "Christina Kinney"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "389267",
+        "title": "An Open Regulated Global Payment Inter-Network",
+        "description": "The infrastructure to achieve total interoperability already exists to a great extent but needs to be better harnessed. By creating an open regulated global payments inter-network, leveraging and cultivating existing infrastructure, any regulated service provider will be able to send money to anyone, anywhere in the inter-network, speeding up total interoper­ability, reducing the cost of transactions, and providing migrants with an easy and efficient way to digitally transfer money to their home countries.\r\n\r\nExploratory paper: https://migrantmoney.uncdf.org/docs/open-regulated-global-payments-inter-network",
+        "startsAt": "2022-11-13T09:45:00",
+        "endsAt": "2022-11-13T10:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "619c6703-1d3c-443e-a176-46c7e66a8b23",
+            "name": "Arunjay Katakam"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "383527",
+        "title": "Making Digital Payments Affordable and Simple for Everyone, Everywhere",
+        "description": "While mobile money services exist in nearly 100 countries, 1.4 billion people still lack access to digital financial services, despite most owning a mobile phone, according to the World Bank's Global Findex. By providing a model for how to simplify and reduce the cost of designing interoperability between individual payment services, countries working with the banks, and mobile money and digital payment providers can develop connected instant payment systems that meet the digital financial services needs of emerging markets - especially the financially excluded. \r\n\r\nBuilt upon the Interledger protocol, Mojaloop is an open source platform for helping hub operators with instant payments clearing. Mojaloop's API protocol does more than just move money: the software helps network participants to interact robustly with each other, helping to bring some financial inclusion principles to life. \r\n\r\nMojaloop is reliant on its community of supporters, contributors, evangelists, developers, and others to make its work possible and help achieve the Foundation’s mission of providing universal financial inclusion to all. This session will go into detail about Mojaloop’s work with Interledger’s Rafiki API work and the need to upgrade to Interledger v4.\r\n",
+        "startsAt": "2022-11-13T10:15:00",
+        "endsAt": "2022-11-13T11:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "e94ceef0-e969-4034-82f5-0f6a39ae26d1",
+            "name": "Michael Richards"
+          },
+          {
+            "id": "a922404b-f903-47cf-954f-770d29bed360",
+            "name": "Paula Hunter"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "393412",
+        "title": "The 5Ps of Diversity, Equity, and Inclusion (DEI)",
+        "description": "Diversity, Equity, and Inclusion (DEI) is a hot topic across multiple industries and sectors, especially since the untimely death of George Floyd in 2020.  While strategies, tools, and techniques to drive development of inclusive financial systems is the focus of the Interledger Summit, is that goal possible without a strong focus on diversity, equity, and inclusion by actors in the financial inclusion space across all aspects of their operations? In this talk, you will hear from Erin Brown, former Acting Chief Diversity Officer at the United States Agency for International Development (USAID) as she discusses the 5 Ps of Diversity, Equity, and Inclusion, and how she used a focus on the 5 Ps of DEI to build USAID's Diversity, Equity, Inclusion, and Accessibility (DEIA) program. Through these 5Ps, you will gain awareness as to how our ability to achieve equity and financial inclusion may not be possible until that same focus and intention is used to increase diversity, equity, and inclusion within our own organizations (i.e., it starts at home). Erin will also cover a few foundational strategies to \"level up\" on our DEI efforts so that it both benefits our organizations internally and improved our ability to promote greater financial equity and inclusion outcomes. ",
+        "startsAt": "2022-11-13T11:30:00",
+        "endsAt": "2022-11-13T12:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "59dd02ef-66e9-41ec-9335-e2d226665ea1",
+            "name": "Erin Brown"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "373700",
+        "title": "DFS Lab work in Sub-Saharan Africa",
+        "description": "Research Share-out",
+        "startsAt": "2022-11-13T12:00:00",
+        "endsAt": "2022-11-13T12:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "b0a14d9b-376a-48e2-9a43-75ee8855c9f4",
+            "name": "Jake Kendall"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "383792",
+        "title": "Payment pointers - the universal payment instrument",
+        "description": "An overview of payment pointers and open payments and how these will create an open and inclusive application layer on the Internet of Value",
+        "startsAt": "2022-11-13T12:30:00",
+        "endsAt": "2022-11-13T13:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "69f97e3e-d0c7-4fe3-9373-7cbcd223c6c8",
+            "name": "Adrian Hope-Bailie"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "383892",
+        "title": "Can web monetization protocols bring about a fairer digital future?",
+        "description": "Our current, advertiser-supported Internet is broken. The business models underpinning data brokers, tracking, and programmatic advertising are predatory, and the tiny percentage of revenue that flows back to content creators often makes their work unsustainable. New technologies, like open payment networks that support micropayments and drip-style donations, are fostering more equitable alternatives for funding the work of individual creators and collectives. More democratic governance mechanisms and processes are able, or have the potential, to scale and support new forms of collective decision-making and digital participation. But how can early adopters ensure that these technologies are used for the public good, rather than supporting hyper-capitalist systems that have made the current digital landscape so inequitable? And what best practices can be learned from existing open source projects that operate in the public interest?\r\n \r\nThis session includes panelists from industry, civil society, and academia who will discuss the challenges and opportunities that exist in an alternatively-funded online world.\r\n \r\nModerator:\r\n \r\nAyden Férdeline, public interest technologist \r\n \r\nPanelists:\r\n \r\nXiaoji Song, interdisciplinary researcher and artist \r\n \r\nDr Stephanie Perrin, past winner of the Electronic Frontier Foundation ‘Pioneer Award’ \r\n\r\nEllen Magallanes, counsel, Wikimedia Foundation",
+        "startsAt": "2022-11-13T14:00:00",
+        "endsAt": "2022-11-13T14:40:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "27429f38-3846-488f-9e53-58837c0b6842",
+            "name": "Ayden Férdeline"
+          },
+          {
+            "id": "9ba11e2e-9aa7-4b7b-80e8-ba22562b90d0",
+            "name": "Ellen Magallanes"
+          },
+          {
+            "id": "3a71dfe5-a936-40b8-853b-46d1652952fe",
+            "name": "Xiaoji Song"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "384019",
+        "title": "Central Bank RTGS and ILP implementation: Mexico's SPEI and the People's Clearinghouse",
+        "description": "SPEI is the RTGS platform of the Central Bank of Mexico, currently serving most financial entities in the country, either directly or through intermediary entities. In this group, we will introduce and discuss the structure of a SPEI-oriented Clearinghouse, based on our development of the People's Clearinghouse, which is meant to serve as an intermediary access point to SPEI for indirect participants. Our goal in this discussion is to collectively identify possible points of intersection with ILP functions. Could such a Clearinghouse serve as both a SPEI node and an ILP node, promoting the interoperability of both structures and thus extending the reach of the ILP network (perhaps in a similar way as Rafiki could eventually interconnect the ILP network with a Mojaloop scheme)? How could an ILP-based remittance order flow platform interact with such a Clearinghouse? We invite all people to learn about this financial inclusion project from a technical perspective and discuss how the ILP could enrich it.",
+        "startsAt": "2022-11-13T14:00:00",
+        "endsAt": "2022-11-13T15:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "9bd85c6e-88b7-4d06-b8c8-0458dc200746",
+            "name": "Roberto Valdovinos"
+          },
+          {
+            "id": "e485ce69-cfcc-49d4-8d31-dda1c45a362d",
+            "name": "Juan francisco Manzano garcia"
+          },
+          {
+            "id": "ea1a7e8e-53b1-4178-850d-c9e5c331d492",
+            "name": "Andrés Arauz"
+          }
+        ],
+        "categories": [],
+        "roomId": 27380,
+        "room": "Breakout Room",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "368493",
+        "title": "The value of Interledger Protocol in Latin America now and in the future",
+        "description": "This session is to share how Latin America has evolved in terms of financial access, but how this has not yet reduced the gap with people with less financial access, and at what point the Interledger Protocol can be the support to provide greater and equitable opportunities for all in the region.",
+        "startsAt": "2022-11-13T14:40:00",
+        "endsAt": "2022-11-13T15:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "c9e83da7-c881-4eed-8e59-01beb295b8f8",
+            "name": "Néstor Campos"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "384007",
+        "title": "Revenue Sharing Language (RSL): a human and machine-readable syntax for profit-sharing and royalties",
+        "description": "Revenue Sharing Language (RSL) is a human and machine readable language for describing complex multiple-step revenue-sharing agreements between multiple parties in an open and interoperable way. RSL agreements are Ricardian contracts – a human and machine readable document – unlike a smart contract, which is only readable by software and developers. Created with Interledger Foundation funding as part of the OpenVideo.tech project, RSL was conceived to make it easier for independent creators to get fair payouts from anyone monetizing their work.\r\n\r\nThis session will look at how revenue sharing and payout agreements and schedules are normally used. Participants will be introduced to the syntax, and revenue sharing agreements expressed as RSL. We will look at some of the current RSL implementations (standalone JS, Svelte.js & CiviCRM), exploring RSL’s relevance to the Web Monetization, digital payments and Interledger ecosystems\r\n\r\nThis should lead to a discussion with participants (who don't need to be technical or legal experts) around potential uses – both promising and challenging. We'll consider some of the possible issues for tools built using RSL, before exploring the draft Variable RSL Syntax which would expand RSL to more complex, dynamic agreements.",
+        "startsAt": "2022-11-13T15:30:00",
+        "endsAt": "2022-11-13T16:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "996c2e33-414c-448e-938f-ea987b311373",
+            "name": "Nic Wistreich"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "373702",
+        "title": "Including GenZ in Digital Affairs: Bowie State University Share-Out",
+        "description": "Banking the unbanked population through digitized financial inclusion may bring positive change in the lives of underprivileged populations and economies globally. What better way to prepare for such change than engaging future change makers, thought leaders and activists to be informed and equipped with the knowledge to enable a more equitable digital financial ecosystem?\r\n \r\nBowie State University has received 25K in grant funding from the Interledger Foundation to execute an undergraduate course with students exploring open payments technologies, digital financial systems and issues in eCommerce. BSU will also create content for the community and other institutions to help increase equitable and inclusive participation.\r\n\r\nThe eCommerce course will be offered through the Management Information Systems Department in the College of Business to students enrolled in Information Systems, Marketing, Entrepreneurship, Management, and Accounting Computer Science, Security, and Technology. Each student will be able to interact with mentors, practitioners, and open web payment advocates. The course model is a funnel from broad foundation concepts to the role of web payments to foster more efficient and equitable commerce.\r\n\r\nProposed Format:\r\nThe proposed duration for this session is 1 hour, broken down as follows:\r\n- Opening Circle (25 minutes): \r\n5-minute introduction session providing an overview and context of the current collaboration between Bowie State University and the Interledger Foundation and the objectives of the revamped eCommerce course. - Dr Andrew Mangle – Bowie State University \r\n- 20-minute Conversation with two Grantees involved in engaging youths on principles relating to open payment systems, web monetization and microfinance/tipping. \r\n- 35-minute Poster Session showcasing student progress on incorporating open payments in eCommerce. Students will hoist posters around the room and give short pitches on their vision for the capstone project and their progress to date. The session will be interactive with audience members having the opportunity to engage with students about their ideas and unique perspectives.\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+        "startsAt": "2022-11-13T15:30:00",
+        "endsAt": "2022-11-13T16:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "2d15432a-4cdb-43ff-a339-a4108822482d",
+            "name": "Andrew Mangle"
+          },
+          {
+            "id": "ceea3685-37aa-4cf0-bf1c-9527930f2232",
+            "name": "Julaire Hall"
+          }
+        ],
+        "categories": [],
+        "roomId": 27380,
+        "room": "Breakout Room",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "383809",
+        "title": "Web Monetization & Creative Culture",
+        "description": "Exploring the intersection of emerging web monetization technologies and how these technologies impact creator's lives and their creative freedom.  How do these new technologies unlock new business models that enable more creative and economic freedom. Will these technologies live up to the hype? From the Crypto winter, to the Interledger Protocol,  the terrain is constantly changing. Hear from some of the leading minds in creativity, innovation and the next wave of digital monetization. With the intersection of culture, creativity and community. New business models are being unleashed thanks to the creation of NFT's,  DAO's and community driven technologies. What does the future hold for creators? Meet some of the faces leading this charge here in Africa and the diaspora and hear their perspectives. \r\n*What does the future of Africa look like as it relates to Web3 Compatibility. Internet penetration, Data cost, VR/AR hardware, Dev communities etc\r\n",
+        "startsAt": "2022-11-13T16:00:00",
+        "endsAt": "2022-11-13T17:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "c9e6ec6a-09b1-4802-8adb-3a85d6651ec0",
+            "name": "Karl Carter"
+          }
+        ],
+        "categories": [],
+        "roomId": 27379,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      }
+    ],
+    "isDefault": false
+  }
+]

--- a/src/data/sessionize/2023-speakers.json
+++ b/src/data/sessionize/2023-speakers.json
@@ -1,0 +1,3458 @@
+[
+  {
+    "id": "69f97e3e-d0c7-4fe3-9373-7cbcd223c6c8",
+    "firstName": "Adrian",
+    "lastName": "Hope-Bailie",
+    "fullName": "Adrian Hope-Bailie",
+    "bio": "Adrian is a co-inventor of the Interledger protocol stack and the Open Payments standards and payment pointers. He is a co-founder of Fynbos where he is building the first account that will issue payment pointers and support Open Payments.",
+    "tagLine": "Founder at Fynbos",
+    "profilePicture": "https://sessionize.com/image/e5b2-400o400o1-UNKX2DhHQEuyQwrn2Xx1vb.png",
+    "sessions": [
+      {
+        "id": 527825,
+        "name": "Digital Wallets - Our financial \"user agents\""
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/ahopebailie",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/adrianhopebailie/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://fynbos.dev",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Fynbos",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Co-Founder",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6f694114-7102-4f53-b180-585d5409afa0",
+    "firstName": "Ana",
+    "lastName": "Rodriguez",
+    "fullName": "Ana Rodriguez",
+    "bio": "Ana Rodríguez (Quito, Ecuador) is a curator, researcher, and professor. Rodríguez served as Minister and Vice-minister of Culture of Ecuador, directed the City Museums Foundation, and the Contemporary Art Center, all in Quito. She was part of CENEDET (National Strategy Center for the Right to the Territory) at the IAEN,  and CITE (Center for Public Policies and Territory Research) in FLACSO-Ecuador. She studied fine arts and aesthetics at Université Paris 1-Panthéon-Sorbonne in France, and cultural studies at the Universidad Andina Simón Bolivar in Quito, Ecuador. Among her main fields of research and publication on urban issues, there are gangs studies and violence, food systems / popular markets, and intercultural tools for public management.\r\n",
+    "tagLine": "Future|Money Awardee",
+    "profilePicture": "https://sessionize.com/image/4961-400o400o1-7ExfJQJfcYzhwdjqqVbb35.jpg",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Company Website",
+        "url": "https://www.urban-front.com",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "URBAN FRONT",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Researcher, Project Coordinator for LATAM",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "bf608549-addb-43ca-88c1-fc564a8c038f",
+    "firstName": "Andres",
+    "lastName": "Arauz",
+    "fullName": "Andres Arauz",
+    "bio": "Economist, former central banker, policymaker and politician, with a Ph.D. in cross-border payment systems.",
+    "tagLine": "People's Clearinghouse, CEO",
+    "profilePicture": "https://sessionize.com/image/7136-400o400o1-9dXV7R2XNbCSzmZYFmSFW1.jpg",
+    "sessions": [
+      {
+        "id": 519348,
+        "name": "Rafiki's “Corridor”: Mexico's PCH remittance use case"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/ecuarauz",
+        "linkType": "Twitter"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "The People’s Clearinghouse",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "2d15432a-4cdb-43ff-a339-a4108822482d",
+    "firstName": "Andrew",
+    "lastName": "Mangle",
+    "fullName": "Andrew Mangle",
+    "bio": "Dr. Mangle is an Assistant Professor in Management Information Systems at Maryland's oldest HBCU Bowie State University.  ",
+    "tagLine": "Assistant Professor - Bowie State University",
+    "profilePicture": "https://sessionize.com/image/c6a4-400o400o1-WTxvQ9dZLpwN4M1MHNW7Vr.jpg",
+    "sessions": [
+      {
+        "id": 529141,
+        "name": "Engaging HBCU Students in Open Communities"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/amangle",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/andrew-mangle",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://andrewmangle.com",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Bowie State University",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Associate Professor",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "1bd3a54f-3b2c-4af7-928d-f36540049037",
+    "firstName": "Ariel",
+    "lastName": "Frankel",
+    "fullName": "Ariel Frankel",
+    "bio": "Ariel is the Director of Public Health at TechChange. She helped establish the Public Health division at TechChange in 2021, and leads a team of public health managers and associates who create, manage and deliver engaging and interactive health-focused training experiences around the world. She is a public health professional with 8+ years of experience in human-centered design, monitoring and evaluation (M&E), and international project management. She has led the development of course content and capacity building programs on some of the largest Public Health team initiatives, including the Digital Health: Planning National Systems course offerings – the flagship foundational course on digital health for the World Health Organization. Ariel holds an MSPH from Johns Hopkins Bloomberg School of Public Health in Social and Behavioral Interventions within the Global Health Department.\r\n",
+    "tagLine": "Senior Director of Public Health, TechChange",
+    "profilePicture": "https://sessionize.com/image/1b47-400o400o1-NuV27czoP2xe9cr6T87hxs.jpeg",
+    "sessions": [
+      {
+        "id": 530162,
+        "name": "Digital Finance – a Woman’s Immersive Experience"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/ariel-frankel-21012942/",
+        "linkType": "LinkedIn"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "TechChange",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Sr. Director of Public Health",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "b0a618f4-fe76-4f41-9548-bf07b94260aa",
+    "firstName": "Arky",
+    "lastName": "AR",
+    "fullName": "Arky AR",
+    "bio": "Arky is a technologist and a visual storyteller, who helps non-profits, social enterprises use Information and communication technology (ICT). He has been involved in Free and Open Source communities for over an decade and worked with various non-profits: Braille Without Borders (BWB), NGO Resource Center and Mozilla in Asia, SE. Asia and Africa. ",
+    "tagLine": "Technologist and Visual Storyteller",
+    "profilePicture": "https://sessionize.com/image/a8ea-400o400o1-NUfeT9X4rP1P8ZCsLXm4gZ.jpg",
+    "sessions": [
+      {
+        "id": 552412,
+        "name": "Première of Bringing Down a Mountain"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Instagram",
+        "url": "https://instagram.com/playingwithsid",
+        "linkType": "Instagram"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": " Civil Societies in SE. Asia and Africa",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Independent Technology Consultant",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "27429f38-3846-488f-9e53-58837c0b6842",
+    "firstName": "Ayden",
+    "lastName": "Férdeline",
+    "fullName": "Ayden Férdeline",
+    "bio": "Ayden Férdeline is a public interest technologist who has worked directly with governments, industry, and civil society organizations to support responsible technological innovation with a focus on social impact. \r\n\r\nHe is currently a Landecker Democracy Fellow with Humanity in Action, in collaboration with the Alfred Landecker Foundation, where he works to bring traditionally-excluded voices from the labor organizing space into Internet governance arenas. \r\n\r\nHe serves on the Steering Committee of the joint Ford Foundation-Mozilla Foundation Public Interest Technologists Network, where he cultivates an empowered community of civic minded stakeholders who share a meaningful and actionable camaraderie to keep the Internet working for everyone. \r\n\r\nIn addition, he is a Fellow with the Internet Law and Policy Foundry in Washington D.C. \r\n\r\nHe previously represented European civil society organizations on ICANN’s GNSO Council, the body which makes binding policy for generic top-level domain names like .COM and .ORG, and was a technology policy fellow with the Mozilla Foundation. He also hosted the Internet governance history podcast POWER PLAYS, which shined a spotlight on many pioneers from within the Internet governance community, and has worked for an array of philanthropic organizations, including the National Endowment for Democracy, the National Democratic Institute, and the New Venture Fund.\r\n\r\nHe is an alumnus of the London School of Economics.",
+    "tagLine": "Landecker Democracy Fellow, Humanity in Action",
+    "profilePicture": "https://sessionize.com/image/5098-400o400o1-B3DT1cQHVhmE35x2YFcGMs.jpg",
+    "sessions": [
+      {
+        "id": 523092,
+        "name": "Harvesting Hope from Hiccups: Overcoming Standardization Hurdles"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Humanity in Action",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Landecker Democracy Fellow",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "12e36289-504e-46ce-94a8-b8e9debdd5b1",
+    "firstName": "Briana ",
+    "lastName": "Marbury ",
+    "fullName": "Briana Marbury",
+    "bio": "Briana Marbury is the CEO of the Interledger Foundation (ILF), a nonprofit organization committed to expanding digital financial inclusion to vulnerable populations. ILF invests in organizations, communities, and entrepreneurs working towards the shared goal of enabling interoperable and frictionless payments around the globe.\r\n\r\nAs CEO of ILF, Briana leads the strategic vision of the organization and has grown ILF from a small team of three to a global workforce of changemakers. Bringing her own firsthand experience with navigating the challenges associated with the lack of equitable financial access,\r\nBriana brings her skills, values and lived experience to the crucial work of enabling communities to create and lead their own financial futures.\r\n\r\nBefore joining ILF, she consulted for 350.org and held financial leadership roles at Repair the World, Uncommon Schools, and the Jack Kent Cooke Foundation. At each organization, Briana built and grew the financial and operational systems that enabled significant progress towards achieving their mission. Additionally, Briana served as an Education Pioneer Graduate Fellow, exploring ways to increase positive educational outcomes in the nation’s most underserved schools.\r\n\r\nBriana holds a BA in Accounting from the University of Michigan, an MBA from Wayne State University, and has completed post-graduate work in strategic leadership at Stanford University. Originally from Detroit, Briana has lived in many cities across the US and has even spent a brief\r\nperiod as a digital nomad. When she’s not exploring new cities, she’s spending time with her pup, Seamus.",
+    "tagLine": "CEO & President of Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/67c6-400o400o1-W5Y7Ccp4Fcdo2kWGMzfN2c.jpg",
+    "sessions": [
+      {
+        "id": 552327,
+        "name": "Keynote Speaker | Briana Marbury CEO & President Interledger Foundation"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/bmarbury",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/brianamarbury/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://twitter.com/bmarbury",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "286b01c1-9dad-4415-a115-78e99ba93ec0",
+    "firstName": "Bruna",
+    "lastName": "Cataldo",
+    "fullName": "Bruna Cataldo",
+    "bio": "Msc and Phd candidate in Economics. Current member of the Research Group in Institutional Design and Regulatory Efficiency at FGV-Rio Law School and Head of Research at Propague Institute, focusing on financial innovation and regulation. ",
+    "tagLine": "Head of Research (Propague Institute)",
+    "profilePicture": "https://sessionize.com/image/920e-400o400o1-hwkznVbhipP2sbdWdrTu26.jpg",
+    "sessions": [
+      {
+        "id": 525073,
+        "name": "Cross Border Payments in the Instant Era"
+      },
+      {
+        "id": 530375,
+        "name": "Standardized Payment Interfaces as Digital Public Infrastructures: Learning from India and Brazil"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/bruna-cataldo-630b02a7/?locale=en_US",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://institutopropague.org/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Instituto Propague",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Head of Research",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3a7cbafd-ef2c-432b-ba43-2ea4920af3d1",
+    "firstName": "Chris",
+    "lastName": "Buckridge",
+    "fullName": "Chris Buckridge",
+    "bio": "Chris Buckridge is an independent advisor, consultant, and commentator more than two decades of experience in the Internet technical governance space. Currently a member of the Internet Governance Forum Multistakeholder Advisory Group, and an incoming member of the ICANN Board of Directors, he is involved in discussions around global digital cooperation and EU digital policy. ",
+    "tagLine": "Independent Internet governance expert",
+    "profilePicture": "https://sessionize.com/image/669a-400o400o1-sbq1p59expwkQDCDh8dfQB.jpg",
+    "sessions": [
+      {
+        "id": 523092,
+        "name": "Harvesting Hope from Hiccups: Overcoming Standardization Hurdles"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/chrisbuckridge/",
+        "linkType": "LinkedIn"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Independent",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Advisor",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8c31891a-1b90-41c9-9419-cb79cdd7494e",
+    "firstName": "Chris",
+    "lastName": "Lawrence",
+    "fullName": "Chris Lawrence",
+    "bio": null,
+    "tagLine": null,
+    "profilePicture": "https://sessionize.com/image/fce0-400o400o1-0095eaf2-329e-4ba4-8ad1-7c500a4414c4.jpg",
+    "sessions": [
+      {
+        "id": 509293,
+        "name": "Partnering for Growth Leveraging Donors and Investors"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/chrislarry/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://interledger.org/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "554229dd-72f1-4f68-afe7-cf6a0bd1d79a",
+    "firstName": "Colin",
+    "lastName": "Rice",
+    "fullName": "Colin Rice",
+    "bio": "Colin is a Research Specialist at CFI, working on the Consumer Protection and Data Risk and Opportunities work streams, in addition to supporting the Responsible Finance Forum.\r\n\r\nColin previously worked as the Social Performance Manager at Small Enterprise Foundation, the largest MFI in South Africa, where he led a team responsible for gathering and analyzing insights on client progress, satisfaction, and challenges. He also reviewed and developed the organization’s social performance practices, in addition to working on the design, monitoring, and evaluation of financial education and savings projects.\r\n\r\nPrior to that, Colin spent time developing M&E tools for BancoSol in Bolivia, consulted with nonprofits and family philanthropic foundations in the DC area to strengthen internal operations, and was an intern on the Bankers without Borders team at Grameen Foundation.\r\n\r\nHe has an M.A. in social enterprise from American University: School of International Service and a B.A. in anthropology from Sewanee.",
+    "tagLine": "Research Specialist, CFI at Accion",
+    "profilePicture": "https://sessionize.com/image/24b5-400o400o1-pAu6XjyFoPckfrhih2WC9C.jpg",
+    "sessions": [
+      {
+        "id": 530057,
+        "name": "Exploring Risks and Consumer Trust in the Shift from Traditional to Open Finance"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/colinmrice/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.centerforfinancialinclusion.org/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Center for Financial Inclusion at Accion",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Research Specialist",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "0e2ffbe0-a8d3-4543-975b-a219f431a76a",
+    "firstName": "Elizabeth",
+    "lastName": "Campos",
+    "fullName": "Elizabeth Campos",
+    "bio": "Elizabeth has spent most of her life fighting for financial inclusion in rural Nicaragua.",
+    "tagLine": "Vicegerente general, Financiera FDL",
+    "profilePicture": "https://sessionize.com/image/fe4d-400o400o1-p1dgeKjvzZ2QTAJBc7gdEi.jpg",
+    "sessions": [
+      {
+        "id": 519137,
+        "name": "Building Digital Financial Inclusion from Below"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "1dad474f-5f51-4aac-9144-304631f40e63",
+    "firstName": "Enej",
+    "lastName": "Mlinarič",
+    "fullName": "Enej Mlinarič",
+    "bio": "Backend Engineer @ GateHub, dedicated to building the backbone of secure and efficient blockchain financial services. I'm passionate about crafting robust solutions that empower the future of digital asset management.",
+    "tagLine": "GateHub, Backend Engineer",
+    "profilePicture": "https://sessionize.com/image/65c4-400o400o1-1f9a0614-13ca-4dfb-b9b9-14e6c09037bd.jpg",
+    "sessions": [
+      {
+        "id": 530042,
+        "name": "GateHub Payments via ILP - Integration with Rafiki"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://si.linkedin.com/in/enej-mlinari%C4%8D-74988098",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://gatehub.net",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "GateHub",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Backend Engineer",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "59dd02ef-66e9-41ec-9335-e2d226665ea1",
+    "firstName": "Erin",
+    "lastName": "Brown",
+    "fullName": "Erin Brown",
+    "bio": "Erin Brown is the Deputy Director of the Management Bureau’s Office of Management Policy, Budget and Performance (M/MPBP) at the United States Agency for International Development (USAID).  Prior to serving as Deputy Director of M/MPBP, she launched USAID’s new Diversity, Equity, Inclusion, and Accessibility (DEIA) agenda as the Agency’s Acting Chief DEIA Officer in the Office of the Administrator, including development of its 2021 DEIA Strategic Plan and an Equity Action Plan. Ms. Brown joined the USAID in 2012 after 13 years in the private sector. Prior to joining USAID, Ms. Brown was a Senior Principal at the Hay Group, a global management consulting firm, where she led the Building Effective Organizations Practice in the Federal Sector. \r\n\r\nA two-time Gears of Government award-winner at USAID, Ms. Brown helped establish a new Safeguarding Unit to help protect recipients of USAID assistance from sexual exploitation and abuse, and launched a new Organizational Health Index to gauge the strength of USAID’s internal operations and mission readiness. \r\n\r\nShe holds a bachelor of arts (BA) degree in Political Science from the Loyola University of New Orleans, a master’s degree in public policy (MPP) from the University of Chicago and a master of arts (MA) in organizational sciences from The George Washington University. \r\n\r\n",
+    "tagLine": "Equity and Partnerships",
+    "profilePicture": "https://sessionize.com/image/c06c-400o400o1-nv5dQQydeGDphfMZAKidmg.jpg",
+    "sessions": [
+      {
+        "id": 509293,
+        "name": "Partnering for Growth Leveraging Donors and Investors"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/erinbrown1913/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.usaid.gov",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "USAID",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Panel moderator",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "596d5e24-c923-4716-adfa-2c18d07d9e43",
+    "firstName": "Esther",
+    "lastName": "Mwema",
+    "fullName": "Esther Mwema",
+    "bio": "Esther Mwema is an artist and a digital inequalities practitioner with expertise in internet governance, digital transformation, and innovation. She has over ten years commitment to social impact at the intersection of youth, technology, and gender and holds extensive experience at the United Nations. Esther is an Open Internet leader who prioritises African feminist and decolonial practices. She has been awarded the Mozilla Creative Media Awards, the Interledger Foundation Future|Money award, the C/Change R&D arts and culture awards, among more. Esther graduated with an MSc in Inequalities and Social Science from the London School of Economics.",
+    "tagLine": "Future|Money Awardee,  / Sikhula Sonke: Living Archives of Afrofuturist Village Banking",
+    "profilePicture": "https://sessionize.com/image/d427-400o400o1-724804c5-1271-4121-968a-8b26e442e89e.jpg",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Blog",
+        "url": "http://esthermwema.persona.co",
+        "linkType": "Blog"
+      },
+      {
+        "title": "Company Website",
+        "url": "http://esthermwema.persona.co",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Future|Money awardee",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Artist and Digital Inequalities Practitioner",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6f3d6b3c-458a-4c80-9e0d-99752456339e",
+    "firstName": "Eunice",
+    "lastName": "de Asis",
+    "fullName": "Eunice de Asis",
+    "bio": "Eunice de Asis - activist, community organizer and  filmmaker known for producing several documentaries that shed light on important social issues. She has also taken on leadership roles, serving as the Chairwoman of Migrante Amsterdam, a grassroots organization created by and for irregular migrants, as well as spokesperson/member of Amsterdam City Rights.\r\n",
+    "tagLine": "Activist, community orgganizer and chair woman MIgrante Netherlands",
+    "profilePicture": "https://sessionize.com/image/8adc-400o400o1-fb8UdpD3jHSJfAeCroehAw.jpeg",
+    "sessions": [
+      {
+        "id": 530246,
+        "name": "Financial inclusion for undocumented people"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Facebook",
+        "url": "https://www.facebook.com/amsterdamcityrights",
+        "linkType": "Facebook"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.amsterdamcityrights.org/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Amsterdam City Rights/ Migrante Netherlands/ International MIgrant Alliance Europe",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "spokesperson/ Chairwoman/ International Coordinating Body",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3e15c776-358b-4f72-838e-b29fa956182a",
+    "firstName": "Federico",
+    "lastName": "Lorenzi",
+    "fullName": "Federico Lorenzi",
+    "bio": "Federico started off wearing a sysadmin hat, before moving to web development and founding an online education startup along the way. He now works at TigerBeetle, and keeps himself busy by thinking about operator experience, ensuring the CI is green, and optimizing LSM tree compaction.",
+    "tagLine": "Staff Software Engineer at TigerBeetle",
+    "profilePicture": "https://sessionize.com/image/7855-400o400o1-fZMovB2wmtM4B3YKfhwBfP.jpg",
+    "sessions": [
+      {
+        "id": 530276,
+        "name": "Where the Beetle meets the Road."
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/fedcb22",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/federico-l-8a129180/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://tigerbeetle.com",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "TigerBeetle",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Staff Software Engineer",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "4ec77047-4f16-4b3b-9381-9385fbc21e28",
+    "firstName": "Felipe",
+    "lastName": "Brugues",
+    "fullName": "Felipe Brugues",
+    "bio": "Felipe Brugués is a Mexico City-based researcher specializing in development economics, using interdisciplinary methods to analyze decision-making in weak institutional settings, with a particular focus on the physical ramifications of his work. ",
+    "tagLine": "Future|Money Awardee, Assistant Professor, ITAM",
+    "profilePicture": "https://sessionize.com/image/6b3c-400o400o1-KVSZ4XDfJgLEyVNbcf1wWM.png",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Company Website",
+        "url": "https://www.felipebrugues.com",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "ITAM",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Assistant Professor",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "5e27eb01-d22e-4db5-b6ad-0ce26d1a3a22",
+    "firstName": "Fernando",
+    "lastName": "Almiñana",
+    "fullName": "Fernando Almiñana",
+    "bio": "Fernando's entrepreneurial journey spans across various industries, including real estate development and operations, food manufacturing, financial consulting, electronic security and telecommunications. With over 16 years of experience in mission-critical communications, he has gained a comprehensive understanding of telecom infrastructure design and operations. Fernando is a co-founder of Wallet Guru and has been instrumental in guiding the company's strategic planning and software development.\r\n",
+    "tagLine": "Wallet Guru Co-Founder. Pioneering streaming payments and subscription-less services.",
+    "profilePicture": "https://sessionize.com/image/433b-400o400o1-wirVqRWfk1cBJ6AMgbBhUE.jpg",
+    "sessions": [
+      {
+        "id": 530265,
+        "name": "Subscription Services in the Age of Streaming Payments: Embracing Disruption"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/WalletGuruLLC",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/company/mywalletguru/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.mywalletguru.com/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Wallet Guru",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Co-Founder",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e08233ef-99fc-4e39-b298-3db97b2abba6",
+    "firstName": "Helena Tude",
+    "lastName": "& Patrick Rahy",
+    "fullName": "Helena Tude & Patrick Rahy",
+    "bio": "Helena Tude & Patrick Rahy are the co-founders of Kult, a community-centered platform for cultural content curation. Kult is aiming to build an open-source digital wallet that connects ILP to PIX – an instant and free payment method created by the Brazilian government. ",
+    "tagLine": "Co-founders of Kult, ILP Grantees",
+    "profilePicture": "https://sessionize.com/image/7a52-400o400o1-UKCCnSDjQQ9EaDtDBquicJ.png",
+    "sessions": [
+      {
+        "id": 528726,
+        "name": "How PIX is revolutionizing financial inclusion in Brazil and what ILP has to do with it"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Instagram",
+        "url": "https://instagram.com/kult_app",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://kult.pt",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Kult (Paginas Esbeltas Lda)",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Co-founders",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "0676e0b4-c743-457a-885f-ec8722bb6a13",
+    "firstName": "Hollis ",
+    "lastName": "Wong-Wear ",
+    "fullName": "Hollis Wong-Wear",
+    "bio": null,
+    "tagLine": "Interledger Ambassador ",
+    "profilePicture": "https://sessionize.com/image/217b-400o400o1-9iGYVSdAb6mLxYqBVisGc4.jpg",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Ambassador",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "297fd54b-f93c-4996-89bc-f96b3b7f8258",
+    "firstName": "Ioana",
+    "lastName": "Chiorean",
+    "fullName": "Ioana Chiorean",
+    "bio": "Ioana is an engineer manager flavored in communities, and devrel, that has more than 14 years of experience in tech with a specialization in all things web and mobile apps.  Besides her daily job, she dedicates her time to building tech communities and improving access to education. She is the Module Owner for Mozilla Reps, one of the alumna of MozTechSpeakers, and stands as an ambassador for CodeWeek at the European Commission. She is an advisor and board member for Women in Tech Cluj. In her free time, she contributes to Open Source and different volunteering programs, while enjoying a coffee or a good wine. ",
+    "tagLine": "Engineering Manager ",
+    "profilePicture": "https://sessionize.com/image/44c8-400o400o1-4b-f93c-4996-89bc-f96b3b7f8258.62f36cf5-e00c-4169-a68f-a1e0ab2a41a7.jpg",
+    "sessions": [
+      {
+        "id": 530314,
+        "name": "Diversity in war times / knowledge as safe place"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/ioana_cis",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/ioanachiorean/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://instagram.com/ioana_cis",
+        "linkType": "Instagram"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "-",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "-",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "99cf8d10-170e-4e92-a873-e32e8a39c7e8",
+    "firstName": "Isabel ",
+    "lastName": "Cruz Hernandez",
+    "fullName": "Isabel Cruz Hernandez",
+    "bio": "Mexican anthropologist, social finance activist and builder of community financial systems. For four decades she has worked in diverse regions of her country with peasant and indigenous organizations to promote grassroots financial inclusion. She is the CEO of the Mexican Association of Social Sector Credit Unions (AMUCSS).\r\n\r\nIsabel studied Anthropology at the National School of Anthropology and History, Financial Administration at Tecnológico de Monterrey and Business Management at the Technology Institute of Mexico (ITAM). She has made multiple international trips in Latin America, Europe,\r\nNorth America and Africa, to discover the most important popular financial experiences around the world and implement their solutions in Mexico.\r\n\r\nThroughout her career, Isabel has supported the construction of multiple local financial institutions and services for marginalized communities. She designed and implemented micro-savings methodologies for remote communities, including the creation of models for agricultural and non-agricultural productive credits, and financial methodologies for social housing development combining savings, credit, subsidies and assistance technique. She has also developed social strategies for strengthening binational communities and fostering the social impact of remittances.\r\n\r\nBecause of her work for financial inclusion, Isabel has received various international awards in the last 20 years. She is currently dedicated to producing strategic community banks (SOFINCOs) in rural and indigenous areas of Oaxaca, Chiapas, Puebla, Hidalgo, among others\r\nregions, and to the development of the Peoples Clearinghouse, an innovative financial network\r\nfor connecting social financial institutions between them and with international networks. \r\n\r\nShe writes at \"El Financiero\" newspaper and has published several public policy books.",
+    "tagLine": "CEO of the Mexican Association of Social Sector Credit Unions (AMUCSS).",
+    "profilePicture": "https://sessionize.com/image/873e-400o400o1-WAzprMTgpxiL7Qn3SWgUAJ.png",
+    "sessions": [
+      {
+        "id": 552349,
+        "name": "Keynote Speaker | Isabel Cruz Hernandez, CEO Mexican Association of Social Sector Credit Unions"
+      },
+      {
+        "id": 519137,
+        "name": "Building Digital Financial Inclusion from Below"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "9361292e-40bf-49e3-b82d-679273214a81",
+    "firstName": "James",
+    "lastName": "Dailey",
+    "fullName": "James Dailey",
+    "bio": "James Dailey is a founding member and Chief Executive Officer of BaasFlow.com.  A serial entrepreneur, James has worked on or launched a number of initiatives including OpenG2P, GovStack, openLMIS, and Mifos. He is, alongside Orang Dialemah and Tim Dorcey, a member of the ExtoPay team.  James is a fintech expert in emerging markets focused on banking and payment interoperability; over the past few decades he has been on the ground in dozens of countries and on multiple payments and banking projects for a range of international organizations, including Bill & Melinda Gates Foundation, World Bank, IFC, and the Asian Development Bank. Previously he built a venture-funded company linking carbon markets to microfinance.  He lives in Seattle, Washington State in the US.",
+    "tagLine": "CEO of BaaSFlow, VP of Apache Fineract, financial inclusion advocate.  ",
+    "profilePicture": "https://sessionize.com/image/8646-400o400o1-hoyJnvakb6H2fY1XypZByx.jpg",
+    "sessions": [
+      {
+        "id": 529931,
+        "name": "PaymentHUB: Connecting to eCurrencies and legacy payment systems"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/jamespdailey/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.baasflow.com",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "BaaSFlow",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a770436d-860a-4937-8c24-2cafa4f460fd",
+    "firstName": "Jaskaran (Jay)",
+    "lastName": "Kambo",
+    "fullName": "Jaskaran (Jay) Kambo",
+    "bio": "My Name is Jaskaran (Jay) Kambo & I am based in Edmonton, Canada. I am the CEO & Founder at spendthebits. I have over ten years of working experience in I.T across multiple domains & technologies.",
+    "tagLine": "SpendTheBits Inc. CEO & Founder",
+    "profilePicture": "https://sessionize.com/image/197f-400o400o1-QZbcm5Ut2r54GWwnXfxnsb.jpg",
+    "sessions": [
+      {
+        "id": 501847,
+        "name": "Interoperable Payments"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/Jay_SpendDBits",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/jaskaran-k-0bb250a9/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Facebook",
+        "url": "https://www.facebook.com/spendthebits",
+        "linkType": "Facebook"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://www.instagram.com/spendthebits/",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://spendthebits.com/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "SpendTheBits Inc.",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "c1cb76f8-806a-4b13-8a99-ab7b3c24c350",
+    "firstName": "Jasper",
+    "lastName": "Voorendonk",
+    "fullName": "Jasper Voorendonk",
+    "bio": "Background in Philosophy and Tech Startups.\r\n\r\nInterested in Networks, Ecosystems, and Abundance.\r\n",
+    "tagLine": "AgnostiPay",
+    "profilePicture": "https://sessionize.com/image/9506-400o400o1-PEzRd8EqBnCpwCB6EseF53.jpeg",
+    "sessions": [
+      {
+        "id": 529671,
+        "name": "AgnostiPay's ecosystem perspective, a different networked view"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/agnostipay",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/company/agnostipay",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://agnostipay.io/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "AgnostiPay",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Lead Evangelist",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "624f1540-059e-4db1-90b4-b17156b94ff8",
+    "firstName": "Jayshree",
+    "lastName": "Venkatesan",
+    "fullName": "Jayshree Venkatesan",
+    "bio": "Jayshree leads research on fintechs, platforms and other DFS providers to understand their incentives, practices, and how/if they serve low-income consumers; contribute to advocacy on consumer protection and other policy priorities for inclusive finance and co-lead the development of influence strategies and campaigns with the communications team. She joined CFI after working for eight years as an independent global consultant to several partners including: CGAP, World Bank, JICA, and ITAD. As a consultant, she worked on customer centric business models, and challenges faced by customers in accessing and using financial services. \r\n\r\nFrom 2009 to 2013, Jayshree was part of the founding team at IFMR Trust (now Dvara Trust), where she led a mezzanine fund that invested in microfinance institutions in India. She began her career at ICICI Bank in India.\r\n \r\nJayshree is a senior policy fellow at the Leir Institute housed within the Fletcher school of Law and Diplomacy, where she works on challenges faced by vulnerable segments such as migrants/refugees in accessing financial services. In 2014, she received the Chevening fellowship for leadership by the Foreign and Commonwealth Office, UK.\r\n\r\nShe earned an MA in International Relations from the Fletcher School of Law and Diplomacy, MBA from MDI Gurgaon (India) and a Bachelor’s in Mathematics from Mumbai University, graduating at the top of her class.",
+    "tagLine": "Senior Director, Consumer Protection & Responsible Finance",
+    "profilePicture": "https://sessionize.com/image/a288-400o400o1-HVWxBCEXEjTBbmoEp3NDmM.jpg",
+    "sessions": [
+      {
+        "id": 525073,
+        "name": "Cross Border Payments in the Instant Era"
+      },
+      {
+        "id": 530057,
+        "name": "Exploring Risks and Consumer Trust in the Shift from Traditional to Open Finance"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/jayshreevenkatesan/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.centerforfinancialinclusion.org",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Center for Financial Inclusion at Accion",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Senior Director",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "c0b28c32-9164-4cef-b80a-3668f84956e3",
+    "firstName": "Jennifer",
+    "lastName": "Fenwick",
+    "fullName": "Jennifer Fenwick",
+    "bio": "Jen Fenwick brings 23 years of nonprofit experience in fundraising, educational programming, administration, operations, and social science research. She has worked at organizations such as California Science Center, Lawrence Berkeley National Lab, and New York Hall of Science. She served as the Director of Institutional Giving for the public radio producer and science education nonprofit Science Friday from 2012-2022. ",
+    "tagLine": "Consultant to nonprofit organizations seeking to make impact at the intersection of science and technology and society.",
+    "profilePicture": "https://sessionize.com/image/c337-400o400o1-WsbJrQnKprLmCuTKDBHY8H.png",
+    "sessions": [
+      {
+        "id": 509293,
+        "name": "Partnering for Growth Leveraging Donors and Investors"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/jentunefenwick/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://fenwicknonprofitstrategies.com/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Fenwick Nonprofit Strategies",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "715acb29-2834-4d55-b102-d75ec3e3136d",
+    "firstName": "Jeremiah",
+    "lastName": "Lee",
+    "fullName": "Jeremiah Lee",
+    "bio": "Jeremiah Lee is an Interledger technology ambassador grant recipient working on Web Monetization support within Mastodon and other federated social network apps. He previously worked as a software engineer and product manager at Stripe, Spotify, and Fitbit among other places. He grew up under the California sun, but now calls Stockholm home.",
+    "tagLine": "Humanist & Technologist",
+    "profilePicture": "https://sessionize.com/image/69da-400o400o1-StfibW1MiqBiRMQSMBQMVe.jpg",
+    "sessions": [
+      {
+        "id": 523092,
+        "name": "Harvesting Hope from Hiccups: Overcoming Standardization Hurdles"
+      },
+      {
+        "id": 524247,
+        "name": "Mastodon, micropayments, and the next era of the creator economy"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://linkedin.com/in/jeremiah-x-lee/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Blog",
+        "url": "https://www.jeremiahlee.com/posts/",
+        "linkType": "Blog"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://restoration.software/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "(Stealth)",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e8d66139-9a11-471d-8feb-060d95b32f04",
+    "firstName": "Jon Adam",
+    "lastName": "Chen",
+    "fullName": "Jon Adam Chen",
+    "bio": "Jon Adam Chen is a strategic communications specialist with a background in social impact, storytelling, and African development. He thrives as an editor, writer, and researcher. Jon Adam holds a master’s degree in media studies from the University of Cape Town and was an Engineers Without Borders Canada long-term fellow. He has supported grassroots organizations in Canada, South Africa, Kenya and Nigeria. Most recently, he has worked with the Ontario Ministry of Health and the Canadian Red Cross.",
+    "tagLine": "Future|Money Awardee, Researcher and Co-Lead, Sikhula Sonke: Living Archives of Afrofuturist Village Banking",
+    "profilePicture": "https://sessionize.com/image/ffd4-400o400o1-4n9GQeRp1aS7ytWbKe3fs1.jpeg",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/JonAdam_Chen",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://ca.linkedin.com/in/jonadamchen",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.sikhulasonke.net",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": " Future Money Arts and Culture Awardee",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Researcher and Co-Lead",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "9487c937-a599-4e9d-90ad-c1ea7e7a0888",
+    "firstName": "José Isidro",
+    "lastName": "Tzunún",
+    "fullName": "José Isidro Tzunún",
+    "bio": "With many years working in communities of Guatemala, José Isidro is the main advisor of the growing network of savings coops Federural.",
+    "tagLine": "General Advisor, Federural",
+    "profilePicture": "https://sessionize.com/image/64ec-400o400o1-KSWHYLtuN5AE5RVoJUFKVa.jpeg",
+    "sessions": [
+      {
+        "id": 519137,
+        "name": "Building Digital Financial Inclusion from Below"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e4ebed56-56d5-4326-8aee-4d86ddea84ac",
+    "firstName": "Juan Carlos",
+    "lastName": "Ditmeyer",
+    "fullName": "Juan Carlos Ditmeyer",
+    "bio": "Trained as software engineer, Juan Carlos has spent several decades building technological services for regional financial institutions of Latin America, from offline ATMs and offline smart cards with biometric authentication for rural areas, to transactional switches and core banking systems.",
+    "tagLine": "People's Clearinghouse, Acting CTO",
+    "profilePicture": "https://sessionize.com/image/4b58-400o400o1-72fhyPcypWGKKQxyYPzN4R.png",
+    "sessions": [
+      {
+        "id": 519348,
+        "name": "Rafiki's “Corridor”: Mexico's PCH remittance use case"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "People's Clearinghouse",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Acting CTO",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8d38241a-5a24-49e2-808a-acedb34bb1e7",
+    "firstName": "Juan Carlos",
+    "lastName": "Urgilés",
+    "fullName": "Juan Carlos Urgilés",
+    "bio": "CEO of the largest savings coop in Ecuador, with decades working for financial inclusion and financial technologies for rural areas",
+    "tagLine": "CEO, Cooperativa Jardín Azuayo",
+    "profilePicture": "https://sessionize.com/image/006a-400o400o1-J7a8hRU4mq4xqyVjtRJpu8.jpeg",
+    "sessions": [
+      {
+        "id": 519137,
+        "name": "Building Digital Financial Inclusion from Below"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "9c41b58c-011e-4729-817e-b5e3d5d1e6a1",
+    "firstName": "Juan Carlos ",
+    "lastName": "Leon",
+    "fullName": "Juan Carlos Leon",
+    "bio": null,
+    "tagLine": "Future|Money Awardee",
+    "profilePicture": "https://sessionize.com/image/f4f5-400o400o1-fsJekYCisspg21sJ64edwC.png",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "ceea3685-37aa-4cf0-bf1c-9527930f2232",
+    "firstName": "Julaire",
+    "lastName": "Hall",
+    "fullName": "Julaire Hall",
+    "bio": "TBC",
+    "tagLine": "Program Outreach Manager - Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/b1c9-400o400o1-BPpS53MhqrSXKnunM3uM6B.jpg",
+    "sessions": [
+      {
+        "id": 530396,
+        "name": "Payment Parity Perspectives: Women of Color Reshaping Financial Inclusion"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/JulaireHall",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/julairefhall/?originalSubdomain=jm",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "http://www.interledger.org",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation ",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Programs Outreach Manager",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8c35105d-a6aa-47b9-aa63-0bf2103af42b",
+    "firstName": "Kokayi",
+    "lastName": "Walker",
+    "fullName": "Kokayi Walker",
+    "bio": "Preeminent Improvisational Vocalist, Artist, Producer, GRAMMY-nominated musician, and multi-disciplinary fine artist is a 2023 Guggenheim Fellow for Music Composition, Halcyon Arts Fellow, and Nicholson Arts Fellow, who can be heard on over 60 titles\r\nspanning: Jazz, Hip Hop, Rock, and R&B. KOKAYI serves as art and creative consultant for Grammy Nominated artist GoldLink, Guillermo Brown (James Corden Show) and theInterledger Foundation assisting in designing their FUTURE | Money arts-centered grants and projects around financial equity in the open payments and web 2/3 spaces.",
+    "tagLine": "Ideator|Artist|Designer",
+    "profilePicture": "https://sessionize.com/image/45d9-400o400o1-TNUaPQeZhX1Mj5Cn1sH3FC.JPG",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/kokayi?lang=en",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/kokayi",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Facebook",
+        "url": "https://www.facebook.com/KokayiMusic/",
+        "linkType": "Facebook"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://www.instagram.com/kokayi/",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Blog",
+        "url": "https://community.interledger.org/kokayi",
+        "linkType": "Blog"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.kokayi.com",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "ILF",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Ideator",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a18620f0-bc47-46f7-9b02-2b74a3223836",
+    "firstName": "Larissa",
+    "lastName": "Magalhães",
+    "fullName": "Larissa Magalhães",
+    "bio": "Larissa is a Research Associate at the United Nations University (UNU-EGOV). She is also researcher in Digital Policies at CyberBRICS, School of Law, Getúlio Vargas Foundation. Her research is located between government technology and innovation, with a special focus on open data, smart cities, and digital transformation strategies.",
+    "tagLine": "CyberBRICS Project, Fundação Getúlio Vargas",
+    "profilePicture": "https://sessionize.com/image/816d-400o400o1-9d7982e9-48be-441d-90dd-89890ce253cf.jpg",
+    "sessions": [
+      {
+        "id": 530375,
+        "name": "Standardized Payment Interfaces as Digital Public Infrastructures: Learning from India and Brazil"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/larissamagalhãescsc",
+        "linkType": "LinkedIn"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Fundação Getúlio Vargas, School of Law, CyberBRICS",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Research Fellow",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "2be62447-6e04-4f88-9dfa-13e73a759bf4",
+    "firstName": "Lawil ",
+    "lastName": "Karama ",
+    "fullName": "Lawil Karama",
+    "bio": "Contemporary Artist, Researcher, Blockchain Strategist, Program Office, little bit of everything ",
+    "tagLine": "Program Officer ",
+    "profilePicture": "https://sessionize.com/image/1e2a-400o400o1-pAQGQvfxhrGDZF89Tgj11p.png",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/lawil-k-03867213b/",
+        "linkType": "LinkedIn"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation ",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Program Officer ",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "bf792c2c-09fd-453b-92a7-42772fa1da1d",
+    "firstName": "Layanah",
+    "lastName": "AlWreikat",
+    "fullName": "Layanah AlWreikat",
+    "bio": "Layanah has been working at JoPACC for five years, heading the development and operations department and, recently the FinTech innovation departments. \r\nShe was the project manager for the Instant Payment System (CliQ) deployment in Jordan and the project manager for the JoMoPay upgrade to the ISO20022.\r\nAs part of her role at JoPACC, Layanah is responsible for the high-level component designs and data flows of new services and platforms. Additionally, she is responsible for developing and reviewing system integration documents (Business and Technical ones). She also acts as the focal point for system participants and stakeholders.\r\nLayanah holds a bachelor's degree in telecommunication engineering, a master's degree in Data Science, an MBA, and a master's degree in Communications and Information Systems.",
+    "tagLine": "Business Development and Operations Director @JoPACC",
+    "profilePicture": "https://sessionize.com/image/b074-400o400o1-s7NfnxfNG36Xy7FK64VH3y.png",
+    "sessions": [
+      {
+        "id": 525073,
+        "name": "Cross Border Payments in the Instant Era"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/layanah-al-wreikat-29b7811a/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://jopacc.com/Default/En",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "NA",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Business Development and Operations Director",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "209d595a-a261-487f-a5f8-7ec09f179989",
+    "firstName": "Lena",
+    "lastName": "Ghaninejad",
+    "fullName": "Lena Ghaninejad",
+    "bio": "Lena Ghaninejad uses food as a medium for building bridges between people, places and various fields of knowledge, as well as between past and future scenarios. She has worked with Sainte Anne Gallery, Stedelijk Museum Schiedam & Lafayette Anticipations amongst others, and has collaborated with brands such as Lalique and Acne Studios.",
+    "tagLine": "Future | Money Awardee",
+    "profilePicture": "https://sessionize.com/image/bc5d-400o400o1-BLhytvsuwLNtP4bryoMsF2.JPG",
+    "sessions": [
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Instagram",
+        "url": "https://instagram.com/Lena.ghaninejad",
+        "linkType": "Instagram"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Future money grant ",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Artist ",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6acc0bce-61ef-4ccc-9419-735d16c0f0b7",
+    "firstName": "Lena ",
+    "lastName": "Ghaninejad",
+    "fullName": "Lena Ghaninejad",
+    "bio": null,
+    "tagLine": "Future|Money Awardee",
+    "profilePicture": "https://sessionize.com/image/d11e-400o400o1-Y2iEuAHnq7LLJtDHpX7Xmc.JPG",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "c0195cc3-97eb-47fc-96d0-7222b7c61381",
+    "firstName": "Maha ",
+    "lastName": "Bahou ",
+    "fullName": "Maha Bahou",
+    "bio": "Ms. Maha serves as CEO of JoPACC since June 2018. The Company is mandated with enhancing and promoting digital payments in Jordan and is the operator of\r\nseveral payment systems in the country.\r\n \r\nBefore JoPACC, Ms. Maha worked at the Central Bank of Jordan for 30 years, where she was most recently the Executive Manager of the Payment Systems, Domestic Banking Operations and Financial Inclusion Department for 7 years. She has done consulting work in Libya and has\r\nexperience as a lecturer at the University of Jordan and as a trainer in cooperation with Philadelphia Consulting, the Institute of Banking Studies, the Central Bank of Jordan, and different NGOs.\r\n\r\nMs. Maha holds a master’s degree in Banking and Finance, a bachelor’s degree in Economics and Business Administration, in addition to a Leadership and Strategic\r\nManagement certificate from The Royal Military Academy of Sandhurst. She has been honored by King Abdullah II with the Distinguished Government Leader Award for the year 2016.\r\n\r\nMs. Maha has been appointed a member of Jordanian Senate in 2022. She currently sits on several local and international boards, including Innovative Start-\r\nups and SMEs Fund (ISSF), Interledger Foundation in Luxemburg, and the Global Action Network on Forced Displacement. She has served on the board of the\r\nConsultative Group to Assist the Poor (CGAP) of the World Bank from 2017 to 2022.",
+    "tagLine": "CEO of Jordan Payments and Clearing Company (JoPACC)",
+    "profilePicture": "https://sessionize.com/image/d50d-400o400o1-LKXweNqsUDMcX7jvJ21cb3.png",
+    "sessions": [
+      {
+        "id": 552344,
+        "name": "Keynote Speaker | Maha Bahou, CEO of Jordan Payments and Clearing Company (JoPACC)"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "edf0d8b1-3504-4478-ab79-e0c215a4e382",
+    "firstName": "Malcolm",
+    "lastName": "Kastiro",
+    "fullName": "Malcolm Kastiro",
+    "bio": "Passionate about building Fintech systems",
+    "tagLine": "Builder of Fintech and Mobile Payment systems",
+    "profilePicture": "https://sessionize.com/image/6436-400o400o1-EPhnKcACS8feNnaUG85TEY.jpg",
+    "sessions": [
+      {
+        "id": 516839,
+        "name": "Mobile Money 2.0: Mainstream Financial Service"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/maali",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/kastiro-malcolm-5732273/",
+        "linkType": "LinkedIn"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "UAP Old Mutual General Uganda Limited",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Innovation & Digital Officer",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a055a6cf-45d9-4cd2-8273-435ad54d5baf",
+    "firstName": "Malou",
+    "lastName": "Lintmeijer",
+    "fullName": "Malou Lintmeijer",
+    "bio": " Co-director of Stichting Here to Support since 2018, Malou is experienced in the strategy, entrepreneurship and finance of non-governmental organisations. She fights for human rights and advocates for municipalism. ",
+    "tagLine": "Co-director Stichting Here to Support",
+    "profilePicture": "https://sessionize.com/image/964f-400o400o1-QUfy8N1rLFae2ubRLEQiGE.jpg",
+    "sessions": [
+      {
+        "id": 530246,
+        "name": "Financial inclusion for undocumented people"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/malou-lintmeijer-6155b960/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Facebook",
+        "url": "https://www.facebook.com/heretosupport",
+        "linkType": "Facebook"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://www.instagram.com/here_to_support_amsterdam/",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.heretosupport.nl/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Here to Support",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "co-director",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "26639585-017e-434e-8f11-42933e1c9cad",
+    "firstName": "Martijn Jeroen",
+    "lastName": "van der Linden",
+    "fullName": "Martijn Jeroen van der Linden",
+    "bio": "Martijn Jeroen van der Linden explores the digitization of money and new economic structures.\r\n\r\nVan der Linden is a professor of New Finance at The Hague University of Applied Sciences and obtained his Ph.D. from Delft University of Technology in 2022. In his research, he developed design guidelines for the monetary and financial system in the digital age.\r\n\r\nCurrently, his research focuses on public digital money (called central bank digital currencies, CBDCs by central bankers), stablecoins, deposit banks, cryptocurrencies, financial instability, monetary policy, and the liberalization and re-regulation of banking.\r\n\r\nHe regularly publishes, participates in public debates, and gives tens of lectures and keynotes a year.",
+    "tagLine": "Future|Money Awardee, Professor of practice in new finance at The Hague University of Applied Sciences",
+    "profilePicture": "https://sessionize.com/image/1a4a-400o400o1-73PxHeqAfQJyzmnwAHCmv7.jpg",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      },
+      {
+        "id": 554174,
+        "name": "The Waterworks of Money and Future Scenarios for the Monetary System"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/MartijnJvdL",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/martijnjeroenvanderlinden/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Blog",
+        "url": "https://mjvdl.com/",
+        "linkType": "Blog"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.dehaagsehogeschool.nl/onderzoek/lectoraten/new-finance",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "The Hague University of Applied Sciences",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Professor of practice in new finance",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a63af0da-3b51-42ad-9775-ff52212884ba",
+    "firstName": "Max",
+    "lastName": "Kurapov",
+    "fullName": "Max Kurapov",
+    "bio": "As a software developer at the Interledger Foundation, Max builds open source tools and APIs that provide developers & institutions access to the Interledger network. Before joining the Foundation, Max spent 5 years working at startups: one of which a Fintech company, where he was one of the leads on the card payments processing team.",
+    "tagLine": "Software Developer @ Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/0f90-400o400o1-badeceef-ae1a-4430-8524-cf1c39854a2e.jpg",
+    "sessions": [
+      {
+        "id": 552259,
+        "name": "Rafiki - Our friend has grown"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Software Developer",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "dc2dd614-d811-4155-862f-b23bf9b0eb5e",
+    "firstName": "Melissa",
+    "lastName": "Malzkuhn",
+    "fullName": "Melissa Malzkuhn",
+    "bio": "Melissa Malzkuhn is an activist, academic, artist, and digital strategist with a love for language play, interactive experiences, and community-based change. She founded and leads creative research and development at Motion Light Lab, at a Gallaudet University research center. The Lab uses creative literature and digital technology techniques to create immersive learning experiences- from storybook apps that have been translated into over 20 international languages to motion-capture projects that build signing avatars- all of which expand the 3D technology landscape for deaf children, visual learners, and more. Melissa is a cofounder of CREST Network, focusing on the equity and inclusion of deaf people in sign language technology. Her production company developed an app to teach American Sign Language, The ASL App, which has been downloaded over 2 million times. Third-generation Deaf, she has organized deaf youth and worked with international deaf youth programs, fostering leadership and self-representation. Now, she collaborates with teams in different countries to support literacy development for deaf children through sign language resources. Melissa started a campaign, Hu - To Sign Is Human, to continue positive advocacy for language access for all deaf children. Her work has been recognized nationally and internationally. Melissa is one of the selected artists part of the CripTech Lab and is building a Deaf Club experience in the Metaverse, exploring inclusion and access in the digital realm. She is an Obama Fellow, inaugural class 2018, and an Ashoka Fellow. She resides in Maryland with her family.",
+    "tagLine": "3rd generation Deaf, artist, advocate, & community changemaker",
+    "profilePicture": "https://sessionize.com/image/2708-400o400o1-K1sTVzwidtZeHLmdPj4eRJ.jpg",
+    "sessions": [
+      {
+        "id": 530359,
+        "name": "Redefining the cost of access: financial equity in the Deaf Community"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/melissamalzkuhn",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://www.instagram.com/mezmalz",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.mezmalz.com",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Motion Light Lab",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder & Director ",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "0b78c79b-f15d-4659-b6f1-bd5c00b2a733",
+    "firstName": "Mia",
+    "lastName": "Wright-Ross",
+    "fullName": "Mia Wright-Ross",
+    "bio": "Mia Wright-Ross is a leather artisan who focuses her works in sculptural installations and object design. The leather cording techniques that appear as a signature motif across her luxury design house, MWR Collection, represent Wright-Ross’ art & design philosophy— material as connector of human emotions and the hand as the ultimate tool of dexterous design. \r\nWright-Ross developed this philosophy to revive the importance of the artisan as healer; to educate future designers and audiences about the valuable narrative in craft language that is cultivated with the human hands; and exemplify the emotional, spiritual, structural, and ancestral connections between craft practitioners. \r\nWright-Ross is currently exploring new iterations of leatherwork, including large scale tapestries and lighting installations.\r\nShe has worked in the Footwear & Accessory Industry for over 12 years and been a leading designer for several contemporary designer brands. Brands including Calvin Klein, 3.1 Phillip Lim, and Tibi. She worked as the Senior Footwear & Accessories Designer, where she oversaw all design & development in Italy, Brazil, and China. In 2020, Wright-Ross became the Artist Fellow at the Musuem of Art & Design in New York City. There, she began to exploring new interactions of her work within ancestral and systemic structures in the African Ameri-Indian community.  Currently, she is an Adjunct Professor of Footwear Design at Parsons The New School of Design, Carnegie Hall’s NeON Arts 2023 grantee, and maintains her Art & Design Atelier in New York City. \r\n",
+    "tagLine": "Future|Money Awardee, - Loose Change (Chains)",
+    "profilePicture": "https://sessionize.com/image/5a39-400o400o1-P5qh24keiLrpQ3nwcN5sfB.jpeg",
+    "sessions": [
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Company Website",
+        "url": "HTTPS://Www.Miawrightross.com",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Grantee",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e2f09125-c1ee-4d7f-ab94-b989a449f1e2",
+    "firstName": "Mia ",
+    "lastName": "Wright- Ross ",
+    "fullName": "Mia Wright- Ross",
+    "bio": "Mia Wright-Ross: Loose Change (CHAINS) is a series of large-scale multi-media tapestries (primarily leather & paper lottery tickets) as a reflection/projection of the reimagination of Hope that has become a lethal tool of capitalism within the community-rich centers of Black & Brown neighborhoods throughout the United States of America. ",
+    "tagLine": "Future|Money Cohort",
+    "profilePicture": "https://sessionize.com/image/4673-400o400o1-aFbztVPFrLdjzrdxfvAXrK.jpeg",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "42e841a3-7a0b-4a96-86d1-cb0689c47382",
+    "firstName": "Nandini",
+    "lastName": "Harihareswara",
+    "fullName": "Nandini Harihareswara",
+    "bio": "Nandini Harihareswara is a Digital Finance, FinTech, Digital Development and Inclusive Digital Economies expert. She previously served as Senior Advisor on Inclusive Digital Economies, Gender Equality and Women’s Economic Empowerment for the UN Capital Development Fund. She also served as the Digital Finance Regional Technical Specialist from 2015-2019, responsible for the creation & implementation of the UNCDF Digital Economy Strategy in Zambia and Malawi. She also helped to author the Inclusive Digital Economies and Gender Equality Playbook, launched in 2021. In these roles, she worked with more 20 fintechs, banks, telcos and ecommerce companies to successfully increase their women customers and partner MSME businesses, and increase their financial return on investment.\r\n\r\nShe was a founding member of the United States Agency for International Development (USAID) Digital Development Division. Prior to working for the Digital Development team, Nandini worked as an Investment Officer for the USAID Development Credit Authority Office, and a Presidential Management Fellow at the US Department of Transportation as well as the Urban Transport Division of the World Bank.\r\n\r\nShe is the author of numerous publications on the intersection of finance, technology and international development. Nandini has an MBA and a Masters in International Trade and Investment Policy from the George Washington University. She also holds a BS in Psychology and a BA in Political Science from the University of California at San Diego. \r\n",
+    "tagLine": "Digital Development Expert, TechChange",
+    "profilePicture": "https://sessionize.com/image/c37a-400o400o1-W8SDXW1DHj8MeBCoAfoDJB.PNG",
+    "sessions": [
+      {
+        "id": 530162,
+        "name": "Digital Finance – a Woman’s Immersive Experience"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/nandinish",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/nandini/",
+        "linkType": "LinkedIn"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "TechChange",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Consultant",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "c0cdf5ec-604b-48fa-a88d-475fe89a8932",
+    "firstName": "Nathan",
+    "lastName": "Lie",
+    "fullName": "Nathan Lie",
+    "bio": "Nathan is a software developer who has been working on technologies built on Interledger since 2018. He now focuses on directly contributing to Interledger and hopes to connect global communities with financial resources and strengthen the creator economy.\r\n\r\nOutside of work Nathan has taken an interest in cooking, sketching, and video games.",
+    "tagLine": "Your friendly neighborhod GNathan",
+    "profilePicture": "https://sessionize.com/image/af36-400o400o1-PNZ9r9hfgdPohSvfTE681i.jpg",
+    "sessions": [
+      {
+        "id": 552501,
+        "name": "Authorizing Payments with GNAP & Open Payments"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/nathan-lie-138a73121/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Blog",
+        "url": "https://www.linkedin.com/in/nathan-lie-138a73121/",
+        "linkType": "Blog"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://interledger.org/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Software Engineer",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "526711d3-3681-4fa1-aca6-d962efa1bb30",
+    "firstName": "Nicolo",
+    "lastName": "Zingales",
+    "fullName": "Nicolo Zingales",
+    "bio": "Nicolo Zingales is Professor of Information Law and Regulation at the law school of the Fundação Getulio Vargas in Rio de Janeiro. Fascinated by the interaction of law, technology and markets, he writes and researches on a range of issues revolving around the roles and responsibilities of digital platforms and intermediaries in the online ecosystem. His research has been cited, among others, by the UN Special Rapporteur for the Protection and Promotion of Freedom of Opinion and Expression, the Council of Europe, the Organization for Cooperation and Development, the UK House of Lords, and the European Parliament. ",
+    "tagLine": "Fundação Getulio Vargas ",
+    "profilePicture": "https://sessionize.com/image/199f-400o400o1-GLzmHcpgfFyMwxJSCskRVd.png",
+    "sessions": [
+      {
+        "id": 530375,
+        "name": "Standardized Payment Interfaces as Digital Public Infrastructures: Learning from India and Brazil"
+      },
+      {
+        "id": 530369,
+        "name": "Equitable Interoperability For Ecosystem Value Creation"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/JusTechne",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/nicolo-zingales-b926284/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://direitorio.fgv.br/en/pesquisa/centro-de-tecnologia-e-sociedade",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Fundação Getulio Vargas",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Professor of Law",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "15b842af-2bc2-4844-8f35-c31872cb8c84",
+    "firstName": "Nyi",
+    "lastName": "Aye",
+    "fullName": "Nyi Aye",
+    "bio": "Nyi Aye is the CEO of ThitsaWorks.",
+    "tagLine": "CEO",
+    "profilePicture": "https://sessionize.com/image/ce3a-400o400o1-YEWMWKPKWhi7RJPPe3rr4H.jpg",
+    "sessions": [
+      {
+        "id": 525073,
+        "name": "Cross Border Payments in the Instant Era"
+      },
+      {
+        "id": 528935,
+        "name": "ILP Enabled ThitsaNet Inclusive Payment Network"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/nyinyeinaye/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.thitsaworks.com",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "ThitsaWorks Pte. Ltd.",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "38c7b62e-ee36-407f-ad07-86ab1d5f3a5f",
+    "firstName": "Philliph",
+    "lastName": "Drummond",
+    "fullName": "Philliph Drummond",
+    "bio": "Philliph is Senior Tech Design Researcher at Superbloom Design, an organization that leverages design as a transformative practice and promotes equity through collaborative design. Philliph has 10+ years of experience as a Creative Technologist / System Admin with a focus on digital security, operations, and product/service design working primarily with non-profits and startups.",
+    "tagLine": "Superbloom Design, Senior Tech Design Researcher",
+    "profilePicture": "https://sessionize.com/image/a239-400o400o1-XHCdCvnrgNoaGmLvUS7MvV.jpg",
+    "sessions": [
+      {
+        "id": 530357,
+        "name": "Open Payments For More Inclusive and Secure Research"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/philliph-drummond/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "http://superbloom.design",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Superbloom Design",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Senior Tech Design Researcher",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "295582aa-8c62-450c-a296-6c45573ea0fd",
+    "firstName": "Raashi ",
+    "lastName": "Saxena ",
+    "fullName": "Raashi Saxena",
+    "bio": "Moderator (Confirmed) \r\n\r\nRaashi Saxena is a renowned public interest technologist, trainer, and strategy consultant with Accessibility Lab and carries a wealth of experience in open-source technology, social impact, and practice. She holds several advisory positions, including with The Internet Rights & Principles Dynamic Coalition, Missions Publiques’s “We, the Internet” Project, and Threading Change, a sustainable fashion non-profit. As a consultant, her clients include Digital Communication Network, Accessibility Lab, studio intO, Superbloom, The Innovation for Policy Foundation, Internews, Gapminder Foundation, and the IO Foundation. As a highly sought-after international speaker, Raashi has spoken on panels and conferences across Africa, Asia, Latin America, and Europe. Her expertise has been recognized in prominent publications such as the Mozilla 2022 Internet Health Report and Pew Research Center’s 2021 Report on Digital Spaces. The World Economic Forum has honored Raashi as one of the Six Inspirational Young Female Leaders, and she currently holds the position of Curator of the Global Shapers Bengaluru Hub. Additionally, she was recognized by Women Deliver as a Young Leader. Based in Bangalore, India, Raashi works tirelessly towards creating a positive social impact through her various global endeavours.\r\n\r\n",
+    "tagLine": "Strategy Consultant & Trainer ",
+    "profilePicture": "https://sessionize.com/image/d0ab-400o400o1-PmkcgnkniLqKJHugvfiv8N.jpg",
+    "sessions": [
+      {
+        "id": 530396,
+        "name": "Payment Parity Perspectives: Women of Color Reshaping Financial Inclusion"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/RaashiSxn",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/raashi-saxena-18a90684",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Facebook",
+        "url": "https://www.facebook.com/raashi.saxena.3",
+        "linkType": "Facebook"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://www.instagram.com/raashisxn/",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.a11ylab.com/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Accessibility Lab ",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Strategy Consultant & Trainer ",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "9bd85c6e-88b7-4d06-b8c8-0458dc200746",
+    "firstName": "Roberto",
+    "lastName": "Valdovinos",
+    "fullName": "Roberto Valdovinos",
+    "bio": "B.A. and M.A. in Logic and Philosophy (Pantheon-Sorbonne University), M.Phil. in Comparative Studies (Columbia University). Directed a migrant organization in the US and a national institute in Mexico. Works with migrants and marginalized communities in social justice and financial inclusion projects.",
+    "tagLine": "The People's Clearinghouse, CFO",
+    "profilePicture": "https://sessionize.com/image/50a6-400o400o1-TVUZEfGgJoBQV2E2Fny28S.png",
+    "sessions": [
+      {
+        "id": 519348,
+        "name": "Rafiki's “Corridor”: Mexico's PCH remittance use case"
+      },
+      {
+        "id": 519137,
+        "name": "Building Digital Financial Inclusion from Below"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/CamaraGente",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://mx.linkedin.com/company/pagos-sin-fronteras",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Facebook",
+        "url": "https://www.facebook.com/CamaraDeLaGente",
+        "linkType": "Facebook"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.amucss.org/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Mexican Association of Social Sector Credit Unions",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CFO",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3d6be742-b26a-4da9-b8f4-eda7bd532ba0",
+    "firstName": "Ruth",
+    "lastName": "Buckley",
+    "fullName": "Ruth Buckley",
+    "bio": "Ruth Buckley has 29 years of experience with USAID, both overseas and in Washington, and is a member of the Senior Executive Service.  \r\nAs Performance Improvement Officer, Ms. Buckley provides advice and counsel to Agency leadership on effective management of USAID programs,  operations and budget; oversees implementation of the Government Performance and Results Act Modernization Act; provides executive support for the President’s Management Agenda; and ensures goals of the Agency are achieved through effective results management and efficient use of resources.  As Deputy Assistant Administrator in the Bureau for Management, Ms. Buckley provides oversight and direction for USAID’s operational and regulatory policy, strategic planning, continuous performance improvement, bureau succession planning and is the Senior Agency Official for Privacy (SAOP).  Her executive leadership of business process reviews across eight functions has resulted in implementation of 91 percent of the recommendations and progress reducing process times by as much as 50 percent. She is also a champion on USAID's localization and  burden reduction initiatives.\r\n\r\nPrior to joining the M Bureau, Ms. Buckley held several senior positions in the Africa Bureau. She brought this in-depth experience to develop strategic solutions and continuous improvement to our most intractable operational and organizational problems. \r\n\r\n",
+    "tagLine": "USAID Performance Improvement Officer and Deputy Assistant Administrator for Management",
+    "profilePicture": "https://sessionize.com/image/6b2f-400o400o1-piK49CSbDmYdFXoq8FwLBe.jpg",
+    "sessions": [
+      {
+        "id": 509293,
+        "name": "Partnering for Growth Leveraging Donors and Investors"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://www.twitter.com/usaid",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/company/usaid",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Facebook",
+        "url": "https://www.facebook.com/USAID",
+        "linkType": "Facebook"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://www.instagram.com/usaid",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Blog",
+        "url": "https://www.medium.com/@USAID",
+        "linkType": "Blog"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.usaid.gov/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "USAID",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Panelist",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3e80acea-13f9-4fd2-8e9a-e4b715297d9a",
+    "firstName": "Sabine",
+    "lastName": "Schaller",
+    "fullName": "Sabine Schaller",
+    "bio": "Sabine has always been interested in Data Ownership and the Internet of Value. She works on the specification and implementation of open standards like the Interledger Protocol, Open Payments, and Web Monetization to allow for a Web where content can be paid for with hard currency instead of data.\r\nPrior to joining the Interledger Foundation, Sabine was the Research & Development Lead at Coil.",
+    "tagLine": "Engineering Lead @ Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/c36e-400o400o1-75ygMJTxH1xvpoPZpuBz1G.jpg",
+    "sessions": [
+      {
+        "id": 552259,
+        "name": "Rafiki - Our friend has grown"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Engineering Lead",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "c1653fc3-507d-4ae8-9541-7e7c03e61fd5",
+    "firstName": "Saloni",
+    "lastName": "Garg",
+    "fullName": "Saloni Garg",
+    "bio": "International Red Hat Women in Open Source Awardee | Mozilla Open Leader 2019 | a strong open source diversity supporter | Google Venkat Scholarship winner | Speaker",
+    "tagLine": "Software Engineer at Wayfair | International Women in Open Source Award Winner | Google Venkat Scholar | Mozilla Open Leader",
+    "profilePicture": "https://sessionize.com/image/4be9-400o400o1-NPxAJPFz3f4tPGP2hwehmQ.jpeg",
+    "sessions": [
+      {
+        "id": 529371,
+        "name": "Bridging Two Worlds: How India's UPI Informs the Future of Open Payments"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/salonigarg_",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/saloni-garg/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Blog",
+        "url": "https://medium.com/@saloni_garg",
+        "linkType": "Blog"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Affloir",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6b4980b6-a70f-413d-884d-28c3dd8daf16",
+    "firstName": "Savannah",
+    "lastName": "Koolen",
+    "fullName": "Savannah Koolen",
+    "bio": "Savannah Aleksandra Koolen (1985) is the founder and co-director of the Here to Support Foundation. Koolen studied at the dance academy but unfortunately she had to stop dancing early because of injuries. Her full life she is involved in politics, activism and art and after her study Art & Culture at the University in Maastricht she moved to Amsterdam. For ten years she has been working on how artists and artistic projects can support the struggle of minorities and refugees to equal rights, and strengthen the self-organised-,grassroots- movements. In 2007 she was a coordinator of the Nationwide campaign for funding for the arts, and since the start (2012) of refugee collective We Are Here in Amsterdam she supports their struggle organising educational, artistic projects to gain visibility and work on innovative plans. In 2013 she founded the Here to Support Foundation. In 2016,  the Here to Support Foundation won the Ab Harrewijn Prize under her leadership and in May 2017 Here to Support won the European Citizenship Award with the project We Are Here Media Academy. From June 2017, she was also campaign leader of GroenLinks Amsterdam for the winning, local elections in 2018 in Amsterdam and later joined the board of GroenLinks Amsterdam as president of the board in 2019.",
+    "tagLine": "Activist, Founder & CEO Here to Support Foundation",
+    "profilePicture": "https://sessionize.com/image/b65e-400o400o1-SjLujAy3cm5QSSk9CDSnh5.jpeg",
+    "sessions": [
+      {
+        "id": 530246,
+        "name": "Financial inclusion for undocumented people"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/savannahkoolen/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://www.instagram.com/savannah.k85/",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.heretosupport.nl/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Here to Support",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder & CEO Here to Support Foundation",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "63b68cad-6917-4297-95a4-08fdfa0fd51d",
+    "firstName": "Shelley",
+    "lastName": "Anderson",
+    "fullName": "Shelley Anderson",
+    "bio": "A seasoned innovation leader, Shelley spent 16 years at the U.K.’s Financial Conduct Authority before joining AIR in January 2022. Starting in 2015, she was part of the FCA’s Regtech team, designing and leading TechSprints and developing the regulator’s approach to interacting with the global Regtech ecosystem. Specializing in innovation for vulnerable consumers, Shelley has designed programs that look at the barriers faced by digital financial services consumers, and at how both regulators and firms can design better products for inclusion. At AIR, Shelley leads the organization’s program to further expand its global reach through TechSprints and strategic advisory services, and focuses on ways to ignite technology innovation throughout the financial system. In addition, Shelley is co-founder of the Women In Regulatory Innovation (WIRI) network, which is creating a community of women across the globe with the aim of building meaningful diversity and inclusion within the regulatory system. ",
+    "tagLine": "Program Director - Alliance for Innovative Regulation",
+    "profilePicture": "https://sessionize.com/image/55b2-400o400o1-hQHLCk6pJFmRQaYnYpNq3y.jpeg",
+    "sessions": [
+      {
+        "id": 525073,
+        "name": "Cross Border Payments in the Instant Era"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/shelley-anderson-2b79971a/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://regulationinnovation.org/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Alliance for Innovative Regulation",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Program Director",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6b0e5bf6-b19d-4a1f-9977-4b4d03b984eb",
+    "firstName": "Smriti",
+    "lastName": "Parsheera",
+    "fullName": "Smriti Parsheera",
+    "bio": "Smriti Parsheera is a lawyer and public policy researcher. Her work spans across the areas of data governance, digital rights, regulatory processes and digital competition. She is currently a Fellow with the CyberBRICS Project at FGV Law School, Brazil and a PhD candidate at Indian Institute of Technology Delhi's School of Public Policy. ",
+    "tagLine": "Fellow, CyberBRICS Project",
+    "profilePicture": "https://sessionize.com/image/da31-400o400o1-66f34c9b-c88c-465a-822d-4f4188f7a920.jpg",
+    "sessions": [
+      {
+        "id": 530375,
+        "name": "Standardized Payment Interfaces as Digital Public Infrastructures: Learning from India and Brazil"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/SmritiParsheera",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/smrpar?originalSubdomain=in",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://www.instagram.com/smrpar/",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://www.smritiparsheera.com/home",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "CyberBRICS Project, FGV Law School",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Fellow",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "d77b86a5-6c8c-4976-947b-d2d8424325c5",
+    "firstName": "Stefan ",
+    "lastName": "Thomas ",
+    "fullName": "Stefan Thomas",
+    "bio": "Stefan Thomas is the Co-Creator of the Interledger Protocol and Chairperson of the Board at the Interledger Foundation. He currently works on Dassie, an open-source, peer-to-peer implementation of Interledger. \r\n\r\nHe is also the Founder and CEO of Coil, a startup which created a \"subscription to the whole Web\" and the Open Web Monetization standard.  Over the course of almost five years, Coil made about 78 billion payments over Interledger, providing the first proof- of-concept for the technology at scale. \r\n\r\nStefan was a prominent figure in the blockchain movement. As an early Bitcoin contributor, he produced the popular “What is Bitcoin?” video, introducing millions of users to Bitcoin, and created BitcoinJS, the first implementation of Bitcoin cryptography in the browser. \r\n\r\nAs CTO and one of the first employees at Ripple, Stefan designed new protocols for cross-border payments, now used by banks all over the world. As part of this work, he led the team that created Interledger, an open, Internet-like protocol for value transfer. \r\n\r\nStefan is a passionate supporter of financial access and worked with the Bill & Melinda Gates Foundation to develop Mojaloop, an open-source national payment switch that connects mobile wallets in developing markets.",
+    "tagLine": "Co-Creator of the Interledger Protocol",
+    "profilePicture": "https://sessionize.com/image/a37e-400o400o1-VrFP9YgrUtSqoDkHGHnzYG.jpg",
+    "sessions": [
+      {
+        "id": 552343,
+        "name": "Launching Dassie: An Interledger Peer-to-peer Network"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "9d47cf6f-7cb7-4b1a-8d29-8682da2faf14",
+    "firstName": "Stephanie ",
+    "lastName": "Perrin",
+    "fullName": "Stephanie Perrin",
+    "bio": "\r\nDr. Stephanie Perrin received her doctorate from the University of Toronto Faculty of Information in the spring of 2018.  Her research is on why ICANN, the Internet Corporation of Assigned Names and Numbers that runs critical aspects of the Domain Name System (DNS) for the Internet, does not implement privacy protection for end users in its policies.  She worked for 30 years in the federal government of Canada, mostly on data protection and freedom of information issues in the context of information and communication technologies. Stephanie was the Director of Privacy Policy at Industry Canada in charge of developing PIPEDA, Canada’s privacy legislation for the private sector which passed Parliament in 2000.   She then went to the private sector, where she was the first Chief Privacy Officer in Canada, working for the Montreal start-up Zero Knowledge Systems, promoting their ground breaking anonymous browsing and private credentials products.  Active in domestic and international privacy policy and compliance fora, Stephanie has been involved in privacy issues at the practical, policy and legislative level since 1984.\r\n",
+    "tagLine": "President Digital Discretion",
+    "profilePicture": "https://sessionize.com/image/a259-400o400o1-Yhg86ETArgKvez2ZTmD26g.jpg",
+    "sessions": [
+      {
+        "id": 523092,
+        "name": "Harvesting Hope from Hiccups: Overcoming Standardization Hurdles"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Digital Discretion Inc",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "President",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "1678fa40-6634-440b-9133-1525f93064ef",
+    "firstName": "Subhashish",
+    "lastName": "Panigrahi",
+    "fullName": "Subhashish Panigrahi",
+    "bio": "Subhashish Panigrahi is a filmmaker, researcher and a civil society leader from India. He has directed over 10 non-fiction films including the critically-acclaimed and National Geographic Society-supported documentary Gyani Maiya. He is a National Geographic Explorer, a Digital Identity Fellow at Yoti, a MJ Bear Fellow, a DWeb Fellow and a recipient of Grant for the Web,  Interledger Foundation and Creative Commons grants. As a current Future|Money Artist, he is directing Error 404, a short film around inclusion and digital payment systems in India.",
+    "tagLine": "Future|Money Awardee, Artist / Director, O Foundation",
+    "profilePicture": "https://sessionize.com/image/cc53-400o400o1-Dx3NDeGds2noQwGxc6stWT.JPG",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      },
+      {
+        "id": 552412,
+        "name": "Première of Bringing Down a Mountain"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/subhapa",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/psubhashish/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Blog",
+        "url": "https://theofdn.org",
+        "linkType": "Blog"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://theofdn.org",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "O Foundation",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Director",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "585a769b-db7a-4c75-b1ba-4c4fe8015276",
+    "firstName": "Tadej",
+    "lastName": "Golobic",
+    "fullName": "Tadej Golobic",
+    "bio": "At 10 years old, I began my coding journey with VB6, setting the course for a lifelong tech odyssey. Graduating from the Faculty of Computer and Information Science at the University of Ljubljana, I delved into remote support software with a local enterprise. The 2017 crypto boom lured me into the crypto realm, leading to my pivotal role as a backend developer at GateHub in 2020. Today, I proudly serve as Infrastructure Team Lead, steering projects that power our digital future.",
+    "tagLine": "GateHub, Infrastructure Team Lead",
+    "profilePicture": "https://sessionize.com/image/7f43-400o400o1-fhQgnFKeqnsnhfEU3q6qyM.JPG",
+    "sessions": [
+      {
+        "id": 530042,
+        "name": "GateHub Payments via ILP - Integration with Rafiki"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/golobitch",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://linkedin.com/in/tadej-golobic",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://gatehub.net",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "GateHub",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Infrastructure Team Lead",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "bfee4ab9-933d-4e4b-8e5b-7d69f723e225",
+    "firstName": "Tani",
+    "lastName": "Olhanoski",
+    "fullName": "Tani Olhanoski",
+    "bio": "Tani Olhanoski is a serial entrepreneur who has spent the last decade building software companies and community spaces in the Bay Area. They began their career in tech in 2014 as the Director of Operations for the first fully-compliant crypto exchange in the US and brings a deep understanding of financial systems and regulatory compliance to their current product thinking. They consult on a range of startups and decentralized web projects, and have spent the last 5 years diving deep into community-ownership, alternative investment models, and exploring new technologies that enable deeper financial inclusion. As the CEO of Mysilio, they are working towards the future of user-owned platform cooperatives and a more equitable Web built for all.",
+    "tagLine": "Mysilio - Founder, CEO",
+    "profilePicture": "https://sessionize.com/image/af3e-400o400o1-Rt53HJUEBDdtuE8fSAGfZS.jpeg",
+    "sessions": [
+      {
+        "id": 530313,
+        "name": "Reimagining Tech Platforms of the Future - How to build Digital Public Infrastructure using ILP"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "Twitter",
+        "url": "https://twitter.com/inattani",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/taniolhanoski/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Blog",
+        "url": "https://medium.com/@mysilio",
+        "linkType": "Blog"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://mysilio.com/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Mysilio",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO, Founder",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "405070c5-a46c-4f12-9b68-5b1ed17e98a1",
+    "firstName": "Uchi",
+    "lastName": "Uchibeke",
+    "fullName": "Uchi Uchibeke",
+    "bio": "Developer, and Founder. DevRel leader with track record growing communities around the globe",
+    "tagLine": "Founder and CEO, Chimoney",
+    "profilePicture": "https://sessionize.com/image/22db-400o400o1-UkR1cntswY3cYVzfSZYLc7.png",
+    "sessions": [
+      {
+        "id": 502677,
+        "name": "Integrating Interledger to Chimoney's Wallet as a Service Platform"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/uchiuchibeke",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/nickku",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Facebook",
+        "url": "https://facebook.com/uchibeke",
+        "linkType": "Facebook"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://instagram.com/uchiuchibeke",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Blog",
+        "url": "https://uchibeke.com/blog/",
+        "linkType": "Blog"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://chimoney.io/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Chimoney",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "56d4c506-d323-41b0-9854-605d76121d86",
+    "firstName": "Victoria",
+    "lastName": "Coker",
+    "fullName": "Victoria Coker",
+    "bio": "Victoria Coker is a multi-disciplinary artist and entrepreneur. She graduated from St. John’s University with a Bachelor’s in communication arts. Ms. Coker has more than ten years of design and marketing experience and has worked for organizations such as Carnegie Hall, Bric Arts Media, and Oxford University Press.\r\n\r\nIn 2017, she launched the Black Web Fest, an organization dedicated to celebrating Black creatives and digital content. Her goal is to build a legacy to empower her community. ",
+    "tagLine": "Black Web Fest, Founder",
+    "profilePicture": "https://sessionize.com/image/09cf-400o400o1-9nDrg4BC1QcXHD9GWQJznu.jpg",
+    "sessions": [
+      {
+        "id": 530396,
+        "name": "Payment Parity Perspectives: Women of Color Reshaping Financial Inclusion"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/AddVic_e",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "LinkedIn",
+        "url": "https://www.linkedin.com/in/victoria-coker-2149611b/",
+        "linkType": "LinkedIn"
+      },
+      {
+        "title": "Facebook",
+        "url": "https://www.facebook.com/BlackWebFest",
+        "linkType": "Facebook"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://www.instagram.com/blackwebfest/",
+        "linkType": "Instagram"
+      },
+      {
+        "title": "Blog",
+        "url": "https://blackwebfest.org/news/",
+        "linkType": "Blog"
+      },
+      {
+        "title": "Company Website",
+        "url": "https://blackwebfest.org/",
+        "linkType": "Company_Website"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Black Web Fest",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3a71dfe5-a936-40b8-853b-46d1652952fe",
+    "firstName": "Xiaoji",
+    "lastName": "Song",
+    "fullName": "Xiaoji Song",
+    "bio": "Xiaoji Song (she/they) is an artist, (interdisciplinary) researcher, and creative practitioner based in Berlin. Growing up in China and trained in Europe, I work on socially relevant and community-specific experiences, often with the local networks, NGOs, and local cultural and political institutions, mediated by texts, images, games, and performances. My projects have appeared in local or international media or cultural platforms in China (PRC), the UK, Germany, the Netherlands, and Bulgaria. Working in the liminal spaces of political theory, practice, and art, my research interests include techno-politics, networked social movement, border practices, and the performative aspect of political memory. I am now in a residency at Trust Berlin with two other artists/researchers working on modding practice in the gaming community as well as involved in a collective project on a fictional system of speculative emotional future supported by Light Art Space and Callie’s in Berlin. I am in the study group for the AI Anarchies Project at the German Academy of Art (ADK) and am also an alumna of the Open Set Lab research residency and the University of the Underground research program. Currently, I am finishing my master’s in global communication focusing on political communication of border technology at the University of Erfurt while working as a research assistant for the Humboldt University of Berlin.",
+    "tagLine": "Future|Money Awardee - Artist and Interdisciplinary researcher ",
+    "profilePicture": "https://sessionize.com/image/8cc7-400o400o1-KBYLpKTMU3b2xjrwJF8dZT.png",
+    "sessions": [
+      {
+        "id": 551406,
+        "name": "Future|Money Open Studio"
+      },
+      {
+        "id": 554064,
+        "name": "Future|Money Open Studio Day 2"
+      },
+      {
+        "id": 530396,
+        "name": "Payment Parity Perspectives: Women of Color Reshaping Financial Inclusion"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [
+      {
+        "title": "X (Twitter)",
+        "url": "https://twitter.com/sxj1995",
+        "linkType": "Twitter"
+      },
+      {
+        "title": "Instagram",
+        "url": "https://www.instagram.com/sxj1995/",
+        "linkType": "Instagram"
+      }
+    ],
+    "questionAnswers": [
+      {
+        "id": 51677,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Talonic.ai",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 51678,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Artist and Communication Strategist",
+        "sort": 23,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  }
+]

--- a/src/data/sessionize/2023-talks.json
+++ b/src/data/sessionize/2023-talks.json
@@ -1,0 +1,2326 @@
+[
+  {
+    "groupId": null,
+    "groupName": "All",
+    "sessions": [
+      {
+        "questionAnswers": [],
+        "id": "07ff2684-f7e9-4ca9-be26-7ec390c85ae4",
+        "title": "Registration",
+        "description": null,
+        "startsAt": "2023-11-05T17:30:00",
+        "endsAt": "2023-11-05T18:00:00",
+        "isServiceSession": true,
+        "isPlenumSession": false,
+        "speakers": [],
+        "categories": [],
+        "roomId": 41189,
+        "room": "Bar La Castilla",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "7967fe1f-6474-4bb1-8646-8e980149181d",
+        "title": "Cocktail Party",
+        "description": null,
+        "startsAt": "2023-11-05T18:00:00",
+        "endsAt": "2023-11-05T22:00:00",
+        "isServiceSession": true,
+        "isPlenumSession": false,
+        "speakers": [],
+        "categories": [],
+        "roomId": 41189,
+        "room": "Bar La Castilla",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "dce8886e-c1d1-453b-ae41-25a91f3be06e",
+        "title": "Registration",
+        "description": null,
+        "startsAt": "2023-11-06T09:00:00",
+        "endsAt": "2023-11-06T09:30:00",
+        "isServiceSession": true,
+        "isPlenumSession": false,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "c68a8ca0-dad1-4147-b979-1d5766788df5",
+        "title": "Welcome to ILP Summit",
+        "description": null,
+        "startsAt": "2023-11-06T09:30:00",
+        "endsAt": "2023-11-06T09:45:00",
+        "isServiceSession": true,
+        "isPlenumSession": false,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "552327",
+        "title": "Keynote Speaker | Briana Marbury CEO & President Interledger Foundation",
+        "description": null,
+        "startsAt": "2023-11-06T09:45:00",
+        "endsAt": "2023-11-06T10:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "12e36289-504e-46ce-94a8-b8e9debdd5b1",
+            "name": "Briana Marbury"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [],
+            "sort": 0
+          }
+        ],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "552343",
+        "title": "Launching Dassie: An Interledger Peer-to-peer Network",
+        "description": "Over the last year, Stefan has been working on a new, fully peer-to-peer implementation of Interledger. The Interledger Protocol (ILP) was originally designed for network with explicit peering relationships such as contractual agreements between companies. However, Dassie is intended as an open network which is accessible to anyone with an internet connection. In his talk, Stefan will explain these issues and his approach to solving them. As part of his progress report, he will announce the launch of the Dassie testnet and explain how developers can use it to build and test Interledger applications today.",
+        "startsAt": "2023-11-06T10:15:00",
+        "endsAt": "2023-11-06T11:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "d77b86a5-6c8c-4976-947b-d2d8424325c5",
+            "name": "Stefan Thomas"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [],
+            "sort": 0
+          }
+        ],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "d4ca7b91-c7e9-48fe-9bc1-3bcb22a13d43",
+        "title": "Coffee Break",
+        "description": null,
+        "startsAt": "2023-11-06T11:00:00",
+        "endsAt": "2023-11-06T11:15:00",
+        "isServiceSession": true,
+        "isPlenumSession": false,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The session will engage participants to thoroughly discuss  the two challenges facing instant cross-border payments:\r\n1. Sanction Screening for instant cross-border payments,\r\n2. Variances in the data requirements and formats of multiple regions/countries,\r\n3. Availing instant digital cross-border payments to non-bank FIs' customers (optional).\r\nthen the session will shift to brainstorming potential solutions to overcome those challenges.\r\nDepending on the number of confirmed attendees, the session will have working groups to discuss and challenge the possibility and applicability of the proposed solutions, aspiring to reach a common ground of solution(s) implementation, or potential innovative solution(s).",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "525073",
+        "title": "Cross Border Payments in the Instant Era",
+        "description": "The session aims to engage a fruitful conversation regarding challenges facing INSTANT cross-border payments",
+        "startsAt": "2023-11-06T11:15:00",
+        "endsAt": "2023-11-06T12:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "bf792c2c-09fd-453b-92a7-42772fa1da1d",
+            "name": "Layanah AlWreikat"
+          },
+          {
+            "id": "286b01c1-9dad-4415-a115-78e99ba93ec0",
+            "name": "Bruna Cataldo"
+          },
+          {
+            "id": "15b842af-2bc2-4844-8f35-c31872cb8c84",
+            "name": "Nyi Aye"
+          },
+          {
+            "id": "63b68cad-6917-4297-95a4-08fdfa0fd51d",
+            "name": "Shelley Anderson"
+          },
+          {
+            "id": "624f1540-059e-4db1-90b4-b17156b94ff8",
+            "name": "Jayshree Venkatesan"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "b1a2877d-bb59-41b6-91f1-a9cb8701e744",
+        "title": "Group Photograph",
+        "description": null,
+        "startsAt": "2023-11-06T12:00:00",
+        "endsAt": "2023-11-06T12:15:00",
+        "isServiceSession": true,
+        "isPlenumSession": false,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "29314a21-bea0-4933-b09c-2aa532a9f7bb",
+        "title": "Lunch",
+        "description": null,
+        "startsAt": "2023-11-06T12:15:00",
+        "endsAt": "2023-11-06T13:15:00",
+        "isServiceSession": true,
+        "isPlenumSession": true,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "551406",
+        "title": "Future|Money Open Studio",
+        "description": "FUTURE|MONEY Was the first open grant opportunity for 2023. The goal was to seek artists of any discipline to reimagine outdated financial systems that currently exclude 1.7 billion people from accessing essential services to make and receive payments.\r\nImagining the Future is often based on our own memories and imaginations of our surroundings. We asked the artists to dive into their imagination and envision a world where financial systems were built to serve everyone, everywhere, always. Where borders aren’t barriers to supporting each other financially and emotionally.\r\n\r\nThe Future|Money space is open for the attendees of the Interledger Summit, The space is designed to convene with the artist to reflect on their practise and your own. \r\n\r\nArtist presenting their work \r\nXiaoji Song: The Parallel Society is a cyber-drama that explores financial inclusion and equity by featuring the parallel fate of two characters, a Lebanese migrant in Barcelona and a villager in rural China's Henan province. The game sheds light on financial traumas, such as behavior patterns and psychological impacts as results of financial exclusions experienced by these two characters, and radically imagines a world where such barriers no longer exist, but the characters are still trapped in the old pattern.\r\n\r\nLena Ghaninejad: Liminal Matter is a mixed-media installation combining grains (barley), black obsidian/coltan, and 3D hologram technology. The installation aims to illustrate the evolution of money from tangible matter that originates directly from the Earth (grains, food & stones), into an increasingly immaterial entity that leaves more people behind as financial systems complexify and access to technology remains limited -thus asking the question: how can we best share the planet's resources?\r\n\r\nMia Wright-Ross: Loose Change (CHAINS) is a series of large-scale multi-media tapestries (primarily leather & paper lottery tickets) as a reflection/projection of the reimagination of Hope that has become a lethal tool of capitalism within the community-rich centers of Black & Brown neighborhoods throughout the United States of America. \r\n\r\nSubhashish Panigrahi and Arky for O Foundation (OFDN) :\r\nBringing Down A Mountain is set in a city in India where everything and everyone is superior, including the internet. The tall mountain surrounds a rural village, stopping the internet and everything online. People from the city climb the mountain to make [Insta] reels with a backdrop of the village, where dreams are tall. residents of the latter dream of mobile data, digital payment, and relief from menial work. Does that dream ever end?\r\n\r\nEsther Mwema and Jon Adam: Sikhula Sonke is an isiXhosa phrase which means 'we grow together.' The project seeks to amplify voices from the margins, with a focus on women in South Africa and Zambia. In recognition of the wisdom that already exists within communities but that may be little understood outside of them, our focus will be on building and documenting the living archives of village banking as a decentralized economic model.\r\n\r\nJuan Carlos, Felipe Brugues, Ana Rodrirequez: RE/SIMULATE Economic agendas to (get rich and) stop worrying about the future Juan Carlos León Felipe Brugués Ana Rodríguez Mixed media, 3D clay printer, ceramic objects, infographic sheets, information receiver.\r\n\r\nCarlijn Kingma, Martijn Jeroen van der Linden, Thomas Bollen: The Waterworks of money, If you think of money as water, then our financial system is like an irrigation system, watering the economy. And just as irrigation helps crops grow, money allows the economy to flourish. As long as the money keeps flowing, society will thrive—or at least that’s the idea. In reality, large swaths of society remain parched, while a small group of people is swimming in money.  \r\n\r\n ",
+        "startsAt": "2023-11-06T12:15:00",
+        "endsAt": "2023-11-06T13:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "2be62447-6e04-4f88-9dfa-13e73a759bf4",
+            "name": "Lawil Karama"
+          },
+          {
+            "id": "596d5e24-c923-4716-adfa-2c18d07d9e43",
+            "name": "Esther Mwema"
+          },
+          {
+            "id": "e2f09125-c1ee-4d7f-ab94-b989a449f1e2",
+            "name": "Mia Wright- Ross"
+          },
+          {
+            "id": "3a71dfe5-a936-40b8-853b-46d1652952fe",
+            "name": "Xiaoji Song"
+          },
+          {
+            "id": "4ec77047-4f16-4b3b-9381-9385fbc21e28",
+            "name": "Felipe Brugues"
+          },
+          {
+            "id": "6f694114-7102-4f53-b180-585d5409afa0",
+            "name": "Ana Rodriguez"
+          },
+          {
+            "id": "9c41b58c-011e-4729-817e-b5e3d5d1e6a1",
+            "name": "Juan Carlos Leon"
+          },
+          {
+            "id": "e8d66139-9a11-471d-8feb-060d95b32f04",
+            "name": "Jon Adam Chen"
+          },
+          {
+            "id": "26639585-017e-434e-8f11-42933e1c9cad",
+            "name": "Martijn Jeroen van der Linden"
+          },
+          {
+            "id": "8c35105d-a6aa-47b9-aa63-0bf2103af42b",
+            "name": "Kokayi Walker"
+          },
+          {
+            "id": "1678fa40-6634-440b-9133-1525f93064ef",
+            "name": "Subhashish Panigrahi"
+          },
+          {
+            "id": "6acc0bce-61ef-4ccc-9419-735d16c0f0b7",
+            "name": "Lena Ghaninejad"
+          },
+          {
+            "id": "0676e0b4-c743-457a-885f-ec8722bb6a13",
+            "name": "Hollis Wong-Wear"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 41140,
+        "room": "Future | Money Open Studio",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Join us for an update on Rafiki, our open-source software designed to facilitate instant payments across different networks. Following our previous talk, we'll explore how Rafiki, together with Open Payments, has evolved over the past year to enable new capabilities for account servicing entities and third parties. We’ll also showcase a new part of the friend group: our test network, Rafiki.money.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "552259",
+        "title": "Rafiki - Our friend has grown",
+        "description": "Join us for an update on Rafiki, our open-source software designed to facilitate instant payments across different networks. Following our previous talk, we'll explore how Rafiki, together with Open Payments, has evolved over the past year to enable new capabilities for account servicing entities and third parties. We’ll also showcase a new part of the friend group: our test network, Rafiki.money.",
+        "startsAt": "2023-11-06T13:15:00",
+        "endsAt": "2023-11-06T13:40:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "3e80acea-13f9-4fd2-8e9a-e4b715297d9a",
+            "name": "Sabine Schaller"
+          },
+          {
+            "id": "a63af0da-3b51-42ad-9775-ff52212884ba",
+            "name": "Max Kurapov"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190032,
+                "name": "Product Showcase Demo"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Structure:\r\n\r\nA. Introduction (2 minutes)\r\nB. The Real-World Complexities of Standardization (10 minutes)\r\nC. Audience Interaction Part 1 (5 minutes):\r\n-- Moderator will pose thought-provoking questions to the audience and collect a show of hands. Briefly discuss the responses.\r\nD. Re-defining Standardization Success (15 minutes):\r\n-- Introduce the idea of measuring success not by traditional implementation metrics, but by whether participants achieved their goals.\r\nE. Audience Interaction Part 2 (5 minutes):\r\nF. Broadening the Standardization Perspective (8 minutes)\r\nG. Closing Remarks and Q&A (5 minutes)",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "523092",
+        "title": "Harvesting Hope from Hiccups: Overcoming Standardization Hurdles",
+        "description": "Standardization is an art, not a science. After Meta launched Threads, which promised to interoperate with the fediverse and Mastodon, some in the Interledger community became enchanted by the promise that further down the line this could positively impact the adoption of the Interledger Protocol and the W3C web monetization standard. Cynics, however, have noted that the reality of standards adoption is quite different: the developers of standards work amidst differing economic incentives, a bias towards short-term thinking, and imperfect knowledge. Standards fail even if they are technically brilliant, as large players adopt strategies like “Embrace, Extend, Extinguish” to kill off standards that threaten their business models. This panel will challenge the conventional manner of assessing the success or failure of standards. Rather than solely considering whether a standard was widely adopted, the discussion redirects attention towards evaluating if the participants in the process met their objectives through their involvement in the standardization process. Drawing from a range of real-world examples and grounded in experiential knowledge from those who have participated in multistakeholder dialogues and negotiations, the panel will illustrate the diverse expectations which are embedded within standardization processes. In doing so, it proposes the idea that what might at first glance appear as a market failure could potentially be viewed as a success, particularly for some traditionally-excluded communities. Standards might not always be widely adopted, but when they’re thoughtfully developed, they can truly serve the needs of some communities.",
+        "startsAt": "2023-11-06T13:15:00",
+        "endsAt": "2023-11-06T14:05:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "27429f38-3846-488f-9e53-58837c0b6842",
+            "name": "Ayden Férdeline"
+          },
+          {
+            "id": "9d47cf6f-7cb7-4b1a-8d29-8682da2faf14",
+            "name": "Stephanie Perrin"
+          },
+          {
+            "id": "3a7cbafd-ef2c-432b-ba43-2ea4920af3d1",
+            "name": "Chris Buckridge"
+          },
+          {
+            "id": "715acb29-2834-4d55-b102-d75ec3e3136d",
+            "name": "Jeremiah Lee"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 177655,
+                "name": "Panel"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 39259,
+        "room": "Breakout 2 - Alcazar",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The session is designed as a 70-minute session. Participants will be assigned to round tables, and each table will be assigned a ‘hat’ (representing a different lens for analysis, each with their own focus). Each table will spend 10 minutes per challenge approaching the issues below from their assigned perspective, which together will produce well-rounded analysis and brainstorming of these issues. \r\n\r\nThese will each be introduced with a brief case study or client story to give context and illuminate these issues as they are experienced by consumers. The discussions will be anchored around the needs of consumers, but reflect the different needs and incentives of stakeholders in the industry. Table 1 in the attachment shows an overview of the issues to be discussed.\r\n\r\nAs we prepare the case studies for this session, we will determine targeted questions to be discussed for each issue (overview questions included in Table 1 of attachment). We will also be determining the ideal arrangement, order, and rotation to implement the ‘six-thinking hats’ method to maximize the benefits of this ‘parallel thinking’ approach to brainstorming.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530057",
+        "title": "Exploring Risks and Consumer Trust in the Shift from Traditional to Open Finance",
+        "description": "Does open finance always lead to consumer empowerment? What if you’re poor? What if you’re already vulnerable? What if your data is misused? This session will examine these questions and more through a parallel thinking methodology. \r\n\r\nOpen finance ecosystems have been viewed in the past decade as potential answers to solve inclusion challenges- they can break the hegemony of traditional financial institutions, enable competition between incumbents and entrants, lower costs for consumers and help offer more personalized services based on consumer data trails, and innovative business models can help deliver services to hitherto excluded consumer segments at a fraction of the costs incurred by more traditional players.  Open ecosystems in financial services are designed to make things simpler, faster, and more convenient for consumers. \r\n\r\nHowever, the transition from traditional finance to open finance ecosystems is not without its pitfalls and complexities, as it introduces new risks that may undermine consumer confidence. In emerging markets and developing economies with weak regulatory frameworks in areas such as data sharing protocols, data protection, and consumer rights legislation, the shift towards open finance can be fraught with danger. In more regulated markets like the UK, where legislation specific to open finance exists, trust remains a significant issue. For example, research has found that about 84 percent of users did not trust open banking, signaling deep-seated concerns about security and the potential for harm. The novelty of these ecosystems, coupled with a lack of understanding and transparent regulations, may further exacerbate consumers' mistrust, creating barriers to adoption and potentially leaving more vulnerable individuals unprotected. \r\n\r\nJoin us to explore the risks, opportunities, and co-develop potential solutions to make open finance more responsible.",
+        "startsAt": "2023-11-06T13:15:00",
+        "endsAt": "2023-11-06T14:05:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "554229dd-72f1-4f68-afe7-cf6a0bd1d79a",
+            "name": "Colin Rice"
+          },
+          {
+            "id": "624f1540-059e-4db1-90b4-b17156b94ff8",
+            "name": "Jayshree Venkatesan"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35979,
+        "room": "Breakout 3 - San Antonio",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Agenda\r\n- User Agents and the Web\r\n- Digital Wallets and the Interledger\r\n- Embedded payments\r\n- Programmable money\r\n- Pay people not accounts\r\n- Use cases of the future",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "527825",
+        "title": "Digital Wallets - Our financial \"user agents\"",
+        "description": "Presenting Fynbos, the model digital wallet of the future, offering payment pointers as a universal payment instrument and Interledger as a universal payment rail.\r\n\r\nThis presentation will show what is possible with a digital wallet that connects your existing accounts and identities and exposes them via the Open Payments APIs.",
+        "startsAt": "2023-11-06T13:40:00",
+        "endsAt": "2023-11-06T14:05:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "69f97e3e-d0c7-4fe3-9373-7cbcd223c6c8",
+            "name": "Adrian Hope-Bailie"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190032,
+                "name": "Product Showcase Demo"
+              },
+              {
+                "id": 190034,
+                "name": "Future of Interledger Talk"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "4d486e89-4536-4586-8982-bfe61c3f79c6",
+        "title": "Break",
+        "description": null,
+        "startsAt": "2023-11-06T14:05:00",
+        "endsAt": "2023-11-06T14:25:00",
+        "isServiceSession": true,
+        "isPlenumSession": true,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "- GateHub and team intro (Tadej)\r\n- Wallet overview (Tadej)\r\n- Rafiki integration (Enej Mlinaric)\r\n- QA (Enej Mlinaric & Tadej)",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530042",
+        "title": "GateHub Payments via ILP - Integration with Rafiki",
+        "description": "This talk will give an overview of GateHub Technical integration of Rafiki for the purpose of enabling ILP Payments",
+        "startsAt": "2023-11-06T14:25:00",
+        "endsAt": "2023-11-06T14:50:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "585a769b-db7a-4c75-b1ba-4c4fe8015276",
+            "name": "Tadej Golobic"
+          },
+          {
+            "id": "1dad474f-5f51-4aac-9144-304631f40e63",
+            "name": "Enej Mlinarič"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190032,
+                "name": "Product Showcase Demo"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "This 60-minute session will feature panelists to share information about each financial inclusion and digital finance strategies, efforts to be more inclusive of new and underrepresented actors as companies, programming implementing partners, and how session participants can better access partnership opportunities with these organizations. Erin Brown will serve as the panel moderator. Panelists will each have 8 minutes to provide summaries of each of their organization's investments into financial inclusion/digital finance efforts before beginning a 30-minute moderated panel discussion with 10 minutes for audience Q&A. ",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "509293",
+        "title": "Partnering for Growth Leveraging Donors and Investors",
+        "description": "Donor organizations, foundations, and some venture capital firms are key actors in the financial inclusion ecosystem and are now increasing efforts to engage and partner with new and underrepresented local actors to design and implement programs with sustainable outcomes (actors such as Interledger Foundation grantees). The purpose of this panel is to highlight the efforts of bilateral and multilateral donor organizations, foundations, and VCs to engage with underrepresented actors, such as many of Interledger's grantees, and provide practical information on how session attendees can prepare themselves to pursue awards and investments from these diverse funders successfully.",
+        "startsAt": "2023-11-06T14:25:00",
+        "endsAt": "2023-11-06T15:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "59dd02ef-66e9-41ec-9335-e2d226665ea1",
+            "name": "Erin Brown"
+          },
+          {
+            "id": "3d6be742-b26a-4da9-b8f4-eda7bd532ba0",
+            "name": "Ruth Buckley"
+          },
+          {
+            "id": "c0b28c32-9164-4cef-b80a-3668f84956e3",
+            "name": "Jennifer Fenwick"
+          },
+          {
+            "id": "8c31891a-1b90-41c9-9419-cb79cdd7494e",
+            "name": "Chris Lawrence"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 177655,
+                "name": "Panel"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 39259,
+        "room": "Breakout 2 - Alcazar",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "In the Netherlands, undocumented people are denied access to social services from the government. Estimates say that over 30.000- 60.000undocumented people live in Amsterdam; the capital city. They are not allowed to work, to rent a house, to register in the municipality, or to open a bank account. Opening a bank account is restricted to people with valid identifying documents and a proof of residency in the Netherlands. Despite this, many people have irregular work; unfortunately most often they are exploited. People are often in danger because they are denied access to bank accounts: they can only be paid in cash, which results in people carrying large amounts of money when they go out. They are refused by banks because of the KYC, Know Your Customers principle. This check is the mandatory process of identifying and verifying the client's identity when opening an account and periodically over time. In other words, banks must ensure that their clients are genuinely who they claim to be. In the Netherlands, most undocumented migrants have a proof of identity (from their home countries), but can not obtain the necessary proof of residency, only given out by the state/municipality.\r\n\r\nMoreover, more and more services in the Netherlands can only be paid for by card. Supermarkets, most cafés and public transport are moving towards digital payments and refuse cash payments. During COVID-19, all shops besides supermarkets were closed. It was only possible to order products. For undocumented people however, not being able to pay online, this was impossible to survive without help from people with a bank account.\r\n\r\nMany undocumented people support their families back home. For them, only being able to pay in cash, transferring money is difficult. They have to go through a middle-man, who will take a large percentage of the money to facilitate the transaction. WesternUnion facilitates payments across countries, yet is only available to those with passports and with access to online banking.\r\n\r\nTo make banking and online payments accessible to undocumented people, de Waag Society, Here to Support and (hopefully) Interledger will join forces. A proposal for collaborative research is at the moment being written and on the planning to be executed in 2024. In this research we aim to develop an e-wallet mobile app for the users which uses Interledger protocol in its core. This system is a showcase that makes it possible for the users to login with Yivi, show balance and perform transactions between the users that use the same e-wallet using ILP. \r\nWe aim to develop a prototype for undocumented citizens that consists of two major components: A proof of residency and second an e-wallet that works with the Interledger protocol in the core.\r\n\r\nAt the moment, when a user aims to use an e-wallet like Uphold, they need to identify themselves with a passport and need to already have a bank account.. However, this approach is not always viable, particularly for individuals without a formal residency documentation. Our objective in this part is to establish an inclusive collective proof of residency system based on Yivi (https://www.yivi.app/en) by enabling access to the forthcoming e-wallet that we intend to create as a part of this initiative.\r\nThe residency validation system draws parallel with the New York City ID Card, IDNYC (https://www.nyc.gov/site/idnyc/card/documentation.page). Functioning on a scoring mechanism, the system stipulates a minimum threshold of points required for eligibility to access the e-wallet. Many undocumented individuals are known in different support organisations in their residing city. By including these support organisations, we can architect a dependable framework that verifies locally the proof of residency of citizens. \r\nImportant to take into consideration  is privacy. Undocumented people in the Netherlands work irregular jobs, where they are currently paid in cash. To protect their livelihoods, the cash flows that come through their work should not be visible to the police or authorities. If employers can be identified through this medium, thousands of people will be left without a job, and thousands of employers will risk fines. On the other hand, it should be a protected and safe environment. If anyone can use the wallet, we are afraid it will be used for money laundering. \r\n\r\nWe aim to integrate technological solutions, with political action. Providing alternatives to existing payment structures will include those that lack access to banking, and will prevent people from being exploited and endangered. Yet by providing alternatives, we do not solve the underlying issue: exclusion of undocumented citizens in the Netherlands and in other European countries is a political choice. By providing alternative ways of identifying people, and proving that undocumented citizens can be part of online payment systems, we aim to change the exclusion policies that restrict people from being part of monetary interactions.\r\nDuring the participatory session: We will give a brief introduction. (We also want to make the introduction podcast episode available for all participants). \r\n We will host three tables for the sharing of good practices and insights by the participants of the summit and the interledger community and experiences from all over the world: \r\n- Political action connected to marginalized communities and the access to banking (building alliances of trust using technical innovation)\r\n- Matrix for proof of residency\r\n- Balancing security and privacy\r\nWe think it would be good to have 3 facilitators. Savannah Koolen, Mohamed Bah (who has lived experience as an undocumented migrant) and Taco van Dijk (who is a Tech Developer at the Waag).  We would love to see some initial designs, and to receive input on which parties, experiences and practices we have to involve in the process of our research.\r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530246",
+        "title": "Financial inclusion for undocumented people",
+        "description": "In this participatory creative session we are asking the Interledger community to brainstorm along on making banking, and money transferring accessible for undocumented people in the Netherlands. Undocumented people, are excluded from many governmental services, but can also not open a bank account in the Netherlands. This makes the exclusion every day more extreme because with only cash money it is almost impossible to survive. The shops and services in the city are rapidly only accepting payments with card.  We are interested in the insides, experiences, and good practices the Interledger community can share with us during this session. Two podcast episodes will be a tangible output; one with voices of undocumented people we hope we can bring to the attention about the exclusion they face and one with the input gathered at the summit with knowledge and ideas from the participants.\r\n This session is a follow up, on the conversation Here to Support and Interledger Foundation had in Amsterdam during MozFest Amsterdam in July 2023.\r\n https://www.youtube.com/watch?v=9bFwAqL3S8Q",
+        "startsAt": "2023-11-06T14:25:00",
+        "endsAt": "2023-11-06T15:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "6b4980b6-a70f-413d-884d-28c3dd8daf16",
+            "name": "Savannah Koolen"
+          },
+          {
+            "id": "a055a6cf-45d9-4cd2-8273-435ad54d5baf",
+            "name": "Malou Lintmeijer"
+          },
+          {
+            "id": "6f3d6b3c-458a-4c80-9e0d-99752456339e",
+            "name": "Eunice de Asis"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35979,
+        "room": "Breakout 3 - San Antonio",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The session will start with a refresher on what TigerBeetle is, and the high level issues it's solving. We'll then jump into specifics of how TigerBeetle solves particular pain points (with a focus on the Open Payments ecosystem) as well as some comparisons with the existing state-of-the-art.\r\n\r\nThese include:\r\n* High velocity payments\r\n* Highly contended accounts\r\n* Ease of operation and deployment\r\n* Safety and correctness guarantees\r\n\r\nThere will be live demos mixed in throughout the session; but mostly kept at a high level.\r\n\r\nLastly, there'll be ~5 minutes reserved for Q&A at the end.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530276",
+        "title": "Where the Beetle meets the Road.",
+        "description": "At last year's ILP Summit, Joran introduced TigerBeetle - an Open Source Financial Accounting Database for Interledger and a few of the high level principles that guided our design philosophy. Now, we're excited to show off how TigerBeetle measures up, and how it enables all manners of high velocity, high contention use cases for the open payments ecosystem!",
+        "startsAt": "2023-11-06T14:50:00",
+        "endsAt": "2023-11-06T15:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "3e15c776-358b-4f72-838e-b29fa956182a",
+            "name": "Federico Lorenzi"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190032,
+                "name": "Product Showcase Demo"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "d8d3dac7-67b2-4418-8122-d9cbd0e0f415",
+        "title": "Break",
+        "description": null,
+        "startsAt": "2023-11-06T15:15:00",
+        "endsAt": "2023-11-06T15:35:00",
+        "isServiceSession": true,
+        "isPlenumSession": true,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Agenda 1 (5 min): Overview of ThitsaNet and where we will go from here.\r\nAgenda 2 (10 min): Product Demo \r\nAgenda 3 (10 min): Q&A\r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "528935",
+        "title": "ILP Enabled ThitsaNet Inclusive Payment Network",
+        "description": "In this session, we will provide an overview of the inclusive payment network that is underway of development to serve at least 5 million clients, including 3 million women in Myanmar.",
+        "startsAt": "2023-11-06T15:35:00",
+        "endsAt": "2023-11-06T16:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "15b842af-2bc2-4844-8f35-c31872cb8c84",
+            "name": "Nyi Aye"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190032,
+                "name": "Product Showcase Demo"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "- 5 minutes explanation of the PIX revolution in Brazil (numbers, facts, and context).\r\n\r\n- 5 minutes explanation of how ILP can connect to PIX and its consequences.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "528726",
+        "title": "How PIX is revolutionizing financial inclusion in Brazil and what ILP has to do with it",
+        "description": "In 2020, during the pandemic, the Brazilian government created the PIX payment method, which is revolutionizing digital payments in Brazil and opening a whole new world of possibilities for more financial inclusion. Only in 2022, PIX moved 12 trillion reais (around 2.5 trillion USD) between people and companies in Brazil.\r\n\r\nEspecially for small business owners/entrepreneurs and content creators, the PIX solution facilitates quick transactions, with no fees and high liquidity rates. It helps the entire ecosystem to thrive – from supplier to company to client. PIX has an open API that is constantly under improvement, encouraging open innovation.\r\n\r\nOur goal as Grantees is to connect such an amazing technology with ILP, aiming to unlock a huge financial revolution. In this panel, we will talk about the changes that PIX caused in Brazil, and how ILP can be the bridge that connects open payments worldwide.",
+        "startsAt": "2023-11-06T15:35:00",
+        "endsAt": "2023-11-06T15:50:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "e08233ef-99fc-4e39-b298-3db97b2abba6",
+            "name": "Helena Tude & Patrick Rahy"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190031,
+                "name": "Lightning Talks"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 39259,
+        "room": "Breakout 2 - Alcazar",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Participants will be introduced to:\r\n\r\nHistorical Context: An overview of HBCUs, their unique challenges, strengths, and potential to contribute diversely to open communities.\r\n\r\nCurrent Landscape: Discuss present participation and qualitative insights into why HBCU students may or may not participate in open communities. This includes past and current interventions.\r\n\r\nBarriers & Bridges: A collaborative brainstorming session to identify the obstacles hindering HBCU student participation and potential solutions to overcome them. \r\n\r\nEmpowering Participation: Interactive group work on developing strategies and action plans to engage HBCU students in open communities actively. This session will engage community participants and HBCU students in a crucial conversation.\r\n\r\nSharing Best Practices: Invite participants and students who have successfully engaged HBCU students to share their experiences, successes, and lessons learned.\r\n\r\nNetworking: Opportunities for participants to forge meaningful connections and collaborations that lead to impactful action.\r\n\r\nThis session is ideal for educators, community leaders, open-web advocates, and anyone interested in fostering a more inclusive, diverse, and enriched open community ecosystem.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "529141",
+        "title": "Engaging HBCU Students in Open Communities",
+        "description": "This interactive session seeks to explore, understand, and amplify the engagement of students from Historically Black Colleges and Universities (HBCUs) within open communities. Whether it’s open-source software, open web, or open protocols, open communities play a pivotal role in today's global digital era. ",
+        "startsAt": "2023-11-06T15:35:00",
+        "endsAt": "2023-11-06T16:25:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "2d15432a-4cdb-43ff-a339-a4108822482d",
+            "name": "Andrew Mangle"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35979,
+        "room": "Breakout 3 - San Antonio",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "\r\n- Introduction to UPI: A brief overview of UPI's inception, growth, and impact on the Indian financial ecosystem.\r\n- Global Context of Open Payments: Setting the stage by explaining the significance of open payments and the drive towards interoperable and inclusive financial systems.\r\n- Unpacking UPI's Success:\r\nUPI's Architecture: Examination of UPI's technical design, including its simplicity, accessibility, and security features.\r\n- Adoption and Growth: Analyzing the factors that contributed to UPI's widespread adoption, such as government support, collaboration with banks, and user-centric design.\r\n- Challenges and Lessons Learned: A candid discussion of the hurdles faced by UPI and the lessons that can be drawn from overcoming them.\r\n- Open Payments - Interledger Protocol (ILP): Introduction to ILP and its role in enabling global interoperability in payments.\r\n- Open Payments Ecosystem: Exploration of the global initiatives and trends shaping open payment systems, including regulatory landscapes, innovations, and key players.\r\n- Bridging UPI and ILP: Potential Synergies: \r\nIdentifying the commonalities and complementary aspects between UPI and ILP, such as their shared goals of accessibility and efficiency.\r\n- Integration Possibilities: A discussion on how UPI could be integrated with ILP, including technical, regulatory, and business considerations.\r\n- Use Cases and Benefits: Illustrating potential use cases that could emerge from this integration, such as cross-border remittances, and their benefits to various stakeholders.\r\n- Future Prospects & Opportunities: Discussing the broader opportunities that this integration can unlock, including financial inclusion, innovation, and economic growth.\r\n- Potential Roadblocks: Addressing potential challenges, including technological complexities, regulatory hurdles, and stakeholder alignment.\r\n- Strategies for Success: Offering actionable strategies to navigate these challenges and realize the potential of this integration.\r\n- Call to Action: Encouraging collaboration, innovation, and concerted efforts across regulators, technologists, and financial institutions to realize this vision.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "529371",
+        "title": "Bridging Two Worlds: How India's UPI Informs the Future of Open Payments",
+        "description": "This session explores the revolutionary development of India's Unified Payments Interface (UPI) and its implications on the global open payments landscape. By investigating the successes, challenges, and unique characteristics of UPI, we talk about the potential pathways for integrating systems like UPI with the Interledger Protocol (ILP), setting the stage for a new era in cross-border payments and financial inclusion.",
+        "startsAt": "2023-11-06T15:50:00",
+        "endsAt": "2023-11-06T16:05:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "c1653fc3-507d-4ae8-9541-7e7c03e61fd5",
+            "name": "Saloni Garg"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190034,
+                "name": "Future of Interledger Talk"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 39259,
+        "room": "Breakout 2 - Alcazar",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "We'll quickly introduce PCH's mission. Then we'll compare how Rafiki's and PCH's recording of financial obligations work. After displaying an interoperability solution between both systems, we'll present the flow for a remittance transfer involving a US-based Wallet implementing Rafiki as sending party, a Mexico-based account in a community bank as receiving party, and PCH's platform as middleman between the two, including a Mojaloop hub and a sub-entity of PCH's platform implementing Rafiki and responsible for communicating with the US Wallet. We'll conclude by commenting the results of this flow with respect to our initial expectations and introduce the audience to the other great challenge (and our proposed solution) for an effective remittances' use case: the settlement process. The remaining time will be allocated to Q&A.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "519348",
+        "title": "Rafiki's “Corridor”: Mexico's PCH remittance use case",
+        "description": "The People's Clearinghouse (PCH) is a community-owned tech platform for payments and financial services, that interconnects community banks and savings coops. By implementing Rafiki, PCH will use ILP to record financial obligations that correspond to incoming remittances sent from US-based wallets (which also implement Rafiki) towards PCH's participants. This demo aims to demonstrate the technical viability of the model, namely the interoperability between Rafiki's decentralized system and the clearinghouse's centralized system, which involves the routing, quoting and recoding of obligations between both systems. The settlement process involved in this remittances' use case is out of the scope of the demo, but we'll present our solution in its main lines.",
+        "startsAt": "2023-11-06T16:00:00",
+        "endsAt": "2023-11-06T16:25:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "bf608549-addb-43ca-88c1-fc564a8c038f",
+            "name": "Andres Arauz"
+          },
+          {
+            "id": "9bd85c6e-88b7-4d06-b8c8-0458dc200746",
+            "name": "Roberto Valdovinos"
+          },
+          {
+            "id": "e4ebed56-56d5-4326-8aee-4d86ddea84ac",
+            "name": "Juan Carlos Ditmeyer"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190032,
+                "name": "Product Showcase Demo"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Key takeaways:\r\n\r\n1. Why micropayments will work this time and why federated social networks need it\r\n\r\n2. Direct fan-support of digital creators is possible, preferable, and plausible \r\n\r\n3. The W3C enabled Mastodon’s rise when it standardized the Web platform’s social layer 5 years ago. Now, the W3C and Interledger are defining the payment layer for the Web platform.\r\n\r\nNote: I could present this with either a future of Interledger framing or a product showcase from the perspective of Mastodon.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "524247",
+        "title": "Mastodon, micropayments, and the next era of the creator economy",
+        "description": "Changes at Twitter and Reddit in 2023 caused millions people to rebuild their online communities on new platforms. Many chose products like Mastodon, Pixelfed, and Lemmy that were built on the Web platform’s social APIs. Instead of a single company controlling everything, thousands of independently managed communities joined together to create a social web.\r\n\r\nDigital creators can now own their social network presences, distribution, and relationships with their audiences. It’s a significant change from a few billionaires dictating what billions of people globally can and cannot do online. The next big power shift will be changing the primary form of content monetization online from privacy-invasive advertising to direct fan-support. This change will be even bigger and bring economic opportunity to more people than ever before.\r\n\r\nThis session will cover the financial aspects of the creator economy and demonstrate how Interledger’s global payment network works within federated social network apps.",
+        "startsAt": "2023-11-06T16:05:00",
+        "endsAt": "2023-11-06T16:20:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "715acb29-2834-4d55-b102-d75ec3e3136d",
+            "name": "Jeremiah Lee"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190032,
+                "name": "Product Showcase Demo"
+              },
+              {
+                "id": 190034,
+                "name": "Future of Interledger Talk"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 39259,
+        "room": "Breakout 2 - Alcazar",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Explanation on how GNAP is used within Open Payments to authorize an account servicer's access to:\r\n* Incoming Payments\r\n* Outgoing Payments\r\n* Quotes",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "552501",
+        "title": "Authorizing Payments with GNAP & Open Payments",
+        "description": "Learn how to authorize payments in Rafiki!",
+        "startsAt": "2023-11-06T16:25:00",
+        "endsAt": "2023-11-06T16:40:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "c0cdf5ec-604b-48fa-a88d-475fe89a8932",
+            "name": "Nathan Lie"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190031,
+                "name": "Lightning Talks"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "- I will present situation in Ukraine/war - I can be politically correct and play unbias even though I am not\r\n- I will present peak moment - realizing how hard it is for those fleeing too. \r\n- I will present solutions\r\n\r\n- if this will be a creative conversation will create 3 situations for brainstorming, sharing experiences, and debating.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530314",
+        "title": "Diversity in war times / knowledge as safe place",
+        "description": "With the Ukrainian war next door, and myself being Romanian, many things changed. Lots of Ukrainians got refuge in Romania and I got to experience first hand their stories.\r\n\r\nWhat surprised me the first time, was the fact that some women struggled with technology - with maps, with exchanges etc. They were the ones fleeing with kids as the husbands (mostly male) remained home/got blocked by the army in their motherland. But they were never the head of the house, they were never the main driver, they were never those paying big things - or at least not alone. And that got me thinking about how an unexpected situation challenges the default system to the ground.\r\n\r\nSo while we create different solutions to empower the world's financial transactions, we need to be more conscious of the blockers that some might have. \r\n\r\nWe have to imagine the unimaginable in 2023. \r\n\r\n",
+        "startsAt": "2023-11-06T16:25:00",
+        "endsAt": "2023-11-06T16:40:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "297fd54b-f93c-4996-89bc-f96b3b7f8258",
+            "name": "Ioana Chiorean"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190031,
+                "name": "Lightning Talks"
+              },
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 39259,
+        "room": "Breakout 2 - Alcazar",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The proposed outline is:\r\n- Introduction to Chimoney's new Wallet as a Service (WaaS) product\r\n- Connecting Payment pointers to Wallets\r\n- Scaling interledger with open source tools and API for other developers to integrate with\r\n- The future",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "502677",
+        "title": "Integrating Interledger to Chimoney's Wallet as a Service Platform",
+        "description": "In this talk, Uchi introduces Chimoney's Wallet integration with Interledger and how it connects traditional financial systems like Bank accounts to emerging payment systems like the XRP ledger to unlock economic opportunities for everyone, everywhere and enhance financial inclusion\r\n\r\nThe talk showcases real-world products using the integration and shares stories of use cases in Africa and North America that have payment pointers in their wallets",
+        "startsAt": "2023-11-06T16:40:00",
+        "endsAt": "2023-11-06T16:55:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "405070c5-a46c-4f12-9b68-5b1ed17e98a1",
+            "name": "Uchi Uchibeke"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190032,
+                "name": "Product Showcase Demo"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The main topics of the presentations shall be around;\r\n1. What is Mobile Money? (A bank in the palm of you hands driving Instant Payments)\r\n2. The impact (Where are we?)\r\n3. Where are we going?\r\n4. Regulations\r\n5. Where does ILP come in?",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "516839",
+        "title": "Mobile Money 2.0: Mainstream Financial Service",
+        "description": "Mobile Money as a Financial Inclusion Tool",
+        "startsAt": "2023-11-06T16:40:00",
+        "endsAt": "2023-11-06T16:55:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "edf0d8b1-3504-4478-ab79-e0c215a4e382",
+            "name": "Malcolm Kastiro"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190031,
+                "name": "Lightning Talks"
+              },
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              },
+              {
+                "id": 190034,
+                "name": "Future of Interledger Talk"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 39259,
+        "room": "Breakout 2 - Alcazar",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Our company, SpendTheBits, is a fintech start-up that specializes in developing user-friendly interoperable multi-currency payment solutions (P2P/P2B). We are excited about the possibilities offered by Interledger Protocol (ILP) and would like to showcase our work that will drive innovation in this\r\nspace.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "501847",
+        "title": "Interoperable Payments",
+        "description": "I want to demonstrate our expertise in interoperability and emphasize the significance of real-time payments to the audience.",
+        "startsAt": "2023-11-06T16:55:00",
+        "endsAt": "2023-11-06T17:10:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "a770436d-860a-4937-8c24-2cafa4f460fd",
+            "name": "Jaskaran (Jay) Kambo"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 177655,
+                "name": "Panel"
+              },
+              {
+                "id": 190032,
+                "name": "Product Showcase Demo"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Agenda:\r\n- What is inclusive, secure user research?\r\n- Key aspects of a potential platform.\r\n- How open payments can help.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530357",
+        "title": "Open Payments For More Inclusive and Secure Research",
+        "description": "This talk explores ways open payments can help in productizing secure user research (and applied research) into a platform. Therefore enabling more remote, distributed research, reducing barriers to entry for conducting research, and promoting more diversity and inclusion among researchers and participants.",
+        "startsAt": "2023-11-06T16:55:00",
+        "endsAt": "2023-11-06T17:10:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "38c7b62e-ee36-407f-ad07-86ab1d5f3a5f",
+            "name": "Philliph Drummond"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190031,
+                "name": "Lightning Talks"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 39259,
+        "room": "Breakout 2 - Alcazar",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "b11ab0e1-d000-4023-85b0-c697c0ce7846",
+        "title": "Drinks",
+        "description": null,
+        "startsAt": "2023-11-06T18:30:00",
+        "endsAt": "2023-11-06T19:10:00",
+        "isServiceSession": true,
+        "isPlenumSession": true,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "8313e225-6ed6-4f27-8580-c6666e1b36cf",
+        "title": "Dinner",
+        "description": null,
+        "startsAt": "2023-11-06T19:45:00",
+        "endsAt": "2023-11-07T00:05:00",
+        "isServiceSession": true,
+        "isPlenumSession": true,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "091bea8e-e855-4521-829c-ec1596bdf4b0",
+        "title": "Welcome to Day 2",
+        "description": null,
+        "startsAt": "2023-11-07T09:45:00",
+        "endsAt": "2023-11-07T10:00:00",
+        "isServiceSession": true,
+        "isPlenumSession": false,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "552344",
+        "title": "Keynote Speaker | Maha Bahou, CEO of Jordan Payments and Clearing Company (JoPACC)",
+        "description": null,
+        "startsAt": "2023-11-07T10:00:00",
+        "endsAt": "2023-11-07T10:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "c0195cc3-97eb-47fc-96d0-7222b7c61381",
+            "name": "Maha Bahou"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [],
+            "sort": 0
+          }
+        ],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "a7b3c9b7-fcb8-4f6c-9808-d54cd2b1b46f",
+        "title": "Break",
+        "description": null,
+        "startsAt": "2023-11-07T10:30:00",
+        "endsAt": "2023-11-07T10:45:00",
+        "isServiceSession": true,
+        "isPlenumSession": true,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "552349",
+        "title": "Keynote Speaker | Isabel Cruz Hernandez, CEO Mexican Association of Social Sector Credit Unions",
+        "description": null,
+        "startsAt": "2023-11-07T10:45:00",
+        "endsAt": "2023-11-07T11:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "99cf8d10-170e-4e92-a873-e32e8a39c7e8",
+            "name": "Isabel Cruz Hernandez"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [],
+            "sort": 0
+          }
+        ],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The panel will include the following participants: \r\n- Isabel Cruz, CEO of the Mexican Association of Social Sector Credit Unions;\r\n- Juan Carlos Urgiles, CEO of Jardín Azuayo, the largest savings coop from Ecuador;\r\n- Elizabeth Campos, Vice-president (Vicegerente General) of Financiera FDL, the largest popular institution of Nicaragua;\r\n- José Isidro Tzunún, General Advisor of Federural, main federation of savings coops of Guatemala \r\n\r\nThis panel will be interesting for audiences interested in grassroots financial inclusion, social justice, popular finances, and regional development through technology.\r\n\r\nSpecific subjects will include:\r\n1) Limits of financial inclusion in their region\r\n2) Effect of digital payments in their communities\r\n3) New opportunities for financial inclusion brought by open source digital payments technologies",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "519137",
+        "title": "Building Digital Financial Inclusion from Below",
+        "description": "Executives from four leading Latin American organizations dedicated to grassroots financial inclusion in poor and marginalized regions of Mexico, Guatemala, Nicaragua and Ecuador, will discuss what real financial inclusion means, how payment digitalization is transforming their regions and why new open source technologies like ILP can become important allies in expanding their mission for real financial inclusion and social justice.",
+        "startsAt": "2023-11-07T11:00:00",
+        "endsAt": "2023-11-07T12:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "9bd85c6e-88b7-4d06-b8c8-0458dc200746",
+            "name": "Roberto Valdovinos"
+          },
+          {
+            "id": "8d38241a-5a24-49e2-808a-acedb34bb1e7",
+            "name": "Juan Carlos Urgilés"
+          },
+          {
+            "id": "9487c937-a599-4e9d-90ad-c1ea7e7a0888",
+            "name": "José Isidro Tzunún"
+          },
+          {
+            "id": "0e2ffbe0-a8d3-4543-975b-a219f431a76a",
+            "name": "Elizabeth Campos"
+          },
+          {
+            "id": "99cf8d10-170e-4e92-a873-e32e8a39c7e8",
+            "name": "Isabel Cruz Hernandez"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 177655,
+                "name": "Panel"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "614c0a36-2c73-41d7-adfc-50dc70a9b606",
+        "title": "Lunch",
+        "description": null,
+        "startsAt": "2023-11-07T12:00:00",
+        "endsAt": "2023-11-07T13:00:00",
+        "isServiceSession": true,
+        "isPlenumSession": true,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "554064",
+        "title": "Future|Money Open Studio Day 2",
+        "description": "FUTURE|MONEY Was the first open grant opportunity for 2023. The goal was to seek artists of any discipline to reimagine outdated financial systems that currently exclude 1.7 billion people from accessing essential services to make and receive payments.\r\nImagining the Future is often based on our own memories and imaginations of our surroundings. We asked the artists to dive into their imagination and envision a world where financial systems were built to serve everyone, everywhere, always. Where borders aren’t barriers to supporting each other financially and emotionally.\r\n\r\nThe Future|Money space is open for the attendees of the Interledger Summit, The space is designed to convene with the artist to reflect on their practice and your own. \r\n\r\nMia Wright-Ross: Loose Change (CHAINS) is a series of large-scale multi-media tapestries (primarily leather & paper lottery tickets) as a reflection/projection of the reimagination of Hope that has become a lethal tool of capitalism within the community-rich centers of Black & Brown neighborhoods throughout the United States of America. \r\n\r\nXiaoji Song: The Parallel Society is a cyber-drama that explores financial inclusion and equity by featuring the parallel fate of two characters, a Lebanese migrant in Barcelona and a villager in rural China's Henan province. The game sheds light on financial traumas, such as behavior patterns and psychological impacts as results of financial exclusions experienced by these two characters, and radically imagines a world where such barriers no longer exist, but the characters are still trapped in the old pattern.\r\n\r\nLena Ghaninejad: Liminal Matter is a mixed-media installation combining grains (barley), black obsidian, and 3D hologram technology. The installation aims to illustrate the evolution of money from tangible matter that originates directly from the Earth (grains, food & stones), into an increasingly immaterial entity that leaves more people behind as financial systems complexify and access to technology remains limited -thus asking the question: how can we best share the planet's resources?\r\n\r\nSubhashish Panigrahi and Arky for O Foundation (OFDN) :\r\nBringing Down A Mountain is set in a city in India where everything and everyone is superior, including the internet. The tall mountain surrounds a rural village, stopping the internet and everything online. People from the city climb the mountain to make [Insta] reels with a backdrop of the village, where dreams are tall. residents of the latter dream of mobile data, digital payment, and relief from menial work. Does that dream ever end?\r\n\r\nEsther Mwema and Jon Adam: Sikhula Sonke is an isiXhosa phrase which means 'we grow together.' The project seeks to amplify voices from the margins, with a focus on women in South Africa and Zambia. In recognition of the wisdom that already exists within communities but that may be little understood outside of them, our focus will be on building and documenting the living archives of village banking as a decentralized economic model.\r\n\r\nJuan Carlos, Felipe Brugues, Ana Rodrirequez: RE/SIMULATE Economic agendas to (get rich and) stop worrying about the future Juan Carlos León Felipe Brugués Ana Rodríguez Mixed media, 3D clay printer, ceramic objects, infographic sheets, information receiver.\r\n\r\nCarlijn Kingma, Martijn Jeroen van der Linden, Thomas Bollen: The Waterworks of money, If you think of money as water, then our financial system is like an irrigation system, watering the economy. And just as irrigation helps crops grow, money allows the economy to flourish. As long as the money keeps flowing, society will thrive—or at least that’s the idea. In reality, large swaths of society remain parched, while a small group of people is swimming in money.  ",
+        "startsAt": "2023-11-07T12:00:00",
+        "endsAt": "2023-11-07T15:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "2be62447-6e04-4f88-9dfa-13e73a759bf4",
+            "name": "Lawil Karama"
+          },
+          {
+            "id": "209d595a-a261-487f-a5f8-7ec09f179989",
+            "name": "Lena Ghaninejad"
+          },
+          {
+            "id": "3a71dfe5-a936-40b8-853b-46d1652952fe",
+            "name": "Xiaoji Song"
+          },
+          {
+            "id": "4ec77047-4f16-4b3b-9381-9385fbc21e28",
+            "name": "Felipe Brugues"
+          },
+          {
+            "id": "6f694114-7102-4f53-b180-585d5409afa0",
+            "name": "Ana Rodriguez"
+          },
+          {
+            "id": "9c41b58c-011e-4729-817e-b5e3d5d1e6a1",
+            "name": "Juan Carlos Leon"
+          },
+          {
+            "id": "e8d66139-9a11-471d-8feb-060d95b32f04",
+            "name": "Jon Adam Chen"
+          },
+          {
+            "id": "26639585-017e-434e-8f11-42933e1c9cad",
+            "name": "Martijn Jeroen van der Linden"
+          },
+          {
+            "id": "8c35105d-a6aa-47b9-aa63-0bf2103af42b",
+            "name": "Kokayi Walker"
+          },
+          {
+            "id": "1678fa40-6634-440b-9133-1525f93064ef",
+            "name": "Subhashish Panigrahi"
+          },
+          {
+            "id": "596d5e24-c923-4716-adfa-2c18d07d9e43",
+            "name": "Esther Mwema"
+          },
+          {
+            "id": "0676e0b4-c743-457a-885f-ec8722bb6a13",
+            "name": "Hollis Wong-Wear"
+          },
+          {
+            "id": "0b78c79b-f15d-4659-b6f1-bd5c00b2a733",
+            "name": "Mia Wright-Ross"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 41140,
+        "room": "Future | Money Open Studio",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "A rural village never wanted to be a city’s landfill or a distant blur in Reels but rather home to new imaginations.\r\n\r\nBringing Down a Mountain dissects the intersecting themes of access, abolition and caste through the experiences of residents of a rural village and that of a hyper-urban city. The film follows the village residents’ dreams—of mobile data, digital payment and relief from menial work. What happens when the landfill is full, and dreams want to break free?\r\n\r\nWhile underlining that all digital barriers are social, the film exposes the plurality of tech innovations and challenges the extractivist and ableist tech.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "552412",
+        "title": "Première of Bringing Down a Mountain",
+        "description": "Bringing Down a Mountain, a speculative film centered around the push and pull between caste abolition and the Unified Payment Interface of India, will be premiered at the Interledger (ILP) Summit 2023.",
+        "startsAt": "2023-11-07T13:00:00",
+        "endsAt": "2023-11-07T13:50:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "1678fa40-6634-440b-9133-1525f93064ef",
+            "name": "Subhashish Panigrahi"
+          },
+          {
+            "id": "b0a618f4-fe76-4f41-9548-bf07b94260aa",
+            "name": "Arky AR"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Step into the future of Interledger at the ILP Summit! Explore networks through a unique lens—inspired by nature's intricate workings, from rhizomes to ecosystems, drawing fascinating parallels with our tech world. We'll journey through the evolution of networks—railroads, mobile networks, DLTs—and how they can revolutionize our perception of value. As we zoom in on ILP's potential as a rhizome for ledgers, we'll unveil subtle hints to tackle the adoption challenges we collectively face—practical, emotional, economic, legal, governance, and political. AgnostiPay envisions the end-user as a pivotal connecting node, anchoring 'inter-est' within a vibrant stakeholder community. Join us at the ILP Summit, where we'll unravel this perspective and its potential to reframe network dynamics. See you at the ILP Summit for a session that could alter the course of your networked journey!",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "529671",
+        "title": "AgnostiPay's ecosystem perspective, a different networked view",
+        "description": "Empowering the individual End-user to become their own 'Payment Service Provider', reducing transaction fees (with ILP), and increasing payment convenience to create a fairer and more inclusive world.",
+        "startsAt": "2023-11-07T13:00:00",
+        "endsAt": "2023-11-07T13:25:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "c1cb76f8-806a-4b13-8a99-ab7b3c24c350",
+            "name": "Jasper Voorendonk"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190034,
+                "name": "Future of Interledger Talk"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "This session will provide an overview of the highly successful approach taken by India and Brazil towards the provision of digital public infrastructure through the standardization of payment interfaces. This is particularly timely as the most recent G20 Digital Economy Ministers meeting held in India recognized the growth of digital public infrastructures, including in the sphere of digital payments, as a key enabler of digital inclusion and innovation. \r\n\r\nThe session will begin by outlining the background, growth story and path to development of digital payments infrastructures in the context of Brazil’s PIX and India’s Unified Payment Interface (UPI). Using a comparative lens, we will take a deep dive into the characteristics of these systems, nature of system participants, and the ownership and governance model. Besides casting the spotlight on these systems, the session will also explore what lessons the experience from PIX and UPI may hold for the development of digital payments infrastructures in other parts of the world. We will open the floor to debate on issues such as the role of public-private partnership models, participation in the framing of payments standards, allocation of costs and responsibilities between participants, and accountability structures for digital payments infrastructures.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530375",
+        "title": "Standardized Payment Interfaces as Digital Public Infrastructures: Learning from India and Brazil",
+        "description": "This session will provide an overview of the highly successful approach taken by India and Brazil towards the provision of digital public infrastructure through the standardization of payment interfaces. This is particularly timely as the most recent G20 Digital Economy Ministers meeting held in India recognized the growth of digital public infrastructures, including in the sphere of digital payments, as a key enabler of digital inclusion and innovation. \r\n\r\nThe session will begin by outlining the background, growth story and path to development of digital payments infrastructures in the context of Brazil’s PIX and India’s Unified Payment Interface (UPI). Using a comparative lens, we will take a deep dive into the characteristics of these systems, nature of system participants, and the ownership and governance model. Besides casting the spotlight on these systems, the session will also explore what lessons the experience from PIX and UPI may hold for the development of digital payments infrastructures in other parts of the world. We will open the floor to debate on issues such as the role of public-private partnership models, participation in the framing of payments standards, allocation of costs and responsibilities between participants, and accountability structures for digital payments infrastructures.",
+        "startsAt": "2023-11-07T13:00:00",
+        "endsAt": "2023-11-07T13:50:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "526711d3-3681-4fa1-aca6-d962efa1bb30",
+            "name": "Nicolo Zingales"
+          },
+          {
+            "id": "6b0e5bf6-b19d-4a1f-9977-4b4d03b984eb",
+            "name": "Smriti Parsheera"
+          },
+          {
+            "id": "a18620f0-bc47-46f7-9b02-2b74a3223836",
+            "name": "Larissa Magalhães"
+          },
+          {
+            "id": "286b01c1-9dad-4415-a115-78e99ba93ec0",
+            "name": "Bruna Cataldo"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 177655,
+                "name": "Panel"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 39259,
+        "room": "Breakout 2 - Alcazar",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "In a fast-paced 60 minute scenario-based exercise, participants will be forced to make decisions on how to support their family - whether it is by paying for their mother in law’s medication, their children’s school fees, or ensuring that there is food on the table. Participants’ access to money to finance these livelihood decisions will change depending on their access to DFS and how they manage their DFS accounts. Participants will get to experience first-hand the benefits and trade offs of DFS vs non-digital finance systems, and how it might impact their lives - particularly as women who are presented with intersectional life challenges.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530162",
+        "title": "Digital Finance – a Woman’s Immersive Experience",
+        "description": "Had enough power point presentations? \r\n\r\nOpt for a get-out-of-your seats Immersive Experience where you can “walk in the shoes” of a woman in a rural geography of a developing country, experiencing the challenges and benefits of a digital wallet in their daily life. \r\n\r\nYou'll laugh, you might cry, and you'll definitely learn something new. \r\n",
+        "startsAt": "2023-11-07T13:00:00",
+        "endsAt": "2023-11-07T13:50:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "42e841a3-7a0b-4a96-86d1-cb0689c47382",
+            "name": "Nandini Harihareswara"
+          },
+          {
+            "id": "1bd3a54f-3b2c-4af7-928d-f36540049037",
+            "name": "Ariel Frankel"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35979,
+        "room": "Breakout 3 - San Antonio",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Mifos began as a system of record for retail microfinance. Since 2018 Mifos has developed an open source payment HUB that serves as a gateway to Mojaloop or other payment switches.  This is being commercial implemented in a number of countries and locations.  Meanwhile ExtoLab developed hardware involving biometric validation, identity offline, and payments security. PaymentHUB natively connects to Apache Fineract and can be configured as a gateway to an eCurrency as is being done in a European country.   The demo starts by showing how the different open source components connect and empower use cases and projects like OpenG2P.   Then, we go further into envisioning the use of secure offline capabilities.  \r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "529931",
+        "title": "PaymentHUB: Connecting to eCurrencies and legacy payment systems",
+        "description": "PaymentHUB is a payments orchestration \"gateway\" that connects legacy banking systems to modern payment infrastructure and is open source.  ExtoPay is a new offline biometric driven hardware solution that is being piloted as part of India's Reserve Bank of India (RBI) Harbinger project to enable secure transactions across a range of use cases.  The demo is about linking these two concepts in a production environment. ",
+        "startsAt": "2023-11-07T13:25:00",
+        "endsAt": "2023-11-07T13:50:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "9361292e-40bf-49e3-b82d-679273214a81",
+            "name": "James Dailey"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190032,
+                "name": "Product Showcase Demo"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "a186ea9e-fc98-4daa-9f12-d4e99539f578",
+        "title": "Break",
+        "description": null,
+        "startsAt": "2023-11-07T13:50:00",
+        "endsAt": "2023-11-07T14:10:00",
+        "isServiceSession": true,
+        "isPlenumSession": true,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "This sessions consists of three parts. First, van der Linden will explain The Waterworks project and show a part of the video titled 'private profits, public costs'. Second, two future scenarios will be presented. Third, there will be a conversation how open payments fit in and how the scenarios could be develop further, could be made more concrete.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "554174",
+        "title": "The Waterworks of Money and Future Scenarios for the Monetary System",
+        "description": "The Waterworks of Money is a metaphorical representation of our money system, made by cartographer Carlijn Kingma, financial journalist Thomas Bollen, and professor New Finance Martijn Jeroen van der Linden. The Waterworks of Money is an artistic attempt to demystify the financial world, boost ‘systemic financial literacy’ and explore alternative future architectures of the monetary system.\r\n\r\nThe Waterworks of Money was exhibited in Rijksmuseum Twenthe, Kunstmuseum Den Haag, and reproductions are currently on display at the Architecture Biennale in Venice, the Dutch Design Week, the Rabobank and The Hague University of Applied Sciences, and will also be shown at the summit. In October 2023, the Waterworks of Money received the Amsterdam Art Prize and the Dutch Design Award in the category Design Research.\r\n",
+        "startsAt": "2023-11-07T14:10:00",
+        "endsAt": "2023-11-07T15:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "26639585-017e-434e-8f11-42933e1c9cad",
+            "name": "Martijn Jeroen van der Linden"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "I will start by explaining the concept of digital ecosystems and  how their nature informs value creation and value appropriation. Following that, I will illustrate the key enabling role of payment interoperability for the development of alternative and overlapping value ecosystems, which can be built around the interest of keystone innovators. I will suggest that a toolkit approach to interoperability (a progressive approach based on different layers) is the right way to stimulate the creation of these alternative ecosystems: it promotes resource mobility while also recognizing that bundling of different components  can be necessary to develop welfare-enhancing solutions in specific contexts (for instance, addressing market failures).",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530369",
+        "title": "Equitable Interoperability For Ecosystem Value Creation",
+        "description": "The coalescence of competitive forces around few major digital platforms has given rise to a new type of competitive environment, which is characterized by the co-existence and interdependence of multiple economic actors with a shared interest in value creation. These dynamics can be explained by some of the characteristic features of the platform economy, namely interconnectedness, modularity, and network effects. These characteristics have given rise to the so-called “inverted firm” phenomenon: digital platforms choosing to innovate and achieve scale by bringing together large numbers of interdependent user groups, and using open external contracts in preference to closed vertical integration or subcontracts within the same production chain. Instead of integrating functionalities inside the firm, these actors achieve growth by externalizing production to so-called “complementors”, which fosters the creation of rich ecosystem and yet allows them to maintain some control over it through contractual rules and technical standards. Their role as regulators of this ecosystem, or more specifically of orchestrators of value creation, is crucial to avoid negative externalities. At the same time, however, it provides them with opportunities for abuse in a way that may hinder competition, innovation, and the effectiveness of public policies. \r\nAccordingly, some authors have called regulators to take a closer look at how value is generated and distributed across different actors in the digital value chain. Indeed, orchestrators may impose rules that allow them to appropriate a substantial share of the “pie” of value that is created within their ecosystems: for instance, taking a substantial cut on the transactions they enable, and favoring their own products and services whenever they decide to enter the secondary market that has been created by one of those complementors. \r\nPayment systems are a key complementor market, not only because they are essential to enable a large variety of economic activities, but also because they are used by orchestrators as a mechanism to extract fees related to a host of orchestrator activities. The antitrust disputes involving Apple in California, Brazil and Europe, and Google and Apple in India, Japan and Korea in relation to the mandatory use of their own payment system for in-app purchases have demonstrated that the restrictions imposed to penalize competing payment systems are not justified by security concerns. This means that mandated interoperability with third party payments provides an effective remedy against undue value extraction, and promotes competition by allowing the development of alternative approaches to ecosystem value creation: for instance, approaches that are more advantageous for content creators and delivery workers, rather than gravitating around platform affordances.  \r\nIn this lightening talk, I would like to illustrate the benefits of applying this remedy to dominant digital ecosystems like the app stores using a toolkit approach. To do that, I will refer to different degrees of interoperability that go beyond merely technical interconnection, and ensures that third parties not only are able to offer services on top of the orchestrator’s platform, but also can do so on qualitatively equal terms (also known as “equitable interoperability”).\r\n",
+        "startsAt": "2023-11-07T14:10:00",
+        "endsAt": "2023-11-07T14:25:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "526711d3-3681-4fa1-aca6-d962efa1bb30",
+            "name": "Nicolo Zingales"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190031,
+                "name": "Lightning Talks"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "A. Introduction (2 minutes)\r\n\r\nB. Barriers to access and participation: Economic perspective on care labor and emotional labor\r\n (10 minutes)\r\n\r\nC. Audience Interaction Part 1 (5 minutes):\r\n-- The Moderator provides for the audience to ask pressing questions and explore interesting overlaps and intersections between disciplines. The facilitator will span a broad scope of topic areas, and participants will be involved through live Q&A, chat, and polls offered by the system.\r\n\r\nD. Re-defining Financial Inclusion (15 minutes):\r\n-- Contrasting socialist infrastructure on bridging gender gap and grassroot women’s movement in the context of financial inclusion practices\r\n--Specific legal training on financial accountability in marriage and partnership constellation\r\n\r\n\r\nE. Audience Interaction Part 2 (5 minutes):\r\n\r\nF. Measuring Success: Community-Centric Approach (10 minutes)\r\n\r\n>How can the Interledger Foundation and the Open payment systems contribute to support these initiatives?\r\n>Acknolwedge and raise awareness on the gender bias and gendered gap in the discourse around financial inclusion\r\n>Promote tools and instruments that take into account of unpaid labor\r\n\r\nG. Closing Remarks and Q&A (5 minutes)\r\n\r\n\r\nTogether, their session will attempt to answer the questions: \r\n\r\n1) What are the most important topics to bring to the table when we apply a gender lens to financial inclusion and equity practices? \r\n2) From financial literacy training, gender informed financial services to targeted legal aid, they will cover a wide range of relevant discourses such as gendered expectation of unpaid and unaccounted emotional and care labor, intersecting other forms of marginalization with gender disparity, diasporic experiences and specific need for diasporic women.  \r\n\r\n\r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530396",
+        "title": "Payment Parity Perspectives: Women of Color Reshaping Financial Inclusion",
+        "description": "The session will feature perspectives from three women of color from diverse sociocultural backgrounds on their situated knowledge related to problems, impacts, and potential solutions to financial inclusion and equity. The panelists have a longstanding background of working with the ILP community and will comment on best practices and open payment standards to enable seamless interoperability between different financial institutions, platforms, and technologies. Thus resulting in greater accessibility and affordability of financial services as both a driver and a gauge of gender equality. \r\n\r\n\r\nModerator:\r\n \r\n---Raashi Saxena – Strategy Consultant & Trainer, Accessibility Lab\r\n \r\nSpeakers: \r\n---Victoria Coker – Founder of Black Web Fest \r\n \r\n---Xiaoji Song – Interdisciplinary Artist, Researcher and Entrepreneur \r\n\r\n--- Julaire Hall -Julaire is a highly accomplished project and program management professional with 10+ years of extensive experience in planning, executing, and overseeing the successful delivery of programs in government and the global services sector. She’s previously worked for Jamaica’s investment and promotions agency and the private sector-led industry outsourcing association.As Programs Outreach Manager for the Interledger Foundation, Julaire will help build the programmatic aspects of the Foundation.\r\n\r\n\r\n",
+        "startsAt": "2023-11-07T14:10:00",
+        "endsAt": "2023-11-07T15:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "295582aa-8c62-450c-a296-6c45573ea0fd",
+            "name": "Raashi Saxena"
+          },
+          {
+            "id": "56d4c506-d323-41b0-9854-605d76121d86",
+            "name": "Victoria Coker"
+          },
+          {
+            "id": "3a71dfe5-a936-40b8-853b-46d1652952fe",
+            "name": "Xiaoji Song"
+          },
+          {
+            "id": "ceea3685-37aa-4cf0-bf1c-9527930f2232",
+            "name": "Julaire Hall"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 177655,
+                "name": "Panel"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 39259,
+        "room": "Breakout 2 - Alcazar",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "This session will kick off with context setting for the group: What is Digital Public Infrastructure and why does it matter? And what are the current available methods for building and funding a tech project that is owned by a commons? \r\n\r\nWe'll then transition into breakout group exercises where we'll collaboratively envision the types of technology institutions that are needed to support a more open, fairer Web, and discuss some of the various funding options for these projects (examples may include DAOs, Exit 2 Community models, stewardship-ownership, capped-returns investment, etc).\r\n\r\nParticipants will then be led through a collaborative brainstorming exercise to determine which of these new financial innovations could be rebuilt with ILP at its core and what these new funding/business models might look like. \r\n\r\nI hope this will inspire attendees to think more creatively about the large-scale applications for ILP as an economic power lever and how it may foster a global ecosystem of technology that is built for public benefit.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530313",
+        "title": "Reimagining Tech Platforms of the Future - How to build Digital Public Infrastructure using ILP",
+        "description": "If ILP can potentially unlock economic power on the Web, how can that economic power be directed towards building Digital Public Infrastructure? In this collaborative world-building workshop, we’ll introduce the idea of DPI and reimagine what our tech institutions of the future could look like, and walk participants through a series of exercises to co-design ways that ILP can be used to bring these institutions to life. \r\n﻿\r\n﻿We’ll investigate possibilities for alternative capital funding models, as well as new innovations in online business models, to produce a set of ideas for how ILP-enabled ecosystems can be sustainably built, funded, and maintained, without needing to resort to extractive resources like venture capital.",
+        "startsAt": "2023-11-07T14:10:00",
+        "endsAt": "2023-11-07T15:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "bfee4ab9-933d-4e4b-8e5b-7d69f723e225",
+            "name": "Tani Olhanoski"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190033,
+                "name": "Creative Conversations"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35979,
+        "room": "Breakout 3 - San Antonio",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "This will be designed for up to 15 minutes with minimal slides, and sufficient time for audience Q&A if welcomed. This talk is intended to feel personal, as I will be sharing some of my experiences as a 3rd generation Deaf person, and as a community advocate - I will share the possibilities and yet the realistic barriers - then map possible directions 'financial equity' can go towards. This talk is intended to provide insightful perspective from a language minority group, part of the disabled community, on how we should think about capacity building, access, and designing the technology that can help with community agency, rather than build a whole new model of gatekeeping. ",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530359",
+        "title": "Redefining the cost of access: financial equity in the Deaf Community",
+        "description": "The Deaf and disabled communities are among the poorest in regard to financial wealth, or having healthy finances. Unemployment is high, and access to financial information poses multiple barriers. Yet there is untapped value. The sign language economy is estimated to be worth 3 billion in the U.S. alone. There are 430 million Deaf people in the world. How much of this value/potential goes straight to the community? Practically nothing.\r\n\r\nThe open payments system suggests a revolution in how we can take the agency into our hands. But when we are talking about financial inclusion - we need to think about access to language to gain access to information, community networking, and capacity building that includes trust and knowledge. \r\n\r\nThis session will outline how we can think about community partnerships, especially in terms of capacity building, and how we can think ahead in creating opportunities for underrepresented communities and how they can become active participants in community wealth creation. How can the open payments systems principle disrupt the current model, by eliminating the ‘banking’ gatekeepers in transactions? How can we assign community agency to data? How can financial equity impact and shape accessibility? \r\n\r\nThis talk will lay possible avenues for the future of financial inclusion, equity, and access from the perspective of the Deaf community, if we are aiming for a world that is equitable, how do we get there and not leave anyone behind? \r\n",
+        "startsAt": "2023-11-07T14:25:00",
+        "endsAt": "2023-11-07T14:40:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "dc2dd614-d811-4155-862f-b23bf9b0eb5e",
+            "name": "Melissa Malzkuhn"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190031,
+                "name": "Lightning Talks"
+              },
+              {
+                "id": 190034,
+                "name": "Future of Interledger Talk"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 54547,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Agenda:\r\n\r\n1.- The current issues with prepaid services\r\n2.-  Our vision of future of streaming payments\r\n3.- Q&A",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "530265",
+        "title": "Subscription Services in the Age of Streaming Payments: Embracing Disruption",
+        "description": "Discover how Interledger is poised to enable subscription-less services, addressing the long-standing hurdle of prepaid payment methods in the service industry. Join us to delve into how this groundbreaking technology will not only overcome existing challenges, promote inclusivity, but also pave the way for improved business models and sweeping disruptions across entire industries.",
+        "startsAt": "2023-11-07T14:40:00",
+        "endsAt": "2023-11-07T14:55:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "5e27eb01-d22e-4db5-b6ad-0ce26d1a3a22",
+            "name": "Fernando Almiñana"
+          }
+        ],
+        "categories": [
+          {
+            "id": 51669,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 190034,
+                "name": "Future of Interledger Talk"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 35978,
+        "room": "Breakout 1 - Cabildos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [],
+        "id": "74b0ca1c-b596-4e04-9acd-17e570fea21f",
+        "title": "Break",
+        "description": null,
+        "startsAt": "2023-11-07T15:10:00",
+        "endsAt": "2023-11-07T15:30:00",
+        "isServiceSession": true,
+        "isPlenumSession": true,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "1f5bd8e5-159c-4df9-8655-8a4984884331",
+        "title": "Closing",
+        "description": null,
+        "startsAt": "2023-11-07T15:30:00",
+        "endsAt": "2023-11-07T16:00:00",
+        "isServiceSession": true,
+        "isPlenumSession": false,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [],
+        "id": "ab3c788a-4716-4996-81f8-ba7edde75187",
+        "title": "Hackathon",
+        "description": null,
+        "startsAt": "2023-11-08T09:00:00",
+        "endsAt": "2023-11-08T18:00:00",
+        "isServiceSession": true,
+        "isPlenumSession": false,
+        "speakers": [],
+        "categories": [],
+        "roomId": 35977,
+        "room": "Main Stage",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": null,
+        "isInformed": false,
+        "isConfirmed": false
+      }
+    ],
+    "isDefault": false
+  }
+]

--- a/src/data/sessionize/2024-speakers.json
+++ b/src/data/sessionize/2024-speakers.json
@@ -1,0 +1,2582 @@
+[
+  {
+    "id": "69f97e3e-d0c7-4fe3-9373-7cbcd223c6c8",
+    "firstName": "Adrian",
+    "lastName": "Hope-Bailie",
+    "fullName": "Adrian Hope-Bailie",
+    "bio": "Adrian is a co-inventor of the Interledger protocol stack and the Open Payments standards and payment pointers. He is a co-founder of Fynbos where he is building the first account that will issue payment pointers and support Open Payments.",
+    "tagLine": "Founder at Fynbos",
+    "profilePicture": "https://sessionize.com/image/e5b2-400o400o1-UNKX2DhHQEuyQwrn2Xx1vb.png",
+    "sessions": [
+      {
+        "id": 695522,
+        "name": "Bridging communities with Rafiki: the migrant/remittances market for account-serving entities"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Fynbos",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "256e1583-4245-4529-bd87-6fa39846b5a7",
+    "firstName": "Akshat",
+    "lastName": "Sharma",
+    "fullName": "Akshat Sharma",
+    "bio": "\r\nMy name is Akshat Sharma, and I've been actively participating in research conferences and presentations from my first few months of college.I have a solid foundation in programming languages, machine learning,cybersecurity,economics as well as an understanding of Financial Technology. I Am also an open source contributor which is available at my GitHub profile (https://github.com/Akshat111111). \r\nThis academic year I also attended to the 2023 International Conference on Advanced Communication and Intelligent Systems (ICACIS), the International Seminar on Artificial Intelligence's Impact on Technological Development (IAITD), hosted by Dambi Dollo University in Ethiopia, and the ACM Chapter's webinar on Bringing Artificial Intelligence to the Edge,Recent Advancement in Communication,Computing and Artificial intelligence (RACCAI 2023) and Third International Conference on Network Security and Blockchain Technology (ICNSBT 2024).\r\nI am well-versed in the fundamentals of computer science,economics and financial technology.I have two research internships under my belt: one at University of California in 2024 and another IIT Indore in 2023 . \r\n\r\nSince high school, I've been a meritorious student.Cabinet officials, non-governmental organizations, and communities in my state have all recognized me for my academic achievements.I had the opportunity to meet with Pranjal Kamra, India's largest financial analyst (subscribers: 5.8 million), after he saw my interest in and expertise in fintech.I was among the top 2% of candidates and was able to secure a summer research internship at IIT Indore.Only 5% of candidates were picked for the Math of Machine Learning Spring School at IIT Kharagpur, where I was also accepted.I've been chosen to join in the Google Summer of Code 2024 program. I am thrilled to be one of 1,220 GSoC contributors chosen for this great opportunity out of 43,984 applicants from 172 countries.\r\n\r\n I have also mentored 1000+ individuals in different regional and national open source program.Some of them are Girlscript summer of code 2024,Kharagpur winter of code 2024,Winter of code 2024 and Vinyasa Summer of code 2024.\r\n",
+    "tagLine": "Open Source contributor and Fintech Researcher",
+    "profilePicture": "https://sessionize.com/image/5e59-400o400o1-9p73kduYoC4PfAfCHJyoxv.jpg",
+    "sessions": [
+      {
+        "id": 732644,
+        "name": "Advancing Secure and Intelligent Transactions: Integrating AI and Cybersecurity in Open Payments"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Mifos Initiative, an American financial software nonprofit",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Google summer of Code Intern",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "aa3deed9-666b-4a27-8a26-b2c792a42663",
+    "firstName": "Alex",
+    "lastName": "Lakatos",
+    "fullName": "Alex Lakatos",
+    "bio": "Alex has spent the past 11 years working on the Open Web within Browser, Communications, and FinTech organizations. With a background in web technologies and developer advocacy, he’s helped organizations build developer-friendly products while engaging with the developer community at large. As the CTO for the Interledger Foundation, he focuses on lowering the barrier to entry into the Interledger ecosystem and drive the adoption of the web standards powering the Interledger Protocol.",
+    "tagLine": "Chief Technology Officer",
+    "profilePicture": "https://sessionize.com/image/ae6f-400o400o1-mj9fUM3LZvGpUXqSy5VYT.jpg",
+    "sessions": [
+      {
+        "id": 754678,
+        "name": "Codius Fireside Chat"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "b030bca8-340c-46fc-945c-dfb865e65b63",
+    "firstName": "Alex",
+    "lastName": "Mozeak",
+    "fullName": "Alex Mozeak",
+    "bio": "Hailing from Queens, NY, Alex Mozeak is an entrepreneurial software engineer with a rich background in both corporate and consulting environments. As a passionate netizen, Alex has witnessed the web's evolution from its early days to the exciting possibilities of Web3. Known for effective communication and his knack for collaboration, Alex has made significant contributions to the web presence of some of the world's most renowned cultural institutions and has championed innovations that make the web more inclusive and accessible.",
+    "tagLine": "Co-Founder, aStar Digital",
+    "profilePicture": "https://sessionize.com/image/5305-400o400o1-WUP7DcGa7rHRfrUwMDAC2f.jpg",
+    "sessions": [
+      {
+        "id": 732580,
+        "name": "Sharing is Caring – Using Web Monetization to Expand Access and Engagement with Gib"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "A* Digital LLC",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Co-Founder",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e0a4be86-c4c7-4374-a728-a331170307cf",
+    "firstName": "Allan",
+    "lastName": "Davids",
+    "fullName": "Allan Davids",
+    "bio": "Dr. Allan Davids is a Senior Lecturer in the School of Economics and the Director of the Financial Innovation Hub, both at the University of Cape Town. In collaboration with the Interledger Foundation, the Financial Innovation Hub brings together the brightest minds on the African continent to spearhead education, research and innovation in financial technologies. At UCT, Allan also convenes the MPhil in Financial Technology, the only Master’s degree specializing in Financial Technology on the African continent. Allan holds a PhD in Economics, has spent time as a visiting researcher at several leading universities, including New York University, the University of Oxford and Imperial College London, and until 2023, held the South African Reserve Bank Research Chair in Financial Stability. Allan’s research spans topics from housing, household and consumer finance, and public finance. ",
+    "tagLine": "Director, Financial Innovation Hub at UCT",
+    "profilePicture": "https://sessionize.com/image/4eda-400o400o1-DTdLYwcBCv3i9GqWx2hXcL.jpg",
+    "sessions": [
+      {
+        "id": 761242,
+        "name": "Towards an inclusive cashless society: the digital payments landscape in South Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Financial Innovation Hub, University of Cape Town",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Senior Lecturer and Director",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a8e2cd00-2d08-41b0-a6c3-4f43640d2276",
+    "firstName": "Andres",
+    "lastName": "Calderon Lopez",
+    "fullName": "Andres Calderon Lopez",
+    "bio": "Professor of Competition Law and Information Law at PUCP (Peru). PhD Candidate at Universidad Catolica of Chile. Legal Advisor to the Board of Directors of Peru's Central Bank.",
+    "tagLine": "Pontificia Universidad Catolica del Peru",
+    "profilePicture": "https://sessionize.com/image/fea1-400o400o1-RAoApHfzH3nz4192vqFbjE.jpg",
+    "sessions": [
+      {
+        "id": 732747,
+        "name": "Competition and financial inclusion: competing or complementing goals in DPI & interoperability"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Pontificia Universidad Catolica del Peru",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Law Professor",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "9230b0cd-1da1-4214-a323-d5d553038b02",
+    "firstName": "Aung Mon",
+    "lastName": "Ko",
+    "fullName": "Aung Mon Ko",
+    "bio": "Aung is the Software Engineering Manager at ThitsaWorks, overseeing the Microfinance Credit Information Exchange platform and Thitsa Payment Portal. With over 10 years of experience, he is responsible for product vision, planning, launching, and performance analysis, as well as technical execution and team management. Aung Mon Ko specializes in Extract, Transform & Load (ETL) processes and SQL, collaborating with stakeholders to design custom Business Intelligence (BI) dashboards and reports. Aung manages a data-sharing platform called MCIX and is responsible for product vision, planning, launching, and performance analysis. He also has experience developing core banking systems, ensuring the successful delivery of software products through strong problem-solving skills and effective project management.\r\n\r\n\r\n",
+    "tagLine": "ThitsaWorks, Software Engineering Manager",
+    "profilePicture": "https://sessionize.com/image/a28f-400o400o1-as3k7d2WgQb4FjLjPHXaf6.jpg",
+    "sessions": [
+      {
+        "id": 695511,
+        "name": "ThitsaX: Interconnected Nodes to Bridge Worlds"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "ThitsaWorks Pte. Ltd.",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Software Engineering Manager",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "27429f38-3846-488f-9e53-58837c0b6842",
+    "firstName": "Ayden",
+    "lastName": "Férdeline",
+    "fullName": "Ayden Férdeline",
+    "bio": "Ayden Férdeline is a public interest technologist who has worked directly with governments, industry, and civil society organizations to support responsible technological innovation with a focus on social impact. \r\n\r\nHe is currently an Interledger Ambassador. Previously, he was a Landecker Democracy Fellow with Humanity in Action, in collaboration with the Alfred Landecker Foundation, where he worked to bring traditionally-excluded voices from the labor organizing space into Internet governance arenas. \r\n\r\nHe serves on the Steering Committee of the joint Ford Foundation-Mozilla Foundation Public Interest Technologists Network, where he cultivates an empowered community of civic minded stakeholders who share a meaningful and actionable camaraderie to keep the Internet working for everyone. \r\n\r\nIn addition, he is a Fellow with the Internet Law and Policy Foundry in Washington D.C. \r\n\r\nHe previously represented European civil society organizations on ICANN’s GNSO Council, the body which makes binding policy for generic top-level domain names like .COM and .ORG, and was a technology policy fellow with the Mozilla Foundation. He also hosted the Internet governance history podcast POWER PLAYS, which shined a spotlight on many pioneers from within the Internet governance community, and has worked for an array of philanthropic organizations, including the National Endowment for Democracy, the National Democratic Institute, and the New Venture Fund.\r\n\r\nHe is an alumnus of the London School of Economics.",
+    "tagLine": "Public Interest Technologist",
+    "profilePicture": "https://sessionize.com/image/2c55-400o400o1-hJy2kMjNEEXKu4ZRZva7bT.jpg",
+    "sessions": [
+      {
+        "id": 731902,
+        "name": "Parliamentarian Perspectives: Fostering Inclusive Open Payments in Africa"
+      },
+      {
+        "id": 732187,
+        "name": "Meet the UN IGF Dynamic Coalition on Digital Financial Inclusion"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Ambassador",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "60ca230a-ed4a-492b-b423-f4fbd279c871",
+    "firstName": "Briana",
+    "lastName": "Marbury",
+    "fullName": "Briana Marbury",
+    "bio": "Briana is passionate about promoting open payments and financial interoperability solutions for the world's population that need it most.  As Executive Director of the Interledger Foundation, her goal is to expand the public’s awareness of the Interledger Protocol's immense potential to improve lives.",
+    "tagLine": "President & CEO, Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/4335-400o400o1-GKsWsXx4ZqJ8jfn8knpqX2.jpg",
+    "sessions": [
+      {
+        "id": 753024,
+        "name": "Interledger Foundation Keynote with President & CEO Briana Marbury"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "President & CEO ",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "b64bb83c-8afd-4452-a083-34b183001afd",
+    "firstName": "Caroline",
+    "lastName": "Sinders",
+    "fullName": "Caroline Sinders",
+    "bio": "Caroline Sinders is a critical designer and artist. For the past few years, she has been examining the intersections of artificial intelligence, abuse, and politics in digital conversational spaces. She has worked with the United Nations, Amnesty International, IBM Watson, the Wikimedia Foundation and others. Sinders has held fellowships with the Harvard Kennedy School, Google's PAIR (People and Artificial Intelligence Research group), the Mozilla Foundation, Pioneer Works, Eyebeam, Ars Electronica, the Yerba Buena Center for the Arts, the Sci Art Resonances program with the European Commission, and the International Center of Photography. Currently, she is a fellow with Ars Electronica AI Lab with the Edinburgh Futures Institute and a visiting fellow with the Weizenbaum Institute looking at labor and systems in AI and platforms. Her work has been featured in the Tate Exchange in Tate Modern, Victoria and Albert Museum, MoMA PS1, LABoral, Wired, Slate, Quartz, the Channels Festival and others. Sinders holds a Masters from New York University's Interactive Telecommunications Program.\r\n",
+    "tagLine": "principal and cofounder, focusing on how design can solve complex tech problems, from community health to AI.",
+    "profilePicture": "https://sessionize.com/image/4e54-400o400o1-cd5cfb7f-f6da-4622-a1f7-8616db25a0ae.jpg",
+    "sessions": [
+      {
+        "id": 732187,
+        "name": "Meet the UN IGF Dynamic Coalition on Digital Financial Inclusion"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Convocation Research + Design",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Executive Director",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8c31891a-1b90-41c9-9419-cb79cdd7494e",
+    "firstName": "Chris",
+    "lastName": "Lawrence",
+    "fullName": "Chris Lawrence",
+    "bio": "Chris is an experienced nonprofit professional who has spent the last 15 years as a dedicated educator, network builder, and advocate for non-profit organizations. Chris is currently the Head of Programs at the Interledger Foundation. He oversees all aspects of the programatic activity of the foundation.",
+    "tagLine": "Chief Program Officer, Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/2bdb-400o400o1-SNinwiRmUVgy57CYVWjhqE.jpg",
+    "sessions": [
+      {
+        "id": 753052,
+        "name": "Interledger Summit Closing Plenary"
+      }
+    ],
+    "isTopSpeaker": true,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Chief Program Officer",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "5f635035-6608-4d43-a0fe-e64717a742b3",
+    "firstName": "Daphnee",
+    "lastName": "Prates Iglesias",
+    "fullName": "Daphnee Prates Iglesias",
+    "bio": "Daphnee is digitisation specialist who holds a Master in Public Policy from the Hertie School and a B.A. in International Relations from the Pontifical Catholic University of Goiás, Brazil (PUC-GO). She is also trained in Social Innovation and Leadership by the United Nations University for Peace (UPEACE). Her field of work analyses the connections between the increasing use or misuse of new technologies and its implications to countries' digital policies: in privacy regulation, government transparency, and human rights protection. Currently she is an independent UN-IGF Consultant/Advisor for Access and Connectivity, being a rapporteur of said multistakeholder discussions. Previously, Daphnee has led the build-up of a few coalitions around digital governance, including acting as a Policy Officer for Financial Inclusion at the International Rescue Committee and a Policy Manager at the Web Foundation. She is fluent in Portuguese, English, Spanish and German, and has become an Alexander von Humboldt Foundation recipient in 2018, being awarded as a German Chancellor Fellow for her leadership trajectory.",
+    "tagLine": "Independent Expert on Digital Policies & Governance | Coalition-builder",
+    "profilePicture": "https://sessionize.com/image/157f-400o400o1-SxWER9Z9ULNjLvVTtoCGZK.jpg",
+    "sessions": [
+      {
+        "id": 732187,
+        "name": "Meet the UN IGF Dynamic Coalition on Digital Financial Inclusion"
+      },
+      {
+        "id": 732717,
+        "name": "Financial Inclusion for Undocumented Communities: From Strategies to Practices"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Independent",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Policy Advisor / Consultant ",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "73a6f00b-8686-436b-9eeb-6d9b2bd5b12a",
+    "firstName": "David",
+    "lastName": "Higgins",
+    "fullName": "David Higgins",
+    "bio": "David has over 23 years experience in managing Enterprise IT and large scale development programmes in the Telecommunications, Financial Services and Fintech sectors. For the past 16 months David has been leading Mifos work with the ITU GovStack programme;  helping them specify a Payment Building Block, and supplying a working Payment Building Block instance based on Mifos DPGs and working on Mifos work for DPIs.  This has included project management of the Interledger Grant funded work on how \"ILP for DPI\".",
+    "tagLine": "Director of Programs - Mifos",
+    "profilePicture": "https://sessionize.com/image/0ae4-400o400o1-MhahaJTuj7p8pkFNLSLwTa.png",
+    "sessions": [
+      {
+        "id": 731179,
+        "name": "Shared Infrastructure to unlock Last-Mile Financial Inclusion using the Mifos DPGs for Core Banking"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Mifos Initiative",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Director of Programs",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "2b7c7fbf-fcc7-4303-948b-7368602778e2",
+    "firstName": "Dre",
+    "lastName": "Ngare",
+    "fullName": "Dre Ngare",
+    "bio": "Andrew Ngare is the Co-founder, Head of Innovation at Snake Nation, a culture, content, and technology company in Cape Town, South Africa connecting young creators with the creative economy, partnering with NGOs, corporates, brands, and governments. ",
+    "tagLine": "Head of Innovation",
+    "profilePicture": "https://sessionize.com/image/927c-400o400o1-V4TyCCDYgaEnX5C1qfGQWz.jpg",
+    "sessions": [
+      {
+        "id": 732595,
+        "name": "Building Trust and Advancing Open Payments in Africa’s Regulatory Ecosystem"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Snake Nation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Head of Innovation",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "621798be-4ae6-4e5b-9345-fa3ceec50333",
+    "firstName": "Edward",
+    "lastName": "Cable",
+    "fullName": "Edward Cable",
+    "bio": "As the President/CEO of the Mifos Initiative and founding member of the Apache Fineract PMC, Edward Cable is a leader in technology-enabled financial inclusion and open service financial services innovation. Since his time at the Wharton School at the University of Pennsylvania, Edward has understood and proven the catalytic power of communities – first through the cooperative movement, then through financial inclusion, and now through open source for financial services. Edward joined the Mifos project in 2007, incubating the open source community as part of the initial team guiding the project within the Grameen Technology Center. He led the spinout of the Mifos Initiative in 2011, overseeing the evolution of both the platform as well as the open source community as a transformative force for microfinance, financial inclusion and now digital financial services. Edward’s strategic vision and foresight has enabled the community to keep pace with rapid fintech innovation and nurtured the growth of a vibrant ecosystem of solution providers reaching nearly 20 million clients through solutions built on top of the open-source Mifos and Fineract APIs. When he’s not focused on cultivating innovative fintech solutions, Edward tends to his menagerie of animals including goats, dogs, rabbits, and chickens in the majestic Redwoods. Edward has spoken at numerous open source and fintech events including a keynote and LF Open Source Summit in Europe, and workshops/talks at Fintech DevCon hosted by Moov and OSCON.",
+    "tagLine": "President/CEO - Mifos",
+    "profilePicture": "https://sessionize.com/image/d3d3-400o400o1-BHN3j4GMXzKdPrL9tsipvD.jpg",
+    "sessions": [
+      {
+        "id": 731179,
+        "name": "Shared Infrastructure to unlock Last-Mile Financial Inclusion using the Mifos DPGs for Core Banking"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "The Mifos Initiative",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "President/CEO",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "ccda5cd7-aeb2-4dd1-97a9-87979237f62f",
+    "firstName": "Enej",
+    "lastName": "Pungercar",
+    "fullName": "Enej Pungercar",
+    "bio": "Enej is the founder and CEO of GateHub, which is the largest wallet and gateway provider on XRP Ledger serving more than 1.3 million customers. For the last 11 years Enej has been working for various crypto asset companies including Bitstamp, one of the largest crypto exchanges, where he served as Chief Design Officer for 4 years, before founding GateHub in 2014. As a trained architect, his passion is building cutting edge products and services using decentralized ledger technologies. ",
+    "tagLine": "Founder and CEO of GateHub",
+    "profilePicture": "https://sessionize.com/image/31f2-400o400o1-siunwuA99mqaMivmgCb4Ve.png",
+    "sessions": [
+      {
+        "id": 695522,
+        "name": "Bridging communities with Rafiki: the migrant/remittances market for account-serving entities"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "GateHub",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "596d5e24-c923-4716-adfa-2c18d07d9e43",
+    "firstName": "Esther",
+    "lastName": "Mwema",
+    "fullName": "Esther Mwema",
+    "bio": "Esther Mwema is an artist and a digital inequalities practitioner with expertise in internet governance, digital transformation, and innovation. She has over ten years commitment to social impact at the intersection of youth, technology, and gender and holds extensive experience at the United Nations. Esther is an Open Internet leader who prioritises African feminist and decolonial practices. She has been awarded the Mozilla Creative Media Awards, the Interledger Foundation Future|Money award, the C/Change R&D arts and culture awards, among more. Esther graduated with an MSc in Inequalities and Social Science from the London School of Economics.",
+    "tagLine": "Future|Money Awardee / Sikhula Sonke: Living Archives of Afrofuturist Village Banking",
+    "profilePicture": "https://sessionize.com/image/e0be-400o400o1-sCJqFUXGZ5TyEDNv6sgtWM.jpg",
+    "sessions": [
+      {
+        "id": 695881,
+        "name": "Views from the Grassroots: Village Banking and Financial Inclusion in Southern Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Sikhula Sonke: Living Archives of Afrofuturist Village Banking",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Artist",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "836d5658-b522-46f2-a032-6cd7debf0101",
+    "firstName": "Eunice",
+    "lastName": "de Asis",
+    "fullName": "Eunice de Asis",
+    "bio": "Eunice de Asis is a dedicated community organizer with over 10 years of experience, originally from the Philippines and now based in the Netherlands. Her work has focused on advocating for undocumented migrants and refugees, having witnessed firsthand the challenges they face in accessing basic rights like banking and social services.\r\n\r\nBefore migrating to the Netherlands, she was a filmmaker, producing impactful, award-winning  films and documentaries that highlighted critical social issues and gave voice to marginalized communities.\r\n\r\nShe is  actively involved in several migrant organization such as Right to Create, de Asis  also function as the chairperson of MiGreat, and Migrante Amsterdam, and serves on the International Coordinating Body of the International Migrant Alliance. In addition to these roles, de Asis is part of the Amsterdam municipality’s sounding board for the undocumented community, advising the city council on policies affecting undocumented migrants in the city.\r\n\r\nMs. de Asis is presently working with the Stichting Here to Support initiative on the Financial Inclusion of the Undocumented Migrant project, where she continues her efforts to empower migrant communities in the Netherlands.",
+    "tagLine": "Activist, Filmmaker, Community Organizer",
+    "profilePicture": "https://sessionize.com/image/74a0-400o400o1-DWCY4Mdep2Ti8P7tDGLexP.jpg",
+    "sessions": [
+      {
+        "id": 732717,
+        "name": "Financial Inclusion for Undocumented Communities: From Strategies to Practices"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Stichting Here to Support",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Community Organizer",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "93026eb0-f1ab-4c49-9ba8-3e63f26a4bee",
+    "firstName": "Fernanda",
+    "lastName": "Pizarro",
+    "fullName": "Fernanda Pizarro",
+    "bio": "Master of Law in Business and Regulation Affairs, with a Solid Track Record in National and International Fintech, Specializing in the Intersection of Law, Technology, and Regulation",
+    "tagLine": "Lawyer, Payment Specialist - LLM Business and Regulatory Affairs",
+    "profilePicture": "https://sessionize.com/image/6176-400o400o1-VGoReypbTo2spzrsCQ3QmN.jpg",
+    "sessions": [
+      {
+        "id": 732747,
+        "name": "Competition and financial inclusion: competing or complementing goals in DPI & interoperability"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "ProntoPaga",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Compliance Analyst",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "5e27eb01-d22e-4db5-b6ad-0ce26d1a3a22",
+    "firstName": "Fernando",
+    "lastName": "Almiñana",
+    "fullName": "Fernando Almiñana",
+    "bio": "Fernando's entrepreneurial journey spans across various industries, including real estate development and operations, food manufacturing, financial consulting, electronic security and telecommunications. With over 16 years of experience in mission-critical communications, he has gained a comprehensive understanding of telecom infrastructure design and operations. Fernando is a co-founder of Wallet Guru and has been instrumental in guiding the company's strategic planning and software development.\r\n",
+    "tagLine": "Wallet Guru Co-Founder. Pioneering streaming payments and subscription-less services.",
+    "profilePicture": "https://sessionize.com/image/a40e-400o400o1-GXZwbe6JaGshGUNTbkxop1.jpg",
+    "sessions": [
+      {
+        "id": 695709,
+        "name": "Wallet Guru: Revolutionizing the Streaming Industry with Interledger’s Streaming Payments"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Wallet Guru",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Co-Founder",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "1118e56c-d6bd-4b8e-ae6a-80a58932e45a",
+    "firstName": "Greg",
+    "lastName": "McCormick",
+    "fullName": "Greg McCormick",
+    "bio": "Greg McCormick, Project Executive Director, is a 30 year tech industry veteran. Starting out as a network engineer, developer, and architect he has held various roles including CEO, CTO. He is focused on inclusive financial systems and how to protect emerging markets by providing trust in the financial system.  Mr. McCormick leads a yet-to-be-named nonprofit that produces the OSS Fraud Risk Management System providing knowledge and tools to solve financial crime and improve financial inclusion.",
+    "tagLine": "Linux real-time fraud detection, from the Project Executive Director",
+    "profilePicture": "https://sessionize.com/image/a106-400o400o1-KHEiiC2iK8QAXbxjoYVsuG.jpg",
+    "sessions": [
+      {
+        "id": 684918,
+        "name": "Tazama Real-Time Open Source Software for Fraud Detection"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Linux Foundation -Tazama Project",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Executive Director",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3bce59a9-7f72-4005-b442-1fae30119442",
+    "firstName": "Hannah",
+    "lastName": "Draper",
+    "fullName": "Hannah Draper",
+    "bio": "Hannah Draper advises Consumers International on its digital rights strategy. Since 2022, she has directed Payne & Routledge, Ltd. (payneroutledge.com), a consultancy firm working in the areas of digital & information rights, public security, and social innovation. Draper previously worked as a program manager for the Open Society Foundations’ Information Program, where she led the organization's global digital rights program for almost a decade. She also co-founded and directed INDELA.fund — an initiative dedicated to advancing digital rights in Latin America.\r\n\r\nDraper holds a common law degree from the University of Ottawa, with a specialization in technology law, and a BA from the University of Guelph, with a focus on international development. ",
+    "tagLine": "Hannah Draper advises Consumers International on its digital rights strategy.",
+    "profilePicture": "https://sessionize.com/image/1afe-400o400o1-HVzMSpKArkycGkfcdeBwbm.png",
+    "sessions": [
+      {
+        "id": 732747,
+        "name": "Competition and financial inclusion: competing or complementing goals in DPI & interoperability"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Consumers International",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Advisor",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "53ba9e9d-d014-4133-bd50-4d7c97a470fd",
+    "firstName": "Hon. Esther",
+    "lastName": "Passaris",
+    "fullName": "Hon. Esther Passaris",
+    "bio": "Delegate in the Interledger Summit 2024 Parliamentarian Track",
+    "tagLine": "Member of Parliament, Kenya",
+    "profilePicture": "https://sessionize.com/image/2186-400o400o1-VRVFAYcXMP9z7Fm5SHGHue.jpg",
+    "sessions": [
+      {
+        "id": 731902,
+        "name": "Parliamentarian Perspectives: Fostering Inclusive Open Payments in Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "f1cbe4f1-29f8-4ac1-9fc3-06d7851bf338",
+    "firstName": "Jason",
+    "lastName": "Bruwer",
+    "fullName": "Jason Bruwer",
+    "bio": "Settlement workstream technical lead.",
+    "tagLine": "ILF, previously Coil",
+    "profilePicture": "https://sessionize.com/image/cd94-400o400o1-re5p7j5XGmmhJDRQRyhXd.jpg",
+    "sessions": [
+      {
+        "id": 695515,
+        "name": "Cross-border inter-scheme transfer demo: from Rafiki to a Mojaloop switch"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "ILF Staff",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Engineer",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "715acb29-2834-4d55-b102-d75ec3e3136d",
+    "firstName": "Jeremiah",
+    "lastName": "Lee",
+    "fullName": "Jeremiah Lee",
+    "bio": "Jeremiah Lee develops monetization tools for digital creators. He previously worked on cloud payment infrastructure at Stripe, hardware integrations at Spotify, and web APIs at Fitbit. He grew up under the California sun, but now calls Stockholm home.",
+    "tagLine": "Software Engineer",
+    "profilePicture": "https://sessionize.com/image/69da-400o400o1-StfibW1MiqBiRMQSMBQMVe.jpg",
+    "sessions": [
+      {
+        "id": 732187,
+        "name": "Meet the UN IGF Dynamic Coalition on Digital Financial Inclusion"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Restoration.software",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e8d66139-9a11-471d-8feb-060d95b32f04",
+    "firstName": "Jon Adam",
+    "lastName": "Chen",
+    "fullName": "Jon Adam Chen",
+    "bio": "Jon Adam Chen is a strategic communications specialist with a background in social impact, storytelling, and African development. He thrives as an editor, writer, and researcher. Jon Adam holds a master’s degree in media studies from the University of Cape Town and was an Engineers Without Borders Canada long-term fellow. He has supported grassroots organizations in Canada, South Africa, Kenya and Nigeria. He currently works with the Assembly of First Nations and previously held roles with the Ontario Ministry of Health and the Canadian Red Cross.",
+    "tagLine": "Researcher and Co-Lead, Sikhula Sonke: Living Archives of Afrofuturist Village Banking",
+    "profilePicture": "https://sessionize.com/image/ffd4-400o400o1-4n9GQeRp1aS7ytWbKe3fs1.jpeg",
+    "sessions": [
+      {
+        "id": 695881,
+        "name": "Views from the Grassroots: Village Banking and Financial Inclusion in Southern Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Sikhula Sonke Project",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Researcher and Co-Lead, ",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "30b3c3bc-2196-4f86-be96-4578358d8818",
+    "firstName": "Joran",
+    "lastName": "Greef",
+    "fullName": "Joran Greef",
+    "bio": "Joran bumped into Coil (and the idea of Interledger) in 2020 on a soccer field in Cape Town. This led to analysis of the Mojaloop payments switch, and the idea for “an accounting database” called TigerBeetle to move the performance needle by three orders of magnitude, as part of providing infrastructure for Interledger and Rafiki. TigerBeetle, Inc. was spun out of Coil as a startup in August 2022.",
+    "tagLine": "Founder & CEO of TigerBeetle",
+    "profilePicture": "https://sessionize.com/image/a875-400o400o1-7fHzM1twg3S8UgpjqsTHia.jpg",
+    "sessions": [
+      {
+        "id": 718166,
+        "name": "The Next 30 Years of Transaction Processing"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "TigerBeetle",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8ed6a7c6-1361-4416-87b7-69471b062704",
+    "firstName": "Julian",
+    "lastName": "Kanjere",
+    "fullName": "Julian Kanjere",
+    "bio": "Julian Kanjere is a founder at Mandla Money, a stablecoin mobile money wallet for emerging markets that is accessible via WhatsApp, USSD and SMS. Julian has experience leading software implementations and blockchain projects, and regularly speaks at technology conferences on building inclusive solutions & blockchain in emerging markets. He has successfully raised innovation funding from various sources and won prestigious awards such as the Schmidt Futures Reimagine Challenge by former Google CEO Eric Schmidt - all testament to his drive to advance society using innovation and technology. ",
+    "tagLine": "Founder - Mandla Money",
+    "profilePicture": "https://sessionize.com/image/9573-400o400o1-EutGdkn9Tbb2AVXVnnVhyv.jpg",
+    "sessions": [
+      {
+        "id": 761242,
+        "name": "Towards an inclusive cashless society: the digital payments landscape in South Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Mandla Money",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "be411f3c-9578-4b55-9b6b-63511ad8e986",
+    "firstName": "Julie",
+    "lastName": "Guetta",
+    "fullName": "Julie Guetta",
+    "bio": "Julie has worked in the global payments industry since 2013, winning leadership roles with firms like Dovetail, RedCompass Labs, and Partior. She has led the functional implementation of several payment systems for banks and has helped with their payments strategy. She has been an active Mojaloop Community member for several years before recently joining them. She is a regular speaker at conferences worldwide. ",
+    "tagLine": "Mojaloop Foundation, Technical Solutions lead",
+    "profilePicture": "https://sessionize.com/image/e041-400o400o1-HTKLgT9CKwzf5aiWJ7N4bd.jpg",
+    "sessions": [
+      {
+        "id": 695522,
+        "name": "Bridging communities with Rafiki: the migrant/remittances market for account-serving entities"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "The Mojaloop Foundation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Technical Solutions Lead",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a6783a70-11c2-49e1-8b9c-c30c6dc929cd",
+    "firstName": "Jurgen",
+    "lastName": "Kuhnel",
+    "fullName": "Jurgen Kuhnel",
+    "bio": "As a surfer, trader, founder, and trustworthy entrepreneur, I earned a reputation for dedication and trustworthiness, always adapting to the changing and evolving landscape of the industry and staying ahead on the curve of innovation.",
+    "tagLine": "CEO",
+    "profilePicture": "https://sessionize.com/image/8338-400o400o1-D9V4V7VBNiUXA7d8Sw97dH.jpg",
+    "sessions": [
+      {
+        "id": 732595,
+        "name": "Building Trust and Advancing Open Payments in Africa’s Regulatory Ecosystem"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Xago",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "dcf728ce-db55-4b40-8d9c-942473b14715",
+    "firstName": "Justus",
+    "lastName": "Ortlepp",
+    "fullName": "Justus Ortlepp",
+    "bio": "With more than 20 years’ experience in the Business Analysis field, Justus has honed his skills in problem solving and system building in South Africa in companies such as IBM, First National Bank (FNB) and Deloitte.\r\n\r\nAt FNB he designed a mainframe-based graph database for customer networks as well as a third-party fund management platform for which the project team earned an FNB Innovators first place award.\r\n\r\nAt Deloitte, Justus attended client projects for the South African Reserve Bank and the Bill & Melinda Gates Foundation from where he pursued full-time the design and development of an Open Source Software Financial Crime Risk Management solution focused on real-time transaction monitoring. That software is now called Tazama, a project of the Linux Foundation.\r\n",
+    "tagLine": "Product Manager",
+    "profilePicture": "https://sessionize.com/image/1ada-400o400o1-BDe3vmn4fs154dXR8WYPuq.jpg",
+    "sessions": [
+      {
+        "id": 684918,
+        "name": "Tazama Real-Time Open Source Software for Fraud Detection"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Tazama.org",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Product Manager",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "26fd7f35-0010-4bf0-895d-a732dd4546f7",
+    "firstName": "Kosta",
+    "lastName": "Peric",
+    "fullName": "Kosta Peric",
+    "bio": "Experienced executive at the intersection of technology, finance and innovation. Digital financial inclusion at the Gates Foundation. Board chair at the Mojaloop Foundation and member of the Board at the Interledger Foundation. Former Chief Architect SWIFTNet. Author. ",
+    "tagLine": "Deputy Director, Inclusive Financial Systems",
+    "profilePicture": "https://sessionize.com/image/fee4-400o400o1-NJgErRS3h54gfCHos1Yw1b.jpg",
+    "sessions": [
+      {
+        "id": 749717,
+        "name": "The History & Future of Digital Financial Inclusion "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Bill & Melinda Gates Foundation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Deputy Director, Inclusive Financial Systems",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a2eb66ef-7238-4800-bf4d-6091cb46e62b",
+    "firstName": "Kungela",
+    "lastName": "Mzuku",
+    "fullName": "Kungela Mzuku",
+    "bio": "Kungela is a platform owner at Nedbank, tasked with bringing sustainable principles and practices to Group Technology. She is also a post-graduate lecturer at the University of Cape Town. ",
+    "tagLine": "Platform Owner, Green Engineering at Nedbank",
+    "profilePicture": "https://sessionize.com/image/c24f-400o400o1-LPstTLszX8o8cceRBXkfWB.jpg",
+    "sessions": [
+      {
+        "id": 761242,
+        "name": "Towards an inclusive cashless society: the digital payments landscape in South Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Nedbank",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Platform Owner",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "23dfc112-b8df-4e82-968c-0b6e9fba3041",
+    "firstName": "Liz",
+    "lastName": "Steininger",
+    "fullName": "Liz Steininger",
+    "bio": "Liz Steininger is the CEO/Managing Director of Least Authority, a leading Web3 security consulting company and builder of privacy enhancing technology products, including Private.Storage and Winden.App. Least Authority specializes in securing Web3 products, capability-based security and implementing advanced cryptography, especially zero-knowledge proofs (ZK) and multi-party computations (MPC). Beyond security audits for new technologies, Least Authority has also released the MoonMath Manual, a practical guide for developers to understand zero-knowledge proofs. The company focuses on cutting-edge security and empowering users to control their right to privacy.",
+    "tagLine": "CEO of Least Authority",
+    "profilePicture": "https://sessionize.com/image/46e0-400o400o1-VP8wWCXpCZQgyGDr2qG7Mg.jpg",
+    "sessions": [
+      {
+        "id": 732719,
+        "name": "Existing Ecosystem Approaches to Inclusive and Accessible Digital Financial Services"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Least Authority",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO/Managing Director",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a6ac7ec7-a053-486c-8778-7294f707c0ab",
+    "firstName": "Lukonga",
+    "lastName": "Lindunda",
+    "fullName": "Lukonga Lindunda",
+    "bio": "Lukonga Lindunda is an innovation leader and entrepreneur with over 17 years of experience in driving digital transformation and fostering entrepreneurship in Zambia and across Africa. As the Executive Director and Co-founder of BongoHive, Zambia’s first technology and innovation hub, he has supported over 2,000 startups and MSMEs, empowering them with the resources, mentorship, and networks needed for success. Lukonga is also at the forefront of advancing Digital Public Infrastructure (DPI) and Artificial Intelligence (AI) in Zambia, having led the State of AI in Zambia Survey in collaboration with ZICTA and Ubuntu AI, and contributing to the development of the country’s National AI Strategy.\r\n\r\nA strong advocate for DPI, Lukonga promotes the use of technology to enhance public services and community well-being. He has contributed as a Digital Economy Country Assessment (DECA) expert for both Zambia and Zimbabwe, working to strengthen their digital economies. He also serves as a trusted advisor to the public sector, collaborating with SmartZambia to ensure that digital infrastructure is inclusive and accessible to the startup and business communities. Lukonga’s work emphasizes customer-centric innovation, and he is a passionate advocate for gender inclusivity in tech, shaping the future of business and digital transformation in Zambia and beyond.\r\n\r\nLukonga holds a Bachelor’s degree in Information Technology from Nelson Mandela Metropolitan University, and an MBA from the African Leadership University. He remains dedicated to leveraging technology for societal growth and economic development.",
+    "tagLine": "Leader in Innovation and Digital Transformation | Advocate for Inclusive Technology and Sustainable Growth",
+    "profilePicture": "https://sessionize.com/image/5aa3-400o400o1-KndMWfydVHtd5KhaQwfMfK.png",
+    "sessions": [
+      {
+        "id": 696099,
+        "name": "Immersive Debate: Is DPI Inherently \"Gender Neutral\"?"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "BongoHive",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Co-founder and Executive Director",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a055a6cf-45d9-4cd2-8273-435ad54d5baf",
+    "firstName": "Malou",
+    "lastName": "Lintmeijer",
+    "fullName": "Malou Lintmeijer",
+    "bio": " Co-director of Stichting Here to Support since 2018, Malou is experienced in the strategy, entrepreneurship and finance of non-governmental organisations. She fights for human rights and advocates for municipalism. ",
+    "tagLine": "Co-director Stichting Here to Support",
+    "profilePicture": "https://sessionize.com/image/bd73-400o400o1-JWNLhE6YDd5NU8YHuYgVNV.jpeg",
+    "sessions": [
+      {
+        "id": 732717,
+        "name": "Financial Inclusion for Undocumented Communities: From Strategies to Practices"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Stichting Here to Support",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "co-director",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "1b08a1e6-d254-420d-b70f-e7f6a198b165",
+    "firstName": "Mardiya",
+    "lastName": "Siba Yahaya",
+    "fullName": "Mardiya Siba Yahaya",
+    "bio": "Mardiya is digital sociologist, researcher, and community\r\nmovement builder. They are the Global Community Manager at Team CommUNITY. Working at the intersection of digital labour, gender and cybersecurity, surveillance, counter-publics and digital identities, she investigates pathways to address surveillance, violence and censorship against minoritized communities in the global South. ",
+    "tagLine": "Team Community, Community Manager",
+    "profilePicture": "https://sessionize.com/image/ed56-400o400o1-K7iqWctNJtqoyzAr49ZKvQ.png",
+    "sessions": [
+      {
+        "id": 726153,
+        "name": "Getting the Money to Public Interest Technologists Building A Feminist Internet"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Team Community",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Community Manager",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "4e4c1bab-cfb7-4170-b88e-38681cad10fe",
+    "firstName": "Maria Gorrettie",
+    "lastName": "Namuddu",
+    "fullName": "Maria Gorrettie Namuddu",
+    "bio": "I love technology. I have seen firsthand how access to technology/digital services has transformed a community. My mission is to harness and leverage community social capital to promote financial inclusion. \r\n\r\nCurrently, I I play a key role in the implementation of Kanzu Banking, a core banking platform designed to streamline and enhance the operations of VSLAs, MFIs, and SACCOs. I focus on ensuring seamless onboarding, efficient data migration, and exceptional customer service. \r\n\r\nHonoured by HiPipo as one of the “40 Women Under 40” pioneering change in the fintech space in Africa and beyond, my innovative strategies have significantly improved the customer experience and driven a product-led approach within our team. \r\n\r\nI am driven by a passion for continuous improvement and innovation, always seeking ways to optimize processes and enhance the value we deliver to our clients.\r\n\r\n",
+    "tagLine": "Kanzu Code Limited, Product & Customer Success",
+    "profilePicture": "https://sessionize.com/image/b230-400o400o1-RtPADhnLGZRSXdbi3WEekf.jpg",
+    "sessions": [
+      {
+        "id": 682327,
+        "name": "Empowering Women: Bridging the Gender Gap in Digital Financial Inclusion"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Kanzu Code Limited",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Product & Customer Success",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a63af0da-3b51-42ad-9775-ff52212884ba",
+    "firstName": "Max",
+    "lastName": "Kurapov",
+    "fullName": "Max Kurapov",
+    "bio": "As a software developer at the Interledger Foundation, Max builds open source tools and APIs that provide developers & institutions access to the Interledger network. Before joining the Foundation, Max spent 5 years working at startups: one of which a Fintech company, where he was one of the leads on the card payments processing team.",
+    "tagLine": "Software Developer @ Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/14a7-400o400o1-NdHoFbJ4brYyf1Hk94hbpW.jpg",
+    "sessions": [
+      {
+        "id": 735787,
+        "name": "Rafiki & Ecosystem Updates"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6caa3775-97c0-4972-827a-f10d7ee0f426",
+    "firstName": "Michael",
+    "lastName": "Mbuthia",
+    "fullName": "Michael Mbuthia",
+    "bio": "Michael is a financial services professional with 15+ years of experience cutting across digital financial services, strategy formulation, project Management and business development. His working knowledge spans across Banking, Aviation, Agriculture, and impact development covering multiple geographies in Africa.\r\n\r\nMichael was the project lead for Rwanda National Digital Payments Platform working directly with Access to Finance Rwanda (AFR) and National Bank Rwanda (BNR) spear-heading Interoperability blueprint development and rollout. Prior to this he served as Pesalink Chief Information Officer (CIO) and Ag-Chief Executive Officer (CEO) for Kenya Bankers Association payments services company - Integrated Payment Services Limited (IPSL) and was instrumental in leading the industry towards launching real-time interoperable payment platform.\r\n\r\nHe holds two Masters degrees, MBA in Strategic Management from United States International University and M.Sc. in Information Technology from Nairobi University respectively and is currently undertaking a PhD in Information Systems at Cape Town University South Africa with research interests in Payments Interoperability, Making Markets Work for the Poor (M4P) and ICT for development (ICT4D). \r\n\r\nWhen he is not studying or deploying payment solutions, Michael is the Secretary at his alma mater “United States International University” and is passionate about youth mentorship. He is also an avid CrossFit enthusiast. \r\n",
+    "tagLine": "DPI Evangelist",
+    "profilePicture": "https://sessionize.com/image/e597-400o400o1-PvFh9Aya17wuithUosyqvP.jpg",
+    "sessions": [
+      {
+        "id": 687327,
+        "name": "Building Digital Public Infrastructure (DPI)  -  BankServAfrica TCIB and PayShap"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Cape Town University",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "PhD Candidate/Researcher",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e6fbde75-b240-4dcb-a6c5-a65c4fa42cfc",
+    "firstName": "Michael",
+    "lastName": "Richards",
+    "fullName": "Michael Richards",
+    "bio": "Michael has worked in the payments industry for the past fifteen years, initially on Kenya's M-Pesa mobile money system, where he became chief architect. Since then, he has worked on other mobile money systems and, since its foundation, with the Mojaloop Foundation. He is a member of the Design Authority, the Product Council and the Community Council, and is the rapporteur of the Change Control Board, which oversees the Mojaloop family of APIs. In addition, he is the Mojaloop Foundation's representative for the ISO 20022 standards organisation, where he is deeply engaged in aligning the standard more closely with the requirements of Emerging Markets and Developing Economies (EMDE); he is also vice-convenor of the ISO 20022 API group. ",
+    "tagLine": "Mojaloop expert, standards practitioner, payments aficionado",
+    "profilePicture": "https://sessionize.com/image/adcd-400o400o1-THJRjoXtmvbgMdbdnz8i71.jpg",
+    "sessions": [
+      {
+        "id": 690760,
+        "name": "Cross-border payments and standards"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Infitx",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Fnance Services Principal",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "42e841a3-7a0b-4a96-86d1-cb0689c47382",
+    "firstName": "Nandini",
+    "lastName": "Harihareswara",
+    "fullName": "Nandini Harihareswara",
+    "bio": "Nandini Harihareswara is a Digital Finance, FinTech, Digital Development and Inclusive Digital Economies expert. She previously served as Senior Advisor on Inclusive Digital Economies, Gender Equality and Women’s Economic Empowerment for the UN Capital Development Fund. She also served as the Digital Finance Regional Technical Specialist from 2015-2019, responsible for the creation & implementation of the UNCDF Digital Economy Strategy in Zambia and Malawi. She also helped to author the Inclusive Digital Economies and Gender Equality Playbook, launched in 2021. In these roles, she worked with more 20 FinTechs, Banks, Telcos and e-commerce companies to successfully increase their women customers and partner MSME businesses, and increase their financial return on investment.\r\n\r\nShe was a founding member of the United States Agency for International Development (USAID) Digital Development Division. Prior to working for the Digital Development team, Nandini worked as an Investment Officer for the USAID Development Credit Authority Office, and a Presidential Management Fellow at the US Department of Transportation as well as the Urban Transport Division of the World Bank.\r\n\r\nShe is the author of numerous publications on the intersection of finance, technology and international development. Nandini has an MBA and a Masters in International Trade and Investment Policy from the George Washington University. She also holds a BS in Psychology and a BA in Political Science from the University of California at San Diego. \r\n",
+    "tagLine": "Digital Payments, Infrastructure & Inclusion Expert",
+    "profilePicture": "https://sessionize.com/image/9f4e-400o400o1-Hk3DaUGDCh6U66aJekcRv4.jpg",
+    "sessions": [
+      {
+        "id": 696099,
+        "name": "Immersive Debate: Is DPI Inherently \"Gender Neutral\"?"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Contigo Global LLC",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Digital Payments, Infrastructure & Inclusion Expert",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "1044e43b-8deb-46f3-8fab-e20275044ef2",
+    "firstName": "Neema",
+    "lastName": "Lugangira",
+    "fullName": "Neema Lugangira",
+    "bio": "Hon. Neema Lugangira (MP) is a Member of Parliament in Tanzania who bring forward extensive experience and successful track record in championing policy advocacy and legislative reforms across different sectors. \r\n\r\nNationally, Hon. Lugangira founded two NGOs; Agri Thamani, which is committed to ending malnutrition, address climate action and hosts the World Food Forum Tanzania Chapter; and Omuka Hub, focused on accelerating digital development, combat online violence on women in politics and hosts the African Parliamentary Network on Internet Governance (APNIG).\r\n\r\nInternationally, Hon. Lugangira is a Member of the Multi-Stakeholder Advisory Group of the United National Internet Governance Forum; Africa Representative to the Global Board of the Parliamentary Network on the World Bank and IMF; Member of the Executive Committee of the Scaling Up Nutrition (SUN) Movement, Africa Representative to Global Executive Board of the International Parliamentary Network on Education (IPNEd); Member of the Women Parliamentarians Network on Foreign and Security Policy for Development under the Munich Security Conference; among others. \r\n\r\nNotably, Hon. Neema Lugangira has advocated for nutrition to be a priority national agenda prior to being a Member of Parliament and has continued to do so as a Member of Parliament. To mention a few, her key achievements in this sphere include nutrition recognised as a key success factor for human capital development, nutrition being prioritized in 2020-2025 Election Manifestos of Three Political Parties in Tanzania, the Ministry of Agriculture launching the National Nutrition-Sensitive Action Plan, the Ministry of Education launching the National School Feeding Guidelines, Tanzania joining the School Meals Coalition, and mobilizing fellow Parliamentarians in Tanzania and across Africa to prioritise nutrition in their advocacy efforts. \r\n",
+    "tagLine": "Chair, African Parliamentary Network on Internet Governance (APNIG) and Member of Parliament Tanzania",
+    "profilePicture": "https://sessionize.com/image/14ad-400o400o1-J6kGsdEvFJ9GJ8wvHskNoU.jpg",
+    "sessions": [
+      {
+        "id": 731902,
+        "name": "Parliamentarian Perspectives: Fostering Inclusive Open Payments in Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "African Parliamentary Network on Internet Governance (APNIG)",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Chairperson",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "526711d3-3681-4fa1-aca6-d962efa1bb30",
+    "firstName": "Nicolo",
+    "lastName": "Zingales",
+    "fullName": "Nicolo Zingales",
+    "bio": "Nicolo Zingales is Professor of Information Law and Regulation at the law school of the Fundação Getulio Vargas in Rio de Janeiro. Fascinated by the interaction of law, technology and markets, he researches on a range of issues revolving around the roles and responsibilities of digital platforms and intermediaries in the online ecosystem.His research has been cited, among others, by the OCDE, THE UN Special Rapporteur for the Protection and Promotion of Freedom of Opinion and Expression, the UK House of Lords, and the European Parliament. ",
+    "tagLine": "Fundação Getulio Vargas ",
+    "profilePicture": "https://sessionize.com/image/7bd0-400o400o1-BRUxzhK94F9WwRLTEP5oS1.png",
+    "sessions": [
+      {
+        "id": 732747,
+        "name": "Competition and financial inclusion: competing or complementing goals in DPI & interoperability"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Fundação Getulio Vargas",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Professor",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "555b62a8-ce3b-4bb1-a549-5e008fb8a037",
+    "firstName": "Nyi Nyein",
+    "lastName": "Aye",
+    "fullName": "Nyi Nyein Aye",
+    "bio": "In 2016, Nyi established ThitsaWorks to develop data-driven solutions that enable financial institutions to efficiently manage payment, data and mi gate risks.  \r\n\r\nNyi has 28+ years of experience in public administration on, finance, fintech, software development, and financial inclusion. Prior to founding ThitsaWorks, Nyi had over 20 years of experience at the United Nations Headquarters in New York in finance and technology where he led a team of information technology professionals and software developers as Chief of Information Systems in the Department for General Assembly and Conference Management in his last position. ",
+    "tagLine": "ThitsaWorks, CEO",
+    "profilePicture": "https://sessionize.com/image/12b8-400o400o1-N175oq6wT7WFeksyWdoTeS.png",
+    "sessions": [
+      {
+        "id": 695511,
+        "name": "ThitsaX: Interconnected Nodes to Bridge Worlds"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "ThitsaWorks Pte. Ltd.",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Chief Executive Officer",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "1ef13e51-23b5-44c7-bfb1-a82af3b5a7a2",
+    "firstName": "Pedro",
+    "lastName": "Sousa Barreto",
+    "fullName": "Pedro Sousa Barreto",
+    "bio": "Have been doing software development, architecture and senior IT leadership positions teams for the last 30 years.\r\nSpecialized in large scale distributed systems for the past 12+ years.\r\nHelped several companies in multiple industries achieve higher scales and/or improve organizational performance.",
+    "tagLine": "Developer / Architect / Consultant for Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/3e74-400o400o1-PrrH5EwLcwab1q1DMivJqv.jpg",
+    "sessions": [
+      {
+        "id": 695515,
+        "name": "Cross-border inter-scheme transfer demo: from Rafiki to a Mojaloop switch"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "ILF / Cyberbones",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Developer/Architect",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "63e10977-23e9-4138-8d46-47351565ca2b",
+    "firstName": "Philip",
+    "lastName": "Green",
+    "fullName": "Philip Green",
+    "bio": "Philip Green is an experienced Technology Lead with a demonstrated history of working in the telecommunications, investment banking and aquaculture industries. He is skilled in Equities Trading Systems, Mobile Financial Systems, Aquaculture, Agriculture and Software Development. He is a well-rounded and strong information technology professional graduated from INSEAD. ",
+    "tagLine": "Technical Solutions Consultant, Mojaloop Foundation",
+    "profilePicture": "https://sessionize.com/image/6d3f-400o400o1-VeSEtx2ruhiSyAxo44hkDh.jpg",
+    "sessions": [
+      {
+        "id": 681475,
+        "name": "Empowering Emerging Economies: Mojaloop's Role in Inclusive Financial Access"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Mojaloop Foundation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Technical Solutions Consultant",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8c583b1f-4911-40e5-9c5a-3fdfc14c1181",
+    "firstName": "Pourya",
+    "lastName": "Omidi",
+    "fullName": "Pourya Omidi",
+    "bio": "Pourya Omidi works as a project developer for Waag’s Future Internet Lab and Commons Lab. He was eighteen years old when he moved to the Netherlands from Iran to study electrical engineering at TU Delft while mastering Dutch. After his study, he started his professional journey in the commercial climate and gained a lot of experience in the high-tech software and (embedded) hardware domain. For a period of four years, he co-founded a medical startup and worked on the development of a diagnostic tool for cardiac patients. Gradually, his interest in the ethics and impact of technology grew and for that reason he joined Waag to pursue this ambition. ",
+    "tagLine": "Waag futurelab, Project lead",
+    "profilePicture": "https://sessionize.com/image/7874-400o400o1-XqB86xSQjg38t837vG4gNx.jpg",
+    "sessions": [
+      {
+        "id": 732729,
+        "name": "Trust-based banking technical session"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Waag Futurelab",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Programme devoper",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "731d2f66-78b0-42fa-b5c4-fc7735a1a343",
+    "firstName": "Prudence",
+    "lastName": "Kalunga",
+    "fullName": "Prudence Kalunga",
+    "bio": "Prudence Chilufya Kalunga is a lecturer at ZCAS University in the School of Computing, Technology, and Applied Sciences, Computer Science Department. Prudence lectures Programming courses being C, C++, C#, Java, and Python. She also lectures courses in Software Engineering, Artificial Intelligence, IoT, Software Research Tools and Techniques, and the development of websites. She is a researcher and has published some journals and conference papers in ICT journals. She coordinates and prepares students who take part in hackathons and competitions that bring about innovation in the country of Zambia. Prudence sits as an Expert judge at the ZICTA innovation competition that is held every year. \r\n\r\nPrudence earned an MEng in software engineering from Nankai University and, a BSc Honors degree in Computing from Greenwich University. Currently, she is pursuing, a master’s in Data Science at Manipal University in India and her PhD in Computer Science at ZCAS University Zambia.",
+    "tagLine": " Lecturer at ZCAS University",
+    "profilePicture": "https://sessionize.com/image/4869-400o400o1-RrE2QE7n7ztoRRRbDq77Dh.jpg",
+    "sessions": [
+      {
+        "id": 695881,
+        "name": "Views from the Grassroots: Village Banking and Financial Inclusion in Southern Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "ZCAS UNIVERSITY",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "LECTURER",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "295582aa-8c62-450c-a296-6c45573ea0fd",
+    "firstName": "Raashi ",
+    "lastName": "Saxena ",
+    "fullName": "Raashi Saxena",
+    "bio": "Raashi Saxena is a renowned public interest technologist, trainer,  consultant and carries a wealth of experience in open-source technology, social impact, and practice. She holds several advisory positions, including with The Internet Rights & Principles Dynamic Coalition, Missions Publiques’s “We, the Internet” Project, and Threading Change, a sustainable fashion non-profit. As a consultant, her clients include Digital Communication Network, Accessibility Lab, studio intO, Superbloom, Accessibility Lab, The Innovation for Policy Foundation, Internews, Gapminder Foundation, and the IO Foundation. As a highly sought-after international speaker, Raashi has spoken on panels and conferences across Africa, Asia, Latin America, and Europe. Her expertise has been recognized in prominent publications such as the Mozilla 2022 Internet Health Report and Pew Research Center’s 2021 Report on Digital Spaces. The World Economic Forum has honored Raashi as one of the Six Inspirational Young Female Leaders, and a member of the Expert Network. She currently holds the position of Curator of the Global Shapers Bengaluru Hub. Additionally, she was recognized by Women Deliver as a Young Leader. Based in Bangalore, India, Raashi works tirelessly towards creating a positive social impact through her various global endeavours.\r\n\r\n",
+    "tagLine": "Public Interest Technologist ",
+    "profilePicture": "https://sessionize.com/image/99c0-400o400o1-NWoModDPsjoJDuxs9P1Y5D.jpg",
+    "sessions": [
+      {
+        "id": 732719,
+        "name": "Existing Ecosystem Approaches to Inclusive and Accessible Digital Financial Services"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Parabl ",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founding team",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3500dc3a-9dcb-4ff0-b6df-b5926071c3b0",
+    "firstName": "Rabeb",
+    "lastName": "Othmani",
+    "fullName": "Rabeb Othmani",
+    "bio": " Rabeb is a developer advocate  focusing on cloud communication APIs and conversational AI.  \r\n\r\nOther than writing code for a living, Rabeb advocates to bring more women and minorities into tech. She is leading the Women Who Code Network in Bristol.",
+    "tagLine": "Making Tech a better place for everyone ",
+    "profilePicture": "https://sessionize.com/image/25a9-400o400o1-3a-9dcb-4ff0-b6df-b5926071c3b0.e97ec69f-4162-4c00-b877-20b5ed3911a3.png",
+    "sessions": [
+      {
+        "id": 735788,
+        "name": "Pay the Web Forward with Web Monetization!"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": " Employee ",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Senior Product Manager",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "2156f39a-1a60-4c76-a328-ad3dcf22e8b7",
+    "firstName": "Radu",
+    "lastName": "Popa",
+    "fullName": "Radu Popa",
+    "bio": "-",
+    "tagLine": "Software Engineer - Web Monetization Extension",
+    "profilePicture": "https://sessionize.com/image/12a4-400o400o1-HNiM93iBqaj9fY4iGC9zYi.jpg",
+    "sessions": [
+      {
+        "id": 735788,
+        "name": "Pay the Web Forward with Web Monetization!"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "BreakPointIT, Interledger Foundation ",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Software Engineer",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6b847b73-a655-43ec-9771-d7d2f557944b",
+    "firstName": "Ritu",
+    "lastName": "David",
+    "fullName": "Ritu David",
+    "bio": "Ritu David is a global creative solutionist who merges data, design, human behaviour and technology to solve problems across industries.   As the founder of The Data Duck, she has established herself as a driving force in creative strategy, digital financial services, and technological innovation for social impact. Ritu's journey in fintech began serendipitously. She was in Nairobi on a consumer banking feasibility study when Safaricom, a groundbreaking mobile money service, revolutionized financial inclusion in Kenya. Collaborating with Safaricom laid the foundation for her continued work in digital payments and financial accessibility across the globe.\r\nRitu has consistently pushed the boundaries of what's possible in financial technology. She has been instrumental in designing voice interfaces for banking. Under her guidance, The Data Duck team has contributed to developing Africa's largest mobile banking systems and pioneering innovative payment methods, including tokenising voice using sound waves. \r\nHer work extends beyond traditional banking, encompassing projects that merge finance with sustainable development. Ritu personally designed the UX/UI for the Trailstone platform to aggregate energy from renewable energy farms and trade it in open markets, helping grids across the world increase the proportion of renewable energy.\r\n At The Data Duck, she leads creative strategies in brand storytelling and guerrilla marketing, focusing on crafting omnichannel customer experiences. Her approach is deeply rooted in data-driven insights, leveraging consumer behavior analysis to enhance customer lifetime value (CLV) and create memorable brand engagements. This multifaceted background allows her to bring a unique perspective to financial inclusion projects, blending user-centric design with cutting-edge technology.\r\nRitu's impact is particularly significant in emerging markets. In 2012, The Data Duck's collaboration with Leapfrog to price micro-insurance in Southeast Asia helped bring affordable financial products to underserved communities. By developing accessible digital infrastructure and secure payment systems, she has played a crucial role in expanding financial services to vulnerable populations across Africa, Asia, and the Middle East.\r\nRitu's multidisciplinary approach, which seamlessly integrates finance, technology, and consumer experiences, has established her as a sought-after expert in creating resilient and inclusive digital ecosystems. Her work consistently demonstrates a deep understanding of the delicate balance between innovation and accessibility, making her insights invaluable in the ongoing dialogue about the future of inclusive and accessible digital financial services.\r\nAs a speaker at the Interledger Summit 2024, Ritu brings a wealth of practical experience and innovative thinking to the discussion on \"Existing Ecosystem Approaches to Inclusive and Accessible Digital Financial Services.\" Her unique blend of creative strategy, technological innovation, and commitment to financial inclusion offers fresh perspectives on creating equitable and accessible financial systems in an increasingly digital world.",
+    "tagLine": "Founder, The Data Duck and Code for Climate",
+    "profilePicture": "https://sessionize.com/image/6cb2-400o400o1-MtxvCRQwCBbvgMZ3Gshf41.jpg",
+    "sessions": [
+      {
+        "id": 732719,
+        "name": "Existing Ecosystem Approaches to Inclusive and Accessible Digital Financial Services"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "The Data Duck",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "94599097-db2a-45a0-b950-f31019f13891",
+    "firstName": "Rob",
+    "lastName": "Reeve",
+    "fullName": "Rob Reeve",
+    "bio": "CEO of LexTego, one of the founding companies building Tazama - an Open Source Transaction Monitoring Platform. Rob is a senior Executive with a track record of delivering innovative Digital Financial Services. Experience in defining and delivering new financial products, combined with a deep understanding of the subsequent legal, technical and operational implications. Experience in more than 50 countries, across five continents in developed and developing markets.",
+    "tagLine": "CEO - LexTego, putting you in control of your payments",
+    "profilePicture": "https://sessionize.com/image/48d6-400o400o1-fqFkyxb4t6zNhdveppgEA1.jpg",
+    "sessions": [
+      {
+        "id": 695522,
+        "name": "Bridging communities with Rafiki: the migrant/remittances market for account-serving entities"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "LexTego Ltd",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "9bd85c6e-88b7-4d06-b8c8-0458dc200746",
+    "firstName": "Roberto",
+    "lastName": "Valdovinos",
+    "fullName": "Roberto Valdovinos",
+    "bio": "B.A. and M.A. in Logic and Philosophy (Pantheon-Sorbonne University), M.Phil. in Comparative Studies (Columbia University). Directed a migrant organization in the US and a national institute in Mexico. Works with migrants and marginalized communities in social justice and financial inclusion projects.",
+    "tagLine": "People's Clearinghouse, CFO",
+    "profilePicture": "https://sessionize.com/image/6f03-400o400o1-nBYkL9ViRZpwWWNKTJmPXY.png",
+    "sessions": [
+      {
+        "id": 695522,
+        "name": "Bridging communities with Rafiki: the migrant/remittances market for account-serving entities"
+      },
+      {
+        "id": 695515,
+        "name": "Cross-border inter-scheme transfer demo: from Rafiki to a Mojaloop switch"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "People's Clearinghouse",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CFO",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3e80acea-13f9-4fd2-8e9a-e4b715297d9a",
+    "firstName": "Sabine",
+    "lastName": "Schaller",
+    "fullName": "Sabine Schaller",
+    "bio": "Sabine has always been interested in Data Ownership and the Internet of Value. She works on the specification and implementation of open standards like the Interledger Protocol, Open Payments, and Web Monetization to allow for a Web where content can be paid for with hard currency instead of data.\r\nPrior to joining the Interledger Foundation, Sabine was the Research & Development Lead at Coil.",
+    "tagLine": "Engineering Manager @ Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/ce1c-400o400o1-GuPeZz64P4TsrKfKMVxrc7.jpg",
+    "sessions": [
+      {
+        "id": 754678,
+        "name": "Codius Fireside Chat"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Engineering Manager",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "677f8255-1bd2-40b9-8441-3acd0f1c829f",
+    "firstName": "Sarah",
+    "lastName": "Habib",
+    "fullName": "Sarah Habib",
+    "bio": "A recognised fintech for good  advocate, Sarah drives sustainable and impactful digital financial solutions through her deep customer research and product expertise",
+    "tagLine": "Fintech Strategist ",
+    "profilePicture": "https://sessionize.com/image/2a6e-400o400o1-4iYKYU7JVYREcYy1CUHryY.jpg",
+    "sessions": [
+      {
+        "id": 732717,
+        "name": "Financial Inclusion for Undocumented Communities: From Strategies to Practices"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Independent Consultant ",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Venture Strategist ",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3578cfa6-cd36-463c-a879-fe3df6f819c2",
+    "firstName": "Sarel ",
+    "lastName": "Myburgh",
+    "fullName": "Sarel Myburgh",
+    "bio": "Strategy and Research Officer & Africa Strategic Business Development BankservAfrica\r\n\r\nAs a Business and Strategy Management Consultant, Sarel has worked in a wide range of industries. He applied most of his knowledge to the financial sector, specifically to the payment and banking sectors. He is an accredited Chartered Management Accountant and holds multiple degrees.\r\n \r\nHe joined BankservAfrica Growth and Transformation Division in 2018 and responsible for multiple business and product innovations and interventions as part of BankservAfrica’s growth endeavours including but not limited to domestic processing hubs and domestic cash start-ups. \r\n\r\nMost prominently, he was responsible as lead designer of the cross-border payment scheme, TCIB (Transactions Cleared on an Immediate Basis) in 2019. More recently he headed the Strategy Business Development for the BankservAfrica’s Africa Business Development Division driving the TCIB mobilization and growth efforts.  \r\n",
+    "tagLine": "BankservAfrica",
+    "profilePicture": "https://sessionize.com/image/07eb-400o400o1-QSAcznJx1t3ghr31iw4NZW.png",
+    "sessions": [
+      {
+        "id": 687327,
+        "name": "Building Digital Public Infrastructure (DPI)  -  BankServAfrica TCIB and PayShap"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6b4980b6-a70f-413d-884d-28c3dd8daf16",
+    "firstName": "Savannah",
+    "lastName": "Koolen",
+    "fullName": "Savannah Koolen",
+    "bio": "Savannah Aleksandra Koolen (1985) is the founder and co-director of the Here to Support Foundation. Koolen studied at the dance academy but unfortunately she had to stop dancing early because of injuries. Her full life she is involved in politics, activism and art and after her study Art & Culture at the University in Maastricht she moved to Amsterdam. For ten years she has been working on how artists and artistic projects can support the struggle of minorities and refugees to equal rights, and strengthen the self-organised-,grassroots- movements. In 2007 she was a coordinator of the Nationwide campaign for funding for the arts, and since the start (2012) of refugee collective We Are Here in Amsterdam she supports their struggle organising educational, artistic projects to gain visibility and work on innovative plans. In 2013 she founded the Here to Support Foundation. In 2016,  the Here to Support Foundation won the Ab Harrewijn Prize under her leadership and in May 2017 Here to Support won the European Citizenship Award with the project We Are Here Media Academy. From June 2017, she was also campaign leader of GroenLinks Amsterdam for the winning, local elections in 2018 in Amsterdam and later joined the board of GroenLinks Amsterdam as president of the board in 2019.",
+    "tagLine": "Activist, Founder & CEO Here to Support Foundation",
+    "profilePicture": "https://sessionize.com/image/dc53-400o400o1-HhZSdEYvoSNVnDAX7xuPyh.jpg",
+    "sessions": [
+      {
+        "id": 732717,
+        "name": "Financial Inclusion for Undocumented Communities: From Strategies to Practices"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Here to Support",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder & Co-Director",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8a02eb2a-7947-4028-831b-b6dac7ea51fd",
+    "firstName": "Sen. Catherine",
+    "lastName": "Mumma",
+    "fullName": "Sen. Catherine Mumma",
+    "bio": "Delegate in the Interledger Summit 2024 Parliamentarian Track ",
+    "tagLine": "Senator, Kenya",
+    "profilePicture": "https://sessionize.com/image/1a91-400o400o1-F4Hd9Q5trP5yTHhgVyDU4.jpg",
+    "sessions": [
+      {
+        "id": 731902,
+        "name": "Parliamentarian Perspectives: Fostering Inclusive Open Payments in Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6b0e5bf6-b19d-4a1f-9977-4b4d03b984eb",
+    "firstName": "Smriti",
+    "lastName": "Parsheera",
+    "fullName": "Smriti Parsheera",
+    "bio": "Smriti Parsheera is lawyer and public policy researcher focused on issues at the intersection of technology and society. She is a current Interledger Research Ambassador working on a project to understand the lived experiences of digital and financial inclusion in the remote Himalayan district of Lahaul-Spiti in northern India. She is also a Non-Resident Fellow with the CyberBRICS Project at FGV Law School, Brazil and serves on the board of Point of View, an organization that explores digital technologies through a feminist lens.\r\n\r\nSmriti has contributed to numerous research publications and book projects on topics that include privacy and data governance, digital public infrastructure and competition policy. Her edited book, Private and Controversial: When Public Health and Privacy Meet in India, was published by HarperCollins in 2023. \r\n\r\nSmriti studied law at the National Law School of India University, Bangalore followed by a LLM from the University of Pennsylvania School of Law. She is currently pursuing a PhD in policy studies from the Indian Institute of Technology Delhi. ",
+    "tagLine": "Research Ambassador, Interledger Foundatin",
+    "profilePicture": "https://sessionize.com/image/7c9c-400o400o1-fJ4fuK7KHgfkU7Eacv4pug.png",
+    "sessions": [
+      {
+        "id": 729556,
+        "name": "The promise and peril of DPI for competition policy: 'Alt big tech' in the making?"
+      },
+      {
+        "id": 732187,
+        "name": "Meet the UN IGF Dynamic Coalition on Digital Financial Inclusion"
+      },
+      {
+        "id": 732747,
+        "name": "Competition and financial inclusion: competing or complementing goals in DPI & interoperability"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Research Ambassador",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "b136ab7f-e6f9-41ce-9e6c-935c5f0a5a3d",
+    "firstName": "Stefan",
+    "lastName": "Thomas",
+    "fullName": "Stefan Thomas",
+    "bio": "Stefan Thomas is the Co-Creator of the Interledger Protocol and Chairperson of the Board at the Interledger Foundation. He currently works on Dassie, an open-source, peer-to-peer implementation of Interledger.\r\n\r\nHe is also the Founder and CEO of Coil, a startup which created a \"subscription to the whole Web\" and the Open Web Monetization standard. Over the course of almost five years, Coil made about 78 billion payments over Interledger, providing the first proof- of-concept for the technology at scale.\r\n\r\nStefan was a prominent figure in the blockchain movement. As an early Bitcoin contributor, he produced the popular “What is Bitcoin?” video, introducing millions of users to Bitcoin, and created BitcoinJS, the first implementation of Bitcoin cryptography in the browser.\r\n\r\nAs CTO and one of the first employees at Ripple, Stefan designed new protocols for cross-border payments, now used by banks all over the world. As part of this work, he led the team that created Interledger, an open, Internet-like protocol for value transfer.\r\n\r\nStefan is a passionate supporter of financial access and worked with the Bill & Melinda Gates Foundation to develop Mojaloop, an open-source national payment switch that connects mobile wallets in developing markets.",
+    "tagLine": "Co-Creator of the Interledger Protocol",
+    "profilePicture": "https://sessionize.com/image/f90c-400o400o1-MxFVGBPu6HeUWJ74vEH7R9.jpg",
+    "sessions": [
+      {
+        "id": 762716,
+        "name": "How I Learned to Love Packetization"
+      },
+      {
+        "id": 754678,
+        "name": "Codius Fireside Chat"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Coil",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Co-Creator of the Interledger Protocol",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a86caa8f-cb2e-41a9-ac38-2ee2a6b5f0a0",
+    "firstName": "Taco",
+    "lastName": "van Dijk",
+    "fullName": "Taco van Dijk",
+    "bio": "Taco van Dijk is software developer at Waag Futurelab. Since 2008, he has been developing apps, installations and other software within the various labs and projects of Waag.",
+    "tagLine": "software developer at Waag Futurelab",
+    "profilePicture": "https://sessionize.com/image/f542-400o400o1-wL1AXtVu2cQmeLoBkJsVbV.png",
+    "sessions": [
+      {
+        "id": 732729,
+        "name": "Trust-based banking technical session"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Waag Futurelab",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Developer",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "585a769b-db7a-4c75-b1ba-4c4fe8015276",
+    "firstName": "Tadej",
+    "lastName": "Golobic",
+    "fullName": "Tadej Golobic",
+    "bio": "At 10 years old, I began my coding journey with VB6, setting the course for a lifelong tech odyssey. Graduating from the Faculty of Computer and Information Science at the University of Ljubljana, I delved into remote support software with a local enterprise. The 2017 crypto boom lured me into the crypto realm, leading to my pivotal role as a backend developer at GateHub in 2020. Today, I proudly serve as Infrastructure Team Lead, steering projects that power our digital future.",
+    "tagLine": "Technical Lead @ GateHub & DevOps Engineer / Consultant for Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/aeeb-400o400o1-HXBuaj6u1eQ7eETh4ykG6u.jpg",
+    "sessions": [
+      {
+        "id": 687571,
+        "name": "The Future of Payments in Your Pocket"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "I am employed by GateHub and I act as a DevOps consultant for Interledger Foundation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Technical Lead @ GateHub and DevOps Engineer / Consultant for Interledger Foundation",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e9505ac1-28e7-4bba-8be0-04c5a346a30c",
+    "firstName": "Tawanda",
+    "lastName": "Brandon",
+    "fullName": "Tawanda Brandon",
+    "bio": "Tawanda Brandon is a technology leader and developer with expertise in building software solutions, particularly at the intersection of technology and payments. He has worked on various projects across different industries, developing mobile apps and digital platforms that integrate seamless payment experiences. With a focus on innovation and delivering products from concept to market, Tawanda is passionate about creating impactful technology that simplifies financial transactions and enhances user experiences.",
+    "tagLine": "Tech Founder, CTO",
+    "profilePicture": "https://sessionize.com/image/2fc0-400o400o1-W97m8hM6dZuE34HQJotWPS.png",
+    "sessions": [
+      {
+        "id": 732595,
+        "name": "Building Trust and Advancing Open Payments in Africa’s Regulatory Ecosystem"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Snake Nation",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CTO",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "dadc8857-a4a4-459a-b484-bc803bde197d",
+    "firstName": "Timea",
+    "lastName": "Nagy",
+    "fullName": "Timea Nagy",
+    "bio": "Timea has been a software developer for many years, mainly passionate about developing frontend and user experience. She has been part of the interesting world of Interledger since the end of 2022.\r\n\r\nTogether with her team, she has built the Interledger Tesnet testing network, in order to help people better understand the possibilities of Open Payments.\r\n\r\nHer passion is travelling, discovering as much as possible about this wonderful world we live in. Her flex is that she has travelled to all 7 continents.",
+    "tagLine": "Engineering Manager & Frontend Developer, BreakPointIT - Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/9842-400o400o1-HfGvB5bBgGDQTHvfYHCGz7.jpg",
+    "sessions": [
+      {
+        "id": 735787,
+        "name": "Rafiki & Ecosystem Updates"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "BreakPoint IT",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Engineering Manager and Frontend Developer for Interledger",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "405070c5-a46c-4f12-9b68-5b1ed17e98a1",
+    "firstName": "Uchi",
+    "lastName": "Uchibeke",
+    "fullName": "Uchi Uchibeke",
+    "bio": "Developer, and Founder. DevRel leader with track record growing communities around the globe",
+    "tagLine": "Founder and CEO Chimoney.",
+    "profilePicture": "https://sessionize.com/image/79d3-400o400o1-Jfmm3fGu2fRS45EHq3ZcFq.jpg",
+    "sessions": [
+      {
+        "id": 723325,
+        "name": "Introducing Chimoney App: The Interledger App bridging Canada and Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Chimoney",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "f6fc2063-f026-473a-9f14-8a016824c3a0",
+    "firstName": "Unathi",
+    "lastName": "Pukwana",
+    "fullName": "Unathi Pukwana",
+    "bio": "Unathi Pukwana Mantakana is an entrepreneur, event host and a speaker.  She is passionate about programmes that empower society, particularly women. She is a leader of society and a Chief Executive Officer of Imizamo Yomfazi stokvels and burial society.",
+    "tagLine": "Entrepreneur and CEO of Imizamo Yomfazi",
+    "profilePicture": "https://sessionize.com/image/e352-400o400o1-QiazdCFtyinxDXMrytE8dk.jpg",
+    "sessions": [
+      {
+        "id": 695881,
+        "name": "Views from the Grassroots: Village Banking and Financial Inclusion in Southern Africa"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "56d4c506-d323-41b0-9854-605d76121d86",
+    "firstName": "Victoria",
+    "lastName": "Coker",
+    "fullName": "Victoria Coker",
+    "bio": "Victoria Coker is a multi-disciplinary artist and entrepreneur. She graduated from St. John’s University with a Bachelor’s in communication arts. Ms. Coker has more than ten years of design and marketing experience and has worked for organizations such as Carnegie Hall, Bric Arts Media, and Oxford University Press.\r\n\r\nIn 2017, she launched the Black Web Fest, an organization dedicated to celebrating Black creatives and digital content. Her goal is to build a legacy to empower her community. ",
+    "tagLine": "Black Web Fest, Founder",
+    "profilePicture": "https://sessionize.com/image/7a0f-400o400o1-wwBD1JwXq6tqFKvnCvUVTi.jpg",
+    "sessions": [
+      {
+        "id": 732724,
+        "name": "Unbanked in America: Exploring the Financial Divide"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Black Web Fest",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "07f391c3-1f00-4c7d-a8f8-162d5a2dce73",
+    "firstName": "Victory",
+    "lastName": "Brown",
+    "fullName": "Victory Brown",
+    "bio": "Victory Brown is a researcher, community builder, strategist, and designer who interacts with designers and software owners about the state of digital design. At Design Matters, she works as an organizer for their yearly digital design event. She is also an open-source community leader at sustain OSS, a researcher, and a design coach on Superbloom's coaching program with the German Prototype Fund, She is also a full-time design researcher at Superbloom, working on diverse projects at the intersection of community, open source, and design. With over four years of experience spanning these roles, she has carved out a niche as a multidisciplinary designer, designing experiences for communities, conferences, and projects through content, experience, or sustainability.\r\n\r\n\r\n\r\n\r\n\r\n",
+    "tagLine": "DESIGN RESEARCHER @Superbloom",
+    "profilePicture": "https://sessionize.com/image/f61d-400o400o1-Y9Gu6xyrTCpvwcikgJxTji.png",
+    "sessions": [
+      {
+        "id": 732719,
+        "name": "Existing Ecosystem Approaches to Inclusive and Accessible Digital Financial Services"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Superbloomdesign",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "design researcher",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3a71dfe5-a936-40b8-853b-46d1652952fe",
+    "firstName": "Xiaoji",
+    "lastName": "Song",
+    "fullName": "Xiaoji Song",
+    "bio": "Xiaoji Song (she/they) is an artist, (interdisciplinary) researcher, and creative practitioner based in Berlin. Growing up in China and trained in Europe, Xiaoji works on socially relevant and community-specific experiences, often with the local networks, NGOs, and local cultural and political institutions, mediated by texts, images, games, and performances. Working in the liminal spaces of political theory, practice, and art, Xiaoji's interests include techno-politics, networked social movement, border practices, and the performative aspect of political memory. ",
+    "tagLine": "Artist and Interdisciplinary researcher ",
+    "profilePicture": "https://sessionize.com/image/8cc7-400o400o1-KBYLpKTMU3b2xjrwJF8dZT.png",
+    "sessions": [
+      {
+        "id": 732717,
+        "name": "Financial Inclusion for Undocumented Communities: From Strategies to Practices"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 70799,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Independent",
+        "sort": 24,
+        "answerExtra": null
+      },
+      {
+        "id": 70800,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Artist and Researcher",
+        "sort": 25,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  }
+]

--- a/src/data/sessionize/2024-talks.json
+++ b/src/data/sessionize/2024-talks.json
@@ -1,0 +1,1750 @@
+[
+  {
+    "groupId": null,
+    "groupName": "All",
+    "sessions": [
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "753024",
+        "title": "Interledger Foundation Keynote with President & CEO Briana Marbury",
+        "description": "Briana Marbury will open the Summit with an overview of the year the Interledger Community has had and a look at where it is going.",
+        "startsAt": "2024-10-26T09:30:00",
+        "endsAt": "2024-10-26T10:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "60ca230a-ed4a-492b-b423-f4fbd279c871",
+            "name": "Briana Marbury"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Aiming for about 20 minutes of slides followed by 5-10 minutes of questions.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "762716",
+        "title": "How I Learned to Love Packetization",
+        "description": "One aspect that consistently perplexes Interledger newcomers: Packetization. In this talk, Stefan explains the choice to break large payments down into tiny packets and how this approach makes protocols hyper-efficient, scalable, and flexible.",
+        "startsAt": "2024-10-26T10:00:00",
+        "endsAt": "2024-10-26T10:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "b136ab7f-e6f9-41ce-9e6c-935c5f0a5a3d",
+            "name": "Stefan Thomas"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Several key players of account-serving entities interested in using Rafiki for remittances will discuss the value of using DPI, the challenges of the remittances’ market, its policies and regulations, and the impact digital financial services can have for underrepresented groups such as migrants in the United States and their families in other countries.\r\n\r\nThis panel will be a useful introduction to the complexities of remittances’ regulation and how new technologies such as Rafiki can adapt to it and have a thorough social impact.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "695522",
+        "title": "Bridging communities with Rafiki: the migrant/remittances market for account-serving entities",
+        "description": "This panel will bring together CEOs of account-serving entities in the US interested in implementing Rafiki so that their users may send remittances, along with specialists in remittances’ regulation, in a provocative discussion around remittances, migrant populations and the use of Rafiki.",
+        "startsAt": "2024-10-26T11:00:00",
+        "endsAt": "2024-10-26T11:45:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "9bd85c6e-88b7-4d06-b8c8-0458dc200746",
+            "name": "Roberto Valdovinos"
+          },
+          {
+            "id": "69f97e3e-d0c7-4fe3-9373-7cbcd223c6c8",
+            "name": "Adrian Hope-Bailie"
+          },
+          {
+            "id": "94599097-db2a-45a0-b950-f31019f13891",
+            "name": "Rob Reeve"
+          },
+          {
+            "id": "be411f3c-9578-4b55-9b6b-63511ad8e986",
+            "name": "Julie Guetta"
+          },
+          {
+            "id": "ccda5cd7-aeb2-4dd1-97a9-87979237f62f",
+            "name": "Enej Pungercar"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267998,
+                "name": "Panel (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "TBD",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "735787",
+        "title": "Rafiki & Ecosystem Updates",
+        "description": "Join us for an update on Rafiki: the current integrators, additions over the last year, future plans, and the growing Rafiki-powered Test Network. In this session, we will demo the Test Wallet, the Test eCommerce application and Interledger Pay.",
+        "startsAt": "2024-10-26T11:00:00",
+        "endsAt": "2024-10-26T11:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "dadc8857-a4a4-459a-b484-bc803bde197d",
+            "name": "Timea Nagy"
+          },
+          {
+            "id": "a63af0da-3b51-42ad-9775-ff52212884ba",
+            "name": "Max Kurapov"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The talk will draw upon India's experience with the UPI system to outline the promise and peril of DPIs in the payments sector from a competition policy perspective. This discussion is also connected with the global trend towards the adoption of DPI and building suitable safeguards around it, including in forums like the G20 and the UN interim report. \r\n\r\nDrawing upon previously published work on this subject, I will present the rationale for the use of the term 'alt big tech' in this context and invite feedback from the participants on this framing. The overall goal of the session would be to collectively reflect on the competition policy implications of payment DPIs and the path toward building inclusive, innovation-friendly and competitive payment infrastructures.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "729556",
+        "title": "The promise and peril of DPI for competition policy: 'Alt big tech' in the making?",
+        "description": "Many countries have reaped the benefits of financial inclusion, efficiency and scale from building DPIs in the field of digital payments. India's Unified Payments Interface (UPI) and the Brazilian PIX system are among the commonly cited examples. A large part of the success of such systems can be attributed to the design principle of pursuing interoperability among market players through the use of standardized protocols and common infrastructure. This makes for an interesting point of intersection between the rise of DPIs and their competition policy implications. The United Nation's interim report on digital public infrastructure (DPI) also recognizes the importance of fair market competition as one of the foundational principles for safe and inclusive DPI. \r\n\r\nAn exploration of the competition effects of DPI would include both the pro-competitive gains from interoperability and innovation and possible threats to competition. For instance, certain DPIs models could give rise to issues of market concentration, infrastructural lock-in, gatekeeping by DPI operators and the use of regulatory coercion to shape market outcomes. Many of these concerns are reminiscent of the challenges posed by the big tech industry, prompting the exploration of whether DPI giants could end up emerging as the new 'alt big tech'?",
+        "startsAt": "2024-10-26T11:00:00",
+        "endsAt": "2024-10-26T11:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "6b0e5bf6-b19d-4a1f-9977-4b4d03b984eb",
+            "name": "Smriti Parsheera"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48362,
+        "room": "Room 11: Workshops & Talks",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "We will start with a walk through the product side of Web Monetization. After we get a grip of the why, we will cover the how part, the technical implementation. ",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "735788",
+        "title": "Pay the Web Forward with Web Monetization!",
+        "description": "The ability to transfer money has been a long-standing omission from the web platform. As a result, the web suffers from a flood of advertising and broken business models. Web Monetization provides an open, native, efficient, and automatic way to compensate creators, pay for content, and support crucial web infrastructure.  \r\n\r\nIn this session, we will cover the latest updates of the Web Monetization implementation. The team will also demo the Web Monetization Extension, now in a private beta testing phase.",
+        "startsAt": "2024-10-26T11:30:00",
+        "endsAt": "2024-10-26T12:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "3500dc3a-9dcb-4ff0-b6df-b5926071c3b0",
+            "name": "Rabeb Othmani"
+          },
+          {
+            "id": "2156f39a-1a60-4c76-a328-ad3dcf22e8b7",
+            "name": "Radu Popa"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "I will address the following main topics in my talk:\r\nKEY TOPICS:\r\n1)Introduction to Interledger and Open Payments:\r\n2)What a high-level overview of Interledger protocol entails.\r\n3)The importance of open payments for digital economy.\r\n4)Role of AI in Enhancing Payment Security:\r\n5)Continuous monitoring as well as real-time risk mitigation.\r\n6)AI algorithms that learn from new threats to ensure tight security.\r\n7)AI-Driven Smart Contracts:\r\n8)How smart contracts enforce security protocols.\r\n9)Dynamic adaptation of transaction rules according to real-time threat assessments\r\n10)Case studies: Application in digital content platforms.\r\n11)Real-Time Threat Assessment:\r\n12)Using AI to analyze IP addresses and transaction patterns\r\n13)Detecting irregularities and preventing frauds\r\n14)Creating a Trustworthy Environment:\r\n15)Secure financial interactions that build trust between users and developers.\r\n16)Strengthening safety and efficacy of digital transactions\r\n\r\n\r\nFuture of FinTech:\r\nSetting new standards for secure and intelligent financial transactions.\r\nThe evolving landscape of FinTech with AI and cybersecurity integration.\r\nLearning Outcomes: Integrate artificial intelligence (AI) with cybersecurity within the framework of the Interledger protocol. Have an understanding about how artificial intelligence (AI) is able to mitigate real time risks automatically. Know-how about various ways by which security based on open payments can be enhanced through smart contracts powered by AI. Future directions, implications, etc.\r\n\r\nSession Format:\r\nFormat: Talk or Demos/workshops followed by Q&A\r\nAudience: Professionals and enthusiasts in FinTech, AI, cybersecurity, and digital payments.\r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "732644",
+        "title": "Advancing Secure and Intelligent Transactions: Integrating AI and Cybersecurity in Open Payments",
+        "description": "I will demonstrate how artificial intelligence (AI) and cybersecurity can be integrated into open payments for Interledger.I also have 2 publications in the related field. It has started a new period of secure and smart monetary transaction processes. AI-driven algorithms are capable of keeping an eye on payment activities continuously to detect and mitigate risks in real-time. Thus, this additional security layer guarantees not only protecting users or digital authors from fraud but also securing the integrity as well as confidentiality of their deals. This means that using advanced models, the system can learn from new threats making it a strong defense mechanism that is constantly evolving along with cyber threats. \r\n\r\n\r\nOne of the major innovations in this space is AI-driven smart contracts that enforce security protocols by themselves. These contracts allow dynamic adaptation of transaction rules depending on real-time threat assessments thereby making sure only genuine and authorized payments are processed. For instance, a digital content platform may apply these smart contracts to automatically verify users and creators’ authenticity protecting the system from ill-willed individuals who could exploit it. Additionally, taking into account also IP addresses, AI algorithms analyse transaction patterns so as to identify any irregularities which would provide an additional layer of safety. This combination of open payments with AI and cybersecurity creates an environment filled with trust that allows users and developers to interact with confidence knowing that their financial interactions are secured by advanced technology. By doing this, it not only boosts the security and effectiveness of digital transactions but also sets a new standard for the future of FinTech.\r\n",
+        "startsAt": "2024-10-26T11:30:00",
+        "endsAt": "2024-10-26T12:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "256e1583-4245-4529-bd87-6fa39846b5a7",
+            "name": "Akshat Sharma"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              },
+              {
+                "id": 268001,
+                "name": "Interledger Innovation Exhibition"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48362,
+        "room": "Room 11: Workshops & Talks",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Discussing real world opportunities and challenges for deploying DPI infrastructure in Africa ",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "687327",
+        "title": "Building Digital Public Infrastructure (DPI)  -  BankServAfrica TCIB and PayShap",
+        "description": "Immediate cross-border payments across the SADC region and beyond",
+        "startsAt": "2024-10-26T11:45:00",
+        "endsAt": "2024-10-26T12:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "6caa3775-97c0-4972-827a-f10d7ee0f426",
+            "name": "Michael Mbuthia"
+          },
+          {
+            "id": "3578cfa6-cd36-463c-a879-fe3df6f819c2",
+            "name": "Sarel Myburgh"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267998,
+                "name": "Panel (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "1.- Introduction to Wallet Guru and Paystreme:\r\nBrief overview of our company and the Paystreme platform.\r\nObjectives of the session.\r\n\r\n2.- Enhancing User Experience:\r\nReal-time payments for content consumption.\r\nElimination of rigid subscription models.\r\nEnabling unbanked or underbanked consumers access streaming services.\r\n\r\n3.- Personalization and Flexibility:\r\nEnabling streaming companies to offer hyper-personalized services.\r\nTailored content and pricing options based on user preferences.\r\n\r\n4.- Impact on Business Model:\r\nDriving increased user engagement and satisfaction.\r\nReducing customer churn.\r\nOpening new revenue streams for streaming services.\r\nExpand customer base \r\n\r\n5.- Technical Aspects:\r\nOverview of Paystreme's basic architecture and back-end design.\r\nIntegration challenges faced and solutions implemented.\r\nAddressing utility company architecture limitations.\r\n\r\n6.- Interactive Q&A:\r\nAudience engagement and feedback.\r\nDiscussion on the potential of Paystreme to reshape the streaming industry.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "695709",
+        "title": "Wallet Guru: Revolutionizing the Streaming Industry with Interledger’s Streaming Payments",
+        "description": "Join us for a compelling session on Wallet Guru’s Paystreme, an innovative payment streaming platform designed to revolutionize the video streaming industry using the Interledger Protocol. Discover how Paystreme enables real-time, secure microtransactions, providing a flexible and efficient payment solution for services such as mobile phone coverage, broadband internet, pay-TV, and streaming content. This session will explore the transformative potential of Paystreme, highlighting its impact on user experience and business models in the streaming industry.",
+        "startsAt": "2024-10-26T12:00:00",
+        "endsAt": "2024-10-26T12:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "5e27eb01-d22e-4db5-b6ad-0ce26d1a3a22",
+            "name": "Fernando Almiñana"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Introduction – Why Sharing Matters\r\n- Alex will briefly discuss the past and present state of hyperlinks and sharing on the Internet.\r\n\r\nUnderstanding Gib\r\n- Alex will briefly discuss how Gib works with Web Monetization to enhance the capabilities of hyperlinks.\r\n\r\nDemo 1 – Speed Matters\r\n- Audience will participate in a first-come-first-served link share.\r\n\r\nDemo 2 – Fair Shot\r\n- Audience will participate in an equitable link share.\r\n\r\nPartnering with Gib\r\n- Alex will highlight opportunities for community collaboration, integration, and partnership with Gib.\r\n\r\nQ&A\r\n- Brief question and answer session.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "732580",
+        "title": "Sharing is Caring – Using Web Monetization to Expand Access and Engagement with Gib",
+        "description": "Join Alex from Gib and learn how Web Monetization enables content creators to earn money online through paid sharing. He’ll explain why this type of sharing matters and how it compares to current methods.\r\n\r\nYou'll get to try out Gib, a Grant for the Web project, right there in the session. See for yourself how it works with a live audience demo! You can test two different ways of accessing this content - one where speed counts, and another that gives everyone a fair shot.\r\n\r\nAlex will also demonstrate how Gib brings together new sharing methods and easy-to-use payment features. This combination makes earning from your content simpler than ever.\r\n\r\nIf you're interested in working with Gib, they are also looking for partners and new ways to use their system. Don't miss this chance to see the future of online content earning.\r\n",
+        "startsAt": "2024-10-26T12:00:00",
+        "endsAt": "2024-10-26T12:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "b030bca8-340c-46fc-945c-dfb865e65b63",
+            "name": "Alex Mozeak"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48362,
+        "room": "Room 11: Workshops & Talks",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "1. Opening Remarks and Introduction (3 minutes)\r\n* Welcome and introduction to the session.\r\n* Overview of the session’s objectives and key themes.\r\n* Introduction of each Parliamentarian.\r\n\r\n2. Opportunities and Challenges of Open Payments (15 minutes)\r\n* Discuss the adoption and implementation by banks, digital wallet providers, and mobile money providers of Open Payments in Africa.\r\n* Promising use cases of Open Payments for SMEs, nonprofits, and individuals.\r\n\r\n3. Aligning Open Payments with Human Rights Principles (8 minutes)\r\n* Examination of how Open Payments deployments serve the public good.\r\n* Importance of alignment with the United Nations Guiding Principles on Business and Human Rights.\r\n* Ensuring ethical practices and preventing human rights abuses.\r\n\r\n4. Advancing Digital Financial Inclusion and Economic Growth (8 minutes)\r\n* Strategies for fostering pan-African innovation in digital financial services.\r\n* Importance of regulatory frameworks that support inclusive digital financial services.\r\n* Ensuring accessibility for underrepresented groups and vulnerable populations.\r\n* Recent regional political developments impacting digital financial inclusion.\r\n\r\n5. Closing Remarks and Summary (7 minutes)\r\n* Summarization of key points discussed during the session.\r\n* One minute closing remark from each Parliamentarian. “Final thoughts on the future of digital public infrastructure and financial inclusion in Africa.”\r\n* Thank you, and closing of the session.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "731902",
+        "title": "Parliamentarian Perspectives: Fostering Inclusive Open Payments in Africa",
+        "description": "This session will bring together four Members of Parliament from various African countries for a mainstage discussion on the role of policy and regulation in developing responsible, ethical, open payment systems in Africa to enhance digital financial inclusion.\r\n\r\n​​In a world increasingly reliant on digital connectivity, access to digital financial services remains a crucial determinant of economic empowerment and social development. Unfortunately, 400 million African adults are excluded from the formal financial system. This gap has left people reliant on cash or informal providers, which is costly and risky and leaves them vulnerable to economic instability. Interledger is unlocking access to the formal financial system and digital financial services for the financially excluded through collaborations with governments, central banks, the private sector, and development institutions.\r\n\r\nThis discussion will explore the opportunities and challenges associated with adopting Open Payments, an open API standard that can be implemented by account servicing entities such as banks, digital wallet providers, and mobile money providers. The discussion will cover how Interledger-enabled Open Payments facilitate interoperability in the setup and completion of payments for various use cases that are of interest to small and medium-sized enterprises, nonprofit organizations, and individuals. \r\n\r\nIn particular, the parliamentarians will discuss (1) how and why deployments of the Open Payments standard serve the public good, (2) whether these efforts align with human rights principles as guided by the United Nations Guiding Principles on Business and Human Rights, and (3) how advancing digital financial inclusion fosters economic participation and growth in their respective country.\r\n\r\nThe parliamentarians will provide insights into recent, relevant, regional, and national political developments and explore strategies for fostering pan-African innovation in digital financial services. They will also discuss the importance of regulatory frameworks that support ethical practices and prevent human rights abuses, drawing on examples from their respective countries, and emphasize the importance of digital financial services being accessible to underrepresented groups and vulnerable populations. \r\n\r\nIntended for a general audience, this session will provide a platform for African parliamentarians to share their perspectives on how regulatory frameworks can support the development of inclusive and ethical digital payment systems. For the broader Interledger ecosystem, this session will offer attendees insights into the regulatory landscape and policy considerations that drive the development and adoption of digital financial infrastructure.\r\n\r\nNeema K. Lugangira, a Member of Parliament from Tanzania, will co-curate the panelists for this mainstage discussion with the involvement of the Interledger Foundation.",
+        "startsAt": "2024-10-26T13:30:00",
+        "endsAt": "2024-10-26T14:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "27429f38-3846-488f-9e53-58837c0b6842",
+            "name": "Ayden Férdeline"
+          },
+          {
+            "id": "1044e43b-8deb-46f3-8fab-e20275044ef2",
+            "name": "Neema Lugangira"
+          },
+          {
+            "id": "53ba9e9d-d014-4133-bd50-4d7c97a470fd",
+            "name": "Hon. Esther Passaris"
+          },
+          {
+            "id": "8a02eb2a-7947-4028-831b-b6dac7ea51fd",
+            "name": "Sen. Catherine Mumma"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267998,
+                "name": "Panel (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The session will both outline a practical case study of grassroots financial inclusion, centring the voices of those directly involved in the practice, and highlight the perspectives shared through the F|M award recipient, 'Sikhula Sonke.'\r\n\r\nThe agenda is as follows:\r\n\r\n1. (6-7 minutes:) Introduction and Context\r\n\r\na) Briefly introduce the members of Masibebanye village bank from Khayelitsha, South Africa, including a description of the community of Makhaza, Khayelitsha.\r\n \r\n b) Incorporate audio storytelling with interviews with the village banking members from the Sikhula Sonke creative project. \r\n\r\nc) Outline attitudes around financial institutions in context of historic financial exclusion.\r\n\r\nd) Situate village banks as a grassroots form of financial inclusion and open payments, bolstering communities’  cultural and financial resilience.\r\n\r\n2. Conversation with the Village Bankers (15 minutes)\r\n\r\na) In conversation between Jon Adam Chen, Esther Mwema and leaders of Masibebanye, discuss the context behind the creation of the village bank.\r\n\r\nb) Discuss how the group became involved with the Sikhua Sonke project and the key insights that were shared.\r\n\r\nc). Where are they now? How has the village bank evolved in the last year and what have their savings been used towards?\r\n\r\nd) How do the members define wealth?\r\n\r\ne) What is the future of village banking and financial inclusion? How can we better bridge the world between the grassroots and innovative practices?\r\n\r\n3. Two minutes: Play original music recording (“Makabongwe”) created for the Sikhula Project\r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "695881",
+        "title": "Views from the Grassroots: Village Banking and Financial Inclusion in Southern Africa",
+        "description": "The session builds upon 2023 Interledger F|M awardees, Esther Mwema and Jon Adam Chen’s creative project, 'Sikhula Sonke: Living Archives of Afrofuturist Village Banking.’\r\n \r\nThrough exploring the  practice of village banking in southern Africa, the session will introduce audiences to the grassroots, locally embedded approach to financial inclusion and open payments. Providing a rare opportunity for audiences to learn from community leaders of village banks in South Africa and village banking experts from Lusaka, Zambia, the session will be host to novel perspectives rooted in African practices of financial inclusion.\r\n \r\nThe session will provide an opportunity for the village banking community members featured in Sikhula Sonke to share their knowledge and achievements through participation in the Indigenous system of a rotating savings and credit association, including how it has empowered themselves and their communities to improve their quality of life. In addition, community leaders will share their involvement in the unique Sikhula Sonke project. The discussion with community leaders from Khayelitsha and Lusaka, Zambia will be combined with audio storytelling and will promote the knowledge that already exists within communities in the host city of Cape Town, South Africa. The session will prompt listeners to re-evaluate how to think about money and wealth.\r\n\r\nFor more information on the Sikhula Sonke project, visit the website: https://www.sikhulasonke.net/\r\n",
+        "startsAt": "2024-10-26T14:30:00",
+        "endsAt": "2024-10-26T15:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "e8d66139-9a11-471d-8feb-060d95b32f04",
+            "name": "Jon Adam Chen"
+          },
+          {
+            "id": "596d5e24-c923-4716-adfa-2c18d07d9e43",
+            "name": "Esther Mwema"
+          },
+          {
+            "id": "731d2f66-78b0-42fa-b5c4-fc7735a1a343",
+            "name": "Prudence Kalunga"
+          },
+          {
+            "id": "f6fc2063-f026-473a-9f14-8a016824c3a0",
+            "name": "Unathi Pukwana"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267998,
+                "name": "Panel (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Financial Crime, and in particular Fraud, is top-of-mind for Financial Service Providers of all sizes and levels of maturity. The solution space is dominated by expensive commercial products and smaller and emerging operators rarely have access to effective solutions. Service providers may be one major fraud incident away from crippling customer attrition or devastating regulatory fines.\r\n\r\nTazama offers an open source answer to what has traditionally been a very costly problem to solve, and possibly an even more costly problem to ignore. Tazama aims to help organizations protect their customers against fraud, especially the most vulnerable of their customers.\r\n\r\nThe Interledger Foundation is a crucial platform from which to reach a vast and influential Web 3.0 finance-focused audience and through their support, democratize effective fraud detection and prevention for the benefit of all.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "684918",
+        "title": "Tazama Real-Time Open Source Software for Fraud Detection",
+        "description": "Tazama is a recently launched project in the Linux Foundation. Tazama offers open source real-time transaction monitoring software for fraud and money-laundering detection.\r\n\r\nOur presentation introduces the product and its origin story, from its ideation as one of the Bill & Melinda Gates Foundation's Level One principles, to its MVP launch in April 2022 and ultimately its integration into the Linux Foundation.\r\n\r\nWe will provide an overview of our mission, specifically to enable financial inclusion by promoting trust in digital financial ecosystems.\r\n\r\nWe will also provide insight into our adjacent work in establishing a standards body that will collect and publish standards for reporting, sharing and actioning information on Financial Crime.\r\n\r\nFinally we will present the product itself to give the audience an overview of the features, capabilities and context within their own ecosystems.",
+        "startsAt": "2024-10-26T14:30:00",
+        "endsAt": "2024-10-26T15:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "1118e56c-d6bd-4b8e-ae6a-80a58932e45a",
+            "name": "Greg McCormick"
+          },
+          {
+            "id": "dcf728ce-db55-4b40-8d9c-942473b14715",
+            "name": "Justus Ortlepp"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Taking a group of people through an immersive debate where they themselves have to make convincing arguments either for or against the “neutrality” of DPI infrastructure (including ID, data systems and payment systems). This fast paced session will help session participants live the real debates happening around the world as governments and private sector are building various parts of their national digital public infrastructure both piecemeal and collectively. This debate will require participants to actively speak, share their experiences and knowledge to try to “win” the debate. There will be reflections at the end to better understand how to build more inclusive DPI in the countries participants work. \r\nThe Brief Run of Show is Below (80 minutes):\r\n9 minutes set up - Sharing the Debate Prompt, Context for both sides\r\n5 minutes - Random Division of Groups to Pro/Con/Judge\r\n15 minutes - Prep time for Each Group, with Expert Consultations from Facilitators\r\n1 minute - Flip a coin to see who goes first\r\n10 minutes - Side 1 Presents Arguments\r\n10 minutes - Side 2 Presents Arguments\r\n15 minutes - Q&A from Judges to both sides\r\n5 minutes - Judges Confer, announce winner\r\n10 minutes - Reflections from at least one Pro, one Con, and one Judge\r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "696099",
+        "title": "Immersive Debate: Is DPI Inherently \"Gender Neutral\"?",
+        "description": "The best way to learn is sometimes to argue both sides of a question. In this session, we offer participants an opportunity to get up out of their seats and actively debate each other on the topic of whether Digital Public Infrastructure is Inherently Gender Neutral.  \r\n\r\nYou will be randomly assigned to be on the side of “Pro”, “Con”, or a judge. With the help of DPI Expert Facilitators, you will make arguments and ask questions to see who “wins”. You will better understand the reality of building inclusive DPI, issues for policy makers, regulators, and private sector; as well as how to build social capital and capacity for those that need the benefits of DPI the most. \r\n\r\nWhatever your assumptions coming in, we promise a fun, fast-paced ride that will leave you walking out the door knowing more than when you walk in.\r\n",
+        "startsAt": "2024-10-26T14:30:00",
+        "endsAt": "2024-10-26T16:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "42e841a3-7a0b-4a96-86d1-cb0689c47382",
+            "name": "Nandini Harihareswara"
+          },
+          {
+            "id": "a6ac7ec7-a053-486c-8778-7294f707c0ab",
+            "name": "Lukonga Lindunda"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 268000,
+                "name": "Workshop (80 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48362,
+        "room": "Room 11: Workshops & Talks",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "1. Brief introduction of ThitsaX connectors (Nyi Nyein Aye)\r\n2. ThitsaX demonstration (Aung Mon Ko)\r\n3. Q&A ",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "695511",
+        "title": "ThitsaX: Interconnected Nodes to Bridge Worlds",
+        "description": "ThitsaX connectors are interconnected nodes that facilitate cross-ledger transactions. They leverage the Interledger Protocol to route and process payments across various payment systems and core back-end systems of different types of financial institutions, enabling transfers between diverse ledgers and networks. This network expansion promotes financial inclusion and creates an easily accessible and interconnected financial ecosystem. ThitsaX connectors will enable secure transactions across diverse payment networks, promoting efficiency and cost-effectiveness. During this session, cross-ledger transactions through ThitsaX connectors will be demonstrated.\r\n \r\n",
+        "startsAt": "2024-10-26T15:00:00",
+        "endsAt": "2024-10-26T15:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "555b62a8-ce3b-4bb1-a549-5e008fb8a037",
+            "name": "Nyi Nyein Aye"
+          },
+          {
+            "id": "9230b0cd-1da1-4214-a323-d5d553038b02",
+            "name": "Aung Mon Ko"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Welcome and Introduction (5 minutes)\r\n\r\nOpening Remarks from Panelists (10 minutes)\r\n- Panelist 1: Overview of financial exclusion and its global impact\r\n- Panelist 2: The potential of open, interoperable payment networks\r\n- Panelist 3: Status of the work of the Dynamic Coalition\r\n\r\nInteractive Discussion (22 minutes)\r\n- Moderated Q&A with panelists and the audience\r\n- Sharing of case studies and experiences from the audience\r\n- Discussion on key barriers and opportunities for financial inclusion\r\n\r\nClosing Remarks and Next Steps (3 minutes)\r\n- Summary of key points discussed\r\n- Outline of the next steps for the Dynamic Coalition\r\n- Invitation to engage in ongoing dialogue and future actions",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "732187",
+        "title": "Meet the UN IGF Dynamic Coalition on Digital Financial Inclusion",
+        "description": "Financial exclusion remains a significant barrier to sustainable development and equitable growth, and is an under-explored topic in United Nations policymaking fora. This in-person convening of the Dynamic Coalition on Digital Financial Inclusion - an intersessional working group convened under the auspices of the UN Internet Governance Forum - will offer the Interledger community an opportunity to substantively feed into the work of the Dynamic Coalition as it explores how the adoption of open, global interoperable payment networks can overcome existing barriers and leverage opportunities to enhance financial inclusion across diverse stakeholder groups. We invite participation from the Interledger community to engage with select members of the Dynamic Coalition and outside experts, and to share case studies on how ILP-driven solutions are contributing towards economic participation and growth. Inputs will later be shared with the entire Dynamic Coalition and will feed into its final report, thus setting the stage for ongoing dialogue and action which contributes to the broader objectives of the Sustainable Development Goals. ",
+        "startsAt": "2024-10-26T15:15:00",
+        "endsAt": "2024-10-26T16:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "27429f38-3846-488f-9e53-58837c0b6842",
+            "name": "Ayden Férdeline"
+          },
+          {
+            "id": "b64bb83c-8afd-4452-a083-34b183001afd",
+            "name": "Caroline Sinders"
+          },
+          {
+            "id": "715acb29-2834-4d55-b102-d75ec3e3136d",
+            "name": "Jeremiah Lee"
+          },
+          {
+            "id": "5f635035-6608-4d43-a0fe-e64717a742b3",
+            "name": "Daphnee Prates Iglesias"
+          },
+          {
+            "id": "6b0e5bf6-b19d-4a1f-9977-4b4d03b984eb",
+            "name": "Smriti Parsheera"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267999,
+                "name": "Workshop (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "We will explain this link between shared infrastructure for core banking and the digital enablement of SACCOs, MFIs, fintechs and any organization reaching the last-mile. \r\n* The pathway to universal financial health and meaningful financial inclusion starts with core digitization which becomes the engine and foundation for digital transformation - digital payments, digital channels, digital onboarding/decisioning, data-driven insights via AI, fraud detection, advanced reporting, and more.\r\nWe will showcase how this can be achieved through existing solutions powered by Mifos DPGs that have been proven at scale for private and public sector use cases ranging from microfinance to digital lending to wallets to G2P, P2G, and P2P, and C2B payment flows. \r\n* Mifos DPGs provide a set of reusable and composable building blocks for banking  to enable DFSPs to modernize core systems to connect into IIPS, enable the delivery of G2P payments into functional wallets & transaction accounts with the capability to layer on additional inclusive financial services\r\nWe will demonstrate how these inclusive fintech solutions are being developed, innovated, scaled, and sustained across the globe by a vibrant ecosystem of local system integrators.\r\nWe will propose how we can fuel widespread adoption of the ILF tech stack by leveraging these widely adopted Mifos DPGs and the local support ecosystem. \r\n* Harnessing our DPGs for managing modern wallets and transactional accounts and connecting to digital payments, we can build connectors to Rafiki and adopt open payment protocols to accelerate adoption of the ILF stack for advancing financial inclusion not only within the DPI space but far beyond to other use cases. \r\nWe will highlight case studies underpinning this.\r\n* We will showcase real-life case studies of these solutions and reference PCH or similar implementations and draw the line between commoditized core banking and shared infrastructure platforms enabling money to stay local \r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "731179",
+        "title": "Shared Infrastructure to unlock Last-Mile Financial Inclusion using the Mifos DPGs for Core Banking",
+        "description": "In this talk we will present our vision for shared infrastructure powered by the Mifos DPGs for core banking and payment orchestration. By enabling access to modern core banking in the cloud for last-mile financial institutions, we can fuel adoption of the ILF technology stack and enable the meaningful usage of digital financial services by under-represented groups and vulnerable populations.",
+        "startsAt": "2024-10-26T15:30:00",
+        "endsAt": "2024-10-26T16:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "621798be-4ae6-4e5b-9345-fa3ceec50333",
+            "name": "Edward Cable"
+          },
+          {
+            "id": "73a6f00b-8686-436b-9eeb-6d9b2bd5b12a",
+            "name": "David Higgins"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Plenary talk",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "749717",
+        "title": "The History & Future of Digital Financial Inclusion ",
+        "description": "Join the Bill & Melinda Gates Foundation's Deputy Director, Inclusive Financial Systems and ILF Board Member, Kosta Peric as he brings his perspective on the trends, innovations and projects that are shaping digital financial inclusion and what we can do together to shape it. ",
+        "startsAt": "2024-10-27T10:00:00",
+        "endsAt": "2024-10-27T10:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "26fd7f35-0010-4bf0-895d-a732dd4546f7",
+            "name": "Kosta Peric"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "While ILP and Rafiki offer a solution to peer an infinite number of nodes, their capacity to interoperate with independent networks and protocols can extend their reach and promote adoption.\r\n\r\nPeople’s Clearinghouse has spent the last year working on an inter-scheme solution that would allow a Rafiki transfer to be routed to participants of a Mojaloop network in a quick, efficient and safe manner, so that Rafiki implementers in one country can route a transfer towards a Mojaloop switch in another country using a single entry point.\r\n\r\nThis solution intends to extend ILP and Rafiki’s reach beyond individual implementers, towards networks of rural and semi-rural banks with a social mission of financial inclusion and sustainable development, building a model that starts with Mexico and continues in more countries with similar social-financial contexts.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "695515",
+        "title": "Cross-border inter-scheme transfer demo: from Rafiki to a Mojaloop switch",
+        "description": "This demo will present the architecture behind People’s Clearinghouse solution and showcase a demo in which the audience will be able to send mock money from their Rafiki instances at rafiki.money towards a community bank’s account that doesn’t implement Rafiki.",
+        "startsAt": "2024-10-27T10:30:00",
+        "endsAt": "2024-10-27T11:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "9bd85c6e-88b7-4d06-b8c8-0458dc200746",
+            "name": "Roberto Valdovinos"
+          },
+          {
+            "id": "f1cbe4f1-29f8-4ac1-9fc3-06d7851bf338",
+            "name": "Jason Bruwer"
+          },
+          {
+            "id": "1ef13e51-23b5-44c7-bfb1-a82af3b5a7a2",
+            "name": "Pedro Sousa Barreto"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The panel discussion will involve 3 speakers from\r\n\r\n- A bank in South Africa\r\n- A mobile money provider in South Africa\r\n- The South African Reserve Bank\r\n\r\nand will be chaired by Allan Davids. The panel will follow a Q&A structure.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "761242",
+        "title": "Towards an inclusive cashless society: the digital payments landscape in South Africa",
+        "description": "Unlike many of its peers, South Africa has made great progress towards financial inclusion, with 82% of the adult population having access to a bank account and 94% being financially included. Despite this, cash remains king and the adoption and utilization of digital payments are slow.  This panel discussion will explore the barriers to increased adoption of digital payments in South Africa and what is needed to overcome these barriers to facilitate the transition to an inclusive cashless society.\r\n",
+        "startsAt": "2024-10-27T11:30:00",
+        "endsAt": "2024-10-27T12:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "e0a4be86-c4c7-4374-a728-a331170307cf",
+            "name": "Allan Davids"
+          },
+          {
+            "id": "8ed6a7c6-1361-4416-87b7-69471b062704",
+            "name": "Julian Kanjere"
+          },
+          {
+            "id": "a2eb66ef-7238-4800-bf4d-6091cb46e62b",
+            "name": "Kungela Mzuku"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267998,
+                "name": "Panel (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "20 mins talk followed by 5 mins Q&A",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "718166",
+        "title": "The Next 30 Years of Transaction Processing",
+        "description": "In the last 7 years, the “transactions of everyday life” have increased 100x to 1,000x, even 10,000x across several sectors (e.g. cloud computing, energy, real time payments). Yet popular transaction databases are 20-30 years old, and even newer cloud databases are circa 2012, designed for a different workload and scale.\r\n\r\nResearch into maximizing durability (and therefore availability) has advanced since 2018 (e.g. storage fault-tolerance, high frequency trading architectures, deterministic simulation testing) but can be hard to retrofit. At the same time, extracting transaction performance from general purpose database designs is becoming more and more expensive.\r\n\r\nHow can we reset transaction infrastructure for the next 30 years? To adapt and apply specialization to unlock three orders of magnitude more performance? How can we evolve our engineering methodologies for tighter tolerances and stricter safety standards?\r\n\r\nJoin us to look at what the world needs, and how these needs invent and predict the future of transaction processing, in the context of micro transactions and Interledger.",
+        "startsAt": "2024-10-27T11:30:00",
+        "endsAt": "2024-10-27T12:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "30b3c3bc-2196-4f86-be96-4578358d8818",
+            "name": "Joran Greef"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Panel Structure:\r\n\r\n- Introduction by Victoria Coker: Providing context about the documentary and its relevance to financial inclusion.\r\n- Short Trailer Screening: Offering a powerful visual insight into the stories and issues explored in the documentary.\r\n- Panel Discussion: Featuring select documentary participants who are working on the ground to support unbanked individuals. The discussion will cover:\r\n1) Solutions for increasing access to digital financial services.\r\n2) Initiatives aimed at advancing financial literacy and digital equity.\r\n3) Success stories of economic empowerment and inclusion.\r\n4) Collaborative approaches and partnerships to drive systemic change.\r\n- Question & Answer",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "732724",
+        "title": "Unbanked in America: Exploring the Financial Divide",
+        "description": "The proposed session, which will be led by the documentary's director, Victoria Coker, will delve into the complex issues that contribute to the significant number of unbanked and underbanked individuals in the United States, specifically people in Mississippi, New Orleans, and the NYC Metro area, and how these factors highly impact Black and Brown communities.\r\n\r\nThe panel will begin with an introduction by Victoria Coker, who will provide an overview of the documentary's key themes and objectives. Attendees will then view the documentary trailer, offering a glimpse into the stories and insights captured during the film's production.\r\n\r\nFollowing the trailer, the discussion will feature select participants from the documentary who are actively working to support unbanked populations across the country. These participants include community leaders, financial literacy educators, tech innovators, and non-profit representatives. Each panelist will bring a unique perspective and firsthand experience in addressing the barriers to financial inclusion and promoting economic empowerment.\r\n\r\nThe panel aims to illuminate the multifaceted challenges and innovative solutions being implemented to increase financial inclusion. It will provide a platform for discussing best practices, sharing success stories, and exploring collaborative approaches to foster greater financial inclusion.\r\n\r\nPanel Objectives:\r\n- Highlight the core factors contributing to the unbanked and underbanked populations in the United States.\r\n- Showcase real-world examples and success stories from across the country.\r\n- Foster dialogue on innovative solutions and collaborative efforts to tackle the problem.\r\n- Engage with summit attendees to inspire and inform them about their work in the field.\r\n",
+        "startsAt": "2024-10-27T11:30:00",
+        "endsAt": "2024-10-27T12:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "56d4c506-d323-41b0-9854-605d76121d86",
+            "name": "Victoria Coker"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267998,
+                "name": "Panel (40 mins)"
+              },
+              {
+                "id": 267999,
+                "name": "Workshop (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48362,
+        "room": "Room 11: Workshops & Talks",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "ISO 20022 is the banking world's standard for payment messages. Recent developments have meant that ISO payment instructions will be able to include ILP V4 packets, opening up the prospect of interactions between very large traditional institutions and very small ones. This session explores the prospects and the ways in which the two worlds might interact with each other, and with last-mile payment systems.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "690760",
+        "title": "Cross-border payments and standards",
+        "description": "Discusses how different protocols can interact with each other to collaborate on making cross-border payments cheaper, simpler and available to everybody",
+        "startsAt": "2024-10-27T12:00:00",
+        "endsAt": "2024-10-27T12:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "e6fbde75-b240-4dcb-a6c5-a65c4fa42cfc",
+            "name": "Michael Richards"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "A. Introduction (2 minutes)\r\nB. The Real-World Complexities of access to digital financial services for at risk communities (10 minutes)\r\nC. Audience Interaction Part 1 (5 minutes):\r\n-- Moderator will pose thought-provoking questions to the audience and collect a show of hands. Briefly discuss the responses.\r\nD.  Redefining access to DFS in restrictive environments (10 minutes):\r\n--Discuss resources, case studies and that aims to bridge accessibility, usability, and security as core principles to consider for designing inclusive digital financial services. \r\nE. Audience Interaction Part 2 (3 minutes):\r\nF. Taking Stock of ILF Community’s Standards and Protocols and compatibility with existing digital infrastructure (8 minutes)\r\nG. Closing Remarks and Q&A (2 minutes)\r\n\r\nModerator\r\n \r\nRaashi Saxena, Public Interest Technologist, studio intO\r\n  \r\nSpeakers\r\n \r\n* Esra'a Al Shafei is the founder of Majal.org, a network of online platforms that amplify under-reported and marginalized voices in West Asia and North Africa. She currently serves on the Board of Trustees at the Wikimedia Foundation, the nonprofit which hosts Wikipedia, as well as Mastodon, the free and open-source software for running self-hosted social networking services. She is also on the Board of the Tor Project, developers of one of the world’s strongest tools for privacy and freedom online. Previously, she served on the Board of Directors of Access Now, an international non-profit dedicated to an open and free Internet. Esra'a was an Echoing Green Fellow, MIT Media Lab Director’s Fellow, and Shuttleworth Foundation Fellow. \r\n  \r\n* Victory Brown – Victory is a user experience designer with Superbloom. She is the founder of Dezignhers a female led design community focused on creating a network among female designers in Africa, focused on creating inclusive and accessible designs across platforms. Brown is a member of the diversity, inclusion, and equity community on the IEEE SA Open community.\r\n \r\n* Liz Steininger – For over 16 years, Liz has supported the advancement of digital rights, access to information, freedom of expression and open source software, including managing funding with the Open Technology Fund. She currently serves as the CEO/Managing Director of Least Authority in Berlin, a company supporting people’s right to privacy through security consulting and building secure solutions.\r\n \r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "732719",
+        "title": "Existing Ecosystem Approaches to Inclusive and Accessible Digital Financial Services",
+        "description": "In today’s landscape of increasingly riskier digital experiences and the recent Crowdstrike related IT global outage, universal access to digital financial services is seen as a critical infrastructural resource.  Taking a decentralized approach that incorporates ethical design principles to safeguard the privacy, security, and autonomy of users is vital, that the  Interledger Protocol seeks to facilitate globally. By prioritising transparency, accountability, and consent in eminent aspects of development of digital financial services (DFS), we ensure alignment with human rights principles and international standards, as enshrined in the Universal Declaration of Human Rights. Drawing from a range of real-world examples and grounded in experiential knowledge from open source evangelists, this panel will illustrate the diverse use cases of the development and dissemination of digital public goods that support financial inclusion that facilitate access to financial services for underserved communities, while carefully addressing potential harms and respecting human rights. Recognizing the global nature of the DFS, our approach takes into account regional differences and cultural contexts from regions with internet blackouts, shutdowns and censorship across Africa, Asia and Europe. \r\n\r\nThe Interledger Protocol seeks to facilitate open, standard, and interoperable payment systems across the globe. The session discusses the very crux of this mission – the development and deployment usable, accessible and secure technical standards and protocols that pave way for decentralised digital infrastructure – by offering a nuanced view of adoption that can help shape the community’s strategy and ensure efforts align with the broader mission of inclusivity, community, and Open Tech.\r\n\r\nThis panel will also address the need for increased investment in resilient and trustworthy digital infrastructure that support the delivery of financial services, especially in rural and remote areas, among traditionally-excluded communities, and among low-income and/or disability communities, elderly people. The absence of of performing regular security, accessibility audits and privacy enhancing technologies as distinct categories in many grant program descriptions, despite the crucial role they play in the ecosystems, is a key to a long term sustainable ecosystem — especially when these systems are managing digital money and assets.\r\n\r\nThe adoption of secure decentralized solutions becomes not just advantageous, but essential for robust, reliable, and resilient operations in our interconnected ILP ecosystem. \r\n\r\n\r\n",
+        "startsAt": "2024-10-27T12:15:00",
+        "endsAt": "2024-10-27T13:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "295582aa-8c62-450c-a296-6c45573ea0fd",
+            "name": "Raashi Saxena"
+          },
+          {
+            "id": "23dfc112-b8df-4e82-968c-0b6e9fba3041",
+            "name": "Liz Steininger"
+          },
+          {
+            "id": "07f391c3-1f00-4c7d-a8f8-162d5a2dce73",
+            "name": "Victory Brown"
+          },
+          {
+            "id": "6b847b73-a655-43ec-9771-d7d2f557944b",
+            "name": "Ritu David"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267998,
+                "name": "Panel (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The 40 minute session will include an interactive , circle-style workshop with participants of the summit. The workshop will serve as a co-learning space, where participants share their perspectives, what is being done, identify the gaps in financial services related to the digital rights, and brainstorm a way forward. \r\n\r\nThe session will begin by exploring the problem and gaps to access. It will subsequently move to identify potential solutions, approaches and perspectives to inclusive financial services, and cross-border remittances that would benefit HRDs. \r\n\r\nAt the end of the session  we hope each participant will be able to: \r\n1. Have a clear mapping of what is needed to build, and advocate for secure financial services that enhance remittances to activists working in at-risk locations in the global majority. \r\n2. Identify points of collaborations , and resources required to promote and support work on sustainable financial inclusion. \r\n\r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "726153",
+        "title": "Getting the Money to Public Interest Technologists Building A Feminist Internet",
+        "description": "This is an interactive session that brings together  technologists, and digital rights defenders to map out contextual accessible financial service challenges while identifying possible inclusive technology solutions to advance financial access within the technology and human rights space.\r\n\r\nA significant aspect of Team Community’s work with digital rights defenders includes providing equity support to marginalised communities of colour, Africans, women, LGBTQ groups and indigenous people. Getting funding to most of these communities has been challenging, posing a structural barrier to accessing network and security resources.  For the most part, there is no way to get the money to the communities that need them.  Financial pathways have either been blocked or have extra layers of difficulty. Thus , increasing marginalities within digital rights defenders who work at the grassroots in the global majority.\r\n\r\nThe session’s goal is to collectively brainstorm and potentially answer the following questions:\r\n\r\n1. What are the key challenges and barriers digital rights defenders in the global majority experience with receiving funding that advance their work? \r\n2. What resources and efforts are needed to improve financial inclusivity? ",
+        "startsAt": "2024-10-27T12:15:00",
+        "endsAt": "2024-10-27T13:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "1b08a1e6-d254-420d-b70f-e7f6a198b165",
+            "name": "Mardiya Siba Yahaya"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267999,
+                "name": "Workshop (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48362,
+        "room": "Room 11: Workshops & Talks",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "1. An introduction to Kanzu Banking and SACCOs digitised\r\n2. Understanding the Gender Gap in Financial Inclusion\r\n3. Women-centred design in Digital Financial Services. Financial Inclusion as a Driver of Gender Equality\r\n4. Before, during and after digitisation. \r\n5. Fauzia's story\r\n6. The impact at the grassroots levels\r\n7. Q&A\r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "682327",
+        "title": "Empowering Women: Bridging the Gender Gap in Digital Financial Inclusion",
+        "description": "The importance of gender-sensitive approaches in promoting digital financial inclusion. It will highlight the unique barriers faced by women in accessing financial services and explore strategies for empowering women economically through innovative digital solutions.",
+        "startsAt": "2024-10-27T12:30:00",
+        "endsAt": "2024-10-27T13:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "4e4c1bab-cfb7-4170-b88e-38681cad10fe",
+            "name": "Maria Gorrettie Namuddu"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "5-person panel including host. \r\n\r\n1. Introduction (3 minutes)\r\n-Welcome and objectives of the session\r\n-Brief overview of the FinTech landscape in Africa\r\n-Importance of trust and open payments in financial inclusion\r\n2.Keynote Presentation (5 minutes)\r\n-Overview of current challenges and opportunities in Africa’s FinTech sector\r\n-The role of financial compliance in building trust and enabling open payments\r\n3. Panel Discussion (22 minutes)\r\n\r\n-Introduction of Panelists (2 minutes)\r\n-Brief bios and roles of each panelist\r\n\r\nDiscussion (15 minutes)\r\nKey topics: Overcoming compliance barriers, enhancing transparency, fostering collaboration.\r\nPanelists share insights, experiences, and innovative solutions\r\n\r\nModerator Q&A (8 minutes)\r\nModerator poses targeted questions to panelists to highlight specific points\r\n\r\n4. Audience Q&A (5 minutes)\r\n-Open floor for questions from the audience\r\n-Panelists provide responses and additional insights\r\n\r\n5. Closing Remarks (3 minutes)\r\n-Recap of key takeaways\r\n-Call to action for continued engagement and collaboration\r\n-Information on follow-up resources or next steps\r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "732595",
+        "title": "Building Trust and Advancing Open Payments in Africa’s Regulatory Ecosystem",
+        "description": "Fostering Trust and Advancing Open Payments in Africa's Regulatory Ecosystem panel explores strategies for fostering trust and advancing open payments within Africa’s FinTech ecosystem. Our focus will be on shaping inclusive financial compliance frameworks that can bridge gaps and facilitate broader participation in the global financial system.",
+        "startsAt": "2024-10-27T14:00:00",
+        "endsAt": "2024-10-27T14:45:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "2b7c7fbf-fcc7-4303-948b-7368602778e2",
+            "name": "Dre Ngare"
+          },
+          {
+            "id": "a6783a70-11c2-49e1-8b9c-c30c6dc929cd",
+            "name": "Jurgen Kuhnel"
+          },
+          {
+            "id": "e9505ac1-28e7-4bba-8be0-04c5a346a30c",
+            "name": "Tawanda Brandon"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267998,
+                "name": "Panel (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The session will feature a series of snapshot presentations (5 mins each) about each country's path to open payments: starting with pioneering India, and then illustrating how Latin America is following a similar trajectory by focusing on the cases of Brazil, Peru and Chile. After the introductory remarks, we will open it up for questions, and conclude with a final round of reactions by all speakers (including to each other's comments) focusing on what lessons their country-study can offer to other countries that are planning to introduce or expand payment DPIs. ",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "732747",
+        "title": "Competition and financial inclusion: competing or complementing goals in DPI & interoperability",
+        "description": "Interoperability in the payments ecosystem and the implementation of a digital public infrastructure (DPI) for digital payments have the potential of fostering two separate goals: market competition and financial inclusion. Nevertheless, depending on the authority advancing each measure and the legal mandate it has been entrusted with, those objectives could be regarded as competing (one is considered, and the other one is neglected) or complementing (both are taken into account, even though one might be more prevalent).\r\nWe analyze how these two targets are considered by antitrust authorities, the central bank, and other relevant authorities in Brazil, India, Peru and Chile. These countries from the Global South share a similar path in terms of legal measures adopted in the digital payments ecosystem consisting of voluntary/ mandatory interoperability. However, some differences also exist, such as the industry-led ownership of India's United Payments Interface (UPI), whereas the Brazilian DPI is owned by its central bank. Furthermore, the countries are at different stages of implementation. India is seen as a pioneer in the field with its UPI being launched in 2016, while Brazil’s PIX has been active since 2020. Peru’s Central Bank first ordered mandatory interoperability in payments in 2022, and this year reached an agreement with the international arm of the National Payments Corporation of Payments, which runs India's UPI, to deploy a similar system in Peru. Chile seems to be at the beginning of a long path, where the Supreme Court declared the mandatory nature of interoperability this year and the Commission for Financial Markets introduced new regulations on the matter, following intense discussions (some still pending) with competition authorities.\r\nA number of actors play a role in pursuing the dual goals of furthering financial inclusion and market competition. This may include national competition authorities, central banks, government departments and industry associations. The institutional arrangements between these actors and coordination among them is paramount to providing predictability to all economic actors in the payment ecosystem and to the seamless attainment of the public interest goals of payment DPIs.",
+        "startsAt": "2024-10-27T15:00:00",
+        "endsAt": "2024-10-27T15:45:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "526711d3-3681-4fa1-aca6-d962efa1bb30",
+            "name": "Nicolo Zingales"
+          },
+          {
+            "id": "a8e2cd00-2d08-41b0-a6c3-4f43640d2276",
+            "name": "Andres Calderon Lopez"
+          },
+          {
+            "id": "6b0e5bf6-b19d-4a1f-9977-4b4d03b984eb",
+            "name": "Smriti Parsheera"
+          },
+          {
+            "id": "93026eb0-f1ab-4c49-9ba8-3e63f26a4bee",
+            "name": "Fernanda Pizarro"
+          },
+          {
+            "id": "3bce59a9-7f72-4005-b442-1fae30119442",
+            "name": "Hannah Draper"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267998,
+                "name": "Panel (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Phil will give a presentation/talk with slides (or not if that's not possible) on Mojaloop's role in inclusive financial access. Outline can be seen in the description.",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "681475",
+        "title": "Empowering Emerging Economies: Mojaloop's Role in Inclusive Financial Access",
+        "description": "Imagine a world where microledgers empower the 1.4 billion underserved in emerging economies to gain access to financial services, and a payment hub facilitates lower-cost instant fund transfers across nations' participating banks. This presentation will unveil how Mojaloop is turning this vision into reality, revolutionizing the accessibility of financial services in emerging economies. With national deployments in Rwanda, Mexico, and the Philippines, a regional deployment across the Common Market for Eastern and Southern Africa (COMESA) and promising proofs of concept underway in five diverse nations, Mojaloop has been actively expanding its reach. Given that the Interledger Protocol is a key part of Mojaloop’s tech stack, through Mojaloop, participants on the Interledger Network can access entire countries and regions. Mojaloop also empowers hub operators with instant, inclusive payment systems (IIPS) to connect thrift banks, rural banks, and microfinance institutions - ones currently excluded from payment networks due to high switching and on-ramp costs.  Furthermore, the presentation will explore how Mojaloop-enabled IIPS allows financial institutions to competitively price instant transactions, thus advancing inclusive financial access. Additionally, we'll illuminate Mojaloop's role as a catalyst for the emergence of new market players, enabling the aggressive development and marketing of innovative payment services to both consumers and merchants.\r\n",
+        "startsAt": "2024-10-27T15:00:00",
+        "endsAt": "2024-10-27T15:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "63e10977-23e9-4138-8d46-47351565ca2b",
+            "name": "Philip Green"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "In this workshop, we want to present our current understanding of the problem and challenges, discuss technical possibilities  for the development of a solution based on ILP and build a network with other technical experts attending to the summit for a longer term collaboration.  \r\n\r\nWe do this in the following format: \r\n\r\n1. Introduction of the Project:A brief presentation of the project and its objectives.\r\n2. Co-creation Workshop: In subgroups, we will translate current project requirements into a technical architecture based on the Interledger Protocol (ILP).\r\n3. Presentation of Results and Reflection: The subgroups will present their findings, followed by a collective reflection.\r\n",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "732729",
+        "title": "Trust-based banking technical session",
+        "description": "Undocumented people are excluded from many governmental services and cannot open a bank account in the Netherlands. This exclusion becomes more severe each day, as it is nearly impossible to survive with only cash. Shops and services in the city are rapidly moving towards accepting only card payments.\r\nWe have now been granted funding from Interledger, together our partner Here to Support, and with the support of the Municipality of Amsterdam and various partners in the Netherlands.",
+        "startsAt": "2024-10-27T15:00:00",
+        "endsAt": "2024-10-27T15:45:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "8c583b1f-4911-40e5-9c5a-3fdfc14c1181",
+            "name": "Pourya Omidi"
+          },
+          {
+            "id": "a86caa8f-cb2e-41a9-ac38-2ee2a6b5f0a0",
+            "name": "Taco van Dijk"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267999,
+                "name": "Workshop (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48362,
+        "room": "Room 11: Workshops & Talks",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The outline for the talk/demo is:\r\n- Why an Interledger App for Canada and comparisons with CashApp\r\n- Key Features\r\n- The Development Story of the App and lessons for the community\r\n- Inteledger-enabled APIs for other Developers to integrate with\r\n- Demo\r\n- Conclusion",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "723325",
+        "title": "Introducing Chimoney App: The Interledger App bridging Canada and Africa",
+        "description": "This talk introduces the Chimoney App with features like Interledger Payment Pointer Creation, Funding, transfers to other Payment Pointers, and Web Monetization Support. Attendees will have an opportunity to see the App in action and create their own Payment Pointers. The talk will conclude with instructions on how to create a Chimoney Payment Pointer via API",
+        "startsAt": "2024-10-27T15:30:00",
+        "endsAt": "2024-10-27T16:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "405070c5-a46c-4f12-9b68-5b1ed17e98a1",
+            "name": "Uchi Uchibeke"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "1) (hopefully): a video/drawing that shows the complexity of our research in a understandable way\r\n2) explaining on the route to finding stakeholders (Here to Support)\r\n3) explaining the importance of the collaboration between tech&social work (de Waag(\r\n4) Talking about how to get the undocumented communities \r\ninvolved\r\n5) conclusion and questions from audience",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "732717",
+        "title": "Financial Inclusion for Undocumented Communities: From Strategies to Practices",
+        "description": "Undocumented communities such as refugees, asylum seekers, and migrants often face significant barriers to accessing digital financial services involuntarily, despite affordable and accessible digital financial services being crucial for their economic integration and empowerment. In order to gain some successful solutions against this exclusion, we needed to build a strong coalition of different partners in different sectors. \r\nWhat strategies can be leveraged to advance financial inclusion for underrepresented communities like these? Which coalitions should be built, what kind of technologies are needed, and what movements should be connected to?\r\nThis panel features diverse experts: Malou Lintmeijer, Savannah Koolen, and Eunice de Asis, all from Stichting Here to Support, a current grantee of Interledger Foundation, working on increasing financial inclusion of refugees and undocumented migrants in the Netherlands together with De Waag and the support of Municipality of Amsterdam; Daphnee Prates Iglesias, policy advisor at UN-IGF, currently leading a working group on digital access, and previously Financial Inclusion Policy Officer at International Rescue Committee;and Sarah Habib, a FinTech Strategies from London that has worked with several FinTech Startups that focuses on supporting refugees. Together, we ask the question: What is the combined role of NGO’s, institutions and communities to create innovative solutions to make social and policy change? They will offer perspectives from their past work and provide a potential blueprint for advancing digital financial rights for refugees, asylum seekers, and migrants.\r\n\r\n\r\n\r\n",
+        "startsAt": "2024-10-27T15:45:00",
+        "endsAt": "2024-10-27T16:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "a055a6cf-45d9-4cd2-8273-435ad54d5baf",
+            "name": "Malou Lintmeijer"
+          },
+          {
+            "id": "6b4980b6-a70f-413d-884d-28c3dd8daf16",
+            "name": "Savannah Koolen"
+          },
+          {
+            "id": "677f8255-1bd2-40b9-8441-3acd0f1c829f",
+            "name": "Sarah Habib"
+          },
+          {
+            "id": "836d5658-b522-46f2-a032-6cd7debf0101",
+            "name": "Eunice de Asis"
+          },
+          {
+            "id": "3a71dfe5-a936-40b8-853b-46d1652952fe",
+            "name": "Xiaoji Song"
+          },
+          {
+            "id": "5f635035-6608-4d43-a0fe-e64717a742b3",
+            "name": "Daphnee Prates Iglesias"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267998,
+                "name": "Panel (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "754678",
+        "title": "Codius Fireside Chat",
+        "description": "Join us for a panel discussion about Codius and Interledger - the namesakes of Coil that remain interconnected.\r\n\r\nCoil’s latest approach to Codius takes learnings from previous iterations that were constrained by limitations of ILP at the time.",
+        "startsAt": "2024-10-27T15:45:00",
+        "endsAt": "2024-10-27T16:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "3e80acea-13f9-4fd2-8e9a-e4b715297d9a",
+            "name": "Sabine Schaller"
+          },
+          {
+            "id": "aa3deed9-666b-4a27-8a26-b2c792a42663",
+            "name": "Alex Lakatos"
+          },
+          {
+            "id": "b136ab7f-e6f9-41ce-9e6c-935c5f0a5a3d",
+            "name": "Stefan Thomas"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267999,
+                "name": "Workshop (40 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48362,
+        "room": "Room 11: Workshops & Talks",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "* Introduction to the Interledger Card\r\n* How the Card Works\r\n* Unique Features and Limitations\r\n* Memorabilia and Privacy\r\n* Future Vision for Payment Networks\r\n* Q&A",
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "687571",
+        "title": "The Future of Payments in Your Pocket",
+        "description": "Developed as a joint venture between GateHub and the Interledger Foundation, this card integrates a real payment pointer and links directly to your wallet, unlocking new possibilities for transactions, interoperability, and global financial access. Learn how this innovative piece of memorabilia is not just a symbol but a functional tool for driving the future of payments.",
+        "startsAt": "2024-10-27T16:00:00",
+        "endsAt": "2024-10-27T16:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "585a769b-db7a-4c75-b1ba-4c4fe8015276",
+            "name": "Tadej Golobic"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 267997,
+                "name": "Talk or demos (25 mins)"
+              }
+            ],
+            "sort": 0
+          }
+        ],
+        "roomId": 48361,
+        "room": "Hall C: Talks & Demos",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 70801,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          }
+        ],
+        "id": "753052",
+        "title": "Interledger Summit Closing Plenary",
+        "description": null,
+        "startsAt": "2024-10-27T17:00:00",
+        "endsAt": "2024-10-27T17:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "8c31891a-1b90-41c9-9419-cb79cdd7494e",
+            "name": "Chris Lawrence"
+          }
+        ],
+        "categories": [
+          {
+            "id": 70793,
+            "name": "Session format",
+            "categoryItems": [],
+            "sort": 0
+          }
+        ],
+        "roomId": 48360,
+        "room": "Hall A: Mainstage & Panels",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      }
+    ],
+    "isDefault": false
+  }
+]

--- a/src/data/sessionize/2025-speakers.json
+++ b/src/data/sessionize/2025-speakers.json
@@ -1,0 +1,3114 @@
+[
+  {
+    "id": "ad86c689-2742-4fac-8d13-f38eb8a09312",
+    "firstName": "Afua",
+    "lastName": "Bruce",
+    "fullName": "Afua Bruce",
+    "bio": "Afua Bruce is a leading voice at the intersection of technology, data, and social impact. With a career spanning the public, private, and nonprofit sectors, she has advised organizations on leveraging technology responsibly to drive meaningful change. Afua is the Principal of ANB Advisory Group, where she helps organizations across sectors strengthen their technical and data strategies.\r\nPrior to founding ANB Advisory Group, Afua held senior science and technology roles at the White House, the FBI, and IBM. Afua is a sought-after speaker and author, known for her insights on ethical technology, responsible AI, and innovation for social enterprises.\r\nHer newest book, The Tech That Comes Next, explores how communities and technologists can collaborate to build a more equitable future. Afua was honored with a statue in the If/Then Exhibit highlighting women in STEM, which was displayed in the Smithsonian. She is an affiliate at Harvard Kennedy School’s Berkman Klein Center, sits on the board of Code the Dream, and is a member of the Center for Democracy and Technology’s Advisory Council. Afua holds a degree in Computer Engineering from Purdue University and an MBA from the University of Michigan.",
+    "tagLine": "ANB Advisory Group",
+    "profilePicture": "https://sessionize.com/image/2363-400o400o1-LhA2kau38B9Vec9EU7nezo.jpg",
+    "sessions": [
+      {
+        "id": 995876,
+        "name": "Rights & Rails: How Philanthropy Links Access, Capacity & Inclusive Payment Systems"
+      }
+    ],
+    "isTopSpeaker": true,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Afua Bruce es una voz destacada en la intersección entre la tecnología, los datos y el impacto social. Con una carrera que abarca los sectores público, privado y sin fines de lucro, ha asesorado a organizaciones sobre cómo aprovechar la tecnología de manera responsable para impulsar un cambio significativo. Afua es directora de ANB Advisory Group, donde ayuda a organizaciones de todos los sectores a fortalecer sus estrategias técnicas y de datos. Antes de fundar ANB Advisory Group, Afua ocupó puestos de responsabilidad en ciencia y tecnología en la Casa Blanca, el FBI e IBM. Afua es una conferencista y autora muy solicitada, conocida por sus conocimientos sobre tecnología ética, IA responsable e innovación para empresas sociales. Su último libro, The Tech That Comes Next, explora cómo las comunidades y los tecnólogos pueden colaborar para construir un futuro más equitativo. Afua fue homenajeada con una estatua en la exposición If/Then, que destaca a las mujeres en el ámbito de las ciencias, la tecnología, la ingeniería y las matemáticas, y que se exhibió en el Smithsonian. Es afiliada al Berkman Klein Center de la Harvard Kennedy School, forma parte de la junta directiva de Code the Dream y es miembro del Consejo Asesor del Center for Democracy and Technology. Afua es licenciada en Ingeniería Informática por la Universidad de Purdue y tiene un MBA por la Universidad de Michigan.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e64492fe-c013-45f7-995a-a2c01065d0e6",
+    "firstName": "Aju",
+    "lastName": "John",
+    "fullName": "Aju John",
+    "bio": "I'm a labour organiser, lawyer, and researcher. My project, Migrant*innen für Menschenwürdige Arbeit (Migrants for Decent Work), researches the co-constitution of migration and precarious work and campaigns for greater sensitivity to migrant precarity in labour and social policy. This project has been shaped by my experiences of organising South Asian food delivery workers in Berlin. I'm also the host and producer of the Delivery Charge podcast, which narrates the stories of worker resistance in platform work, and a member of Lieferando Workers Collective, a migrant-led collective that organises food delivery workers in Berlin.",
+    "tagLine": "Labour Organiser, Researcher, Lawyer",
+    "profilePicture": "https://sessionize.com/image/a4a2-400o400o1-V1R5dYjZBfYSPKgEKQFuKE.png",
+    "sessions": [
+      {
+        "id": 995904,
+        "name": "From Financial Inclusion to Financial Justice: How to Enable an Equitable Future in the Gig Economy "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Migrant*innen für Menschenwürdige Arbeit ",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder and Principal",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Soy organizador laboral, abogado e investigador. Mi proyecto, Migrant*innen für Menschenwürdige Arbeit (Migrantes por un trabajo digno), investiga la co-constitución de la migración y el trabajo precario y hace campaña para que se preste más atención a la precariedad de los migrantes en las políticas laborales y sociales. Este proyecto se ha visto influido por mis experiencias como organizador de los repartidores de comida del sur de Asia en Berlín. También soy presentador y productor del podcast Delivery Charge, que narra las historias de resistencia de los trabajadores en el trabajo por plataformas, y miembro de Lieferando Workers Collective, un colectivo dirigido por migrantes que organiza a los repartidores de comida en Berlín.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "66da924e-03b5-4d5b-8d91-ecf74d4d495a",
+    "firstName": "Alejandra",
+    "lastName": "Cullen Benítez",
+    "fullName": "Alejandra Cullen Benítez",
+    "bio": "Alejandra Cullen Benítez is an economist and master in public administration with more than 25 years of experience in digital transformation, institutional development, and business structure creation in the public and private sectors. Her career is distinguished by her ability to integrate organizational and technological modernization projects in financial institutions and public agencies to strengthen financial inclusion and institutional efficiency in Mexico.\r\n\r\nShe is currently an advisor to the Federal Mortgage Society and the FONADIN financing subcommittee and has served on various boards of directors of financial institutions and civil society organizations, including FINSOCIAL, SEFIA, Financiera Sustentable, the Mexico Foundation at Harvard, and APAC. She is a regular contributor as an analyst on UNO TV, a member of the artificial intelligence research line at the UNAM Institute for Legal Research (LIDIA), and a contributor to Siglo XX, where she collaborated on the creation of the study “Towards a public policy for financial inclusion, opportunities and challenges for Mexico.”\r\n\r\nIn the academic field, she has completed executive programs at Oxford (Saïd Business School) and the IPADE Business School, consolidating a comprehensive vision of technology, finance, and governance.\r\n",
+    "tagLine": "Economist",
+    "profilePicture": "https://sessionize.com/image/d457-400o400o1-JSVW2SbrQWMYPXnsXPwTWX.jpg",
+    "sessions": [
+      {
+        "id": 1049783,
+        "name": "Trustworthy by Default: Designing Digital Finance People Choose to Use "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Alejandra Cullen Benítez es economista y maestra en administración pública con más de 25 años de experiencia en transformación digital, desarrollo institucional y creación de estructuras de negocio en sectores público y privado. Su carrera se distingue por la capacidad de integrar proyectos de modernización organizacional y tecnológica en instituciones financieras y organismos públicos para fortalecer la inclusión financiera y la eficiencia institucional en México. \r\n\r\nEs actualmente consejera de la Sociedad Hipotecaria Federal y del subcomité de financiamiento de FONADIN y ha formado parte de diversos consejos de administración  de entidades financieras y de organizaciones de la sociedad civil, incluyendo FINSOCIAL, SEFIA, Financiera Sustentable, la Fundación México en Harvard y APAC. Es colaboradora habitual como analista en UNO TV, miembro de la línea de investigación de inteligencia artificial del Instituto de Investigaciones Jurídicas de la UNAM (LIDIA) y colaboradora de Siglo XX desde donde colaboró en la creación del estudio “Hacia una política pública para la inclusión financiera, oportunidades y retos para México”.\r\n\r\nEn el ámbito académico, ha cursado programas ejecutivos en Oxford (Saïd Business School) y el IPADE Business School, consolidando una visión integral entre tecnología, finanzas y gobernanza. ",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "4de52905-07df-44b1-8068-5951aef6db9f",
+    "firstName": "Alejandro",
+    "lastName": "Maldonado Viveros",
+    "fullName": "Alejandro Maldonado Viveros",
+    "bio": "I have a degree in Cybernetics and Systems Engineering from La Salle and a Diploma in Economics from ITAM. I have over 20 years of experience in innovation, digital transformation, and financial inclusion in the public and private sectors. \r\n\r\nI have held senior positions as a regulator and supervisor in the banking and pensions sector, I was an advisor to CECOBAN, coordinator of the FinTech Committee of the Mexican Banking Association (ABM), member of the National Council for Financial Inclusion of the CNBV, as well as director of Innovation, Open Finance, and Business Development at Banco Santander and Finsus. In addition, I collaborated in the creation of CONSAR's AforeMovil® and BANXICO's Dimo®, both high-impact projects for financial inclusion and digital payments in Mexico. In 2018, I won the Innovation Award at the World Pension Summit in The Hague, and in 2019, I was a finalist in Grupo Santander's Global Innovation Challenge in Madrid. \r\n\r\nI am currently a member of the Open Finance Committee of the Fintech Mexico Association and CEO of Fintech.land, a consulting firm and digital factory specializing in advising and providing technological services to financial institutions and FinTech companies.",
+    "tagLine": "CEO of Fintech.Land",
+    "profilePicture": "https://sessionize.com/image/2d2b-400o400o1-KbFqyvE4y4M5bUPcArV8AA.png",
+    "sessions": [
+      {
+        "id": 1049783,
+        "name": "Trustworthy by Default: Designing Digital Finance People Choose to Use "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Soy titulado en Ingeniería en Cibernética y Sistemas por La Salle y tengo un Diplomado en Economía por el ITAM. Cuento con más de 20 años de experiencia en innovación, transformación digital e inclusión financiera en el ámbito público y privado.\r\n\r\nHe fungido en roles de alta jerarquía como regulador y supervisor del sector Bancario y Pensiones, fui consejero de CECOBAN, coordinador del Comité FinTech de la Asociación de Bancos de México (ABM), miembro del Consejo Nacional de Inclusión Financiera de la CNBV, así como directivo de Innovación, Open Finance y Desarrollo de Negocios de Banco Santander y Finsus. Adicionalmente, colaboré en la creación de AforeMovil® de CONSAR y Dimo® de BANXICO, ambos proyectos de alto impacto para la inclusión financiera y de pagos digitales en México. En 2018 obtuve el premio de Innovación de “World Pension Summit” en La Haya y en 2019 fuy finalista de “Global Innovation Challenge” de Grupo Santander en Madrid.\r\n\r\nActualmente soy miembro del Comité de Open Finance de la Asociación Fintech México y CEO de Fintech.land, firma de consultoría y fábrica digital especializada en asesorar y brindar de servicios tecnológicos a instituciones financieras y FinTech.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "5ec11732-1afe-4386-8643-1fad38dd1640",
+    "firstName": "Aleksandra",
+    "lastName": "Asscheman",
+    "fullName": "Aleksandra Asscheman",
+    "bio": "Aleksandra Asscheman is a Senior Lecturer in International and European Law at The Hague University of Applied Sciences, where she designs and teaches courses in business law, banking and financial regulation. As a researcher with the Hague Centre of Expertise in Digital Operations and Finance (New Finance group), she focuses on regulatory frameworks for digital assets and payments. Within this role, she is currently developing The Future of Open Payments course, an interdisciplinary pilot project supported by the Interledger Foundation’s NextGen Grant, which aims to equip law and finance students with the knowledge and skills needed to use open payment technologies to solve financial inclusion challenges. Passionate about inclusion and impact, Aleksandra also advises on gender-smart investing initiatives. Before joining academia, she spent over a decade as a legal practitioner in development finance, working on credit and investment transactions across Eastern Europe, India, and South-East Asia.",
+    "tagLine": "The Hague University of Applied Sciences",
+    "profilePicture": "https://sessionize.com/image/013a-400o400o1-pFxnH3pEvpJaWPyGMFVqHX.jpg",
+    "sessions": [
+      {
+        "id": 995879,
+        "name": "From Classroom to Codebase: How Universities Cultivate the Next Generation of Open Payments Talent"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Aleksandra Asscheman es profesora titular de Derecho Internacional y Europeo en la Universidad de Ciencias Aplicadas de La Haya, donde diseña e imparte cursos de derecho mercantil, banca y regulación financiera. Como investigadora del Centro de Experiencia en Operaciones Digitales y Finanzas de La Haya (grupo New Finance), se centra en los marcos regulatorios para los activos y pagos digitales. En el marco de esta función, actualmente está desarrollando el curso «El futuro de los pagos abiertos», un proyecto piloto interdisciplinario respaldado por la beca NextGen de la Fundación Interledger, cuyo objetivo es dotar a los estudiantes de derecho y finanzas de los conocimientos y habilidades necesarios para utilizar las tecnologías de pago abierto con el fin de resolver los retos de la inclusión financiera. Apasionada por la inclusión y el impacto, Aleksandra también asesora sobre iniciativas de inversión con perspectiva de género. Antes de incorporarse al mundo académico, trabajó durante más de una década como abogada en el ámbito de las finanzas para el desarrollo, dedicándose a transacciones crediticias y de inversión en Europa del Este, India y el Sudeste Asiático.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "1b1f8571-7e4f-40fe-8940-81c16be6efe2",
+    "firstName": "Alix",
+    "lastName": "Dunn",
+    "fullName": "Alix Dunn",
+    "bio": "Alix Dunn is the founder and CEO of The Maybe, a critical consultancy, collective, and media studio challenging the power and politics of tech. She hosts the Computer Says Maybe weekly podcast, sits on the board of Foxglove and is an advisor for AI Now and the AI Collaborative.",
+    "tagLine": "The Maybe",
+    "profilePicture": "https://sessionize.com/image/ef75-400o400o1-wbHcr7JmWLMVKoDQ2jqLw5.jpg",
+    "sessions": [
+      {
+        "id": 995871,
+        "name": "Human Rights by Design: Financial Infrastructure that Works for Everyone"
+      }
+    ],
+    "isTopSpeaker": true,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Alix Dunn es la fundadora y directora ejecutiva de The Maybe, una consultoría crítica, colectivo y estudio multimedia que cuestiona el poder y la política de la tecnología. Presenta el podcast semanal Computer Says Maybe, forma parte de la junta directiva de Foxglove y es asesora de AI Now y AI Collaborative.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "50398579-1d0f-45c2-a540-d22c6bd1ff28",
+    "firstName": "Allan",
+    "lastName": "Davids",
+    "fullName": "Allan Davids",
+    "bio": "Dr. Allan Davids is the Director of the Financial Innovation Hub at the University of Cape Town. In collaboration with the Interledger Foundation, the Financial Innovation Hub brings together the brightest minds on the African continent to spearhead education, research and innovation in financial technologies. At UCT, Allan also convenes the MPhil in Financial Technology, the only Master’s degree specializing in Financial Technology on the African continent. Allan holds a PhD in Economics, has spent time as a visiting researcher at several leading universities, including New York University, the University of Oxford and Imperial College London, and until 2023, held the South African Reserve Bank Research Chair in Financial Stability.",
+    "tagLine": "University of Cape Town",
+    "profilePicture": "https://sessionize.com/image/ced4-400o400o1-aQQ7Go3mJYfWMTBdGuUYoJ.jpg",
+    "sessions": [
+      {
+        "id": 995879,
+        "name": "From Classroom to Codebase: How Universities Cultivate the Next Generation of Open Payments Talent"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "El Dr. Allan Davids es director del Centro de Innovación Financiera de la Universidad de Ciudad del Cabo. En colaboración con la Fundación Interledger, el Centro de Innovación Financiera reúne a las mentes más brillantes del continente africano para impulsar la educación, la investigación y la innovación en tecnologías financieras. En la UCT, Allan también coordina el Máster en Tecnología Financiera, el único máster especializado en tecnología financiera del continente africano. Allan tiene un doctorado en Economía, ha sido investigador visitante en varias universidades de prestigio, como la Universidad de Nueva York, la Universidad de Oxford y el Imperial College de Londres, y hasta 2023 ocupó la Cátedra de Investigación en Estabilidad Financiera del Banco de la Reserva de Sudáfrica.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "7f1a2e6f-e78e-4713-9e1c-83a396083805",
+    "firstName": "Amy ",
+    "lastName": "Sample Ward",
+    "fullName": "Amy Sample Ward",
+    "bio": "Amy Sample Ward (they/them) believes that technology should be accessible and accountable to everyone, especially communities historically and systemically excluded from the digital world. They are the CEO of NTEN, a nonprofit creating a world where missions and movements are more successful through the skillful and equitable use of technology. \r\nAmy's second book, “Social Change Anytime Everywhere,” was a Terry McAdam Book Award finalist. Their latest book, “The Tech That Comes Next,” co-authored with Afua Bruce, addresses the opportunities for change makers, technologists, philanthropists, and policymakers to build an equitable world with technology.",
+    "tagLine": "NTEN",
+    "profilePicture": "https://sessionize.com/image/26f8-400o400o1-38PfhsafHhK9mKeHrQdtDj.png",
+    "sessions": [
+      {
+        "id": 995876,
+        "name": "Rights & Rails: How Philanthropy Links Access, Capacity & Inclusive Payment Systems"
+      }
+    ],
+    "isTopSpeaker": true,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Amy Sample Ward (elle) cree que la tecnología debe ser accesible y responsable ante todos, especialmente ante las comunidades que han sido excluidas histórica y sistemáticamente del mundo digital. Es la directore ejecutive de NTEN, una organización sin fines de lucro que crea un mundo en el que las misiones y los movimientos tienen más éxito gracias al uso hábil y equitativo de la tecnología. El segundo libro de Amy, «Social Change Anytime Everywhere» (Cambio social en cualquier momento y en cualquier lugar), fue finalista del premio Terry McAdam Book Award. Su último libro, «The Tech That Comes Next» (La tecnología que viene después), escrito en colaboración con Afua Bruce, aborda las oportunidades que tienen los agentes del cambio, los tecnólogos, los filántropos y los responsables políticos para construir un mundo equitativo con la tecnología.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a9867c99-c0fb-4338-9a8b-cea0f5ab9bdb",
+    "firstName": "Ana",
+    "lastName": "Šemrov",
+    "fullName": "Ana Šemrov",
+    "bio": " ",
+    "tagLine": "Backend Team Lead @ GateHub",
+    "profilePicture": "https://sessionize.com/image/e53e-400o400o1-3LiDPXK7nzDUcvFhvT6aVG.jpg",
+    "sessions": [
+      {
+        "id": 1018856,
+        "name": "Payment Pointers to SEPA"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "GateHub",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Backend Team Lead",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": null,
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "139a555e-27a4-4640-af06-afe3b0cfc6e9",
+    "firstName": "Andres",
+    "lastName": "Alban",
+    "fullName": "Andres Alban",
+    "bio": "Andrés is an entrepreneur and visionary with more than two decades of leadership in the fintech sector in Latin America. As co-founder and CEO of Puntored, he has played a key role in the financial inclusion revolution, impacting more than 18 million people monthly. Andrés holds an MBA from Bayes Business School and executive education from Stanford and LSE. He is co-founder and former president of the Colombia Fintech Association, where he played a key role in regulating this sector. He has been an Endeavor Entrepreneur and Advocate since 2012, winning their “Expert in Economic Transformation” award in 2022. He was recognized as the Best Social Entrepreneur in Latin America by New Ventures and the Swiss Cooperation Center in 2015, and named one of the “75 leaders transforming Colombia” by El Pais América newspaper in 2023.",
+    "tagLine": "CEO at Puntored / Conexred",
+    "profilePicture": "https://sessionize.com/image/61cb-400o400o1-fnWozWJY5sHsqrbZoy4fLd.jpg",
+    "sessions": [
+      {
+        "id": 995886,
+        "name": "Unlocking Financial Interoperability in Latin America"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Andrés es un emprendedor y visionario con más de dos décadas de liderazgo en el sector fintech en LATAM. Como cofundador y CEO de Puntored, ha desempeñado un papel fundamental en la revolución de la inclusión financiera, impactando a más de 18 millones de personas mensualmente. Andrés tiene un MBA de Bayes Business School y educación ejecutiva de Stanford y LSE. Es cofundador y ex presidente de la Asociación Colombia Fintech, donde jugó un papel clave en la regulación de este sector. Es Emprendedor y Advocate de Endeavor desde 2012, ganando su premio \"Experto en Transformación Económica\" en 2022. Fue reconocido como el Mejor Emprendedor Social de América Latina por New Ventures y el Centro de Cooperación Suizo en 2015, y nombrado como uno de los ”75 líderes que transforman a Colombia” por el periodico El Pais América en 2023. ",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6faa6639-4789-4c4b-968f-995c86a7531e",
+    "firstName": "Andrew ",
+    "lastName": "Mangle",
+    "fullName": "Andrew Mangle",
+    "bio": "Dr. Andrew Mangle is Associate Professor of Management Information Systems in the College of Business at Bowie State University. He leads innovative efforts to expand HBCU student engagement in digital financial inclusion. Through partnerships with the Interledger Foundation, he develops hands-on programs that prepare students to design open payment solutions and address the needs of the underbanked and unbanked. His work integrates FinTech, blockchain, and open-web payments into higher education, ensuring that underrepresented communities gain equitable access to the future of finance. By connecting academic research, industry practice, and global collaboration, Dr. Mangle advances Interledger’s mission of universal financial access and inspires the next generation of inclusive FinTech leaders.",
+    "tagLine": "Bowie State University",
+    "profilePicture": "https://sessionize.com/image/b765-400o400o1-nWNKDux8UKYryn2MgCmVBC.jpg",
+    "sessions": [
+      {
+        "id": 995879,
+        "name": "From Classroom to Codebase: How Universities Cultivate the Next Generation of Open Payments Talent"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "El Dr. Andrew Mangle es profesor asociado de Sistemas de Información Gerencial en la Facultad de Negocios de la Universidad Estatal de Bowie. Lidera iniciativas innovadoras para ampliar la participación de los estudiantes de las HBCU en la inclusión financiera digital. A través de asociaciones con la Fundación Interledger, desarrolla programas prácticos que preparan a los estudiantes para diseñar soluciones de pago abiertas y abordar las necesidades de las personas con acceso limitado o sin acceso a servicios bancarios. Su trabajo integra la tecnología financiera, la cadena de bloques y los pagos en la web abierta en la educación superior, garantizando que las comunidades infrarrepresentadas obtengan un acceso equitativo al futuro de las finanzas. Al conectar la investigación académica, la práctica industrial y la colaboración global, el Dr. Mangle promueve la misión de Interledger de acceso financiero universal e inspira a la próxima generación de líderes inclusivos en tecnología financiera.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "d5bc736d-6b83-44b9-9b4c-bcb71535a4ff",
+    "firstName": "Antonia",
+    "lastName": "Valencia",
+    "fullName": "Antonia Valencia",
+    "bio": "Antonia is a creative computing designer, researcher and artist focusing on the potential of translation of creative technology and the Natural world. She has over five years of experience developing participatory methodologies with international partners leading community - centered digital fabrication and technology education initiatives in Chilean Patagonia. During the years she has developed participatory design methodologies, creative technology programs and inclusive educational programs to bridge technology access gaps.with rural communities. Antonia is also co-founder of habita nodriza, an organic technological node that develops object and landscape proposals in pursuit of a healthy and biodiverse ecosystem in the intersection of design, art and technology. ",
+    "tagLine": "Convocation Research + Design",
+    "profilePicture": "https://sessionize.com/image/563c-400o400o1-Xxpvh2JYdYj9ENmNQFXXm5.jpg",
+    "sessions": [
+      {
+        "id": 996920,
+        "name": "Combatting Harmful Design for Consumer Safety"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Convocation Design + Research",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Design Researcher",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Antonia es una diseñadora creativa informática, investigadora y artista centrada en el potencial de la traducción de la tecnología creativa y el mundo natural. Cuenta con más de cinco años de experiencia en el desarrollo de metodologías participativas con socios internacionales que lideran iniciativas de fabricación digital y educación tecnológica centradas en la comunidad en la Patagonia chilena. A lo largo de los años, ha desarrollado metodologías de diseño participativo, programas de tecnología creativa y programas educativos inclusivos para salvar las brechas de acceso a la tecnología en las comunidades rurales. Antonia es también cofundadora de habita nodriza, un nodo tecnológico orgánico que desarrolla propuestas de objetos y paisajes en busca de un ecosistema saludable y biodiverso en la intersección del diseño, el arte y la tecnología.\r\n",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "d55a0ff7-8857-4713-96a3-3898a61d0de6",
+    "firstName": "Ayden",
+    "lastName": "Férdeline",
+    "fullName": "Ayden Férdeline",
+    "bio": "Ayden Férdeline is Lead, Public Policy and Government Affairs at the Interledger Foundation, where he advances digital financial inclusion by advocating for equitable access to digital public infrastructure. He ensures the Foundation’s perspective is well represented within intergovernmental and multistakeholder fora, and is the point of contact for policymakers, lawmakers, and regulators.  \r\nPrior to joining the Interledger Foundation, he was a Landecker Democracy Fellow with the Alfred Landecker Foundation in collaboration with Humanity in Action. In this role, he ensured the voice of workers, trade unions, and labor organizing groups was understood in different multilateral fora. Previously, he was the lead rapporteur of the Working Group on Pluralism of Information in Curation and Indexation Algorithms at the Forum on Information and Democracy, where he contributed to global discussions on algorithmic governance and the integrity of digital information ecosystems. In addition, he was a technology policy fellow at the Mozilla Foundation, researching the development and harmonization of privacy and data protection laws worldwide, and he represented European civil society organizations on the Council of ICANN’s Generic Names Supporting Organization, the policymaking body responsible for setting binding rules for generic top-level domains such as .COM and .ORG.\r\nBefore entering philanthropy, as an independent consultant he conducted qualitative research on the impact of the Internet on society for organizations including Coworker.org, the National Democratic Institute, and the National Endowment for Democracy.\r\nHe is an alumnus of the London School of Economics and Political Science.",
+    "tagLine": "Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/05c5-400o400o1-QXPc4v8QhzKU5nBbHdDMW.jpg",
+    "sessions": [
+      {
+        "id": 995871,
+        "name": "Human Rights by Design: Financial Infrastructure that Works for Everyone"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Ayden Férdeline es directora de Políticas Públicas y Asuntos Gubernamentales de la Fundación Interledger, donde promueve la inclusión financiera digital abogando por un acceso equitativo a la infraestructura pública digital. Se asegura de que la perspectiva de la Fundación esté bien representada en los foros intergubernamentales y multiactores, y es el punto de contacto para los responsables políticos, los legisladores y los reguladores. Antes de incorporarse a la Fundación Interledger, fue becaria Landecker Democracy Fellow de la Fundación Alfred Landecker en colaboración con Humanity in Action. En este cargo, se aseguró de que la voz de los trabajadores, los sindicatos y los grupos de organización laboral se entendiera en diferentes foros multilaterales. Anteriormente, fue relator principal del Grupo de Trabajo sobre Pluralismo de la Información en Algoritmos de Curación e Indexación del Foro sobre Información y Democracia, donde contribuyó a los debates mundiales sobre la gobernanza algorítmica y la integridad de los ecosistemas de información digital. Además, fue becaria de política tecnológica en la Fundación Mozilla, donde investigó el desarrollo y la armonización de las leyes de privacidad y protección de datos en todo el mundo, y representó a las organizaciones de la sociedad civil europea en el Consejo de la Organización de Apoyo a los Nombres Genéricos de la ICANN, el órgano normativo responsable de establecer normas vinculantes para los dominios genéricos de nivel superior, como .COM y .ORG. \r\nAntes de dedicarse a la filantropía, trabajó como consultora independiente realizando investigaciones cualitativas sobre el impacto de Internet en la sociedad para organizaciones como Coworker.org, el Instituto Nacional Demócrata y la Fundación Nacional para la Democracia. Es ex alumna de la London School of Economics and Political Science.\r\n",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8f8b1d5e-b76b-4e33-9959-508c0d85cb1e",
+    "firstName": "Beatriz ",
+    "lastName": "Durán Serrano",
+    "fullName": "Beatriz Durán Serrano",
+    "bio": "Beatriz Durán is a prominent leader in the fintech sector in Mexico. With more than 15 years of experience in investor relations, structured finance, public policy, and product design, she served as a board member of Fintech México and as Vice President of the Open Finance Committee.\r\n\r\nShe is the co-founder of Open Finance Tribe MX, one of the most influential Open Finance communities in Latin America, where she promotes collaborative innovation in open finance. Recognized as a Disruptor 2023 by Iupana, Beatriz holds an MBA from IPADE, a certificate in Digital Technologies from the London Business School, and a degree in Chemical Engineering from Universidad Iberoamericana.",
+    "tagLine": "Co-founder of Open Finance Tribe MX",
+    "profilePicture": "https://sessionize.com/image/72e0-400o400o1-V6uu1TTCRhu1kcgGm8xJfh.jpg",
+    "sessions": [
+      {
+        "id": 995886,
+        "name": "Unlocking Financial Interoperability in Latin America"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Open Finance Tribe MX",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Co-founder",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Beatriz Durán es una destacada líder en el sector fintech en México. Con más de 15 años de experiencia en relaciones con inversionistas, finanzas estructuradas, políticas públicas y diseño de productos, se desempeñó como miembro de la junta directiva de Fintech México y como vicepresidenta del Comité de Finanzas Abiertas. \r\n\r\nEs cofundadora de Open Finance Tribe MX, una de las comunidades de finanzas abiertas más influyentes de América Latina, donde promueve la innovación colaborativa en finanzas abiertas. Reconocida como Disruptor 2023 por Iupana, Beatriz tiene un MBA del IPADE, un certificado en Tecnologías Digitales de la London Business School y una licenciatura en Ingeniería Química de la Universidad Iberoamericana.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "daa019af-2d28-46a0-96b5-f98444e8a9f7",
+    "firstName": "Briana ",
+    "lastName": "Marbury",
+    "fullName": "Briana Marbury",
+    "bio": "Briana is passionate about promoting open payments and financial interoperability solutions for the world's population that need it most. As Executive Director of the Interledger Foundation, her goal is to expand the public’s awareness of the Interledger Protocol's immense potential to improve lives. ",
+    "tagLine": "Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/4287-400o400o1-TACuYPc9JFhkZKbN5FnG1d.jpg",
+    "sessions": [
+      {
+        "id": 995867,
+        "name": "Keynote Speaker"
+      },
+      {
+        "id": 1031417,
+        "name": "Closing Plenary"
+      }
+    ],
+    "isTopSpeaker": true,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "President & CEO",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "A Briana le apasiona promover soluciones de pagos abiertos e interoperabilidad financiera para la población mundial que más lo necesita. Como directora ejecutiva de la Fundación Interledger, su objetivo es dar a conocer al público el inmenso potencial del protocolo Interledger para mejorar la vida de las personas.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "32e79d82-db5e-4380-8af2-3b84001442cd",
+    "firstName": "Carolina",
+    "lastName": "Trivelli",
+    "fullName": "Carolina Trivelli",
+    "bio": "Carolina Trivelli is currently a Senior Researcher at Instituto de Estudios Peruanos, an Associated Researcher at RIMISP, and a consultant for several national and international organizations. Ms. Trivelli is an Economist with an MSc in Agricultural Economics from The Pennsylvania State University. She has been the Minister of Development and Social Inclusion of Peru (2011-2013), has worked as Managing Director of Pagos Digitales Peruanos (2014-2016), as Strategic Analysis Senior Advisor for the Latin American and the Caribbean FAO Regional Office (2021-2022), as a consultant for several international organizations, and as a researcher and Director General of the Instituto de Estudios Peruanos. \r\n \r\nShe serves as a Board member for several private institutions. She is a member of the International Advisory Group of MOSIP (India), and the Technical Advisory Committee of FinEquity (CGAP). She is also a Technical Advisory Committee on Poverty Measurment (INEI) member. She is an Advisor at the Peruvian Fiscal Committee, an independent body overseeing national fiscal sustainability. She is a columnist for El Comercio, the more important national newspaper, and Gestion, the financial newspaper. ",
+    "tagLine": "Instituto de Estudios Peruanos",
+    "profilePicture": "https://sessionize.com/image/a6b6-400o400o1-QNVi7RU6DXHgPJVq68EbQ8.jpg",
+    "sessions": [
+      {
+        "id": 995902,
+        "name": "From Access to Wellbeing: Designing Financial Tools Women Can Trust and Use"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Carolina Trivelli es actualmente investigadora sénior en el Instituto de Estudios Peruanos, investigadora asociada en el RIMISP y consultora para varias organizaciones nacionales e internacionales. La Sra. Trivelli es economista y tiene una maestría en Economía Agrícola de la Universidad Estatal de Pensilvania. Ha sido ministra de Desarrollo e Inclusión Social del Perú (2011-2013), ha trabajado como directora general de Pagos Digitales Peruanos (2014-2016), como asesora principal de Análisis Estratégico de la Oficina Regional de la FAO para América Latina y el Caribe (2021-2022), como consultora de varias organizaciones internacionales y como investigadora y directora general del Instituto de Estudios Peruanos. Es miembro del consejo de administración de varias instituciones privadas. Es miembro del Grupo Asesor Internacional de MOSIP (India) y del Comité Asesor Técnico de FinEquity (CGAP). También es miembro del Comité Asesor Técnico sobre Medición de la Pobreza (INEI). Es asesora del Comité Fiscal Peruano, un organismo independiente que supervisa la sostenibilidad fiscal nacional. Es columnista de El Comercio, el periódico nacional más importante, y de Gestión, el periódico financiero.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "4bc0f1d5-3ad9-4cc2-ae85-d7f317578716",
+    "firstName": "Caroline",
+    "lastName": "Sinders",
+    "fullName": "Caroline Sinders",
+    "bio": "Caroline Sinders is an award winning critical designer, researcher, and artist. They’re the co-founder and executive director human rights research and technology lab, Convocation Research + Design, and a current Interledger Foundation ambassador.. For over the past decade, they have been examining the intersections of human rights, artificial intelligence, intersectional justice, harmful design, and systems in technology and digital platforms. They have worked with the United Nations, Amnesty International, IBM Watson, the Wikimedia Foundation, and others. Sinders has held fellowships with the Harvard Kennedy School, Google’s PAIR (People and Artificial Intelligence Research group), Ars Electronica’s AI Lab, the Weizenbaum Institute, the Mozilla Foundation, Pioneer Works, Eyebeam, Ars Electronica, the Yerba Buena Center for the Arts, the Sci Art Resonances program with the European Commission, and the International Center of Photography. Their work has been featured in the Tate Exchange in Tate Modern, the Contemporary Art Center of New Orleans, Telematic Media Arts, Victoria and Albert Museum, MoMA PS1, LABoral, Wired, Slate, Hyperallergic, Clot Magazine, Quartz, the Channels Festival, and others. Sinders holds a Masters from New York University’s Interactive Telecommunications Program",
+    "tagLine": "Interledger Ambassador",
+    "profilePicture": "https://sessionize.com/image/40e4-400o400o1-f8SMdGnNhB4faFGfSUnEkj.jpg",
+    "sessions": [
+      {
+        "id": 996920,
+        "name": "Combatting Harmful Design for Consumer Safety"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation ",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Ambassador",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Caroline Sinders es una galardonada diseñadora crítica, investigadora y artista. Es cofundadora y directora ejecutiva del laboratorio de investigación y tecnología en derechos humanos Convocation Research + Design, y actualmente es embajadora de la Fundación Interledger. Durante la última década, ha estado examinando las intersecciones entre los derechos humanos, la inteligencia artificial, la justicia interseccional, el diseño perjudicial y los sistemas en la tecnología y las plataformas digitales. Ha trabajado con las Naciones Unidas, Amnistía Internacional, IBM Watson, la Fundación Wikimedia y otras organizaciones. Sinders ha sido becario de la Harvard Kennedy School, el PAIR (grupo de investigación sobre personas e inteligencia artificial) de Google, el laboratorio de IA de Ars Electronica, el Instituto Weizenbaum, la Fundación Mozilla, Pioneer Works, Eyebeam, Ars Electronica, el Centro Yerba Buena para las Artes, el programa Sci Art Resonances de la Comisión Europea y el Centro Internacional de Fotografía. Su trabajo ha sido presentado en el Tate Exchange de la Tate Modern, el Centro de Arte Contemporáneo de Nueva Orleans, Telematic Media Arts, el Victoria and Albert Museum, el MoMA PS1, LABoral, Wired, Slate, Hyperallergic, Clot Magazine, Quartz, el Channels Festival y otros. Sinders tiene un máster del Programa de Telecomunicaciones Interactivas de la Universidad de Nueva York.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "ac4d0d30-bf16-4f00-bc03-7cedd2a41695",
+    "firstName": "Casey",
+    "lastName": "Dike’",
+    "fullName": "Casey Dike’",
+    "bio": "Casey Ariel Dike’ is the Founder and CEO of Blaze Group®, a finance innovation studio creating startups and solutions that transform how money moves in our communities. With over 13 years of experience in global finance, Casey began her career structuring multi-billion-dollar credit facilities for major tech corporations. She later served as Chief Credit Officer at Hello Tractor, where she pioneered pay-as-you-go financing models for underbanked smallholder farmers across Sub-Saharan Africa.\r\nIn 2020, she launched Blaze Group® to bring financial education and access directly to overlooked communities. The Blaze Group® app, available on Android and iOS in 176 countries, offers micro-learning, AI business advisory, and customizable tools that empower entrepreneurs globally. Blaze Group® has earned multiple Webby Awards for excellence in Business, AI, and Technology, and is supported by a growing social media community of over 110,000.\r\nCasey is a board member of Kiva US, a fintech lecturer at Alabama A&M University, and a leading advocate for reparative capital and equitable economic design. She has spoken at respected institutions including Amazon, ESSENCE Festival, Dartmouth College, Georgetown University, and The Wharton School of Business.",
+    "tagLine": "Blaze Group",
+    "profilePicture": "https://sessionize.com/image/79c5-400o400o1-MNg9MTvgisJ2FQKNLwY7PF.jpg",
+    "sessions": [
+      {
+        "id": 995900,
+        "name": "From Mission to Market: Where Fintech and CDFIs Align and Clash"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": " Interledger Foundation | Consultant",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Consultant",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Casey Ariel Dike es la fundadora y directora ejecutiva de Blaze Group®, un estudio de innovación financiera que crea startups y soluciones que transforman la forma en que se mueve el dinero en nuestras comunidades. Con más de 13 años de experiencia en finanzas globales, Casey comenzó su carrera estructurando líneas de crédito multimillonarias para grandes empresas tecnológicas. Más tarde, ocupó el cargo de directora de crédito en Hello Tractor, donde fue pionera en los modelos de financiación de pago por uso para pequeños agricultores sin acceso a servicios bancarios en el África subsahariana. En 2020, lanzó Blaze Group® para llevar la educación financiera y el acceso a los servicios financieros directamente a las comunidades desatendidas. La aplicación Blaze Group®, disponible para Android e iOS en 176 países, ofrece microaprendizaje, asesoramiento empresarial con inteligencia artificial y herramientas personalizables que empoderan a los emprendedores de todo el mundo. Blaze Group® ha ganado varios premios Webby por su excelencia en negocios, inteligencia artificial y tecnología, y cuenta con el apoyo de una comunidad en redes sociales en crecimiento de más de 110 000 personas. Casey es miembro de la junta directiva de Kiva US, profesora de tecnología financiera en la Universidad A&M de Alabama y una de las principales defensoras del capital reparador y el diseño económico equitativo. Ha dado conferencias en instituciones de prestigio como Amazon, ESSENCE Festival, Dartmouth College, Georgetown University y The Wharton School of Business.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8c31891a-1b90-41c9-9419-cb79cdd7494e",
+    "firstName": "Chris",
+    "lastName": "Lawrence",
+    "fullName": "Chris Lawrence",
+    "bio": "Chris Lawrence is an experienced nonprofit professional who has spent the last 15 years as a dedicated educator, network builder, and advocate for non-profit organizations. Chris is currently the Head of Programs at the Interledger Foundation. He oversees all aspects of the programatic activity of the foundation.",
+    "tagLine": "Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/5981-400o400o1-XkGzFDzmw4fdKrrS69PCBS.jpg",
+    "sessions": [
+      {
+        "id": 995876,
+        "name": "Rights & Rails: How Philanthropy Links Access, Capacity & Inclusive Payment Systems"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Chris Lawrence es un experimentado profesional del sector sin fines de lucro que ha dedicado los últimos 15 años a la educación, la creación de redes y la defensa de las organizaciones sin fines de lucro. Actualmente, Chris es director de programas de la Fundación Interledger. Supervisa todos los aspectos de la actividad programática de la fundación.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "9673d6a9-cea3-42a7-afa6-aefc0414a472",
+    "firstName": "Darnell",
+    "lastName": "Garcia",
+    "fullName": "Darnell Garcia",
+    "bio": "Full-stack Engineer at BessPay Ltd., with hands-on experience in building scalable platforms and digital payment integrations. A two-time Microsoft intern, developing the BessPay Plugin MVP and will co-present the live demo, showcasing the technical integration of Open Payments with marketplace platforms.",
+    "tagLine": "BessPay",
+    "profilePicture": "https://sessionize.com/image/f31a-400o400o1-L25L7bM4j2Wtq44XmSpBku.jpg",
+    "sessions": [
+      {
+        "id": 1033769,
+        "name": "BessPay Plugin: Powering MSME Marketplaces on Sharetribe with Interledger Open Payments"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "BessPay Limited",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Full Stack Engineer",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Ingeniero full stack en BessPay Ltd., con experiencia práctica en la creación de plataformas escalables e integraciones de pagos digitales. Ha realizado dos prácticas en Microsoft, ha desarrollado el plugin MVP de BessPay y copresentará la demostración en directo, en la que se mostrará la integración técnica de Open Payments con las plataformas de mercado.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "569cb03f-bb7c-4ab2-957e-859bc047dc28",
+    "firstName": "Douglas",
+    "lastName": "Davidson",
+    "fullName": "Douglas Davidson",
+    "bio": "Douglas Davidson is the Co-Founder & Director of BessPay Ltd. With 14+ years of experience in financial services, telecoms, and technology innovation, he leads projects focused on financial inclusion, cross-border payments, and marketplace transformation. Through BessPay, Douglas is working to make global payments easier, cheaper, and faster for MSMEs across emerging markets.",
+    "tagLine": "BessPay",
+    "profilePicture": "https://sessionize.com/image/988f-400o400o1-3YHRePBLHp7xjEQFwDEUJ4.png",
+    "sessions": [
+      {
+        "id": 1033769,
+        "name": "BessPay Plugin: Powering MSME Marketplaces on Sharetribe with Interledger Open Payments"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "BessPay Limited",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Company Director & CEO",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Douglas Davidson es cofundador y director de BessPay Ltd. Con más de 14 años de experiencia en servicios financieros, telecomunicaciones e innovación tecnológica, dirige proyectos centrados en la inclusión financiera, los pagos transfronterizos y la transformación del mercado. A través de BessPay, Douglas trabaja para que los pagos globales sean más fáciles, baratos y rápidos para las micro, pequeñas y medianas empresas de los mercados emergentes.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "ad2c458b-64a4-401b-aa98-05944bb9f7dd",
+    "firstName": "Ed",
+    "lastName": "Cable",
+    "fullName": "Ed Cable",
+    "bio": "Edward Cable is the President and CEO of the Mifos Initiative, and a founding member of the Apache Fineract PMC. He is a recognized leader in technology-enabled financial inclusion and open service financial services innovation. Edward has been deeply involved in open source fintech solutions since 2007, particularly for emerging markets, and leads the Mifos Initiative in its mission to build innovative financial services with open-source tools. He is passionate about community-driven financial inclusion and oversees a global ecosystem of fintechs and financial institutions. Outside of work, Edward tends to his menagerie of animals in the majestic Redwoods.",
+    "tagLine": "Mifos Initiative",
+    "profilePicture": "https://sessionize.com/image/0f26-400o400o1-BjYufp23D8atM3U3ZM8BGM.jpg",
+    "sessions": [
+      {
+        "id": 995871,
+        "name": "Human Rights by Design: Financial Infrastructure that Works for Everyone"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Edward Cable es presidente y director ejecutivo de Mifos Initiative, y miembro fundador de Apache Fineract PMC. Es un reconocido líder en inclusión financiera basada en la tecnología e innovación en servicios financieros abiertos. Edward lleva desde 2007 profundamente involucrado en soluciones fintech de código abierto, especialmente para mercados emergentes, y lidera la Iniciativa Mifos en su misión de crear servicios financieros innovadores con herramientas de código abierto. Es un apasionado de la inclusión financiera impulsada por la comunidad y supervisa un ecosistema global de fintechs e instituciones financieras. Fuera del trabajo, Edward se dedica a cuidar de su colección de animales en los majestuosos bosques Redwoods.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "dd156dfc-6371-4203-8473-284175d8bd53",
+    "firstName": "Erick",
+    "lastName": "Huerta Velázquez",
+    "fullName": "Erick Huerta Velázquez",
+    "bio": "Doctorate in Rural Development from the Autonomous Metropolitan University (UAM) Xochimilco, Master's Degree in Social Administration with a specialization in Community Development from the University of Queensland, Australia, and Law Degree from the Ibero-American University with postgraduate courses at the Escuela Libre de Derecho. Expert at the International Telecommunication Union (ITU) on connectivity issues in remote areas and indigenous communities. Designed the legal strategy for the world's first Indigenous Community Cellular Telephone Network. Also a member of the organizations Rhizomatica and TIC A.C. Founder and general coordinator of REDES A.C.",
+    "tagLine": "Coordinación General REDES A.C ",
+    "profilePicture": "https://sessionize.com/image/7d85-400o400o1-DPcMCxyeg79So1rnb9T7uo.jpg",
+    "sessions": [
+      {
+        "id": 995890,
+        "name": "From Policy to Practice: Financial Inclusion in Mexico"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Doctor en Desarrollo Rural en la UAM Xochimilco, Maestro en Administración Social con Especialidad en Desarrollo Comunitario por la Universidad de Queensland, Australia, y Licenciado en Derecho por la Universidad Iberoamericana con cursos de postgrado en la Escuela Libre de Derecho.\r\n\r\nExperto de la Unión Internacional de Telecomunicaciones (UIT) para temas de conectividad en zonas apartadas y pueblos indígenas. Diseñó la estrategia jurídica de la primera red de Telefonía Celular Comunitaria Indígena en el mundo. También forma parte de las organizaciones Rhizomatica y TIC A.C.\r\n\r\nEs fundador y coordinador general de REDES A.C. ",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "0e20465e-b9bb-4348-9732-2c67874188ef",
+    "firstName": "Evan",
+    "lastName": "Schwartz",
+    "fullName": "Evan Schwartz",
+    "bio": "Evan Schwartz is the Co-Creator of the Interledger Protocol and Board of Director at the Interledger Foundation. \r\n\r\n--\r\n\r\nEvan Schwartz es cofundador del protocolo Interledger y miembro del consejo de administración de la Fundación Interledger.",
+    "tagLine": "Co-Creator of the Interledger Protocol ",
+    "profilePicture": "https://sessionize.com/image/b530-400o400o1-AM3CkXWVZYgWSL6TUH5hV.jpg",
+    "sessions": [
+      {
+        "id": 995867,
+        "name": "Keynote Speaker"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Co-Creator of the Interledger Protocol",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Evan Schwartz es cofundador del protocolo Interledger y miembro del consejo de administración de la Fundación Interledger.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "1b090fa6-f61e-4f24-92e3-d2f41c174946",
+    "firstName": "Faheed",
+    "lastName": "Alli-Balogun",
+    "fullName": "Faheed Alli-Balogun",
+    "bio": "Faheed Alli-Balogun is a fintech product leader and multidisciplinary designer focused on building trust-first, globally scalable financial technology. As Head of Product at Chimoney, he leads cross-functional teams in shipping global fintech infrastructure that enables open, programmable access to money and financial value.\r\n\r\nWith a background that spans product strategy, UX design, and growth, Faheed excels at translating complex, compliance-heavy systems into usable, human-centered experiences. He is a passionate ecosystem contributor and a strong advocate for leveraging open standards like the Interledger Protocol to create a more equitable and inclusive financial future.",
+    "tagLine": "Head of Product, Chimoney",
+    "profilePicture": "https://sessionize.com/image/8847-400o400o1-TwBYe95GSBFzHHRptxvyaE.png",
+    "sessions": [
+      {
+        "id": 1018855,
+        "name": "Chimoney's ILP Stack & Chimoney App Updates"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Chimoney",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Head of Product",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Faheed Alli-Balogun es un líder en productos fintech y diseñador multidisciplinario enfocado en crear tecnología financiera escalable a nivel mundial y basada en la confianza. Como jefe de producto en Chimoney, dirige equipos multifuncionales en el envío de infraestructura fintech global que permite un acceso abierto y programable al dinero y al valor financiero. Con una trayectoria que abarca la estrategia de producto, el diseño de la experiencia de usuario y el crecimiento, Faheed destaca por su capacidad para traducir sistemas complejos y con un alto grado de cumplimiento normativo en experiencias útiles y centradas en las personas. Es un apasionado colaborador del ecosistema y un firme defensor del aprovechamiento de estándares abiertos como el protocolo Interledger para crear un futuro financiero más equitativo e inclusivo.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "42127c6c-f9ec-48e1-a603-4171c838deeb",
+    "firstName": "Feintz",
+    "lastName": "Pierre",
+    "fullName": "Feintz Pierre",
+    "bio": "Feintz Pierre is the Vice President, Business Development Officer for the Mid-Atlantic Market at  Lendistry, where he helps business owners access the capital they need to grow. With more than  20 years in banking and finance, he combines deep expertise in credit strategy, risk analysis, and project management with a client-first approach. His career has been dedicated to building  lending solutions that are practical, sustainable, and tailored to the unique needs of businesses  across diverse industries.  \r\nFeintz began his career in commercial and residential banking, where he gained a strong  foundation in underwriting, portfolio management, and compliance. From 2021 to 2023, he  served as Vice President, East Coast Team Lead for Residential Lending at City National Bank,  leading a high-performing team that increased market share by 24% and consistently surpassed  revenue goals. He later transitioned into real estate as Vice President of Multifamily Acquisitions  and Syndications at Markinvest Real Estate in New York, where he led investment strategies,  managed syndications, and forged strong partnerships with institutional investors to maximize  returns and enhance portfolio performance.  \r\nIn 2025, Feintz joined Lendistry to expand the firm’s presence in the Mid-Atlantic Market. In his  current role, he develops referral networks, partners with centers of influence, and provides  strategic credit guidance to small business clients. Drawing on his leadership background and  subject matter expertise in SBA 7(a), 504, and acquisition lending, he ensures clients receive  financing options designed to meet both immediate and long-term goals. Passionate about  financial literacy and equitable access to capital, Feintz is committed to helping entrepreneurs  and communities thrive through smarter lending solutions. ",
+    "tagLine": "Lendistry",
+    "profilePicture": "https://sessionize.com/image/85fd-400o400o1-Ho5YETE7wCHEbMNFanAsRJ.jpg",
+    "sessions": [
+      {
+        "id": 995900,
+        "name": "From Mission to Market: Where Fintech and CDFIs Align and Clash"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Feintz Pierre es vicepresidente y director de desarrollo comercial para el mercado del Atlántico Medio en Lendistry, donde ayuda a los empresarios a acceder al capital que necesitan para crecer. Con más de 20 años de experiencia en banca y finanzas, combina una profunda experiencia en estrategia crediticia, análisis de riesgos y gestión de proyectos con un enfoque centrado en el cliente. Ha dedicado su carrera a crear soluciones de crédito prácticas, sostenibles y adaptadas a las necesidades específicas de empresas de diversos sectores. Feintz comenzó su carrera en la banca comercial y residencial, donde adquirió una sólida base en suscripción, gestión de carteras y cumplimiento normativo. De 2021 a 2023, ocupó el cargo de vicepresidente y jefe del equipo de la costa este para préstamos residenciales en City National Bank, donde dirigió un equipo de alto rendimiento que aumentó la cuota de mercado en un 24 % y superó constantemente los objetivos de ingresos. Más tarde pasó al sector inmobiliario como vicepresidente de adquisiciones y sindicaciones multifamiliares en Markinvest Real Estate en Nueva York, donde dirigió estrategias de inversión, gestionó sindicaciones y forjó sólidas alianzas con inversores institucionales para maximizar la rentabilidad y mejorar el rendimiento de la cartera. En 2025, Feintz se incorporó a Lendistry para ampliar la presencia de la empresa en el mercado de la costa atlántica central. En su cargo actual, desarrolla redes de referencia, se asocia con centros de influencia y proporciona orientación estratégica en materia de crédito a clientes de pequeñas empresas.  Gracias a su experiencia en liderazgo y sus conocimientos especializados en los programas SBA 7(a), 504 y préstamos para adquisiciones, se asegura de que los clientes reciban opciones de financiamiento diseñadas para satisfacer tanto sus objetivos inmediatos como a largo plazo. Apasionado por la educación financiera y el acceso equitativo al capital, Feintz se compromete a ayudar a los emprendedores y a las comunidades a prosperar mediante soluciones de préstamo más inteligentes.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "69435364-304f-4884-ab47-e0c84e57c4be",
+    "firstName": "Fiorentina ",
+    "lastName": "García Miramón",
+    "fullName": "Fiorentina García Miramón",
+    "bio": "Fiorentina co-founded Tec-Check, the first civil society organization in Mexico dedicated exclusively to the protection and defense of consumer rights in the digital economy. Tec-Check works to promote transparency in e-commerce, demand accountability from authorities and businesses, and support consumers in collectively enforcing their rights. Since 2022, it has been a member of Consumers International, the global network of consumer associations, and in 2025 it joined the Advisory Council of the Federal Consumer Protection Agency (Profeco) in Mexico.\r\nFiorentina holds a master’s degree in public policy from the Hertie School of Governance in Berlin and a bachelor’s degree in economics from Tecnológico de Monterrey. In 2020, she was awarded the Global Governance Academy Fellowship by the German Federal Ministry for Economic Cooperation and Development.",
+    "tagLine": "Tec-Check",
+    "profilePicture": "https://sessionize.com/image/9864-400o400o1-VXmC1qhJwEbqHiED3m6Q2D.jpg",
+    "sessions": [
+      {
+        "id": 1049783,
+        "name": "Trustworthy by Default: Designing Digital Finance People Choose to Use "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Fiorentina cofundó Tec-Check, la primera organización de la sociedad civil en México dedicada exclusivamente a la protección y defensa de los derechos de los consumidores en la economía digital. Tec-Check trabaja para promover la transparencia en el comercio electrónico, exigir la rendición de cuentas a las autoridades y las empresas, y apoyar a los consumidores en la defensa colectiva de sus derechos. Desde 2022, es miembro de Consumers International, la red mundial de asociaciones de consumidores, y en 2025 se incorporó al Consejo Asesor de la Procuraduría Federal de Protección al Consumidor (Profeco) en México.\r\nFiorentina tiene una maestría en políticas públicas de la Hertie School of Governance de Berlín y una licenciatura en economía del Tecnológico de Monterrey. En 2020, recibió la beca de la Global Governance Academy del Ministerio Federal Alemán de Cooperación Económica y Desarrollo.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "179ba8c7-f00e-448f-8002-6f2d3e349096",
+    "firstName": "Gavin",
+    "lastName": "Chait",
+    "fullName": "Gavin Chait",
+    "bio": "I lead software- and systems development in open data and open science, with a focus on ethics and curation. I am fascinated by the frontiers of human progress: innovation vs ignorance; wealth vs poverty, migration vs stasis.  I spent more than a decade in economic and business development initiatives in South Africa before moving to the UK where I entered the fledgling open knowledge industry, going on to lead open data technical and research projects around the world, including Pakistan, Ghana, Nigeria, Tanzania, Mauritius, Australia and in Europe and the Americas. I have extensive experience in leading research projects, implementing open source software initiatives, and developing and leading seminars and workshops. I am currently an Interledger Ambassador and a previously-funded ILF grantee for my Qwyre.com epub reader app.",
+    "tagLine": "Interledger Ambassador",
+    "profilePicture": "https://sessionize.com/image/da61-400o400o1-HjDk8Vhi8dRBApNLFcYaW.jpg",
+    "sessions": [
+      {
+        "id": 1033789,
+        "name": "Hop Sauna for federated community-moderated commerce"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Whythawk",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Data-scientist",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Dirijo el desarrollo de software y sistemas en el ámbito de los datos abiertos y la ciencia abierta, centrándome en la ética y la curación. Me fascinan las fronteras del progreso humano: innovación frente a ignorancia; riqueza frente a pobreza, migración frente a estancamiento. Pasé más de una década en iniciativas de desarrollo económico y empresarial en Sudáfrica antes de trasladarme al Reino Unido, donde me incorporé a la incipiente industria del conocimiento abierto y pasé a dirigir proyectos técnicos y de investigación sobre datos abiertos en todo el mundo, incluyendo Pakistán, Ghana, Nigeria, Tanzania, Mauricio, Australia, Europa y América. Tengo una amplia experiencia en la dirección de proyectos de investigación, la implementación de iniciativas de software de código abierto y el desarrollo y la dirección de seminarios y talleres. Actualmente soy embajador de Interledger y he recibido una beca del ILF por mi aplicación de lectura de libros electrónicos Qwyre.com.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6dc84f36-6462-4938-ad3d-00abf3ae6952",
+    "firstName": "Hannah",
+    "lastName": "Draper",
+    "fullName": "Hannah Draper",
+    "bio": "Hannah Draper is a Visiting Scholar at FGV Law School, where she researches consumer rights in payment digital public infrastructure in BRICS countries, and Director of Payne & Routledge, Ltd., an international consulting firm advancing the internet in the public interest through research, compliance support, and strategic advice for a diverse portfolio of clients, including from civil society, academia, and philanthropy. Previously, she spent nearly a decade at the Open Society Foundations, where she oversaw a global digital rights program and led several special initiatives, including on human rights in digital ID systems and secure communications for journalists and human rights defenders. She also co-founded INDELA.fund, a Latin American initiative strengthening regional digital rights organizations. Earlier, she advised the Information and Privacy Commissioner of Ontario and worked on regulatory frameworks with the CRTC. Draper holds a JD in technology law from the University of Ottawa and a BA in International Development from the University of Guelph, and has completed additional legal training at the University of Puerto Rico School of Law and the University of Amsterdam’s Institute for Information Law.\r\n",
+    "tagLine": "FGV Law School",
+    "profilePicture": "https://sessionize.com/image/a7eb-400o400o1-piCoGhd9yioYY4TNXSrQmX.jpg",
+    "sessions": [
+      {
+        "id": 995871,
+        "name": "Human Rights by Design: Financial Infrastructure that Works for Everyone"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Hannah Draper es profesora visitante en la Facultad de Derecho de la FGV, donde investiga los derechos de los consumidores en la infraestructura pública digital de pagos en los países BRICS, y directora de Payne & Routledge, Ltd., una consultora internacional que promueve el uso de Internet en beneficio del interés público mediante la investigación, el apoyo al cumplimiento normativo y el asesoramiento estratégico a una amplia cartera de clientes, entre los que se incluyen la sociedad civil, el mundo académico y el sector filantrópico. Anteriormente, trabajó durante casi una década en Open Society Foundations, donde supervisó un programa global de derechos digitales y dirigió varias iniciativas especiales, entre ellas las relacionadas con los derechos humanos en los sistemas de identificación digital y las comunicaciones seguras para periodistas y defensores de los derechos humanos. También cofundó INDELA.fund, una iniciativa latinoamericana que refuerza las organizaciones regionales de derechos digitales. Anteriormente, asesoró al Comisionado de Información y Privacidad de Ontario y trabajó en marcos normativos con la CRTC. Draper tiene un doctorado en Derecho Tecnológico por la Universidad de Ottawa y una licenciatura en Desarrollo Internacional por la Universidad de Guelph, y ha completado formación jurídica adicional en la Facultad de Derecho de la Universidad de Puerto Rico y en el Instituto de Derecho de la Información de la Universidad de Ámsterdam.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "ac1ceac1-f843-4904-b8c9-2f5021010d44",
+    "firstName": "Iñigo",
+    "lastName": "Rumayor",
+    "fullName": "Iñigo Rumayor",
+    "bio": "Iñigo Rumayor is a Mexican entrepreneur from Saltillo, Coahuila. From an early age, he showed an interest in business, helping to sell in the family business. He studied economics at the University of Pennsylvania, where he participated in several startup programs. In 2013, Iñigo co-founded Regalii, a platform that allowed immigrants in the United States to pay for services in their home countries. Regalii evolved into Arcus, a multi-rail payment platform and the second non-bank entity with a direct connection to SPEI in Mexico. In 2021, Arcus was acquired by Mastercard, marking the company's first acquisition in Latin America. After leaving Arcus (now Arcus by MasterCard), Iñigo decided to found Monato, a company dedicated to facilitating access to financial products and infrastructure for businesses. Throughout his career, Iñigo has held various roles, including founder, director, consultant, and mentor within the fintech ecosystem. His career reflects his entrepreneurial vision and dedication to improving the financial infrastructure in the region.",
+    "tagLine": "CEO & Founder, Monato",
+    "profilePicture": "https://sessionize.com/image/623a-400o400o1-QumGr6nk4s247nve4wcuso.png",
+    "sessions": [
+      {
+        "id": 995886,
+        "name": "Unlocking Financial Interoperability in Latin America"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Iñigo Rumayor es un emprendedor mexicano originario de Saltillo, Coahuila. Desde temprana edad mostró interés por los negocios, ayudando a vender en el negocio familiar. Estudió Economía en la Universidad de Pensilvania, donde participó en varios programas de startups.\r\n\r\nEn 2013, Iñigo co-fundó Regalii, una plataforma que permitía a inmigrantes en Estados Unidos pagar servicios en sus países de origen. Regalii evolucionó y se convirtió en Arcus, una plataforma de pagos multi-riel y la segunda entidad no bancaria con conexión directa al SPEI en México. En 2021, Arcus fue adquirida por Mastercard, marcando la primera adquisición de la compañía en América Latina.\r\n\r\nDespués de su salida de Arcus (ahora Arcus by MasterCard), Iñigo decidió fundar Monato, una empresa dedicada a facilitar el acceso de las empresas a productos e infraestructura financiera. A lo largo de su carrera, Iñigo ha desempeñado diversos roles, incluyendo fundador, director, consultor y mentor dentro del ecosistema fintech. Su trayectoria refleja su visión empresarial y dedicación para mejorar la infraestructura financiera en la región.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "297fd54b-f93c-4996-89bc-f96b3b7f8258",
+    "firstName": "Ioana",
+    "lastName": "Chiorean",
+    "fullName": "Ioana Chiorean",
+    "bio": "Ioana is an Engineering Manager with a flavor of Community and DevRel.  She has a strong experience in web technologies and her experience spans over 15 years, covering Release Engineering in large international corporations, foundations and series-A start-ups.\r\n\r\nBesides her work she dedicates her time to building tech communities and improving access to education. She is the Module Owner for Mozilla Programmes, an alumnae of the Mozilla Tech Speakers, and stands as an ambassador for CodeWeek at the European Commission.\r\n\r\nShe is an advisor and board member for Women in Tech, contributes to Open Source and different volunteering programs and is passionate about closing the gaps when it comes to inclusivity and diversity.",
+    "tagLine": "Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/49ba-400o400o1-PVgB9apgZTqMZeGoWjrDSg.jpg",
+    "sessions": [
+      {
+        "id": 1018846,
+        "name": "All about Web Monetization "
+      },
+      {
+        "id": 995909,
+        "name": "Open Payments, Open Mic"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Senior Engineering Manager",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Ioana es directora de ingeniería con experiencia en comunidad y relaciones con desarrolladores. Cuenta con una sólida trayectoria en tecnologías web que abarca más de 15 años, incluyendo ingeniería de lanzamiento en grandes corporaciones internacionales, fundaciones y startups de serie A. Además de su trabajo, dedica su tiempo a crear comunidades tecnológicas y mejorar el acceso a la educación. Es propietaria de módulos para Mozilla Programmes, antigua alumna de Mozilla Tech Speakers y embajadora de CodeWeek en la Comisión Europea. Es asesora y miembro de la junta directiva de Women in Tech, colabora con Open Source y diferentes programas de voluntariado y le apasiona cerrar las brechas en materia de inclusión y diversidad.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "ecdf7e19-f808-4042-8e05-48349d72805b",
+    "firstName": "Isabel",
+    "lastName": "Cruz Hernandez",
+    "fullName": "Isabel Cruz Hernandez",
+    "bio": "Isabel Cruz is CEO of the Mexican Association of Social Sector Credit Unions (AMUCSS).\r\nMexican anthropologist, social finance activist and builder of community financial systems. For four decades she has worked in diverse regions of her country with peasant and indigenous organizations to promote grassroots financial inclusion. She is the CEO of the Mexican Association of Social Sector Credit Unions (AMUCSS).\r\n\r\nIsabel studied Anthropology at the National School of Anthropology and History, Financial Administration at Tecnológico de Monterrey and Business Management at the Technology Institute of Mexico (ITAM). She has made multiple international trips in Latin America, Europe,\r\nNorth America and Africa, to discover the most important popular financial experiences around the world and implement their solutions in Mexico.\r\n\r\nThroughout her career, Isabel has supported the construction of multiple local financial institutions and services for marginalized communities. She designed and implemented micro-savings methodologies for remote communities, including the creation of models for agricultural and non-agricultural productive credits, and financial methodologies for social housing development combining savings, credit, subsidies and assistance technique. She has also developed social strategies for strengthening binational communities and fostering the social impact of remittances.\r\n\r\nBecause of her work for financial inclusion, Isabel has received various international awards in the last 20 years. She is currently dedicated to producing strategic community banks (SOFINCOs) in rural and indigenous areas of Oaxaca, Chiapas, Puebla, Hidalgo, among others\r\nregions, and to the development of the Peoples Clearinghouse, an innovative financial network\r\nfor connecting social financial institutions between them and with international networks.\r\n\r\nShe writes at \"El Financiero\" newspaper and has published several public policy books.\r\n",
+    "tagLine": null,
+    "profilePicture": "https://sessionize.com/image/d3a1-400o400o1-G7aQBmqU8bbusv7fEPm3tG.png",
+    "sessions": [
+      {
+        "id": 1037913,
+        "name": "Community Showcase"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Mexican Association of Social Sector Credit Unions (AMUCSS)",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO of the Mexican Association of Social Sector Credit Unions (AMUCSS)",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Isabel Cruz es directora general de la Asociación Mexicana de Cooperativas de Crédito del Sector Social (AMUCSS). Antropóloga mexicana, activista en finanzas sociales y constructora de sistemas financieros comunitarios. Durante cuatro décadas ha trabajado en diversas regiones de su país con organizaciones campesinas e indígenas para promover la inclusión financiera de base. Es directora general de la Asociación Mexicana de Cooperativas de Crédito del Sector Social (AMUCSS). Isabel estudió Antropología en la Escuela Nacional de Antropología e Historia, Administración Financiera en el Tecnológico de Monterrey y Administración de Empresas en el Instituto Tecnológico de México (ITAM). Ha realizado múltiples viajes internacionales por América Latina, Europa, América del Norte y África, con el fin de descubrir las experiencias financieras populares más importantes del mundo e implementar sus soluciones en México. A lo largo de su carrera, Isabel ha apoyado la creación de múltiples instituciones y servicios financieros locales para comunidades marginadas. Diseñó e implementó metodologías de microahorro para comunidades remotas, incluyendo la creación de modelos de créditos productivos agrícolas y no agrícolas, y metodologías financieras para el desarrollo de viviendas sociales que combinan ahorro, crédito, subsidios y asistencia técnica. También ha desarrollado estrategias sociales para fortalecer las comunidades binacionales y fomentar el impacto social de las remesas. Gracias a su labor en favor de la inclusión financiera, Isabel ha recibido diversos premios internacionales en los últimos 20 años. Actualmente se dedica a la creación de bancos comunitarios estratégicos (SOFINCO) en zonas rurales e indígenas de Oaxaca, Chiapas, Puebla, Hidalgo, entre otras regiones, y al desarrollo de Peoples Clearinghouse, una innovadora red financiera para conectar a las instituciones financieras sociales entre sí y con redes internacionales. Escribe en el periódico «El Financiero» y ha publicado varios libros sobre políticas públicas.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "bdfa2c7f-2c92-4eae-a7eb-24c0e8fa4052",
+    "firstName": "Jeffrey",
+    "lastName": "Bower",
+    "fullName": "Jeffrey Bower",
+    "bio": "Jeffrey Bower is the founder of Bower & Partners, a boutique consulting firm focused on financial services and financial inclusion. With over 20 years of experience in the payments and fintech sector, Jeffrey is a recognized expert in designing and launching innovative and impactful digital payment solutions worldwide that enable financial inclusion and reduce the use of cash. His practice has delivered work for global clients such as the World Bank, IFC, Alliance for Financial Inclusion, the Better Than Cash Alliance, Scotiabank, and HSBC, and has worked on all continents.\r\n\r\nMost recently, Jeffrey was a Senior Investment Officer at the International Finance Corporation (IFC), where he led new market development to scale the use of digital financial services across Latin America and the Caribbean. Prior to this, he acted as Payment Services Lead for the World Food Programme, where he built the next generation of payment products for recipients of the world’s largest humanitarian organization.\r\n\r\nJeffrey has a Masters in International Relations from the University of Toronto, and speaks English, Spanish, and French.",
+    "tagLine": "Bower & Partners",
+    "profilePicture": "https://sessionize.com/image/08b4-400o400o1-pJyLYi4R9rDoA37GaMNnC4.jpg",
+    "sessions": [
+      {
+        "id": 995902,
+        "name": "From Access to Wellbeing: Designing Financial Tools Women Can Trust and Use"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Jeffrey Bower es el fundador de Bower & Partners, una consultora boutique especializada en servicios financieros e inclusión financiera. Con más de 20 años de experiencia en el sector de los pagos y la tecnología financiera, Jeffrey es un reconocido experto en el diseño y lanzamiento de soluciones de pago digitales innovadoras y de gran impacto en todo el mundo que permiten la inclusión financiera y reducen el uso de efectivo. Ha trabajado para clientes globales como el Banco Mundial, la CFI, la Alianza para la Inclusión Financiera, la Alianza Better Than Cash, Scotiabank y HSBC, y ha trabajado en todos los continentes. \r\n\r\nMás recientemente, Jeffrey fue director senior de inversiones en la Corporación Financiera Internacional (CFI), donde dirigió el desarrollo de nuevos mercados para ampliar el uso de los servicios financieros digitales en América Latina y el Caribe. Antes de eso, fue responsable de servicios de pago del Programa Mundial de Alimentos, donde creó la próxima generación de productos de pago para los beneficiarios de la mayor organización humanitaria del mundo. \r\n\r\nJeffrey tiene un máster en Relaciones Internacionales por la Universidad de Toronto y habla inglés, español y francés.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "83cc3863-e48d-42e4-8055-86c53c9ef693",
+    "firstName": "Jeremiah",
+    "lastName": "Lee",
+    "fullName": "Jeremiah Lee",
+    "bio": "Jeremiah Lee is a technology lead for the Interledger Foundation. He previously participated in the foundation’s ambassadorship program, managed data infrastructure teams at Stripe, managed Spotify’s partner playback technology, and led Fitbit’s API platform and partner integrations. He grew up under the California sun, but now calls Stockholm home.",
+    "tagLine": "Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/76fa-400o400o1-YX18z6LXKZwjCecBJZrpGT.jpg",
+    "sessions": [
+      {
+        "id": 995376,
+        "name": "The Regulator's Dilemma"
+      },
+      {
+        "id": 1037939,
+        "name": "The Regulator's Dilemma (repeat session)"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Jeremiah Lee es responsable tecnológico de la Interledger Foundation. Anteriormente participó en el programa de embajadores de la fundación, dirigió equipos de infraestructura de datos en Stripe, gestionó la tecnología de reproducción de socios de Spotify y dirigió la plataforma API y las integraciones de socios de Fitbit. Creció bajo el sol de California, pero ahora vive en Estocolmo.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "5360141a-45a1-4cd4-9dbe-a25b2031daec",
+    "firstName": "Jordi",
+    "lastName": "Puig",
+    "fullName": "Jordi Puig",
+    "bio": "Jordi Puig Viladomiu is a professional with over 6 years of experience leading projects in the Fintech and innovation ecosystem across Latin America. He currently serves as Director of Programs & Innovation at Finnosummit, the leading platform for the Fintech ecosystem in Latin America, which empowers and connects innovators and key industry players to transform finance and create a better world through events, startup programs, publications and studies, and high-impact networking that unleashes the power of entrepreneurship, innovation, and collaboration.\r\n\r\nAt Finnosummit, Jordi leads the development of insights and reports such as the Finnovista Fintech Radar, as well as strategic programs in collaboration with startups and global institutions, focusing on research, automation, and the design of innovative solutions for the financial sector.\r\n\r\nHe has a solid academic background, including an MBA in International Management, a degree in Law and Business Administration, and specialized studies in Fintech and Blockchain. He has worked on the design of new business models in the financial sector, supporting digital transformation through the use of artificial intelligence, data analysis, and agile methodologies.",
+    "tagLine": "Finnosummit",
+    "profilePicture": "https://sessionize.com/image/8ba5-400o400o1-SiK57Fe42EzwA3aQ8mULm7.jpg",
+    "sessions": [
+      {
+        "id": 995886,
+        "name": "Unlocking Financial Interoperability in Latin America"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Jordi Puig Viladomiu es un profesional con más de 6 años de experiencia liderando proyectos en el ecosistema Fintech y de innovación en América Latina. Actualmente, se desempeña como Director de Programas & Innovación en Finnosummit, la plataforma líder del ecosistema Fintech de América Latina que impulsa y conecta a innovadores y actores clave de la industria para transformar las finanzas y crear un mundo mejor a través de eventos, programas para startups, publicaciones y estudios, y networking de alto impacto para liberar el poder del emprendimiento, la innovación y la colaboración.\r\n\r\nEn Finnosummit, Jordi lidera el desarrollo de insights y reportes como los Finnovista Fintech Radar, así como los programas estratégicos en colaboración con startups e instituciones globales, enfocándose en investigación, automatización y diseño de soluciones innovadoras para el sector financiero.\r\n\r\nCuenta con una sólida formación académica, incluyendo un MBA en International Management, una licenciatura en Derecho y Administración de Empresas, y estudios especializados en Fintech y Blockchain. Ha trabajado en el diseño de nuevos modelos de negocio en el sector financiero, apoyando la transformación digital mediante el uso de inteligencia artificial, análisis de datos y metodologías ágiles.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "076b027b-dab7-41b4-b8f9-f51ff076d523",
+    "firstName": "Jorge ",
+    "lastName": "Ortiz",
+    "fullName": "Jorge Ortiz",
+    "bio": "Strategist in the digital economy, senior specialist in digital trends, is considered a leader in Fintech, Digital Identity and Digital Economy, with extensive experience in innovation, regulation, investments and banking. He is driving the creation and adoption of digital ecosystems with disruptive technologies. He played a key role in shaping fintech regulation in Mexico and has collaborated with organizations like EBSI, LACChain, and OpenID Connect.\r\n\r\nPreviously, he held leadership roles in banking and asset management, including positions at UBS AG and Citigroup Private Bank in New York, where he managed ultra-high-net-worth clients and led strategic investment initiatives. \r\n\r\nHis expertise spans digital transformation, open finance, and cross-border identity solutions.",
+    "tagLine": null,
+    "profilePicture": "https://sessionize.com/image/85b7-400o400o1-4ZGjw9iWpvQHZAckcFXaHb.jpg",
+    "sessions": [
+      {
+        "id": 1058096,
+        "name": "Digital Payments Strategy"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Estratega en economía digital y especialista sénior en tendencias digitales, es considerado un líder en tecnología financiera, identidad digital y economía digital, con amplia experiencia en innovación, regulación, inversiones y banca. Impulsa la creación y adopción de ecosistemas digitales con tecnologías disruptivas. Desempeñó un papel clave en la configuración de la regulación de la tecnología financiera en México y ha colaborado con organizaciones como EBSI, LACChain y OpenID Connect. Anteriormente, ocupó puestos de liderazgo en banca y gestión de activos, entre ellos en UBS AG y Citigroup Private Bank en Nueva York, donde gestionó clientes de alto patrimonio y dirigió iniciativas de inversión estratégica. Su experiencia abarca la transformación digital, las finanzas abiertas y las soluciones de identidad transfronterizas.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "58ec7ac2-d517-43a8-a12c-e73a381735da",
+    "firstName": "Karim",
+    "lastName": "Jindani",
+    "fullName": "Karim Jindani",
+    "bio": "23+ years of experience in Digital Financial services domain, worked with multiple Central banks, Payment system operators. Workstream lead for Merchant payments in Mojaloop community",
+    "tagLine": "CEO at Paysys Labs Pvt Ltd",
+    "profilePicture": "https://sessionize.com/image/15fc-400o400o1-NhFFMTQm52U7irTe9XzzX2.jpg",
+    "sessions": [
+      {
+        "id": 1033766,
+        "name": "Enabling Banks in Pakistan to offer faster, cost-effective remittance services via ILP"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Paysys Labs Pvt Ltd",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Más de 23 años de experiencia en el ámbito de los servicios financieros digitales, ha trabajado con múltiples bancos centrales y operadores de sistemas de pago. Responsable del flujo de trabajo para pagos comerciales en la comunidad Mojaloop.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "d31924a5-5e58-419e-a57f-13c9b9de7c48",
+    "firstName": "Lincon",
+    "lastName": "Ssebugwawo [ Kanzu Finance ]",
+    "fullName": "Lincon Ssebugwawo [ Kanzu Finance ]",
+    "bio": "Lincon holds a bachelor's degree in Software Engineering and has dedicated himself to mastering the art of coding, designing, testing, and implementing software solutions for financial applications. His primary area of expertise revolves around creating scalable and high-performance software solutions that streamline financial operations, enhance data integrity and security, and drive overall operational efficiency\r\nLincon holds a bachelor's degree in Software Engineering and has dedicated himself to mastering the art of coding, designing, testing, and implementing software solutions for financial applications. His primary area of expertise revolves around creating scalable and high-performance software solutions that streamline financial operations, enhance data integrity and security, and drive overall operational efficiency",
+    "tagLine": "Kanzu Finance, Software Engineer",
+    "profilePicture": "https://sessionize.com/image/5d99-400o400o1-fup6BurEj3efdiLmX7r4zd.jpg",
+    "sessions": [
+      {
+        "id": 1033568,
+        "name": "Kanzu Finance"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Employee",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Software Engineering",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": null,
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "4971741e-f209-4d85-aa6a-0e7d77e0a0d8",
+    "firstName": "Lizette",
+    "lastName": "Neme Bechara",
+    "fullName": "Lizette Neme Bechara",
+    "bio": "Lizette Neme holds a law degree from Escuela Libre de Derecho and a master's degree in international financial law from King's College London. She founded the law firm Áurea Partners (formerly InStrag Law), where she is in charge of financial regulation and FinTech, providing legal advice to participants in the financial ecosystem. Previously, she held various positions at the Ministry of Finance and Public Credit. Starting in 2016, she was in charge of drafting and designing the FinTech Law in the Banking, Securities, and Savings Unit. Additionally, she served as Legal Director of Investment Banking in the Public Credit Unit, where she participated in the structuring and negotiation of financing for government infrastructure projects. She was also Advisor Coordinator and Legal Advisor to the Undersecretary of Revenue, where she was involved in reviewing tax policy issues.",
+    "tagLine": "Partner - Áurea Partners | Law & Regulation",
+    "profilePicture": "https://sessionize.com/image/4c65-400o400o1-R2PHYAtWdpfFZ5Nb5DM6bE.jpg",
+    "sessions": [
+      {
+        "id": 995890,
+        "name": "From Policy to Practice: Financial Inclusion in Mexico"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "\"Lizette Neme es Abogada por la Escuela Libre de Derecho y Maestra en Derecho Financiero Internacional por King’s College London. \r\n\r\nFundó el despacho Áurea Partners (antes InStrag Law), donde se encuentra a cargo del área regulatoria financiera y FinTech, dando consultoría legal a los participantes del ecosistema financiera.\r\n\r\nPreviamente tuvo diversas responsabilidades en la Secretaría de Hacienda y Crédito Público. A partir de 2016 estuvo a cargo de la redacción y diseño de la Ley FinTech en la Unidad de Banca, Valores y Ahorro. Adicionalmente, se desempeñó como Directora Jurídica de Banca de Inversión en la Unidad de Crédito Público, donde participó en la estructuración y negociación de financiamientos para proyectos de infraestructura gubernamental. También fue Coordinadora de Asesores y Asesora Legal del Subsecretario de Ingresos, donde se involucró en la revisión de temas de política tributaria.\"",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "ca7796ea-d481-4fd2-8f80-e5c721f4244b",
+    "firstName": "Maria",
+    "lastName": "Francis",
+    "fullName": "Maria Francis",
+    "bio": "Maria Franci brings over two decades of experience in the payments industry, with a strong focus on driving innovation, scale, and adoption in real-time payment systems. Maria has been part of the NPCI group for more than nine years and currently serve with NPCI International Payments Ltd. (NIPL), where I have spent over five years contributing to the organization’s global payments strategy and initiatives.\r\n\r\nPrior to this, Maria was one of the founding product managers for the Unified Payments Interface (UPI) at the National Payments Corporation of India (NPCI). Being part of the core team that conceptualized and launched UPI — a platform that has redefined India’s digital payments ecosystem — remains one of the most rewarding milestones in her career.\r\n\r\nEarlier, Maria spent close to a decade with Axis Bank, leading the Merchant Acquiring business at one of India’s foremost private sector banks. This experience gave her a strong foundation in payments infrastructure, merchant partnerships, and the broader dynamics of the financial ecosystem.\r\n\r\n ",
+    "tagLine": "Head Business Development – Americas Region",
+    "profilePicture": "https://sessionize.com/image/9b18-400o400o1-3zF64pDjd4eTsqTEiNoGLX.jpg",
+    "sessions": [
+      {
+        "id": 1065719,
+        "name": "The UPI Story"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": null,
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8bb62141-31b1-4635-9f57-324d4eb0dcd5",
+    "firstName": "Maria Gorrettie",
+    "lastName": "Namuddu",
+    "fullName": "Maria Gorrettie Namuddu",
+    "bio": "Maria is the Chief Operations Officer of Kanzu Finance Limited, leading operations, strategy, and customer success for digital financial solutions serving SACCOs, MFIs, and investment clubs. With a BSc in Telecommunications Engineering and 5+ years of cross-functional leadership, she has driven efficiency, compliance, and customer-focused product adoption. Recognised by HiPipo’s 2024 “40 Women Under 40”, Maria is passionate about using technology to advance financial inclusion in Africa.",
+    "tagLine": "Kanzu Finance, COO",
+    "profilePicture": "https://sessionize.com/image/9b2c-400o400o1-3B39n1frvN4Qo3vxYcUYYi.png",
+    "sessions": [
+      {
+        "id": 1033568,
+        "name": "Kanzu Finance"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Kanzu Finance Limited",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Chief Operations Officer",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "María es directora de operaciones de Kanzu Finance Limited, donde dirige las operaciones, la estrategia y el éxito de los clientes para soluciones financieras digitales que prestan servicios a cooperativas de ahorro y crédito, instituciones microfinancieras y clubes de inversión. Con una licenciatura en Ingeniería de Telecomunicaciones y más de cinco años de liderazgo interfuncional, ha impulsado la eficiencia, el cumplimiento normativo y la adopción de productos centrados en el cliente. Reconocida por HiPipo en su lista «40 mujeres menores de 40 años» de 2024, María es una apasionada del uso de la tecnología para promover la inclusión financiera en África.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "d28aade5-16d6-4682-aa4b-92fdf2c66fd9",
+    "firstName": "María José ",
+    "lastName": "Roa",
+    "fullName": "María José Roa",
+    "bio": "María José Roa holds a bachelor's degree in Economics from Carlos III University in Madrid and a PhD in Economics and Business Sciences from the Autonomous University of Madrid, Spain. She has thirty years of experience in research and teaching. She currently works as a researcher, professor, and international consultant with governments and public institutions, research centers and universities, foundations, and international organizations. Her work agenda integrates gender gaps and social norms, behavioral economics and neuroscience, inclusion, financial health and education, and national strategies for financial education and inclusion. Dr. Roa coordinates courses and diploma programs in Financial Education and Inclusion for universities and public and private institutions. She has taught at various universities and research centers in Spain, Mexico, and the United States. For nine years, she worked as a senior researcher at the Center for Latin American Monetary Studies (CEMLA), supporting central banks in the region in the development of financial education and inclusion programs. Her research work has been presented at conferences and published in indexed international journals and several books. She is a member of the Research Committee of the OECD's International Financial Education Network and the Advisory Committee of FinEquity ALC, CGAP, World Bank.",
+    "tagLine": "Independent Researcher",
+    "profilePicture": "https://sessionize.com/image/7b77-400o400o1-RCJcdXGaLprqLhsdgxUiK9.jpg",
+    "sessions": [
+      {
+        "id": 995902,
+        "name": "From Access to Wellbeing: Designing Financial Tools Women Can Trust and Use"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "María José Roa es licenciada en Economía por la Universidad Carlos III de Madrid y doctora en Economía y Ciencias Empresariales por la Universidad Autónoma de Madrid, España. Cuenta con treinta años de experiencia en investigación y docencia. Actualmente trabaja como investigadora, profesora y consultora internacional para gobiernos e instituciones públicas, centros de investigación y universidades, fundaciones y organizaciones internacionales. Su agenda de trabajo integra las brechas de género y las normas sociales, la economía conductual y la neurociencia, la inclusión, la salud y la educación financieras, y las estrategias nacionales de educación e inclusión financieras. La Dra. Roa coordina cursos y programas de diplomado en Educación e Inclusión Financieras para universidades e instituciones públicas y privadas. Ha impartido clases en diversas universidades y centros de investigación en España, México y Estados Unidos. Durante nueve años, trabajó como investigadora senior en el Centro de Estudios Monetarios Latinoamericanos (CEMLA), apoyando a los bancos centrales de la región en el desarrollo de programas de educación e inclusión financiera. Su trabajo de investigación ha sido presentado en conferencias y publicado en revistas internacionales indexadas y varios libros. Es miembro del Comité de Investigación de la Red Internacional de Educación Financiera de la OCDE y del Comité Asesor de FinEquity ALC, CGAP, Banco Mundial.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "ae6d657c-14d3-4c22-8dac-ef5719273219",
+    "firstName": "Mariana ",
+    "lastName": "Jiménez Hernández",
+    "fullName": "Mariana Jiménez Hernández",
+    "bio": "Mariana Jiménez Hernández is a Mexican labor lawyer, activist, and co-founder of Laboralista de Confianza, a nonprofit organization that promotes labor rights and workplace inclusion for women, LGBT+ communities. She has strong experience in the Mexican legal labor context, providing training and legal support on labor issues, while also engaging in activism and the formation of networks to advance social justice. Mariana is passionate about bridging law, activism, and community empowerment to foster equitable workplaces and futures.",
+    "tagLine": "Laboralista de Confianza",
+    "profilePicture": "https://sessionize.com/image/efbd-400o400o1-KoGDQAA4Y3rDifd8MGw6iq.jpg",
+    "sessions": [
+      {
+        "id": 995904,
+        "name": "From Financial Inclusion to Financial Justice: How to Enable an Equitable Future in the Gig Economy "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Mariana Jiménez Hernández es una abogada laboral mexicana, activista y cofundadora de Laboralista de Confianza, una organización sin fines de lucro que promueve los derechos laborales y la inclusión en el lugar de trabajo para las mujeres y las comunidades LGBT+. Cuenta con una amplia experiencia en el contexto laboral mexicano, impartiendo capacitación y apoyo legal en temas laborales, al tiempo que participa en el activismo y la formación de redes para promover la justicia social. Mariana es una apasionada de tender puentes entre el derecho, el activismo y el empoderamiento de la comunidad para fomentar lugares de trabajo y futuros equitativos.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a63af0da-3b51-42ad-9775-ff52212884ba",
+    "firstName": "Max",
+    "lastName": "Kurapov",
+    "fullName": "Max Kurapov",
+    "bio": "As a software developer at the Interledger Foundation, Max Kurapov builds open source tools and APIs that provide developers & institutions access to the Interledger network, primarily, Rafiki. Before joining the Foundation, Max spent 5 years working at startups: one of which a Fintech company, where he was one of the leads on the card payments processing team.",
+    "tagLine": "Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/c161-400o400o1-GUzdx8eeDYPvqoGGJaGVLy.jpg",
+    "sessions": [
+      {
+        "id": 1051900,
+        "name": "Evolution of Rafiki & Open Payments in 2025"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Como desarrollador de software en la Fundación Interledger, Max Kurapov crea herramientas de código abierto y API que proporcionan a los desarrolladores e instituciones acceso a la red Interledger, principalmente a Rafiki. Antes de unirse a la Fundación, Max trabajó durante cinco años en startups, una de ellas una empresa de tecnología financiera, donde fue uno de los responsables del equipo de procesamiento de pagos con tarjeta.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "df71ae97-3d07-4f93-a0d9-2a22d96cc6e6",
+    "firstName": "Miguel",
+    "lastName": "Alecio",
+    "fullName": "Miguel Alecio",
+    "bio": "Miguel is the founder and CEO of miPlata. Prior to starting miPlata, he served as a Principal on Apollo’s Private Equity portfolio operations team. Before that, he was a Deployment Strategist at Palantir’s commercial business leading global teams on projects spanning three continents, including South America.",
+    "tagLine": "miPlata",
+    "profilePicture": "https://sessionize.com/image/2909-400o400o1-NQYvwG2DrZdvEfJfLYgXZe.jpg",
+    "sessions": [
+      {
+        "id": 1033772,
+        "name": "miPlata - Payroll that reaches home"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Plata Financial Inc",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Miguel es el fundador y director ejecutivo de miPlata. Antes de fundar miPlata, trabajó como director en el equipo de operaciones de la cartera de capital privado de Apollo. Anteriormente, fue estratega de implementación en la división comercial de Palantir, donde dirigió equipos globales en proyectos que abarcaban tres continentes, incluida Sudamérica.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "42e841a3-7a0b-4a96-86d1-cb0689c47382",
+    "firstName": "Nandini",
+    "lastName": "Harihareswara",
+    "fullName": "Nandini Harihareswara",
+    "bio": "Nandini Harihareswara is a global expert in Digital Finance, Instant Payment Systems, and Inclusive Digital Economies with 18+ years of experience across 25+ markets in Africa, Asia, and Eastern Europe. She is the Founder of Contigo Global LLC, where she partners with governments, regulators, and the private sector to design instant payment systems and financial products that balance profitability with inclusion—especially for women, MSMEs, and underserved communities.\r\n\r\nPreviously, Nandini served as a Country Director at the UN Capital Development Fund, where she led a Digital Finance & Inclusive Digital Economies Program in Zambia and Malawi. She was also a founding member of the USAID Digital Development Division and worked as an Investment Officer at USAID’s Development Credit Authority.\r\n\r\nBeyond advisory work, Nandini is known for developing immersive learning experiences—including policy simulations and innovation games—that help regulators and industry leaders co-create responsible, inclusive digital finance ecosystems.\r\n\r\nShe holds an MBA and a Master’s in International Trade & Investment Policy from George Washington University, and dual BAs in Psychology and Political Science from UC San Diego.",
+    "tagLine": "Contigo Global LLC",
+    "profilePicture": "https://sessionize.com/image/9b91-400o400o1-s1yKUTM6VFidxnPUauULSd.PNG",
+    "sessions": [
+      {
+        "id": 995376,
+        "name": "The Regulator's Dilemma"
+      },
+      {
+        "id": 1037939,
+        "name": "The Regulator's Dilemma (repeat session)"
+      }
+    ],
+    "isTopSpeaker": true,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Nandini Harihareswara es una experta mundial en finanzas digitales, sistemas de pago instantáneo y economías digitales inclusivas, con más de 18 años de experiencia en más de 25 mercados de África, Asia y Europa del Este. Es fundadora de Contigo Global LLC, donde colabora con gobiernos, reguladores y el sector privado para diseñar sistemas de pago instantáneo y productos financieros que equilibran la rentabilidad con la inclusión, especialmente para las mujeres, las micro, pequeñas y medianas empresas y las comunidades desfavorecidas. \r\n\r\nAnteriormente, Nandini fue directora nacional del Fondo de las Naciones Unidas para el Desarrollo de Capital, donde dirigió un programa de finanzas digitales y economías digitales inclusivas en Zambia y Malaui. También fue miembro fundador de la División de Desarrollo Digital de USAID y trabajó como responsable de inversiones en la Autoridad de Crédito para el Desarrollo de USAID. \r\n\r\nMás allá de su labor de asesoría, Nandini es conocida por desarrollar experiencias de aprendizaje inmersivas, como simulaciones de políticas y juegos de innovación, que ayudan a los reguladores y a los líderes del sector a crear conjuntamente ecosistemas financieros digitales responsables e inclusivos. \r\n\r\nTiene un MBA y una maestría en Comercio Internacional y Política de Inversiones por la Universidad George Washington, y una doble licenciatura en Psicología y Ciencias Políticas por la Universidad de California en San Diego.\r\n",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "925df3a9-96d7-4a3a-8b45-fed2d08718d3",
+    "firstName": "Nasser",
+    "lastName": "Eledroos",
+    "fullName": "Nasser Eledroos",
+    "bio": "Nasser Eledroos is a public interest technologist committed to making public systems work for ordinary people. He develops technical tools and advocates for policies that prioritizes local needs, transparency, and democracy. From online platforms to Extended Reality (XR), Nasser’s work considers the evolving ways people interact and build community. Nasser is a Fellow with the Atlantic Institute at Rhodes Trust, University of Oxford. He has worked at organizations like Color Of Change, Northeastern University School of Law, the Suffolk County District Attorney’s Office, and the ACLU of Massachusetts.",
+    "tagLine": "Color Of Change",
+    "profilePicture": "https://sessionize.com/image/4180-400o400o1-W27RZJNEV498YPk8L1MJDB.jpg",
+    "sessions": [
+      {
+        "id": 995871,
+        "name": "Human Rights by Design: Financial Infrastructure that Works for Everyone"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Nasser Eledroos es un tecnólogo de interés público comprometido con hacer que los sistemas públicos funcionen para todas las personas. Desarrolla herramientas técnicas y aboga por políticas que priorizan las necesidades locales, la transparencia y la democracia. Desde plataformas en línea hasta la realidad extendida (XR), el trabajo de Nasser tiene en cuenta las formas cambiantes en que las personas interactúan y construyen comunidades. Nasser es miembro del Atlantic Institute del Rhodes Trust de la Universidad de Oxford. Ha trabajado en organizaciones como Color Of Change, la Facultad de Derecho de la Universidad Northeastern, la Fiscalía del Condado de Suffolk y la ACLU de Massachusetts.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "bbbb1a45-cd4c-416f-a84a-147b751b5d1a",
+    "firstName": "Natalia",
+    "lastName": "Cueto",
+    "fullName": "Natalia Cueto",
+    "bio": "Natalia Cueto is a strategist, entrepreneur, and financial technology expert with 23 years of experience forging a unique career in capital markets, Web3, FOREX, and corporate finance in Mexico and Latin America. \r\n\r\nHer career began in 2002 as an analyst and trader in the currency markets, before moving in 2012 to information product design for the Mexican Stock Exchange (BMV) and INDEVAL, where she led key projects to optimize the country's financial infrastructure and digital transformation. \r\n\r\nAs a Blockchain enthusiast and pioneer, she founded the Blockitlab innovation think tank in 2017 and has participated as an angel investor in various startups. She has also held leadership roles in innovation, such as director of Círculo de Crédito's C°Labs, and has shared her experience as a speaker and columnist in specialized media. \r\n\r\nShe is currently the CEO and founder of VADI, Mexico's first crowdequity and real-world asset (RWA) tokenization platform based on blockchain technology. Its mission is to drive financial democratization by providing new avenues of access to capital for the region's FinTech ecosystem and SMEs. \r\n\r\nNatalia Cueto has a bachelor's degree in International Relations, postgraduate studies in Finance (UANL), and a Master's degree in Political Journalism.",
+    "tagLine": "CEO - VADI Latam",
+    "profilePicture": "https://sessionize.com/image/6294-400o400o1-hYDxej7tzyTCCxZ6tNaHn2.jpg",
+    "sessions": [
+      {
+        "id": 995890,
+        "name": "From Policy to Practice: Financial Inclusion in Mexico"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "\"Natalia Cueto es una estratega, emprendedora y experta en tecnología financiera, con 23 años de experiencia forjando una trayectoria única en los mercados de capitales, Web3, FOREX y finanzas corporativas en México y Latinoamérica.\r\n\r\nSu carrera inició en 2002 como analista y operadora en los mercados de divisas, para luego migrar en 2012 al diseño de productos de información para la Bolsa Mexicana de Valores (BMV) y el INDEVAL, donde lideró proyectos clave de optimización de la infraestructura financiera del país y transformación digital.\r\n\r\nComo entusiasta y pionera Blockchain, fundó en 2017 el think tank de innovación Blockitlab y ha participado como ángel inversionista en diversos startups. También ha ocupado roles de liderazgo en innovación, como directora del C°Labs de Círculo de Crédito, y ha compartido su experiencia como ponente y columnista en medios especializados.\r\n\r\nActualmente, es CEO y fundadora de VADI, la primera plataforma en México de crowdequity y tokenización de activos del mundo real (RWA) sobre tecnología blockchain. Su misión es impulsar la democratización financiera al brindar nuevas vías de acceso al capital para el ecosistema FinTech y PYMES de la región.\r\n\r\nNatalia Cueto cuenta con una licenciatura en Relaciones Internacionales, estudios de posgrado en Finanzas (UANL) y una Maestría en Periodismo Político.\"",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "c0cdf5ec-604b-48fa-a88d-475fe89a8932",
+    "firstName": "Nathan",
+    "lastName": "Lie",
+    "fullName": "Nathan Lie",
+    "bio": "Nathan is a software developer who has been working on technologies built on Interledger since 2018. He now focuses on directly contributing to Interledger and hopes to connect global communities with financial resources and strengthen the creator economy.\r\n\r\nOutside of work Nathan has taken an interest in cooking, sketching, and video games.",
+    "tagLine": "Your friendly neighborhod GNathan",
+    "profilePicture": "https://sessionize.com/image/007e-400o400o1-12f3b58a-4c44-40a5-bca1-b906f228d9e1.jpg",
+    "sessions": [
+      {
+        "id": 1051900,
+        "name": "Evolution of Rafiki & Open Payments in 2025"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Typescript Developer",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": null,
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "c6428e78-fd0c-4348-bca1-4a4d81b7e81f",
+    "firstName": "Pablo",
+    "lastName": "Antón Díaz ",
+    "fullName": "Pablo Antón Díaz",
+    "bio": "Pablo Antón Díaz is a strategic leader with over 16 years of experience designing and launching financial products across Latin America. He has led product management teams in Mexico, Brazil, and Peru, and driven UX research and design initiatives across Latin America, working for multilateral organizations, venture capital firms, and non-profit organizations. With deep expertise in fintech, inclusive finance, and microinsurance, Pablo has mobilized over $1.4 billion USD in loan portfolios through diverse innovative, human-centered solutions that are tailored to fit the needs of the populations they serve. \r\n\r\nPablo holds a Master of Public Administration from Columbia University and a BSc in Economics from ITAM, and is fluent in four languages.",
+    "tagLine": "Expert, FinTech & Inclusive Finance",
+    "profilePicture": "https://sessionize.com/image/7287-400o400o1-7bp9rFaHdnzQZjLw14bjGD.jpg",
+    "sessions": [
+      {
+        "id": 995376,
+        "name": "The Regulator's Dilemma"
+      },
+      {
+        "id": 1037939,
+        "name": "The Regulator's Dilemma (repeat session)"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Pablo Antón Díaz es un líder estratégico con más de 16 años de experiencia en el diseño y lanzamiento de productos financieros en toda América Latina. Ha dirigido equipos de gestión de productos en México, Brasil y Perú, y ha impulsado iniciativas de investigación y diseño de experiencia de usuario en toda América Latina, trabajando para organizaciones multilaterales, empresas de capital de riesgo y organizaciones sin fines de lucro. Con una amplia experiencia en tecnología financiera, finanzas inclusivas y microseguros, Pablo ha movilizado más de 1400 millones de dólares en carteras de préstamos a través de diversas soluciones innovadoras y centradas en las personas, adaptadas a las necesidades de las poblaciones a las que sirven. \r\n\r\nPablo tiene una maestría en Administración Pública de la Universidad de Columbia y una licenciatura en Economía del ITAM, y habla cuatro idiomas con fluidez.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a161a1e8-e360-49cc-bb09-b5fa5ebfc5ef",
+    "firstName": "Pedro Sousa ",
+    "lastName": "Barreto",
+    "fullName": "Pedro Sousa Barreto",
+    "bio": "Have been doing software development, architecture and senior IT leadership positions teams for the last 30 years.\r\nSpecialized in large scale distributed systems for the past 12+ years.\r\nHelped several companies in multiple industries achieve higher scales and/or improve organizational performance.",
+    "tagLine": "Interledger Foundation",
+    "profilePicture": "https://sessionize.com/image/17b0-400o400o1-J3Lm37Lq6iN9Lge3SM8xir.jpg",
+    "sessions": [
+      {
+        "id": 1031403,
+        "name": "The People's Clearinghouse "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "ILF / Cyberbones",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Developer / Architect / Consultant for Interledger Foundation",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "He trabajado en el desarrollo de software, la arquitectura y puestos de liderazgo sénior en equipos de TI durante los últimos 30 años. Me he especializado en sistemas distribuidos a gran escala durante los últimos 12 años. He ayudado a varias empresas de múltiples sectores a alcanzar mayores escalas y/o mejorar el rendimiento organizativo.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "f05f5ce1-24b4-4f8f-b644-357305ebf3fd",
+    "firstName": "Peter",
+    "lastName": "Kakoma",
+    "fullName": "Peter Kakoma",
+    "bio": "Kakoma has over 17 years of experience in software engineering, 8 of which were spent in MTN, Africa's largest telecommunications company, holding various telecom & software engineering positions through the years.\r\n \r\nHe designed, built and supported the company's loyalty platform that, in months, grew to support 4 million customers. As MTN’s Principal VAS & New Solutions engineer, Peter led a team that set up infrastructure to support internal products for the company's 10 million customers and designed, built and supported hundreds of company solutions such as the data & voice bundle provisioning system.\r\n \r\nAs a Senior Consultant at Andela, an international software development company, he was a lead developer and technical team lead for one of Andela’s offshore clients in the Financial technology space, where he built a reward platform that processed credit card transactions to be used by, among others, Heritage Bank Nigeria.\r\nHe also served as a mentor and technical resource to other engineers on the team across 3 African countries.\r\n \r\nHe is deeply invested in the tech ecosystem in Uganda as a mentor at hackathons, speaker at Hubs and tech consultant to some startups. ",
+    "tagLine": "Kanzu Finance, Founder & CEO",
+    "profilePicture": "https://sessionize.com/image/b622-400o400o1-LMXivFDYHCsUxm4jrH98GC.jpg",
+    "sessions": [
+      {
+        "id": 1033568,
+        "name": "Kanzu Finance"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Kanzu Finance Limited",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CEO",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": null,
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "d5f742a7-2e15-4515-9364-91970db523f0",
+    "firstName": "Pilar ",
+    "lastName": "Islas Rodríguez",
+    "fullName": "Pilar Islas Rodríguez",
+    "bio": "Pilar Islas is a specialist in financial education, capacity building, and strategic marketing with a social focus. She currently serves as General Manager at Noahui Soluciones, a firm dedicated to market research, the design of financial inclusion strategies, and the development of educational programs for vulnerable people in Mexico.\r\nIn addition to leading the company's strategy and operations, Pilar promotes an inclusive work model, in which women with different employment needs are hired and given support to adapt to the dynamics of the organization, creating opportunities for development and economic autonomy.\r\nWith more than 10 years of experience in responsible sales, financial services, and  community development, Pilar has led multidisciplinary teams, coordinated workshops, and designed educational campaigns aimed at women, young people, and microentrepreneurs. Her work combines strategic vision with human warmth: she listens firsthand to users' stories, understands their contexts, vocabulary, and aspirations, and turns that knowledge into reliable and useful financial tools. These tools promote the responsible use of financial products, encourage informed decision-making, and strengthen communities' ability to improve their economic well-being and resilience.\r\nPilar has a Diploma in Financial Education and Skills from Anáhuac University, Insurance for Development certification from ITC-ILO, and has participated in training programs in digital marketing, growth marketing, and social leadership (EGADE Business School, Tec de Monterrey). Convinced that financial education is a powerful tool for transforming realities, Pilar continues to further her professional development and is currently pursuing a Bachelor's Degree in SME Management and Administration, with the aim of continuing to promote high social impact projects that contribute to inclusive economic development.\r\n",
+    "tagLine": "Noahui Soluciones",
+    "profilePicture": "https://sessionize.com/image/0c0a-400o400o1-fBfRofwCSajxxee4YS33LR.png",
+    "sessions": [
+      {
+        "id": 995902,
+        "name": "From Access to Wellbeing: Designing Financial Tools Women Can Trust and Use"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Pilar Islas es especialista en educación financiera, desarrollo de capacidades y marketing estratégico con enfoque social. Actualmente se desempeña como directora general de Noahui Soluciones, una empresa dedicada a la investigación de mercados, el diseño de estrategias de inclusión financiera y el desarrollo de programas educativos para personas vulnerables en México. Además de liderar la estrategia y las operaciones de la empresa, Pilar promueve un modelo de trabajo inclusivo, en el que se contrata a mujeres con diferentes necesidades laborales y se les brinda apoyo para adaptarse a la dinámica de la organización, creando oportunidades de desarrollo y autonomía económica. Con más de 10 años de experiencia en ventas responsables, servicios financieros y desarrollo comunitario, Pilar ha liderado equipos multidisciplinarios, coordinado talleres y diseñado campañas educativas dirigidas a mujeres, jóvenes y microempresarios. Su trabajo combina la visión estratégica con la calidez humana: escucha de primera mano las historias de los usuarios, comprende sus contextos, su vocabulario y sus aspiraciones, y convierte ese conocimiento en herramientas financieras fiables y útiles. Estas herramientas promueven el uso responsable de los productos financieros, fomentan la toma de decisiones informadas y fortalecen la capacidad de las comunidades para mejorar su bienestar económico y su resiliencia.\r\nPilar cuenta con un Diploma en Educación y Habilidades Financieras de la Universidad Anáhuac, la certificación en Seguros para el Desarrollo del ITC-OIT, y ha participado en programas de formación en marketing digital, marketing de crecimiento y liderazgo social (EGADE Business School, Tec de Monterrey). Convencida de que la educación financiera es una herramienta poderosa para transformar realidades, Pilar continúa su desarrollo profesional y actualmente cursa una licenciatura en Gestión y Administración de Pymes, con el objetivo de seguir promoviendo proyectos de alto impacto social que contribuyan al desarrollo económico inclusivo.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "57a0f0dd-9b26-4559-bc3d-7d9b0b094799",
+    "firstName": "Rabeb",
+    "lastName": "Othmani",
+    "fullName": "Rabeb Othmani",
+    "bio": "Rabeb Othmani  is a technologist and product leader with 15 years in the industry. She combines engineering depth, product strategy, and leadership experience from roles at Microsoft, Nokia, Vonage, and Zebra Technologies.\r\nAs Lead Product Manager at the Interledger Foundation, she drives the evolution of Web Monetization, helping create a more equitable, accessible web for all. Her work bridges technology, product strategy, and community impact.",
+    "tagLine": "Lead Product Manager ",
+    "profilePicture": "https://sessionize.com/image/ac22-400o400o1-SeKwa81PyrjY7BJZNn1Utn.jpg",
+    "sessions": [
+      {
+        "id": 1018846,
+        "name": "All about Web Monetization "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "The Interledger Foundation",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Lead Product Manager ",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Rabeb Othmani es una tecnóloga y líder de productos con 15 años de experiencia en el sector. Combina sus profundos conocimientos de ingeniería, estrategia de productos y experiencia en liderazgo adquiridos en puestos en Microsoft, Nokia, Vonage y Zebra Technologies. Como gerente principal de productos en la Interledger Foundation, impulsa la evolución de la monetización web, contribuyendo a crear una web más equitativa y accesible para todos. Su trabajo une la tecnología, la estrategia de productos y el impacto en la comunidad.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "d35ddcb5-3563-4cca-b731-6845dc0d406f",
+    "firstName": "Rafe",
+    "lastName": "Mazer",
+    "fullName": "Rafe Mazer",
+    "bio": "Rafe is a leading global voice on consumer protection and competition policy in digital financial services and the digital economy. For nearly 20 years, Rafe has been a leading voice for the needs and rights of consumers in digital finance. Rafe brings a researcher’s creativity to the challenges of policymaking, and works with governments and financial service providers in countries across Africa, Asia, and Latin America. Rafe’s current work includes analysis of open finance policy models and consumer protection issues such as fraud risks in mobile money. As the first Director of the Consumer Protection Research Initiative from 2019-2022, Rafe developed a portfolio of more than 20 consumer protection research projects addressing digital consumer credit, pricing transparency, fraud in digital app stores, and other emerging risks in digital economies. Prior to his time at IPA, Rafe was the director of a Kenyan consulting firm specializing in consumer protection policy, and before that led CGAP’s work on consumer protection and behavioral research for 7+ years. A talented researcher and writer, Rafe has designed and executed field research including surveys, mystery shopping, behavioral experiments, and randomized impact evaluations, as well as policy analysis and regulatory reforms.",
+    "tagLine": "Fair Finance Consulting",
+    "profilePicture": "https://sessionize.com/image/0871-400o400o1-sQw36NAgFCY9GFEXAUj7ev.png",
+    "sessions": [
+      {
+        "id": 995376,
+        "name": "The Regulator's Dilemma"
+      },
+      {
+        "id": 1037939,
+        "name": "The Regulator's Dilemma (repeat session)"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Rafe es una voz líder a nivel mundial en materia de protección del consumidor y política de competencia en los servicios financieros digitales y la economía digital. Durante casi 20 años, Rafe ha sido una voz destacada en defensa de las necesidades y los derechos de los consumidores en las finanzas digitales. Rafe aporta la creatividad de un investigador a los retos de la formulación de políticas y colabora con gobiernos y proveedores de servicios financieros en países de África, Asia y América Latina. El trabajo actual de Rafe incluye el análisis de modelos de políticas de finanzas abiertas y cuestiones de protección al consumidor, como los riesgos de fraude en el dinero móvil. Como primer director de la Iniciativa de Investigación sobre Protección al Consumidor entre 2019 y 2022, Rafe desarrolló una cartera de más de 20 proyectos de investigación sobre protección al consumidor que abordan el crédito al consumo digital, la transparencia de los precios, el fraude en las tiendas de aplicaciones digitales y otros riesgos emergentes en las economías digitales. Antes de su etapa en IPA, Rafe fue director de una consultora keniana especializada en políticas de protección al consumidor y, anteriormente, dirigió durante más de siete años el trabajo de CGAP en materia de protección al consumidor e investigación del comportamiento. Investigador y escritor de gran talento, Rafe ha diseñado y llevado a cabo investigaciones de campo que incluyen encuestas, compras misteriosas, experimentos de comportamiento y evaluaciones de impacto aleatorias, así como análisis de políticas y reformas normativas.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "5defb85a-6d82-4e67-9ad5-e1661067ff0d",
+    "firstName": "Raul",
+    "lastName": "Ranete",
+    "fullName": "Raul Ranete",
+    "bio": "Raul is an Engineering Manager at the Interledger Foundation, where he works on building and improving the Interledger Wallet. He focuses on designing seamless frontend and backend systems, ensuring secure and user-friendly experiences, and helping his team deliver reliable, high-quality software.",
+    "tagLine": "Engineering Manager",
+    "profilePicture": "https://sessionize.com/image/41e2-400o400o1-EvFc3MbbdtubdKxKBhq3ww.jpg",
+    "sessions": [
+      {
+        "id": 1018847,
+        "name": "Interledger Wallet "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Engineering Manager",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Raúl es director de ingeniería en la Interledger Foundation, donde trabaja en la creación y mejora de la cartera Interledger. Se centra en diseñar sistemas frontend y backend sin fisuras, garantizar experiencias seguras y fáciles de usar, y ayudar a su equipo a ofrecer software fiable y de alta calidad.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "a695b8c9-13c1-40e7-bacb-223332c6f998",
+    "firstName": "Roberto ",
+    "lastName": "Valdovinos",
+    "fullName": "Roberto Valdovinos",
+    "bio": "B.A. and M.A. in Logic and Philosophy (Pantheon-Sorbonne University), M.Phil. in Comparative Studies (Columbia University). Directed a migrant organization in the US and a national institute in Mexico. Works with migrants and marginalized communities in social justice and financial inclusion projects.",
+    "tagLine": "People's Clearinghouse",
+    "profilePicture": "https://sessionize.com/image/02cc-400o400o1-KLBo1a3FKkp4m3G8Y73Tio.png",
+    "sessions": [
+      {
+        "id": 1031403,
+        "name": "The People's Clearinghouse "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "People's Clearinghouse",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CFO",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Licenciatura y Maestría en Lógica y Filosofía (Universidad Panthéon-Sorbona), Maestría en Estudios Comparativos (Universidad de Columbia). Dirigió una organización de migrantes en los Estados Unidos y un instituto nacional en México. Trabaja con migrantes y comunidades marginadas en proyectos de justicia social e inclusión financiera.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e23853f1-0524-4b73-8661-77afaecf8c1e",
+    "firstName": "Rocío ",
+    "lastName": "Mejía Flores",
+    "fullName": "Rocío Mejía Flores",
+    "bio": "She holds a degree in economics from Anahuac University and a master's degree in economics from the Center for Economic Research and Teaching (CIDE). She also completed a diploma course in Popular Finance for Low Incomes, taught by the University of Miami and UAM-Azcapotzalco. In the banking sector, she participated in the seminar “Sector Risk Analysis by the Strategic Decision Group” at Stanford University, San Francisco, California, USA, in February 1993. She was Deputy Director of Economic and Sectoral Analysis at the consulting firm Macro Asesoría Económica, S.C., affiliated with “Operadora de Bolsa” from 1990 to 1997. In the microfinance sector, she served as Director General of the Mexico City Social Development Fund (FONDESO), of the Government of Mexico City, under the administration of then-Head of Government Andrés Manuel López Obrador, and in 2015, Director of Economic Development in the Tlalpan Delegation, where she promoted and operated the Microenterprise and Cooperative Support Program under the administration of Dr. Claudia Sheinbaum. She was Head of the Microcredit Program for Welfare in the Government of Mexico (2018-2020) and on September 2, 2020, she was appointed by President Andrés Manuel López Obrador as Head of Telecommunications of Mexico, an agency that in just four years she transformed into the Financial Institution for Welfare. She is a driving force behind the popular, solidarity-based, feminist economy, popular savings and credit, and social finance, as well as financial and business opportunities and challenges for the migrant community and their families.",
+    "tagLine": "Directora de Financiera del Bienestar ",
+    "profilePicture": "https://sessionize.com/image/1f24-400o400o1-7JJWDr2r8HTSYPUuDiENtM.jpg",
+    "sessions": [
+      {
+        "id": 995890,
+        "name": "From Policy to Practice: Financial Inclusion in Mexico"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Financiera para el Bienestar",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Directora",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Es economista por la Universidad Anáhuac y tiene Maestría en Economía en el Centro de Investigación y Docencia Económicas (CIDE), asimismo cursó el Diplomado en Finanzas Populares para Bajos Ingresos, impartido por la Universidad de Miami y la UAM-Azcapotzalco.  \r\n\r\nEn el sector bancario participó en el Seminario “Sector Risk Analysis by the Strategic Decision Group”, en Stanford University, San Francisco, California USA.  Febrero, 1993. Fue Subdirectora de Análisis Económico y Sectorial en la empresa consultora Macro Asesoría Económica, S.C. afiliada a “Operadora de Bolsa” de 1990 a 1997.\r\n\r\nEn el sector de las Microfinanzas, se desempeñó como Directora General del Fondo para el Desarrollo Social de la Ciudad de México, (FONDESO), del Gobierno de la Ciudad de México, en la administración del entonces Jefe de Gobierno Andrés Manuel López Obrador y en 2015 Directora de Desarrollo Económico en la Delegación Tlalpan donde impulsó y operó el Programa de Apoyo a Microempresas y a Cooperativas en la administración de la Dra. Claudia Sheinbaum. \r\n\r\nFue Titular del Programa de Microcréditos para el Bienestar en el Gobierno de México (2018-2020) y a partir del 2 de septiembre del 2020 fue nombrada por el Presidente Andrés Manuel López Obrador como Titular de Telecomunicaciones de México -organismo que en solo 4 años- transformó en la Financiera para el Bienestar.\r\n\r\nEs impulsora de la economía popular, solidaria, feminista, del ahorro y crédito popular y de las finanzas sociales.Así como de las oportunidades y retos financieros y empresariales para la comunidad migrante y sus familias",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "98c9897c-e8b2-4924-8f9d-928b3d75daa3",
+    "firstName": "Sarah",
+    "lastName": "Corley",
+    "fullName": "Sarah Corley",
+    "bio": "Sarah Corley is CEO of the Alliance of Digital Finance Associations. She has over 20 years’ experience in leading capacity building, community development and knowledge management focused on facilitating change. She has an MA in HR Management, BSc in Psychology and spent the first ten years of her career delivering training and team building for individuals and teams before moving into organisational development, strategy, and transformation.\r\nHer current focus is catalysing the development of the digital finance profession. Sarah led the formation of national associations in thirteen countries in Africa and Asia. She was instrumental in bringing peers together and supporting them through writing constitutions, developing a brand, legally registering, attracting members, and implementing actions to make impact in their countries. She also facilitates a variety of activities to ensure the continual development of digital finance professionals through webinars, podcasts, blogs, a cultivated knowledge bank and a highly engaged LinkedIn group.\r\nShe then went on to found the Alliance of Digital Finance Associations, the collective voice leading the inclusive digital finance profession, with membership including the above national associations. The Alliance is facilitating the exchange of best practice and driving innovation and inclusion. The Alliance has already received interest from well-known global organisations wishing to join or partner.\r\nShe also created the Pathway to 17 Summit brand, and successfully delivered its first e-conference. She is now working on options for growth including bringing new streams of content relating to the SDGs and income generation through sponsorship.\r\nPrevious projects include increasing the operational efficiency, staff and patient satisfaction in various NHS departments whilst simultaneously reducing costs and supporting an NGO in Nigeria pivot in their business model to provide stability in income and change in organisational leadership and culture. She was also Director of an award-winning volunteer tourism business operating across multiple countries.",
+    "tagLine": "Alliance of Digital Finance and Fintech Associations",
+    "profilePicture": "https://sessionize.com/image/3268-400o400o1-s7svNr14R1vyctZyMoz7jE.png",
+    "sessions": [
+      {
+        "id": 1049783,
+        "name": "Trustworthy by Default: Designing Digital Finance People Choose to Use "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Sarah Corley es directora ejecutiva de la Alianza de Asociaciones de Finanzas Digitales. Cuenta con más de 20 años de experiencia en el liderazgo del desarrollo de capacidades, el desarrollo comunitario y la gestión del conocimiento centrados en facilitar el cambio. Tiene una maestría en Gestión de Recursos Humanos, una licenciatura en Psicología y pasó los primeros diez años de su carrera impartiendo formación y fomentando el espíritu de equipo a personas y equipos antes de pasar al desarrollo organizativo, la estrategia y la transformación. Actualmente se centra en catalizar el desarrollo de la profesión de las finanzas digitales. Sarah dirigió la formación de asociaciones nacionales en trece países de África y Asia. Desempeñó un papel fundamental a la hora de reunir a sus compañeros y apoyarlos en la redacción de constituciones, el desarrollo de una marca, el registro legal, la captación de miembros y la implementación de acciones para lograr un impacto en sus países. También facilita una variedad de actividades para garantizar el desarrollo continuo de los profesionales de las finanzas digitales a través de seminarios web, podcasts, blogs, un banco de conocimientos cultivado y un grupo de LinkedIn muy activo. A continuación, fundó la Alianza de Asociaciones de Finanzas Digitales, la voz colectiva que lidera la profesión inclusiva de las finanzas digitales, cuyas miembros incluyen las asociaciones nacionales mencionadas anteriormente. La Alianza facilita el intercambio de mejores prácticas e impulsa la innovación y la inclusión. La Alianza ya ha despertado el interés de organizaciones mundiales de renombre que desean unirse o asociarse. También creó la marca Pathway to 17 Summit y llevó a cabo con éxito su primera conferencia electrónica. Actualmente está trabajando en opciones de crecimiento, como la incorporación de nuevas fuentes de contenido relacionadas con los ODS y la generación de ingresos a través del patrocinio. Entre sus proyectos anteriores se incluyen el aumento de la eficiencia operativa y la satisfacción del personal y los pacientes en varios departamentos del Servicio Nacional de Salud (NHS), al tiempo que se reducían los costos y se apoyaba a una ONG de Nigeria en el cambio de su modelo de negocio para proporcionar estabilidad en los ingresos y un cambio en el liderazgo y la cultura de la organización. También fue directora de una galardonada empresa de turismo voluntario que opera en varios países.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "e6a50e12-85dd-40ff-b041-bfe0ded30bf7",
+    "firstName": "Shaundra ",
+    "lastName": "Jacobs",
+    "fullName": "Shaundra Jacobs",
+    "bio": "Shaundra Jacobs is the Texas Market President for AltCap, where she leads lending across the state with a focus on expanding access to capital for underserved entrepreneurs. She forges partnerships with banks, community organizations, and technical assistance providers to help founders move from idea to investment.\r\nA proud Prairie View A&M University alumna, Shaundra serves her community through the Spring Branch Independent School District, Zeta Phi Beta Sorority, Inc., and City of Houston boards. She also contributes her leadership as a board member with the 1876 Athletic Foundation.\r\nBorn and raised in Port Arthur, Texas, Shaundra now resides in Houston. She is a devoted mother of two boys and enjoys exploring new restaurants in her free time.",
+    "tagLine": "AltCap",
+    "profilePicture": "https://sessionize.com/image/0cf8-400o400o1-P884dwpJ447V6N4QDi8Gyi.jpg",
+    "sessions": [
+      {
+        "id": 995900,
+        "name": "From Mission to Market: Where Fintech and CDFIs Align and Clash"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Shaundra Jacobs es la presidenta de AltCap para el mercado de Texas, donde dirige las operaciones crediticias en todo el estado con el objetivo de ampliar el acceso al capital para los emprendedores desfavorecidos. Establece alianzas con bancos, organizaciones comunitarias y proveedores de asistencia técnica para ayudar a los fundadores a pasar de la idea a la inversión. Orgullosa exalumna de la Universidad Prairie View A&M, Shaundra sirve a su comunidad a través del Distrito Escolar Independiente de Spring Branch, la hermandad Zeta Phi Beta Sorority, Inc. y las juntas directivas de la ciudad de Houston. También aporta su liderazgo como miembro de la junta directiva de la Fundación Atlética 1876. Nacida y criada en Port Arthur, Texas, Shaundra reside actualmente en Houston. Es una madre dedicada de dos niños y disfruta explorando nuevos restaurantes en su tiempo libre.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "47f35bcf-71d5-4e11-8a5d-c967ab08ede1",
+    "firstName": "Sheena",
+    "lastName": "Allen",
+    "fullName": "Sheena Allen",
+    "bio": "Sheena Allen is a tech entrepreneur, author, international speaker, and creative strategist\r\npassionate about building innovative, impact-driven solutions.\r\nWhile still in college, Sheena founded her first startup, Sheena Allen Apps, bootstrapping it into a mobile tech parent company that housed five apps and generated millions of downloads worldwide. In 2019, she launched CapWay, a fintech company dedicated to expanding economic access through inclusive digital banking, financial content, and payment infrastructure. As the founder of CapWay, Sheena raised millions in venture capital and became the youngest woman in the U.S. to own and operate a digital bank.\r\nShe is currently the co-founder of GRITS, a parent company and community-driven launchpad for creators and entrepreneurs. GRITS is home to a growing portfolio of ventures, including the Rich Lessons podcast. In addition, she is building a stealth startup at the intersection of fintech and artificial intelligence.\r\nSheena’s work has been featured in multiple publications, including Forbes, Inc., Business Insider, and Entrepreneur Magazine. She has earned recognition as a Forbes 30 Under 30 honoree, Business Insider Under 30 Innovator, Inc. Female Founders 100 recipient, and one of Entrepreneur Magazine’s Most Influential. In 2021, she was awarded the Maggie Lena Walker Emerging Leader Award from PayPal for her contributions to financial empowerment.\r\nIn addition to her ventures, Sheena is the author of The Starting Guide and has been featured in two documentaries, She Started It and a Google-produced short for its Black Women in Tech series, highlighting her journey as a non-technical founder breaking barriers in tech.",
+    "tagLine": "Interledger Ambassador",
+    "profilePicture": "https://sessionize.com/image/c0a9-400o400o1-SDPAirRQoBt6fEiHNx5ZhR.jpg",
+    "sessions": [
+      {
+        "id": 995900,
+        "name": "From Mission to Market: Where Fintech and CDFIs Align and Clash"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Sheena Allen es una emprendedora tecnológica, autora, conferencista internacional y estratega creativa apasionada por crear soluciones innovadoras y con impacto. Mientras aún estaba en la universidad, Sheena fundó su primera empresa emergente, Sheena Allen Apps, y la convirtió en una empresa matriz de tecnología móvil que albergaba cinco aplicaciones y generaba millones de descargas en todo el mundo. En 2019, lanzó CapWay, una empresa de tecnología financiera dedicada a ampliar el acceso económico a través de la banca digital inclusiva, los contenidos financieros y la infraestructura de pagos. Como fundadora de CapWay, Sheena recaudó millones en capital de riesgo y se convirtió en la mujer más joven de Estados Unidos en poseer y operar un banco digital. Actualmente es cofundadora de GRITS, una empresa matriz y plataforma de lanzamiento impulsada por la comunidad para creadores y emprendedores. GRITS alberga una cartera cada vez mayor de empresas, entre las que se incluye el podcast Rich Lessons. Además, está creando una startup sigilosa en la intersección entre la tecnología financiera y la inteligencia artificial. El trabajo de Sheena ha aparecido en múltiples publicaciones, entre ellas Forbes, Inc., Business Insider y Entrepreneur Magazine. Ha sido reconocida como una de las 30 menores de 30 años de Forbes, innovadora menor de 30 años de Business Insider, una de las 100 fundadoras de Inc. y una de las personas más influyentes de Entrepreneur Magazine. En 2021, recibió el premio Maggie Lena Walker Emerging Leader Award de PayPal por sus contribuciones al empoderamiento financiero. Además de sus proyectos empresariales, Sheena es autora de The Starting Guide y ha aparecido en dos documentales, She Started It y un cortometraje producido por Google para su serie Black Women in Tech, en los que se destaca su trayectoria como fundadora sin conocimientos técnicos que rompe barreras en el mundo de la tecnología.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "6b0e5bf6-b19d-4a1f-9977-4b4d03b984eb",
+    "firstName": "Smriti",
+    "lastName": "Parsheera",
+    "fullName": "Smriti Parsheera",
+    "bio": "Smriti Parsheera is a lawyer and independent researcher working on issues at the intersection of technology and society. She was an Ambassador with the Interledger Foundation from 2024-25. Her previous experience, spanning over 18 years, included working with the CyberBRICS Project at FGV Law School, Brazil, leading the tech policy work at National Institute of Public Finance and Policy, India, and working with the UNDP and the Competition Commission of India. \r\n\r\nHer research touches upon the areas of digital access, privacy and data governance, regulatory processes and digital public infrastructure. In 2023, she published the edited book, Private and Controversial, that studied the intersection between public health and privacy in India. \r\n\r\nSmriti studied law at the National Law School of India University, Bangalore followed by a Masters degree from the University of Pennsylvania. She is completing her PhD from the Indian Institute of Technology Delhi.",
+    "tagLine": "Interledger Ambassador ",
+    "profilePicture": "https://sessionize.com/image/ec0d-400o400o1-skKSd44bC3VpEkGpqczr8i.jpg",
+    "sessions": [
+      {
+        "id": 995879,
+        "name": "From Classroom to Codebase: How Universities Cultivate the Next Generation of Open Payments Talent"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Ambassador",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Smriti Parsheera es abogada e investigadora independiente que trabaja en temas relacionados con la intersección entre la tecnología y la sociedad. Fue embajadora de la Fundación Interledger entre 2024 y 2025. Su experiencia previa, que abarca más de 18 años, incluye su trabajo en el proyecto CyberBRICS de la Facultad de Derecho de la FGV, en Brasil, la dirección de las políticas tecnológicas del Instituto Nacional de Finanzas Públicas y Políticas, en la India, y su colaboración con el PNUD y la Comisión de Competencia de la India. Su investigación abarca las áreas de acceso digital, privacidad y gobernanza de datos, procesos regulatorios e infraestructura pública digital. En 2023, publicó el libro editado Private and Controversial, que estudiaba la intersección entre la salud pública y la privacidad en la India. Smriti estudió Derecho en la Facultad Nacional de Derecho de la Universidad de la India, en Bangalore, y posteriormente obtuvo una maestría en la Universidad de Pensilvania. Actualmente está completando su doctorado en el Instituto Indio de Tecnología de Delhi.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "d0c28aa3-f2ca-4af8-abc1-1f561b9e4408",
+    "firstName": "Stefan  ",
+    "lastName": "Thomas",
+    "fullName": "Stefan Thomas",
+    "bio": "Stefan Thomas is the Co-Creator of the Interledger Protocol and Chairperson of the Board at the Interledger Foundation. \r\n\r\nStefan was a prominent figure in the blockchain movement. As an early Bitcoin contributor, he produced the popular “What is Bitcoin?” video, introducing millions of users to Bitcoin, and created BitcoinJS, the first implementation of Bitcoin cryptography in the browser.\r\n\r\nAs CTO and one of the first employees at Ripple, Stefan designed new protocols for cross-border payments, now used by banks all over the world. As part of this work, he led the team that created Interledger, an open, Internet-like protocol for value transfer.\r\n\r\n--\r\n\r\nStefan Thomas es cofundador del protocolo Interledger y presidente del consejo de administración de la Fundación Interledger. Stefan fue una figura destacada en el movimiento blockchain. Como uno de los primeros colaboradores de Bitcoin, produjo el popular vídeo «¿Qué es Bitcoin?», que introdujo a millones de usuarios en Bitcoin, y creó BitcoinJS, la primera implementación de la criptografía Bitcoin en el navegador. Como director técnico y uno de los primeros empleados de Ripple, Stefan diseñó nuevos protocolos para pagos transfronterizos, que ahora utilizan bancos de todo el mundo. Como parte de este trabajo, dirigió el equipo que creó Interledger, un protocolo abierto similar a Internet para la transferencia de valor.\r\n",
+    "tagLine": null,
+    "profilePicture": "https://sessionize.com/image/c1f4-400o400o1-hvvyDeYLkoRDy52cTt9TN2.jpg",
+    "sessions": [
+      {
+        "id": 995867,
+        "name": "Keynote Speaker"
+      },
+      {
+        "id": 1046412,
+        "name": "Keynote: Liquidity"
+      }
+    ],
+    "isTopSpeaker": true,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Co-Creator of the Interledger Protocol ",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Stefan Thomas es cofundador del protocolo Interledger y presidente del consejo de administración de la Fundación Interledger. Stefan fue una figura destacada en el movimiento blockchain. Como uno de los primeros colaboradores de Bitcoin, produjo el popular vídeo «¿Qué es Bitcoin?», que introdujo a millones de usuarios en Bitcoin, y creó BitcoinJS, la primera implementación de la criptografía Bitcoin en el navegador. Como director técnico y uno de los primeros empleados de Ripple, Stefan diseñó nuevos protocolos para pagos transfronterizos, que ahora utilizan bancos de todo el mundo. Como parte de este trabajo, dirigió el equipo que creó Interledger, un protocolo abierto similar a Internet para la transferencia de valor.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "585a769b-db7a-4c75-b1ba-4c4fe8015276",
+    "firstName": "Tadej",
+    "lastName": "Golobic",
+    "fullName": "Tadej Golobic",
+    "bio": "At 10 years old, I began my coding journey with VB6, setting the course for a lifelong tech odyssey. Graduating from the Faculty of Computer and Information Science at the University of Ljubljana, I delved into remote support software with a local enterprise. The 2017 crypto boom lured me into the crypto realm, leading to my pivotal role as a backend developer at GateHub in 2020. Today, I proudly serve as Infrastructure Team Lead, steering projects that power our digital future.",
+    "tagLine": "GateHub",
+    "profilePicture": "https://sessionize.com/image/aeeb-400o400o1-HXBuaj6u1eQ7eETh4ykG6u.jpg",
+    "sessions": [
+      {
+        "id": 1037916,
+        "name": "Interledger Cards and POS "
+      },
+      {
+        "id": 1018856,
+        "name": "Payment Pointers to SEPA"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "GateHub & Interledger Foundation",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Head of Engineering @ GateHub & Engineering Manager @ Interledger Foundation",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "A los 10 años, comencé mi andadura en la programación con VB6, lo que marcó el rumbo de una odisea tecnológica que duraría toda mi vida. Tras graduarme en la Facultad de Informática y Ciencias de la Información de la Universidad de Liubliana, me sumergí en el mundo del software de asistencia remota con una empresa local. El auge de las criptomonedas en 2017 me atrajo al mundo de las criptomonedas, lo que me llevó a desempeñar un papel fundamental como desarrollador backend en GateHub en 2020. Hoy en día, me enorgullece desempeñar el cargo de jefe del equipo de infraestructura, dirigiendo proyectos que impulsan nuestro futuro digital.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "405070c5-a46c-4f12-9b68-5b1ed17e98a1",
+    "firstName": "Uchi",
+    "lastName": "Uchibeke",
+    "fullName": "Uchi Uchibeke",
+    "bio": "Developer, and Founder. DevRel leader with track record growing communities around the globe",
+    "tagLine": "Chimoney",
+    "profilePicture": "https://sessionize.com/image/79d3-400o400o1-Jfmm3fGu2fRS45EHq3ZcFq.jpg",
+    "sessions": [
+      {
+        "id": 1018855,
+        "name": "Chimoney's ILP Stack & Chimoney App Updates"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Chimoney",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Founder",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Desarrollador y fundador. Líder de DevRel con experiencia en el crecimiento de comunidades en todo el mundo.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "8344beef-93f2-448d-aaa7-de1df719d89f",
+    "firstName": "Víctor Manuel",
+    "lastName": "Romero Rodríguez",
+    "fullName": "Víctor Manuel Romero Rodríguez",
+    "bio": "Hailing from Mexico City, Victor Romero now has over 20 years of experience in the area of ​​Information Technology applied to Financial Services after completing his Bachelor of Computer Science at the National Polytechnic Institute,\r\n\r\nAs co-founder of Fintechando, the company that creates digital solutions based on the Apache Software Ecosystem, he has successfully overcome challenges related to aligning Open Source Technologies to the regulatory rules for bringing best in class software to Public and Private  Institutions to strike a balance between innovation and compliance.\r\n\r\nDuring this journey, Victor has implemented technology that enables customer-facing flows and improves the user experience while handling securely the sensitive data of the Mexican population.\r\n\r\nHaving used Software as the pillars to solve the needs of people, Victor is adept at crafting innovative solutions using information technologies.\r\n",
+    "tagLine": "Fintecheando",
+    "profilePicture": "https://sessionize.com/image/abff-400o400o1-JtwN2B9o1VxeTfF87sDK3d.jpg",
+    "sessions": [
+      {
+        "id": 1037917,
+        "name": "Brief Architecture - Mifos PCH Switch Connector"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "MIFOS",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "CTO",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Originario de la Ciudad de México, Víctor Romero cuenta con más de 20 años de experiencia en el área de Tecnología de la Información aplicada a los Servicios Financieros tras completar su licenciatura en Ciencias de la Computación en el Instituto Politécnico Nacional. Como cofundador de Fintechando, la empresa que crea soluciones digitales basadas en el ecosistema de software Apache, ha superado con éxito los retos relacionados con la adaptación de las tecnologías de código abierto a las normas reguladoras para llevar el mejor software de su clase a las instituciones públicas y privadas, con el fin de lograr un equilibrio entre la innovación y el cumplimiento normativo. Durante este recorrido, Víctor ha implementado tecnología que permite flujos orientados al cliente y mejora la experiencia del usuario, al tiempo que maneja de forma segura los datos confidenciales de la población mexicana. Habiendo utilizado el software como pilar para resolver las necesidades de las personas, Víctor es experto en crear soluciones innovadoras utilizando tecnologías de la información.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "22270cdd-1a5d-499e-9a2c-d45834d20e10",
+    "firstName": "Vlad",
+    "lastName": "Daneliuc",
+    "fullName": "Vlad Daneliuc",
+    "bio": "Vlad is a seasoned iOS developer with over 12 years of experience building high-quality, user-centered mobile applications. Since beginning his career in IT in 2012, he has specialized in iOS development, delivering intuitive, reliable, and maintainable solutions across a variety of projects and industries. Currently, he is leading the development of the Interledger Foundation’s mobile Wallet app, focusing on creating seamless and secure user experiences for open payments.\r\n\r\nPassionate about clean code, usability, and continuous learning, Vlad combines deep technical expertise with a commitment to innovation in the rapidly evolving mobile ecosystem.",
+    "tagLine": "BreakPoint IT",
+    "profilePicture": "https://sessionize.com/image/0849-400o400o1-LZ8sN3LDrL8umXtoRg5pLp.png",
+    "sessions": [
+      {
+        "id": 1018847,
+        "name": "Interledger Wallet "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "BreakPoint IT",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "iOS Developer & Co-Founder",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Vlad es un experimentado desarrollador de iOS con más de 12 años de experiencia en la creación de aplicaciones móviles de alta calidad centradas en el usuario. Desde que comenzó su carrera en TI en 2012, se ha especializado en el desarrollo de iOS, ofreciendo soluciones intuitivas, fiables y fáciles de mantener en una gran variedad de proyectos y sectores. Actualmente, lidera el desarrollo de la aplicación móvil Wallet de la Interledger Foundation, centrándose en crear experiencias de usuario fluidas y seguras para los pagos abiertos. Apasionado por el código limpio, la usabilidad y el aprendizaje continuo, Vlad combina una profunda experiencia técnica con un compromiso con la innovación en el ecosistema móvil en rápida evolución.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "5897fd4a-a09b-4352-b7f8-d150bd4b0736",
+    "firstName": "Wilneida",
+    "lastName": "Negrón",
+    "fullName": "Wilneida Negrón",
+    "bio": "Dr. Wilneida Negrón is a political scientist, technologist, and social entrepreneur who works at the intersection of labor, technology, and financial markets. She currently leads Worker Innovation & Impact at Coworker.org, co-founded the Startups & Society Initiative, and founded the Future of Workers Initiative. Her work helps founders, investors, policy makers, and civil society understand how emerging technologies, from AI and algorithmic management to employment and payments infrastructure, shape workers’ rights, dignity, and agency. She builds frameworks, standards, and practices that ensure innovations are equitable and human-centered.",
+    "tagLine": "Coworker.org",
+    "profilePicture": "https://sessionize.com/image/54dd-400o400o1-KDcwNrS9WhsEWGdAQgn11d.jpg",
+    "sessions": [
+      {
+        "id": 995876,
+        "name": "Rights & Rails: How Philanthropy Links Access, Capacity & Inclusive Payment Systems"
+      }
+    ],
+    "isTopSpeaker": true,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "La Dra. Wilneida Negrón es politóloga, tecnóloga y emprendedora social que trabaja en la intersección entre el trabajo, la tecnología y los mercados financieros. Actualmente dirige Worker Innovation & Impact en Coworker.org, es cofundadora de Startups & Society Initiative y fundadora de Future of Workers Initiative. Su trabajo ayuda a fundadores, inversionistas, responsables políticos y la sociedad civil a comprender cómo las tecnologías emergentes, desde la inteligencia artificial y la gestión algorítmica hasta la infraestructura de empleo y pagos, configuran los derechos, la dignidad y la capacidad de acción de los trabajadores. Desarrolla marcos, normas y prácticas que garantizan que las innovaciones sean equitativas y centradas en las personas.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "3a71dfe5-a936-40b8-853b-46d1652952fe",
+    "firstName": "Xiaoji",
+    "lastName": "Song",
+    "fullName": "Xiaoji Song",
+    "bio": "Xiaoji Song (b. 1995, Wuhan, she/they) is a Berlin-based artist, activist, performance-maker, game-maker, and researcher. Recent works include participatory performance Lake Reclamation Code, supported by Intermediae Matadero; theater performance Alien without Extraordinary Ability, supported by Ringtheater Berlin and the Asian Performing Artists Lab as part of the art collective EAST ALIEN COMPANY; and web-based game Emotional Futures, supported by LAS Foundation as part of the IRL collective. Xiaoji was also one of the FUTURE I MONEY grantees of the Interledger Foundation.  Xiaoji is a 2025 Ambassador of the Interledger Foundation, researching and advocating for the communities involved in the informal economy in Berlin and Madrid. \r\n\r\nXiaoji’s practice spans text, games, social practices, and performance to construct critical fabulations around bordering practices, notions of security, and alternative economies. They focus on exploring post-capitalist and post-border approaches to creating safety, community, and kinship, often activating social interactions and mechanisms to examine how non-belonging and fluidity can open spaces for resistance. Their work has been presented at Ringtheater Berlin, Berliner Festspiele, Goethe-Institut Bulgaria, NECE Festival, Sofia Art Week, and Matadero Madrid Contemporary Art Center, with support from DOMiD Lab (DE), Light Art Space Foundation (DE), and Interledger Foundation (USA). They have participated in residencies at Callie’s Berlin, Asian Performing Artists Lab@AmnAsia, Ideas Factory Association Bulgaria, and Matadero Madrid Contemporary Art Center. Xiaoji is also an alum of the New Politics and Afrofuturism Research Programme at University of the Underground, Practicing Rhythm Site-specific Research Lab at Open Set Lab, AI Anarchies Autumn School at the Academy of Arts Berlin, and the School for Dissident Friendship at Berliner Festspiele.\r\n\r\nFor their social practices, activism, community, and advocacy work, they regularly collaborate with local networks, grassroots initiatives, NGOs, and various civil society groups. Together with Yve Oh and Yumo Cheng, they founded the interdisciplinary art collective EAST ALIEN COMPANY.\r\n",
+    "tagLine": "Artist and Researcher ",
+    "profilePicture": "https://sessionize.com/image/8cc7-400o400o1-KBYLpKTMU3b2xjrwJF8dZT.png",
+    "sessions": [
+      {
+        "id": 995904,
+        "name": "From Financial Inclusion to Financial Justice: How to Enable an Equitable Future in the Gig Economy "
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": "Interledger Foundation / Independent",
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": "Ambassador 2025",
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Xiaoji Song (nacida en 1995 en Wuhan, ella/elle) es una artista, activista, creadora de performances, creadora de juegos e investigadora afincada en Berlín. Entre sus trabajos recientes se incluyen la performance participativa Lake Reclamation Code, con el apoyo de Intermediae Matadero; la obra de teatro Alien without Extraordinary Ability, con el apoyo de Ringtheater Berlin y Asian Performing Artists Lab como parte del colectivo artístico EAST ALIEN COMPANY; y el videojuego Emotional Futures, con el apoyo de la Fundación LAS como parte del colectivo IRL. Xiaoji también fue uno de los becarios FUTURE I MONEY de la Interledger Foundation. Xiaoji es embajador 2025 de la Interledger Foundation, investigando y defendiendo a las comunidades involucradas en la economía informal en Berlín y Madrid. La práctica de Xiaoji abarca el texto, los juegos, las prácticas sociales y la performance para construir fabulaciones críticas en torno a las prácticas fronterizas, las nociones de seguridad y las economías alternativas. Se centra en explorar enfoques poscapitalistas y posfronterizos para crear seguridad, comunidad y parentesco, a menudo activando interacciones y mecanismos sociales para examinar cómo la no pertenencia y la fluidez pueden abrir espacios para la resistencia. Su trabajo se ha presentado en el Ringtheater Berlin, el Berliner Festspiele, el Goethe-Institut Bulgaria, el NECE Festival, la Sofia Art Week y el Matadero Madrid Contemporary Art Center, con el apoyo de DOMiD Lab (Alemania), Light Art Space Foundation (Alemania) e Interledger Foundation (Estados Unidos). Han participado en residencias en Callie's Berlin, Asian Performing Artists Lab@AmnAsia, Ideas Factory Association Bulgaria y Matadero Madrid Contemporary Art Center. Xiaoji también es antiguo alumno del Programa de Investigación sobre Nueva Política y Afrofuturismo de la Universidad del Underground, del Laboratorio de Investigación Site-specific Practicing Rhythm del Open Set Lab, de la Escuela de Otoño AI Anarchies de la Academia de las Artes de Berlín y de la Escuela para la Amistad Disidente del Berliner Festspiele. Por sus prácticas sociales, activismo, trabajo comunitario y de defensa, colaboran regularmente con redes locales, iniciativas de base, ONG y diversos grupos de la sociedad civil. Junto con Yve Oh y Yumo Cheng, fundaron el colectivo artístico interdisciplinario EAST ALIEN COMPANY.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  },
+  {
+    "id": "b8c6942f-d96e-491b-bdef-0afc64456c9b",
+    "firstName": "Yiannis ",
+    "lastName": "Giannelos",
+    "fullName": "Yiannis Giannelos",
+    "bio": " Yiannis Giannelos is a Staff Software Engineer at the Wikimedia Foundation, where he works on the Product Infrastructure team supporting Wikipedia - one of the top 10 most visited websites globally. His work focuses on building and maintaining large-scale distributed systems that serve millions of users daily.\r\nPrior to Wikimedia, Yiannis spent over seven years at Mozilla in various software engineering roles, working on community tools, support platforms, web compatibility and authentication infrastructure. He was also a co-founder and Board Member of the Libre Space Foundation.\r\nOriginally from Athens, Greece, Yiannis currently lives in Berlin, Germany, and is an active contributor to open-source projects, with expertise in Python and large-scale web infrastructure.\r\n",
+    "tagLine": "Wikimedia Foundation",
+    "profilePicture": "https://sessionize.com/image/f7df-400o400o1-TeDXQVG75rKaLWAcuZEkNX.png",
+    "sessions": [
+      {
+        "id": 995909,
+        "name": "Open Payments, Open Mic"
+      }
+    ],
+    "isTopSpeaker": false,
+    "links": [],
+    "questionAnswers": [
+      {
+        "id": 106564,
+        "question": "Organizational Affiliation ",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 21,
+        "answerExtra": null
+      },
+      {
+        "id": 106565,
+        "question": "Role",
+        "questionType": "Short_Text",
+        "answer": null,
+        "sort": 22,
+        "answerExtra": null
+      },
+      {
+        "id": 114100,
+        "question": "Biografía",
+        "questionType": "Long_Text",
+        "answer": "Yiannis Giannelos es ingeniero de software en la Fundación Wikimedia, donde trabaja en el equipo de infraestructura de productos que da soporte a Wikipedia, uno de los diez sitios web más visitados del mundo. Su trabajo se centra en la creación y el mantenimiento de sistemas distribuidos a gran escala que dan servicio a millones de usuarios cada día. Antes de trabajar en Wikimedia, Yiannis pasó más de siete años en Mozilla desempeñando diversas funciones de ingeniería de software, trabajando en herramientas comunitarias, plataformas de soporte, compatibilidad web e infraestructura de autenticación. También fue cofundador y miembro de la junta directiva de la Fundación Libre Space. Originario de Atenas, Grecia, Yiannis vive actualmente en Berlín, Alemania, y es un activo colaborador de proyectos de código abierto, con experiencia en Python e infraestructura web a gran escala.",
+        "sort": 42,
+        "answerExtra": null
+      }
+    ],
+    "categories": []
+  }
+]

--- a/src/data/sessionize/2025-talks.json
+++ b/src/data/sessionize/2025-talks.json
@@ -1,0 +1,2562 @@
+[
+  {
+    "groupId": null,
+    "groupName": "All",
+    "sessions": [
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Esta ponencia marca el tono de una cumbre llena de conversaciones audaces, colaboraciones significativas y una celebración compartida de lo que es posible cuando construimos juntos un futuro financiero abierto e inclusivo.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Ponencia",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995867",
+        "title": "Keynote Speaker",
+        "description": "Speaker: Briana Marbury, President & CEO, Interledger Foundation\r\n\r\nThis keynote sets the stage for a Summit filled with bold conversations, meaningful collaborations, and a shared celebration of what’s possible when we build an open, inclusive financial future, together.",
+        "startsAt": "2025-11-05T10:00:00",
+        "endsAt": "2025-11-05T11:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "daa019af-2d28-46a0-96b5-f98444e8a9f7",
+            "name": "Briana Marbury"
+          },
+          {
+            "id": "d0c28aa3-f2ca-4af8-abc1-1f561b9e4408",
+            "name": "Stefan Thomas"
+          },
+          {
+            "id": "0e20465e-b9bb-4348-9732-2c67874188ef",
+            "name": "Evan Schwartz"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "A medida que la infraestructura pública digital se convierte en la columna vertebral de los sistemas financieros mundiales, nos encontramos en una encrucijada crítica: ¿estas tecnologías fundamentales amplificarán las desigualdades existentes o se convertirán en motores de inclusión? Este panel examinará cómo se pueden poner en práctica los principios de derechos humanos dentro de la infraestructura financiera pública digital. Aprovechando la experiencia en materia de inclusión financiera, desarrollo de infraestructura pública digital y defensa de la justicia racial, el debate abordará cuestiones fundamentales como: ¿Cómo se traducen las normas mundiales de derechos humanos en especificaciones técnicas? ¿Dónde suelen frustrar los retos de implementación las buenas intenciones? ¿Cómo es cuando la justicia no es una idea secundaria, sino un principio básico del diseño? Y, lo que es más importante, ¿quién toma estas decisiones y cómo garantizamos que los más afectados tengan voz en la configuración de los sistemas que les servirán?",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Derechos humanos por diseño: una infraestructura financiera que funciona para todos",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995871",
+        "title": "Human Rights by Design: Financial Infrastructure that Works for Everyone",
+        "description": "As digital public infrastructure becomes the backbone of global financial systems, we stand at a critical juncture: will these foundational technologies amplify existing inequalities or become engines of inclusion? This panel will examine how human rights principles can be operationalized within digital public financial infrastructure. Drawing on expertise from financial inclusion, digital public infrastructure development, and racial justice advocacy, the discussion will tackle critical questions: How do global human rights norms translate into technical specifications? Where do implementation challenges most often derail good intentions? What does it look like when justice isn't an afterthought but a core design principle? And critically, who gets to make these decisions, and how do we ensure those most affected have a voice in shaping the systems that will serve them?",
+        "startsAt": "2025-11-05T11:30:00",
+        "endsAt": "2025-11-05T12:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "d55a0ff7-8857-4713-96a3-3898a61d0de6",
+            "name": "Ayden Férdeline"
+          },
+          {
+            "id": "ad2c458b-64a4-401b-aa98-05944bb9f7dd",
+            "name": "Ed Cable"
+          },
+          {
+            "id": "6dc84f36-6462-4938-ad3d-00abf3ae6952",
+            "name": "Hannah Draper"
+          },
+          {
+            "id": "925df3a9-96d7-4a3a-8b45-fed2d08718d3",
+            "name": "Nasser Eledroos"
+          },
+          {
+            "id": "1b1f8571-7e4f-40fe-8940-81c16be6efe2",
+            "name": "Alix Dunn"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Step into the shoes of innovators and regulators in this fast-paced, 90-minute simulation. \r\n\r\nParticipants will form small teams, either pitching bold new fintech solutions and serving on a regulatory panel that debates, challenges, and decides whether these ideas should move forward.\r\n\r\nArmed with innovation cards and guided briefings, FinTech teams will craft their proposals while Regulators prepare their oversight lens. The energy builds as proposals are pitched, regulators deliberate, and tough Q&A unfolds—culminating in real-time decisions that shape the fate of each innovation.\r\n\r\nThe session closes with an open reflection, inviting both sides to step back, share insights, and explore the balance between innovation, inclusion, and responsible regulation.\r\n\r\nFast. Interactive. Insightful. This is not just a session—it’s an immersive experience in the future of digital finance.\r\n\r\n__\r\n\r\nPonte en los zapatos de innovadores y reguladores en esta simulación trepidante de 90 minutos. Los participantes formarán pequeños equipos, ya sea para presentar nuevas y audaces soluciones fintech o para formar parte de un panel regulador que debate, cuestiona y decide si estas ideas deben seguir adelante. Armados con tarjetas de innovación y sesiones informativas guiadas, los equipos FinTech elaborarán sus propuestas mientras los reguladores preparan su perspectiva de supervisión. La energía va en aumento a medida que se presentan las propuestas, los reguladores deliberan y se desarrollan duras sesiones de preguntas y respuestas, que culminan en decisiones en tiempo real que determinan el destino de cada innovación. La sesión concluye con una reflexión abierta, en la que se invita a ambas partes a dar un paso atrás, compartir ideas y explorar el equilibrio entre la innovación, la inclusión y la regulación responsable. Rápida. Interactiva. Perspicaz. No se trata solo de una sesión, sino de una experiencia inmersiva en el futuro de las finanzas digitales.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "El dilema del regulador es un juego de rol atractivo y basado en el debate que sitúa a los participantes en la compleja encrucijada de permitir la innovación financiera y garantizar al mismo tiempo la protección de los consumidores. Los jugadores interpretarán el papel de innovadores FinTech o equipos reguladores, simulando las tensiones reales a las que se enfrentan los responsables políticos. Los equipos debatirán... y finalmente decidirán: si aprobar, aprobar con condiciones o rechazar las tecnologías financieras emergentes. El juego está diseñado para promover un debate reflexivo, cuestionar estereotipos y sacar a la luz las compensaciones éticas y estructurales inherentes a la toma de decisiones reguladoras.\r\nFormato de la sesión: Laboratorio de aprendizaje",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "El dilema del regulador",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995376",
+        "title": "The Regulator's Dilemma",
+        "description": "The Regulator’s Dilemma is an engaging, debate-driven role-playing game that places participants in the complex intersection of enabling financial innovation while ensuring consumer protection. Players will role-play being FinTech Innovators or Regulatory Teams, simulating the real-world tensions faced by policymakers. Teams will debate...and ultimately decide: whether to approve, conditionally approve, or reject emerging financial technologies. The game is designed to promote thoughtful discussion, challenge assumptions, and surface the ethical and structural trade-offs embedded in regulatory decision-making.\r\n",
+        "startsAt": "2025-11-05T11:30:00",
+        "endsAt": "2025-11-05T13:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "42e841a3-7a0b-4a96-86d1-cb0689c47382",
+            "name": "Nandini Harihareswara"
+          },
+          {
+            "id": "d35ddcb5-3563-4cca-b731-6845dc0d406f",
+            "name": "Rafe Mazer"
+          },
+          {
+            "id": "83cc3863-e48d-42e4-8055-86c53c9ef693",
+            "name": "Jeremiah Lee"
+          },
+          {
+            "id": "c6428e78-fd0c-4348-bca1-4a4d81b7e81f",
+            "name": "Pablo Antón Díaz"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383932,
+                "name": "Learning Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69442,
+        "room": "Learn Together Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "This session opens up the process behind Kanzu’s interoperable credit engine, how we built it, what broke along the way, and what we learned about scaling inclusion through infrastructure. \r\nWe’ll share current progress and outline what lies ahead as we prepare for user testing and nationwide rollout.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Finanzas Kanzu",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1033568",
+        "title": "Kanzu Finance",
+        "description": "The Infrastructure of Inclusion: Inside Kanzu Finance’s ILP Microloan Engine.",
+        "startsAt": "2025-11-05T11:30:00",
+        "endsAt": "2025-11-05T11:50:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "8bb62141-31b1-4635-9f57-324d4eb0dcd5",
+            "name": "Maria Gorrettie Namuddu"
+          },
+          {
+            "id": "d31924a5-5e58-419e-a57f-13c9b9de7c48",
+            "name": "Lincon Ssebugwawo [ Kanzu Finance ]"
+          },
+          {
+            "id": "f05f5ce1-24b4-4f8f-b644-357305ebf3fd",
+            "name": "Peter Kakoma"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": " In this workshop we will cover:\r\n\r\n-Customer Needs and existing challenges while receiving remittances in Pakistan\r\n-Regulatory Compliance Requirements (KYC-AML-CFT for Inward Remittances to Pakistan)\r\n- A demonstration of receiving remittances via ILP\r\n",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Paysys Labs, una empresa líder en tecnología financiera conocida por sus innovadoras soluciones de pago digital y servicios financieros, se ha asociado con Allied Bank Limited para transformar el panorama de las remesas en Pakistán. Los bancos de Pakistán se enfrentan actualmente a retos como los altos costes y los retrasos en los pagos transfronterizos, lo que repercute en la satisfacción de los clientes. Este acuerdo permitirá a ABL ofrecer servicios de remesas más rápidos y rentables, mejorando la experiencia del cliente y ampliando la inclusión financiera en Pakistán.\r\nEste proyecto tiene como objetivo revolucionar los pagos transfronterizos mediante la integración de ABL en la red global Interledger Protocol  a través de la implementación de Open Connect Middleware por parte de Paysys Labs. Esto establecerá el nodo de ABL en la red ILP, lo que permitirá que las cuentas de los clientes funcionen como monederos digitales dentro del ecosistema ILP.\r\n\r\nDetalles de la sesión: En este taller trataremos los siguientes temas: -Las necesidades de los clientes y los retos actuales a la hora de recibir remesas en Pakistán. -Requisitos de cumplimiento normativo (KYC-AML-CFT para remesas entrantes en Pakistán). -Una demostración de cómo recibir remesas a través de ILP.\r\n",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Acompañando a los bancos de Pakistán para ofrecer servicios de envío de remesas más rápidos y rentables a través de ILP.",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1033766",
+        "title": "Enabling Banks in Pakistan to offer faster, cost-effective remittance services via ILP",
+        "description": "Paysys Labs, a leading fintech company known for its innovative digital payment and financial service solutions, is partnering with Allied Bank Limited to transform the remittance landscape in Pakistan. Banks in Pakistan currently face challenges such as high costs and delays in cross-border payments, which impact customer satisfaction. This arrangement will enable ABL to offer faster, more cost-effective remittance services, enhancing customer experience and expanding financial inclusion in Pakistan.\r\n\r\nThis project aims to revolutionize cross-border payments by integrating ABL into the global Interledger Protocol  network through the implementation of Open Connect Middleware by Paysys Labs. This will establish ABL's node on the ILP network, allowing customer accounts to function as digital wallets within the ILP ecosystem.",
+        "startsAt": "2025-11-05T11:55:00",
+        "endsAt": "2025-11-05T12:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "58ec7ac2-d517-43a8-a12c-e73a381735da",
+            "name": "Karim Jindani"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Agenda (20 minutes):\r\n1.\tBessPay Plugin Introduction & Context – 2 min\r\n2.\tTechnical Overview: Open Payments Integration – 3 min\r\n3.\tLive Demo Part 1: Marketplace Owner Onboarding – 3 min\r\n4.\tLive Demo Part 2: Seller Onboarding – 4 min\r\n5.\tLive Demo Part 3: Buyer Checkout Experience – 5 min\r\n6.\tQ&A – 3 min",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "El complemento BessPay para Sharetribe integra el estándar de pagos abiertos de Interledger, lo que permite a las micro, pequeñas y medianas empresas realizar transacciones a nivel mundial en monedas locales de forma más rápida, económica y segura. En este laboratorio de demostración, los participantes verán una presentación en directo de SouthLink Marketplace, que abarca la configuración del propietario del mercado, la incorporación de vendedores, la vinculación de carteras y los flujos de pago de los compradores.\r\n\r\n\r\nLa demostración muestra cómo Open Payments hace que los pagos en los mercados sean interoperables e inclusivos. Los participantes aprenderán cómo los vendedores de micro, pequeñas y medianas empresas (MIPYMES) se unen a los ecosistemas de comercio digital, mientras que los propietarios de los mercados configuran carteras y gestionan transacciones transparentes. Con 440 millones de MIPYMES en el Sur Global que emplean a 1000 millones de personas (Banco Mundial), esta innovación impulsa el comercio transfronterizo, la inclusión financiera y el crecimiento sostenible.\r\n\r\n\r\nDetalles de la sesión: \r\nAgenda (20 minutes): 1.Introducción y contexto del complemento BessPay: 2 min. \r\n2. Descripción técnica general: integración de Open Payments: 3 min. \r\n3. Demostración en vivo, parte 1: incorporación del propietario del mercado: 3 min. \r\n4. Demostración en vivo, parte 2: incorporación del vendedor: 4 min. \r\n5. Demostración en vivo, parte 3: experiencia de pago del comprador: 5 min. \r\n6. Preguntas y respuestas: 3 min.\r\n",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "BessPay Plugin: impulsando los mercados de micro, pequeñas y medianas empresas en Sharetribe con pagos abiertos Interledger",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1033769",
+        "title": "BessPay Plugin: Powering MSME Marketplaces on Sharetribe with Interledger Open Payments",
+        "description": "The BessPay Plugin for Sharetribe integrates Interledger’s Open Payments standard, enabling MSMEs to transact globally in local currencies, faster, cheaper, and more securely. In this Demo Lab, participants will see a live walkthrough of SouthLink Marketplace, covering marketplace owner setup, seller onboarding, wallet linking, and buyer checkout flows.\r\n\r\nThe demo shows how Open Payments make marketplace payments interoperable and inclusive. Participants will learn how MSME sellers join digital trade ecosystems while marketplace owners configure wallets and manage transparent transactions. With 440 million MSMEs in the Global South employing 1 billion people (World Bank), this innovation drives cross-border trade, financial inclusion, and sustainable growth.",
+        "startsAt": "2025-11-05T12:20:00",
+        "endsAt": "2025-11-05T12:40:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "569cb03f-bb7c-4ab2-957e-859bc047dc28",
+            "name": "Douglas Davidson"
+          },
+          {
+            "id": "9673d6a9-cea3-42a7-afa6-aefc0414a472",
+            "name": "Darnell Garcia"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Fireside chat\r\n\r\nPossible focus areas for prep:\r\n\r\n- Lessons from Mexico’s national inclusion strategy and Fintech Law\r\n- The role of open, interoperable infrastructure in enabling last-mile access\r\n- How community and cooperative finance institutions are digitizing responsibly\r\n- Opportunities for collaboration between policymakers, innovators, and local actors\r\n\r\n--\r\n\r\nDetalles de la sesión:  Charla informal. Posibles áreas de interés para la preparación: - Lecciones de la estrategia nacional de inclusión de México y la Ley Fintech - El papel de la infraestructura abierta e interoperable para permitir el acceso de última milla - Cómo las instituciones financieras comunitarias y cooperativas están digitalizando de forma responsable - Oportunidades de colaboración entre responsables políticos, innovadores y actores locales.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "La inclusión financiera ya no se limita a la apertura de cuentas, sino que consiste en garantizar una participación significativa en la economía digital. Esta sesión reúne a líderes de los sectores financiero público, privado y comunitario de México para debatir cómo los objetivos de las políticas nacionales se traducen en un impacto local.\r\nCon aportaciones del gobierno, las fintech y las redes comunitarias, la conversación explorará lo que se necesita para pasar de la inclusión sobre el papel a la inclusión en la práctica: los facilitadores normativos, la infraestructura tecnológica y las redes humanas que la hacen realidad. Juntos, los panelistas reflexionarán sobre el panorama financiero digital en evolución de México y las oportunidades para tender puentes entre las políticas públicas, las finanzas comunitarias y la innovación con el fin de lograr un sistema financiero más conectado e inclusivo.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "De la Política a la práctica: Inclusión financiera en México ",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995890",
+        "title": "From Policy to Practice: Financial Inclusion in Mexico",
+        "description": "Financial inclusion is no longer just about opening accounts, it’s about ensuring meaningful participation in the digital economy. This session brings together leaders from across Mexico’s public, private, and community finance sectors to discuss how national policy goals translate into local impact.\r\n\r\nWith insights from government, fintech, and community networks, the conversation will explore what it takes to move from inclusion on paper to inclusion in practice: the regulatory enablers, the technology infrastructure, and the human networks that make it real. Together, panelists will reflect on Mexico’s evolving digital finance landscape and the opportunities to bridge public policy, community finance, and innovation for a more connected, inclusive financial system.\r\n",
+        "startsAt": "2025-11-05T12:30:00",
+        "endsAt": "2025-11-05T13:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "e23853f1-0524-4b73-8661-77afaecf8c1e",
+            "name": "Rocío Mejía Flores"
+          },
+          {
+            "id": "4971741e-f209-4d85-aa6a-0e7d77e0a0d8",
+            "name": "Lizette Neme Bechara"
+          },
+          {
+            "id": "dd156dfc-6371-4203-8473-284175d8bd53",
+            "name": "Erick Huerta Velázquez"
+          },
+          {
+            "id": "bbbb1a45-cd4c-416f-a84a-147b751b5d1a",
+            "name": "Natalia Cueto"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388271,
+                "name": "Spanish"
+              },
+              {
+                "id": 402870,
+                "name": "English Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "miPlata es una empresa fintech con sede en EE. UU. que colabora con empresas de obreros para ayudar a los empleados a acceder, gastar y enviar sus nóminas de forma más eficiente. Al integrar sistemas de nóminas, productos de tarjetas de débito estadounidenses, transferencias internacionales de dinero y monedas estables, miPlata hace que sea más rápido, barato y seguro para los empleados mantener a sus familias al otro lado de la frontera.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "miPlata: nóminas que llegan a casa",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1033772",
+        "title": "miPlata - Payroll that reaches home",
+        "description": "miPlata is a US-based fintech working with blue-collar businesses to help employees access, spend, and send their paycheck more efficiently. By integrating payroll systems, US debit card products, international money transfer, and stablecoins, miPlata makes it faster, cheaper and safer for employees to support their families across borders. ",
+        "startsAt": "2025-11-05T12:45:00",
+        "endsAt": "2025-11-05T13:05:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "df71ae97-3d07-4f93-a0d9-2a22d96cc6e6",
+            "name": "Miguel Alecio"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Imagine federated Uber, where groups of drivers organise themselves, set their own coverage and hours and bill using open payments, without intermediary or platform fees, and where you can choose from amongst a group of drivers you know. Imagine federated Amazon, where every Amazon 'shop' is a different website all sharing a common interface and search engine. Or federated Booking.com, where hotels use their websites as they were originally intended, but still get to offer an interoperable single booking system.\r\n\r\nHop Sauna is about reimagining e-commerce and social media. A place where communities set up their own creator and product spaces running software built on Hop Sauna, moderate their own content, establish their own rules, and own their own means of distribution.\r\n\r\nJoin me as I demo the current state of Hop Sauna and the roadmap to fully independent, federated and community-moderated commerce.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Hop Sauna reinventa el comercio electrónico y las redes sociales. Acompáñame mientras muestro la versión actual del software y la hoja de ruta hacia un comercio totalmente independiente, federado y moderado por la comunidad.\r\nDetalles de la sesión: Imagínese un Uber sindical, en el que grupos de conductores se organizan, establecen su propia cobertura y horarios y facturan mediante pagos abiertos, sin intermediarios ni comisiones de plataforma, y en el que se puede elegir entre un grupo de conductores que se conocen. Imagina un Amazon federal, donde cada «tienda» de Amazon es un sitio web diferente que comparte una interfaz y un motor de búsqueda comunes. O una Booking.com federal, donde los hoteles utilizan sus sitios web tal y como se concibió originalmente, pero siguen ofreciendo un sistema de reservas único e interoperable. Hop Sauna consiste en reinventar el comercio electrónico y las redes sociales. Un lugar donde las comunidades crean sus propios espacios de creadores y productos con software basado en Hop Sauna, moderan su propio contenido, establecen sus propias reglas y son dueños de sus propios medios de distribución. Acompáñeme en la demostración del estado actual de Hop Sauna y la hoja de ruta hacia un comercio totalmente independiente, federado y moderado por la comunidad.\r\n",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Hop Sauna para el comercio federal moderado por la comunidad",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1033789",
+        "title": "Hop Sauna for federated community-moderated commerce",
+        "description": "Hop Sauna reimagines e-commerce and social media. Join me as I demo the current software build, and the roadmap to fully independent, federated and community-moderated commerce.",
+        "startsAt": "2025-11-05T13:10:00",
+        "endsAt": "2025-11-05T13:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "179ba8c7-f00e-448f-8002-6f2d3e349096",
+            "name": "Gavin Chait"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Del acceso al bienestar: diseño de herramientas financieras que las mujeres pueden utilizar y en las que puedan confiar\r\n\r\nAmérica Latina ha reducido las brechas de género en la titularidad de cuentas, pero las mujeres siguen siendo un 9,4 % menos propensas a utilizar los servicios financieros formales. El acceso por sí solo no es suficiente; los productos deben ser fáciles de usar, fiables y relevantes para la vida cotidiana. En México, el debate se está desplazando hacia el bienestar financiero y la resiliencia, vinculando el dinero a prioridades como la salud, la estabilidad familiar y la educación. En esta sesión se examina cómo una perspectiva centrada en el bienestar puede ofrecer un punto de partida más atractivo y cómo los pagos abiertos e interoperables pueden apoyar ese cambio.\r\nNos preguntaremos cómo las instituciones y las fintech pueden diseñar para la usabilidad y la agencia, no solo para el acceso; qué papel desempeñan la confianza, las barreras culturales y la educación financiera en la adopción en el mundo real; y si vincular los servicios a resultados como la atención sanitaria, la escolarización o la seguridad familiar puede desbloquear una participación más amplia.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Del acceso al bienestar: diseño de herramientas financieras que las mujeres pueden utilizar y en las que puedan confiar",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995902",
+        "title": "From Access to Wellbeing: Designing Financial Tools Women Can Trust and Use",
+        "description": "Latin America has narrowed gender gaps in account ownership, yet women remain 9.4% less likely to use formal financial services. Access alone is not enough; products must be usable, trustworthy, and relevant to daily life. In Mexico the conversation is shifting toward financial wellbeing and resilience, linking money to priorities such as health, family stability, and education. This session examines how a wellbeing lens can offer a more compelling entry point and how open, interoperable payments can support that shift.\r\n\r\nWe will ask how institutions and fintechs can design for usability and agency, not only access; what roles trust, cultural barriers, and financial literacy play in real-world uptake; and whether tying services to outcomes like healthcare, schooling, or family security can unlock broader participation.\r\n",
+        "startsAt": "2025-11-05T14:30:00",
+        "endsAt": "2025-11-05T15:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "32e79d82-db5e-4380-8af2-3b84001442cd",
+            "name": "Carolina Trivelli"
+          },
+          {
+            "id": "d28aade5-16d6-4682-aa4b-92fdf2c66fd9",
+            "name": "María José Roa"
+          },
+          {
+            "id": "d5f742a7-2e15-4515-9364-91970db523f0",
+            "name": "Pilar Islas Rodríguez"
+          },
+          {
+            "id": "bdfa2c7f-2c92-4eae-a7eb-24c0e8fa4052",
+            "name": "Jeffrey Bower"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388271,
+                "name": "Spanish"
+              },
+              {
+                "id": 402870,
+                "name": "English Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "In this interactive workshop, Interledger Foundation Ambassador Caroline Sinders will present findings from their ambassadorship research project on harmful design patterns and create space to ideate with policymakers, experts, designers, technologists, and advocacy-focused solutions and mitigations to address these patterns. Harmful design patterns (often called ‘deceptive design’ or ‘dark patterns’) are design patterns that nudge, confuse, exploit, manipulate, or trick the user into making a decision that they might not have meant to. Different countries, regions, and regulatory blocks have recently codified legislation to curb and mitigate harmful design patterns. Other countries will utilize pre-existing laws and regulations, as seen in the US with the FTC's definitions of deception and as seen in the UK under GDPR and competition law, to combat harmful design practices and patterns. \r\n\r\n\r\nIn 90 minutes, this workshop will provide a brief presentation of the research project's findings, including the current state of regulation related to harmful design patterns, a breakdown of what they are, and suggestions for next steps. Following the presentation will be space for lively discussion, questions, and answers. After that, the room will then be divided into small working groups to discuss a series of questions related to harmful design patterns, including: public awareness, support for technologists/designers/product teams who are building products for people, gaps/barriers in regulation, mitigation tactics, and any outstanding questions surfaced from the previous Q&A. \r\n\r\nThe workshop will conclude with information on how to stay in touch (including the possibility of forming a working group for the Interledger Foundation community) and outline the next steps for the project.\r\n",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "¿Qué es el diseño perjudicial y cómo afecta a los usuarios? ¿Cómo puede afectar a la seguridad de los consumidores? ¡Ven a este taller para obtener más información!\r\nLos patrones de diseño perjudiciales, a menudo denominados «patrones oscuros» o «diseño engañoso», son diseños que pueden influir, manipular, confundir o engañar a los usuarios para que tomen decisiones que no tenían intención de tomar. En California, la UE y la India existen normativas específicas contra los patrones de diseño perjudiciales, pero muchos países utilizan normativas preexistentes para combatirlos. Este taller se centrará en el proyecto embajador de Caroline Sinders sobre la investigación de patrones de diseño perjudiciales en los servicios financieros, proporcionará consejos y trucos sobre cómo identificar y evitar los patrones de diseño perjudiciales, y desentrañará cómo se entrecruzan el diseño y la política, todo ello centrándose en cómo diseñar para proteger a los consumidores marginados y vulnerables.\r\nFormato de la sesión Laboratorio de aprendizaje\r\nDetalles de la sesión: En este taller interactivo, Caroline Sinders, embajadora de la Fundación Interledger, presentará los resultados de su proyecto de investigación sobre patrones de diseño perjudiciales y creará un espacio para intercambiar ideas con responsables políticos, expertos, diseñadores y tecnólogos, así como soluciones y medidas de mitigación centradas en la defensa de los derechos para abordar estos patrones. Los patrones de diseño perjudiciales (a menudo denominados «diseño engañoso» o «patrones oscuros») son patrones de diseño que empujan, confunden, explotan, manipulan o engañan al usuario para que tome una decisión que tal vez no tenía intención de tomar. Diferentes países, regiones y bloques reguladores han codificado recientemente la legislación para frenar y mitigar los patrones de diseño perjudiciales. Otros países utilizan leyes y reglamentos preexistentes, como se observa en los Estados Unidos con las definiciones de engaño de la FTC y en el Reino Unido con el RGPD y la ley de competencia, para combatir las prácticas y patrones de diseño perjudiciales. En 90 minutos, este taller ofrecerá una breve presentación de los resultados del proyecto de investigación, incluyendo el estado actual de la regulación relacionada con los patrones de diseño perjudiciales, un desglose de lo que son y sugerencias para los próximos pasos. Tras la presentación, habrá espacio para un animado debate, preguntas y respuestas. A continuación, la sala se dividirá en pequeños grupos de trabajo para debatir una serie de cuestiones relacionadas con los patrones de diseño perjudiciales, entre las que se incluyen: la concienciación pública, el apoyo a los tecnólogos/diseñadores/equipos de producto que crean productos para las personas, las lagunas/barreras en la normativa, las tácticas de mitigación y cualquier cuestión pendiente que haya surgido en la ronda anterior de preguntas y respuestas. El taller concluirá con información sobre cómo mantenerse en contacto (incluida la posibilidad de formar un grupo de trabajo para la comunidad de la Fundación Interledger) y se esbozarán los próximos pasos del proyecto.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Combatir contra los diseños peligrosos para la seguridad de los consumidores",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "996920",
+        "title": "Combatting Harmful Design for Consumer Safety",
+        "description": "What is harmful design and how does it impact users? How can does impact consumer safety? Come to this workshop to find out more! \r\n\r\nHarmful design patterns, often called dark patterns or deceptive design, is design that can nudge, manipulate, confuse or deceive users into making decisions they didn't intend to make. In California, the EU, and India, there is specific regulation against harmful design patterns but many countries use pre-existing regulation to combat harmful design patterns. This workshop will focus on Caroline Sinders' ambassador project on researching harmful design patterns in financial services, provide tips and tricks on how to identify and avoid harmful design patterns, and unpack how design and policy intersect, all while centering how to design to protect marginalized and vulnerable consumers. \r\n",
+        "startsAt": "2025-11-05T14:30:00",
+        "endsAt": "2025-11-05T16:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "4bc0f1d5-3ad9-4cc2-ae85-d7f317578716",
+            "name": "Caroline Sinders"
+          },
+          {
+            "id": "d5bc736d-6b83-44b9-9b4c-bcb71535a4ff",
+            "name": "Antonia Valencia"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383932,
+                "name": "Learning Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 388271,
+                "name": "Spanish"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69442,
+        "room": "Learn Together Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "tbd",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Cartera Interledger ",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1018847",
+        "title": "Interledger Wallet ",
+        "description": null,
+        "startsAt": "2025-11-05T14:30:00",
+        "endsAt": "2025-11-05T15:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "22270cdd-1a5d-499e-9a2c-d45834d20e10",
+            "name": "Vlad Daneliuc"
+          },
+          {
+            "id": "5defb85a-6d82-4e67-9ad5-e1661067ff0d",
+            "name": "Raul Ranete"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "In this live demo, we will showcase the future of open, interoperable payments with the Interledger Card. The card is powered by a custom chip we designed, enabling seamless transactions across ILP network. We will demonstrate a payment initiated on a POS device running our KaiOS-based application, which securely communicates with the card and initiates the transaction.\r\nOn the backend, the payment is routed through Rafiki and underlying ASE where authorization is handled in real-time.\r\nThis session highlights the complete payment flow we developed end-to-end: from the chip inside the card, to the POS terminal experience, to the processing infrastructure. Participants will get a first-hand look at how Interledger technology enables fast, secure, and universal payments, and why it's a game-changer for financial inclusion and global commerce.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "En esta demostración en directo, mostraremos el futuro de los pagos abiertos e interoperables con la tarjeta Interledger. La tarjeta funciona con un chip personalizado que hemos diseñado, lo que permite realizar transacciones fluidas a través de la red ILP. Mostraremos un pago iniciado en un dispositivo POS que ejecuta nuestra aplicación basada en KaiOS, que se comunica de forma segura con la tarjeta e inicia la transacción. En el backend, el pago se enruta a través de Rafiki y el ASE subyacente, donde la autorización se gestiona en tiempo real. Esta sesión destaca el flujo de pago completo que hemos desarrollado de principio a fin: desde el chip dentro de la tarjeta, hasta la experiencia del terminal POS, pasando por la infraestructura de procesamiento. Los participantes podrán ver de primera mano cómo la tecnología Interledger permite pagos rápidos, seguros y universales, y por qué supone un cambio revolucionario para la inclusión financiera y el comercio global.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Tarjetas Interledger y puntos de venta",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1037916",
+        "title": "Interledger Cards and POS ",
+        "description": null,
+        "startsAt": "2025-11-05T15:00:00",
+        "endsAt": "2025-11-05T15:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "585a769b-db7a-4c75-b1ba-4c4fe8015276",
+            "name": "Tadej Golobic"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Mexico’s payment ecosystem remains fragmented, costly, and highly dependent on cash. According to our joint study with Finnovista, 92% of adults still use cash for daily transactions, remittances lose an average of 5% in fees, and only 13.5% of microenterprises can afford to accept digital payments. At the same time, Mexico has one of the most vibrant fintech ecosystems in Latin America - yet the benefits of innovation are blocked by silos, regulatory uncertainty, and market concentration.\r\n\r\nThis panel will unpack the findings of \"El Internet de las Oportunidades: Desbloqueando la interoperabilidad financiera en América Latina\", highlighting the opportunities and barriers to building a truly interoperable financial system. The discussion will explore lessons from Brazil’s Pix and India’s UPI, the potential to reduce merchant costs by up to 85%, and how greater interoperability could unlock over $1 billion USD annually in remittance savings for Mexican households.\r\n\r\nModerated by Beatriz Durán, the conversation will feature principal researcher Jordi Puig, Finnosummit, and industry leaders. Together, they will debate the role of regulators, incumbents, and innovators in transforming Mexico’s “archipelago” of financial systems into a seamless Internet of Opportunity.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "El ecosistema de pagos en México sigue estando fragmentado, es costoso y depende en gran medida del efectivo. Según nuestro estudio conjunto con Finnovista, el 92 % de los adultos sigue utilizando efectivo para las transacciones diarias, las remesas pierden una media del 5 % en comisiones y solo el 13,5 % de las microempresas puede permitirse aceptar pagos digitales. Al mismo tiempo, México tiene uno de los ecosistemas fintech más dinámicos de América Latina, pero los beneficios de la innovación se ven bloqueados por los silos, la incertidumbre regulatoria y la concentración del mercado.\r\n\r\nEste panel analizará las conclusiones de «El Internet de las Oportunidades: Desbloqueando la interoperabilidad financiera en América Latina», destacando las oportunidades y las barreras para construir un sistema financiero verdaderamente interoperable. El debate explorará las lecciones aprendidas de Pix en Brasil y UPI en la India, el potencial de reducir los costes de los comerciantes hasta en un 85 % y cómo una mayor interoperabilidad podría suponer un ahorro de más de 1000 millones de dólares anuales en remesas para los hogares mexicanos.\r\n\r\nModerada por Beatriz Durán, la conversación contará con la participación del investigador principal Jordi Puig, Finnosummit y líderes del sector. Juntos debatirán el papel de los reguladores, los operadores tradicionales y los innovadores en la transformación del «archipiélago» de sistemas financieros de México en una Internet de oportunidades sin fisuras.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Desbloqueando la interoperabilidad financiera en América Latina",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995886",
+        "title": "Unlocking Financial Interoperability in Latin America",
+        "description": "Mexico’s payment ecosystem remains fragmented, costly, and highly dependent on cash. According to our joint study with Finnovista, 92% of adults still use cash for daily transactions, remittances lose an average of 5% in fees, and only 13.5% of microenterprises can afford to accept digital payments. At the same time, Mexico has one of the most vibrant fintech ecosystems in Latin America - yet the benefits of innovation are blocked by silos, regulatory uncertainty, and market concentration.\r\n\r\nThis panel will unpack the findings of \"El Internet de las Oportunidades: Desbloqueando la interoperabilidad financiera en América Latina\", highlighting the opportunities and barriers to building a truly interoperable financial system. The discussion will explore lessons from Brazil’s Pix and India’s UPI, the potential to reduce merchant costs by up to 85%, and how greater interoperability could unlock over $1 billion USD annually in remittance savings for Mexican households.\r\n\r\nModerated by Beatriz Durán, the conversation will feature principal researcher Jordi Puig, Finnosummit, and industry leaders. Together, they will debate the role of regulators, incumbents, and innovators in transforming Mexico’s “archipelago” of financial systems into a seamless Internet of Opportunity.\r\n",
+        "startsAt": "2025-11-05T15:15:00",
+        "endsAt": "2025-11-05T16:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "8f8b1d5e-b76b-4e33-9959-508c0d85cb1e",
+            "name": "Beatriz Durán Serrano"
+          },
+          {
+            "id": "5360141a-45a1-4cd4-9dbe-a25b2031daec",
+            "name": "Jordi Puig"
+          },
+          {
+            "id": "ac1ceac1-f843-4904-b8c9-2f5021010d44",
+            "name": "Iñigo Rumayor"
+          },
+          {
+            "id": "139a555e-27a4-4640-af06-afe3b0cfc6e9",
+            "name": "Andres Alban"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388271,
+                "name": "Spanish"
+              },
+              {
+                "id": 402870,
+                "name": "English Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "In this session, Ioana and Rabeb will walk you through the latest implementation in the Web Monetization world. From the standard work, to its in browser implementation and all the work done to support our publishers with the right tools! \r\n",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "La economía de los contenidos digitales está evolucionando rápidamente, con previsiones que alcanzan los 69 800 millones de dólares para 2030 (Grand View Research). A medida que este panorama crece, los creadores de contenidos, los editores y los usuarios buscan formas más flexibles e intuitivas de conectarse y realizar transacciones. Si bien los anuncios, las suscripciones y los muros de pago siguen siendo herramientas esenciales, el futuro pasa por ampliar las posibilidades y potenciar las opciones.\r\nÚnase a nosotros para descubrir la monetización web, una nueva forma de ofrecer a los editores más opciones de ingresos y al público más formas de mantener los contenidos que les gustan. El apoyo puede adoptar muchas formas, desde una contribución única hasta un modelo continuo de pago por uso. Todo fluye a la perfección mientras las personas interactúan con los contenidos que les gustan. Los editores ganan dinero en el momento en que alguien interactúa, mientras que el público contribuye en tiempo real, utilizando un saldo que ellos mismos controlan.\r\n\r\nEn esta sesión, Ioana y Rabeb te guiarán a través de las últimas novedades en el mundo de la monetización web. Desde el trabajo estándar hasta su implementación en el navegador, pasando por todo el trabajo realizado para apoyar a nuestros editores con las herramientas adecuadas.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Todo sobre la monetización web",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1018846",
+        "title": "All about Web Monetization ",
+        "description": "The digital content economy is evolving rapidly with projections reaching $69.8 billion by 2030 (Grand View Research). As this landscape grows, content creators, publishers and users alike are looking for more flexible, intuitive ways to connect and transact. While ads, subscriptions and paywalls remain essential tools, the future is about expanding possibilities and empowering choice.\r\n\r\nJoin us to discover Web Monetization, a new way to give publishers more revenue options and audiences more ways to sustain the content they love. Support can take many forms, from a one-time contribution to a continuous, pay-as-you-browse model. It all flows seamlessly while people engage with the content they love. Publishers earn the moment someone engages, while audiences contribute in real time, using a balance they control.",
+        "startsAt": "2025-11-05T15:30:00",
+        "endsAt": "2025-11-05T16:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "297fd54b-f93c-4996-89bc-f96b3b7f8258",
+            "name": "Ioana Chiorean"
+          },
+          {
+            "id": "57a0f0dd-9b26-4559-bc3d-7d9b0b094799",
+            "name": "Rabeb Othmani"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Descubra cómo People’s Clearinghouse, una infraestructura de pagos digitales de propiedad comunitaria basada en Interledger, está permitiendo a los bancos comunitarios y cooperativas de crédito de México recibir remesas, liquidar pagos a nivel local y fortalecer la autodeterminación económica en las regiones rurales.\r\nEsta sesión incluye el estreno de The People’s Code, una fascinante película que da vida a las voces de los productores rurales, sus comunidades y el equipo de AMUCSS mientras navegan por la intersección entre la tradición, la confianza y la infraestructura.\r\n",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "The People's Clearinghouse ",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1031403",
+        "title": "The People's Clearinghouse ",
+        "description": "Discover how the People’s Clearinghouse a community-owned digital payments infrastructure built on Interledger is enabling community banks and credit unions in Mexico to receive remittances, clear payments locally, and strengthen economic self-determination across rural regions.\r\nThis session features the premiere of The People’s Code, a compelling film that brings to life the voices of rural producers, their communities, and the AMUCSS team as they navigate the intersection of tradition, trust, and infrastructure",
+        "startsAt": "2025-11-05T16:15:00",
+        "endsAt": "2025-11-05T17:45:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "a161a1e8-e360-49cc-bb09-b5fa5ebfc5ef",
+            "name": "Pedro Sousa Barreto"
+          },
+          {
+            "id": "a695b8c9-13c1-40e7-bacb-223332c6f998",
+            "name": "Roberto Valdovinos"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "At the Interledger Summit, hear directly from rural producers and the AMUCSS team as they spotlight how community banks and open payment systems—like the People’s Clearing House app—are reshaping economic self-determination in rural Mexico, in a celebration of resilience, culture, and community-led innovation.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "En la Interledger Summit, escucha directamente a los productores rurales y al equipo de AMUCSS mientras destacan cómo los bancos comunitarios y los sistemas de pago abiertos, como la aplicación People's Clearing House, están remodelando la autodeterminación económica en las zonas rurales de México, en una celebración de la resiliencia, la cultura y la innovación impulsada por la comunidad.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Presentación comunitaria",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1037913",
+        "title": "Community Showcase",
+        "description": "At the Interledger Summit, hear directly from rural producers and the AMUCSS team as they spotlight how community banks and open payment systems—like the People’s Clearing House app—are reshaping economic self-determination in rural Mexico, in a celebration of resilience, culture, and community-led innovation.",
+        "startsAt": "2025-11-05T18:00:00",
+        "endsAt": "2025-11-05T21:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "ecdf7e19-f808-4042-8e05-48349d72805b",
+            "name": "Isabel Cruz Hernandez"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388271,
+                "name": "Spanish"
+              },
+              {
+                "id": 402870,
+                "name": "English Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69444,
+        "room": "Community Hall",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Liquidity is the lifeblood of the global economy — essential, invisible, and often misunderstood. In this talk, Stefan Thomas, who led the team that created Interledger, reveals what liquidity truly is, how it has shaped the rise and fall of nations, economies, and empires, and why it remains one of the most powerful yet overlooked forces shaping our world today. He then explores how Interledger redefines global liquidity — and what this transformation means for the future of payments, markets, and money itself.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "La liquidez es el alma de la economía global: esencial, invisible y, a menudo, incomprendida. En esta charla, Stefan Thomas, que dirigió el equipo que creó Interledger, revela qué es realmente la liquidez, cómo ha influido en el auge y la caída de naciones, economías e imperios, y por qué sigue siendo una de las fuerzas más poderosas, aunque a menudo ignoradas, que dan forma a nuestro mundo actual. A continuación, explora cómo Interledger redefine la liquidez global y qué significa esta transformación para el futuro de los pagos, los mercados y el dinero mismo.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Tema clave: Liquidez",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1046412",
+        "title": "Keynote: Liquidity",
+        "description": "Liquidity is the lifeblood of the global economy — essential, invisible, and often misunderstood. In this talk, Stefan Thomas, who led the team that created Interledger, reveals what liquidity truly is, how it has shaped the rise and fall of nations, economies, and empires, and why it remains one of the most powerful yet overlooked forces shaping our world today. He then explores how Interledger redefines global liquidity — and what this transformation means for the future of payments, markets, and money itself.",
+        "startsAt": "2025-11-06T10:00:00",
+        "endsAt": "2025-11-06T11:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "d0c28aa3-f2ca-4af8-abc1-1f561b9e4408",
+            "name": "Stefan Thomas"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "As digital finance expands across Latin America, public confidence in these systems remains fragile. From embedded fintechs to traditional banks, trust is increasingly shaped by transparency, accountability, and user control, not just access. This session brings together financial leaders and innovators working at the intersection of technology, regulation, and consumer protection to explore what it takes to earn and sustain trust in a digital-first economy.\r\n\r\nPanelists will discuss how the next generation of digital financial services can build trust through interoperability, data privacy, and responsible innovation. Drawing on experiences from banks, fintechs, and associations across the region, this conversation will look at what it means to design systems people actually want to use and how open, standards-based infrastructure can make that possible.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "A medida que las finanzas digitales se expanden por América Latina, la confianza del público en estos sistemas sigue siendo frágil. Desde las fintech integradas hasta los bancos tradicionales, la confianza se ve cada vez más determinada por la transparencia, la rendición de cuentas y el control de los usuarios, y no solo por el acceso. Esta sesión reúne a líderes financieros, innovadores y defensores que trabajan en la intersección entre la tecnología, la regulación y la protección del consumidor para explorar qué se necesita para ganarse y mantener la confianza en una economía digital.\r\nLos panelistas debatirán cómo la próxima generación de servicios financieros digitales puede generar confianza a través de la interoperabilidad, la privacidad y la protección de datos, y la innovación responsable. Basándose en las experiencias de bancos, fintechs y asociaciones de toda la región, esta conversación analizará lo que significa diseñar sistemas que la gente realmente quiera utilizar y cómo una infraestructura abierta y basada en estándares puede hacerlo posible.\r\n",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Confiable por default: diseñar finanzas digitales que la gente elija utilizar",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1049783",
+        "title": "Trustworthy by Default: Designing Digital Finance People Choose to Use ",
+        "description": "As digital finance expands across Latin America, public confidence in these systems remains fragile. From embedded fintechs to traditional banks, trust is increasingly shaped by transparency, accountability, and user control, not just access. This session brings together financial leaders, innovators and advocates working at the intersection of technology, regulation, and consumer protection to explore what it takes to earn and sustain trust in a digital-first economy.\r\n\r\nPanelists will discuss how the next generation of digital financial services can build trust through interoperability, privacy and data protection, and responsible innovation. Drawing on experiences from banks, fintechs, and associations across the region, this conversation will look at what it means to design systems people actually want to use and how open, standards-based infrastructure can make that possible.",
+        "startsAt": "2025-11-06T11:30:00",
+        "endsAt": "2025-11-06T12:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "98c9897c-e8b2-4924-8f9d-928b3d75daa3",
+            "name": "Sarah Corley"
+          },
+          {
+            "id": "4de52905-07df-44b1-8068-5951aef6db9f",
+            "name": "Alejandro Maldonado Viveros"
+          },
+          {
+            "id": "69435364-304f-4884-ab47-e0c84e57c4be",
+            "name": "Fiorentina García Miramón"
+          },
+          {
+            "id": "66da924e-03b5-4d5b-8d91-ecf74d4d495a",
+            "name": "Alejandra Cullen Benítez"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Part 1: Introductory Exercises on Gig Workers' Dilemma and Reality Check (25 minutes)\r\nPart 2: Interactive Presentations: Case studies of Mexico City & Berlin, Financial Inclusion to Financial Justice; (35 minutes)\r\nPart 3: Collective re-imagining workshop. (30 minutes)",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "¿Cómo sería el futuro de un sistema financiero justo, equitativo y equitativo desde la perspectiva de un repartidor que vive en condiciones precarias? ¿En qué condiciones se puede hacer realidad ese futuro? ¿Cuál puede ser el papel de los pagos abiertos en el futuro?\r\n\r\nA medida que continúa la expansión de las plataformas de trabajo temporal, millones de trabajadores de todo el mundo están recurriendo al trabajo basado en plataformas en sectores como la entrega de paquetes y los servicios domésticos. Las plataformas de trabajo temporal se están convirtiendo cada vez más en un salvavidas para los trabajadores con bajos ingresos y marginados. Sin embargo, la realidad de los trabajadores afectados se caracteriza por horarios irregulares, ingresos volátiles, falta de prestaciones y protecciones laborales limitadas. El acceso limitado a los servicios financieros que satisfacen sus necesidades contribuye de manera significativa a sus condiciones actuales.\r\n\r\nEn el taller, tomamos las desigualdades estructurales a las que se enfrentan estos trabajadores como punto de partida para el debate y la reinvención colectiva de nuestras estrategias para adaptarnos a las economías cambiantes en el marco de las plataformas mediadas digitalmente: más allá de la inclusión financiera, ¿cómo podemos aprovechar la oportunidad de diseñar un mundo de justicia financiera?\r\n",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "De la inclusión financiera a la justicia financiera: cómo lograr un futuro equitativo en la economía gig",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995904",
+        "title": "From Financial Inclusion to Financial Justice: How to Enable an Equitable Future in the Gig Economy ",
+        "description": "What would the future of a fair, just, and equitable financial system look like from the perspective of a delivery driver living under precarity? In what conditions can that future be enabled? What can be the roles of open payments in the future?\r\n\r\nAs the expansion of the gig platform continues, millions of workers across the world are turning to platform-based work in sectors like delivery and domestic services. Gig platforms increasingly serve as a lifeline for low-income and marginalized workers. However, the realities of the workers involved are shaped by irregular hours, income volatility, lack of benefits, and limited labor protections. Limited access to financial services that serve their needs contributes significantly to their current conditions.\r\n\r\nIn the workshop, we take the structural inequalities these workers face as a starting point for the discussion and collective re-imagining of our strategies to adapt to the changing economies under digitally mediated platforms: beyond financial inclusion, how can we take the chance of designing for a world of financial justice? \r\n",
+        "startsAt": "2025-11-06T11:30:00",
+        "endsAt": "2025-11-06T13:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "3a71dfe5-a936-40b8-853b-46d1652952fe",
+            "name": "Xiaoji Song"
+          },
+          {
+            "id": "e64492fe-c013-45f7-995a-a2c01065d0e6",
+            "name": "Aju John"
+          },
+          {
+            "id": "ae6d657c-14d3-4c22-8dac-ef5719273219",
+            "name": "Mariana Jiménez Hernández"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383932,
+                "name": "Learning Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69442,
+        "room": "Learn Together Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "A year ago at the Interledger Summit in Cape Town, Chimoney showcased a developer-focused demo of ILP-powered P2P transfers using the Chimoney App. This year, we return to demonstrate a significant leap forward: a seamless, user-centric Web Monetization experience that works with real money, for real users, right now.\r\n\r\nFaheed and Uchi will guide the audience through the evolution of the Chimoney App, highlighting key advancements including direct funding & cashouts to Mexico via SPEI, MoMo payouts to 14 African countries, and the introduction of a new fiat-backed MXN-pegged wallet (MXNB). The core of this session will be a live, end-to-end Web Monetization demo featuring a \"Supporter\" (Faheed, Head of Product at Chimoney) and a \"Creator\" (Uchi Uchibeke, CEO of Chimoney).\r\n\r\nWe will demonstrate how a creator can effortlessly embed their Chimoney App issued Interledger Wallet on their webpage, and instantly begin receiving streaming of micropayments from a supporter using the Interledger Web Monetization extension. The audience will see the transactions happen in real-time, from the supporter's wallet being debited to the creator's wallet being credited, complete with transaction histories. \r\n\r\nThis session will show that with a focus on user experience and robust infrastructure, real-world Web Monetization and usage of the Interledger Web Monetization Extension  is not just a future possibility, but a present-day reality.\r\n\r\nKey Takeaways for the Audience:\r\n- From Theory to Utility: Witness a live demonstration of a complete, real-world Interledger Web Monetization extension payment flow, from a supporter's wallet to a creator's webpage and back to their wallet.\r\n- Product Evolution: Learn how Chimoney has evolved its interledger-enabled app over the past year, adding multi-jurisdictional payout options like SPEI in Mexico and MoMo in Africa to create real utility for creators receiving ILP payments.\r\n- User-Centric Design: Gain insights from our 1-on-1 community testing sessions, understanding the key UI/UX challenges (like wallet address complexity) and successes (like the ease of setup) in making Web Monetization accessible to non-technical users.\r\n- A Path to Adoption: Understand how Chimoney's infrastructure provides a practical and scalable model for activating the Web Monetization ecosystem and empowering the global creator economy.\r\n",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Únete a Faheed Alli-Balogun (jefe de producto) y Uchi Uchibeke (director ejecutivo de Chimoney) para una demostración en vivo y completa de la monetización web en acción. Basándose en su trabajo del año pasado, mostrarán la evolución de la aplicación Chimoney, que ahora permite pagos multijurisdiccionales y una experiencia de usuario fluida. Sea testigo de un micropago en tiempo real con dinero real de un seguidor a un creador utilizando la extensión de monetización web Interledger y la cartera de la aplicación Chimoney. Descubra cómo Chimoney está convirtiendo la promesa de una monetización web con pagos abiertos en una realidad actual.\r\n\r\n\r\nDetalles de la sesión: Hace un año, en la Cumbre Interledger celebrada en Ciudad del Cabo, Chimoney presentó una demostración centrada en los desarrolladores de las transferencias P2P impulsadas por ILP utilizando la aplicación Chimoney. Este año, volvemos para mostrar un importante avance: una experiencia de monetización web fluida y centrada en el usuario que funciona con dinero real, para usuarios reales, en este mismo momento. Faheed y Uchi guiarán al público a través de la evolución de la aplicación Chimoney, destacando avances clave como la financiación directa y los retiros de efectivo a México a través de SPEI, los pagos MoMo a 14 países africanos y la introducción de una nueva cartera respaldada por moneda fiduciaria y vinculada al MXN (MXNB). El núcleo de esta sesión será una demostración en vivo y de principio a fin de la monetización web con un «seguidor» (Faheed, jefe de producto de Chimoney) y un «creador» (Uchi Uchibeke, director ejecutivo de Chimoney). Demostraremos cómo un creador puede integrar fácilmente en su página web la cartera Interledger emitida por la aplicación Chimoney y comenzar a recibir al instante micropagos de un colaborador utilizando la extensión Interledger Web Monetization. La audiencia verá cómo se realizan las transacciones en tiempo real, desde el cargo en la cartera del colaborador hasta el abono en la cartera del creador, con el historial de transacciones completo. Esta sesión demostrará que, centrándose en la experiencia del usuario y en una infraestructura sólida, la monetización web en el mundo real y el uso de la extensión Interledger Web Monetization no son solo una posibilidad futura, sino una realidad actual. Puntos clave para el público: - De la teoría a la utilidad: sea testigo de una demostración en vivo de un flujo de pago completo y real de la extensión de monetización web Interledger, desde la cartera de un colaborador hasta la página web del creador y de vuelta a su cartera. - Evolución del producto: descubra cómo Chimoney ha evolucionado su aplicación habilitada para Interledger durante el último año, añadiendo opciones de pago multijurisdiccionales como SPEI en México y MoMo en África para crear una utilidad real para los creadores que reciben pagos ILP. - Diseño centrado en el usuario: obtenga información valiosa de nuestras sesiones de pruebas comunitarias individuales y comprenda los principales retos (como la complejidad de las direcciones de las carteras) y éxitos (como la facilidad de configuración) de la interfaz de usuario y la experiencia de usuario a la hora de hacer que la monetización web sea accesible para usuarios sin conocimientos técnicos. - El camino hacia la adopción: comprenda cómo la infraestructura de Chimoney proporciona un modelo práctico y escalable para activar el ecosistema de monetización web y potenciar la economía global de los creadores.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Del prototipo a la producción: activación de la monetización web en el mundo real con la aplicación Chimoney",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1018855",
+        "title": "Chimoney's ILP Stack & Chimoney App Updates",
+        "description": "Join Faheed Alli-Balogun (Head of Product) and Uchi Uchibeke (CEO of Chimoney) for a live, end-to-end demonstration of Web Monetization in action. Building on their work from last year, they will showcase the evolution of the Chimoney App, now enabled with multi-jurisdictional payouts and a seamless user experience. Witness a real-money, real-time micropayment from a supporter to a creator using the Interledger Web Monetization Extension and Chimoney App wallet. Learn how Chimoney is turning the promise of a web monetization with open payments into a present-day reality.\r\n\r\n\r\n\r\n",
+        "startsAt": "2025-11-06T11:30:00",
+        "endsAt": "2025-11-06T11:50:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "405070c5-a46c-4f12-9b68-5b1ed17e98a1",
+            "name": "Uchi Uchibeke"
+          },
+          {
+            "id": "1b090fa6-f61e-4f24-92e3-d2f41c174946",
+            "name": "Faheed Alli-Balogun"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Open Payments provides a modern, interoperable way to move money across networks currently using only the Interledger Protocol. But in order to bridge the gap between traditional finance and the open payments ecosystem, we need to connect to established rails like SEPA. In this talk, we'll explore what it takes to add SEPA support to Open Payments, or better to say, how we added support for SEPA to Open Payments. Attendees will get deeper insight into the new payment method of Open Payments and how to support this payment rail through Open Payments",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Open Payments ofrece una forma moderna e interoperable de transferir dinero a través de redes que actualmente solo utilizan el protocolo Interledger. Sin embargo, para salvar la brecha entre las finanzas tradicionales y el ecosistema de pagos abiertos, necesitamos conectarnos a sistemas establecidos como SEPA. En esta charla, exploraremos lo que se necesita para añadir compatibilidad con SEPA a Open Payments o, mejor dicho, cómo hemos añadido compatibilidad con SEPA a Open Payments. Los asistentes obtendrán una visión más profunda del nuevo método de pago de Open Payments y de cómo dar soporte a este canal de pago a través de Open Payments.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Sumando apoyo a SEPA en Open Payments",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1018856",
+        "title": "Payment Pointers to SEPA",
+        "description": "Open Payments provides a modern, interoperable way to move money across networks currently using only the Interledger Protocol. But in order to bridge the gap between traditional finance and the open payments ecosystem, we need to connect to established rails like SEPA. In this talk, we'll explore what it takes to add SEPA support to Open Payments, or better to say, how we added support for SEPA to Open Payments. Attendees will get deeper insight into the new payment method of Open Payments and how to support this payment rail through Open Payments",
+        "startsAt": "2025-11-06T11:55:00",
+        "endsAt": "2025-11-06T12:15:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "585a769b-db7a-4c75-b1ba-4c4fe8015276",
+            "name": "Tadej Golobic"
+          },
+          {
+            "id": "a9867c99-c0fb-4338-9a8b-cea0f5ab9bdb",
+            "name": "Ana Šemrov"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Una conversación sincera sobre las tensiones filosóficas y operativas entre la velocidad/escala de la tecnología financiera y la misión/responsabilidad de las instituciones financieras de desarrollo comunitario (CDFI). ¿Qué modelos han funcionado? ¿Dónde han fracasado las asociaciones? ¿Qué se necesita para generar confianza? Este debate se centrará en conversaciones reales y cuestiones prácticas.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "De la misión al mercado: dónde coinciden y chocan las fintech y las CDFI",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995900",
+        "title": "From Mission to Market: Where Fintech and CDFIs Align and Clash",
+        "description": "A candid conversation about the philosophical and operational tensions between fintech speed/scale and Community Development Financial Institutions (CDFI) mission/responsibility. What models have worked? Where have partnerships failed? What’s needed to build trust? This discussion will be centered on real talk and practical issues.",
+        "startsAt": "2025-11-06T12:15:00",
+        "endsAt": "2025-11-06T13:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "ac4d0d30-bf16-4f00-bc03-7cedd2a41695",
+            "name": "Casey Dike’"
+          },
+          {
+            "id": "e6a50e12-85dd-40ff-b041-bfe0ded30bf7",
+            "name": "Shaundra Jacobs"
+          },
+          {
+            "id": "42127c6c-f9ec-48e1-a603-4171c838deeb",
+            "name": "Feintz Pierre"
+          },
+          {
+            "id": "47f35bcf-71d5-4e11-8a5d-c967ab08ede1",
+            "name": "Sheena Allen"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Join us to see what we've been working on in Rafiki and Open Payments over the last year. We'll cover how the projects have evolved in 2025, what new features we have released, our plans for the future, and how Rafiki & Open Payments leverage the Interledger Protocol to simplify payments between integrators.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Únete a nosotros para ver en qué hemos estado trabajando en Rafiki y Open Payments durante el último año. Hablaremos de cómo han evolucionado los proyectos en 2025, qué nuevas funciones hemos lanzado, nuestros planes para el futuro y cómo Rafiki y Open Payments aprovechan el protocolo Interledger para simplificar los pagos entre integradores.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Evolución de Rafiki y Open Payments en 2025",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1051900",
+        "title": "Evolution of Rafiki & Open Payments in 2025",
+        "description": "Join us to see what we've been working on in Rafiki and Open Payments over the last year. We'll cover how the projects have evolved in 2025, what new features we have released, our plans for the future, and how Rafiki & Open Payments leverage the Interledger Protocol to simplify payments between integrators.",
+        "startsAt": "2025-11-06T12:15:00",
+        "endsAt": "2025-11-06T12:35:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "a63af0da-3b51-42ad-9775-ff52212884ba",
+            "name": "Max Kurapov"
+          },
+          {
+            "id": "c0cdf5ec-604b-48fa-a88d-475fe89a8932",
+            "name": "Nathan Lie"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "- Enable Real-Time Payments (RTP): Ensure instant settlement between partner institutions.\r\n\r\n- Interoperability Across Networks: Facilitate payments between core banking systems, digital wallets, and payment rails without requiring proprietary integrations.\r\n\r\n- Reduce Costs & Friction: Lower transaction fees by removing intermediaries and supporting direct settlement.\r\n\r\n- Improve Transparency: Enable traceability of payment flows through ILP and programmable settlement rules.\r\n\r\n- Scalability & Extensibility: Create a framework that can expand to national, regional, and cross-border ecosystems.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Esta propuesta describe la integración de PCH con Mifos X, una solución bancaria central de código abierto, para permitir pagos seguros, interoperables y en tiempo real entre instituciones financieras. Al aprovechar las capacidades de PCH, las instituciones pueden interconectarse sin problemas entre diferentes sistemas de pago, monedas y carteras digitales, lo que reduce los tiempos de liquidación, disminuye los costos de transacción y mejora el acceso a los servicios financieros.\r\nLa iniciativa apoya la colaboración entre instituciones, al tiempo que se alinea con los objetivos de inclusión financiera, liquidación instantánea y cumplimiento normativo.\r\n\r\nHabilitar pagos en tiempo real (RTP): garantizar la liquidación instantánea entre instituciones asociadas. - Interoperabilidad entre redes: facilite los pagos entre sistemas bancarios centrales, carteras digitales y vías de pago sin necesidad de integraciones propietarias. - Reduzca los costos y las fricciones: reduzca las comisiones por transacción eliminando los intermediarios y admitiendo la liquidación directa. - Mejore la transparencia: permita la trazabilidad de los flujos de pago a través de ILP y reglas de liquidación programables. - Escalabilidad y extensibilidad: cree un marco que pueda expandirse a ecosistemas nacionales, regionales y transfronterizos.\r\n",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "PCH - Integración de Mifos X para pagos en tiempo real entre instituciones",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1037917",
+        "title": "Brief Architecture - Mifos PCH Switch Connector",
+        "description": "This proposal outlines the integration of PCH with Mifos X, an open-source Core Banking solution, to enable secure, interoperable, and real-time payments between financial institutions. By leveraging PCH’s capabilities, institutions can interconnect seamlessly across different payment systems, currencies, and digital wallets—reducing settlement times, lowering transaction costs, and improving access to financial services.\r\n\r\nThe initiative supports cross-institutional collaboration while aligning with financial inclusion, instant settlement, and regulatory compliance goals.",
+        "startsAt": "2025-11-06T12:40:00",
+        "endsAt": "2025-11-06T13:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "8344beef-93f2-448d-aaa7-de1df719d89f",
+            "name": "Víctor Manuel Romero Rodríguez"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 388271,
+                "name": "Spanish"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "The 2026 FIFA World Cup represents a once-in-a-generation opportunity to accelerate digital payments adoption in Mexico. The National Digital Payments Strategy leverages the massive influx of international visitors, cross-border wallets, and real-time commerce to promote interoperability, inclusion, and innovation. By connecting local merchants, fintechs, and global payment systems, the initiative aims to transform everyday transactions—turning each purchase into a gateway for financial inclusion and digital empowerment across the country.",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "La Copa Mundial de la FIFA 2026 representa una oportunidad única para acelerar la adopción de los pagos digitales en México. La Estrategia Nacional de Pagos Digitales aprovecha la afluencia masiva de visitantes internacionales, las carteras transfronterizas y el comercio en tiempo real para promover la interoperabilidad, la inclusión y la innovación. Al conectar a los comerciantes locales, las fintech y los sistemas de pago globales, la iniciativa tiene como objetivo transformar las transacciones cotidianas, convirtiendo cada compra en una puerta de entrada a la inclusión financiera y el empoderamiento digital en todo el país.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Estrategia de pagos digitales",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1058096",
+        "title": "Digital Payments Strategy",
+        "description": "The 2026 FIFA World Cup represents a once-in-a-generation opportunity to accelerate digital payments adoption in Mexico. The National Digital Payments Strategy leverages the massive influx of international visitors, cross-border wallets, and real-time commerce to promote interoperability, inclusion, and innovation. By connecting local merchants, fintechs, and global payment systems, the initiative aims to transform everyday transactions—turning each purchase into a gateway for financial inclusion and digital empowerment across the country.",
+        "startsAt": "2025-11-06T14:00:00",
+        "endsAt": "2025-11-06T14:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "076b027b-dab7-41b4-b8f9-f51ff076d523",
+            "name": "Jorge Ortiz"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388271,
+                "name": "Spanish"
+              },
+              {
+                "id": 402870,
+                "name": "English Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": null,
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1065719",
+        "title": "The UPI Story",
+        "description": "The UPI Story - How India became a leader in interoperable payments and what the future holds.",
+        "startsAt": "2025-11-06T14:30:00",
+        "endsAt": "2025-11-06T15:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "ca7796ea-d481-4fd2-8f80-e5c721f4244b",
+            "name": "Maria Francis"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "Este panel analiza los enfoques pedagógicos y las innovaciones curriculares que están surgiendo en las universidades que han recibido subvenciones de la Fundación Interledger para integrar las tecnologías de Open Payments en sus programas académicos. Los representantes del cuerpo docente presentarán sus metodologías para enseñar conceptos complejos como el protocolo Interledger y su relación con la API de Open Payments, la mecánica de los pagos transfronterizos y la infraestructura financiera descentralizada dentro de los cursos existentes de informática, economía y tecnología financiera. El debate se centrará en los retos del diseño curricular, las estrategias de evaluación y la integración de los marcos teóricos con la experiencia práctica de implementación.",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Del aula al código: cómo las universidades forman a la próxima generación de talentos en pagos abiertos",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995879",
+        "title": "From Classroom to Codebase: How Universities Cultivate the Next Generation of Open Payments Talent",
+        "description": "This panel  examines the pedagogical approaches and curricular innovations emerging from universities that have received Interledger Foundation grants to integrate Open Payments technologies into their academic programs. Faculty representatives will present their methodologies for teaching complex concepts such as the Interledger Protocol and its relationship to the Open Payments API, cross-border payment mechanics, and decentralized financial infrastructure within existing computer science, economics, and financial technology coursework. The discussion will focus on curriculum design challenges, assessment strategies, and the integration of theoretical frameworks with hands-on implementation experience.",
+        "startsAt": "2025-11-06T15:15:00",
+        "endsAt": "2025-11-06T16:00:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "6b0e5bf6-b19d-4a1f-9977-4b4d03b984eb",
+            "name": "Smriti Parsheera"
+          },
+          {
+            "id": "6faa6639-4789-4c4b-968f-995c86a7531e",
+            "name": "Andrew Mangle"
+          },
+          {
+            "id": "50398579-1d0f-45c2-a540-d22c6bd1ff28",
+            "name": "Allan Davids"
+          },
+          {
+            "id": "5ec11732-1afe-4386-8643-1fad38dd1640",
+            "name": "Aleksandra Asscheman"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "Step into the shoes of innovators and regulators in this fast-paced, 60-minute simulation. Participants will form small teams, alternating between pitching bold new fintech solutions and serving on a regulatory panel that debates, challenges, and decides whether these ideas should move forward.\r\n\r\nArmed with innovation cards and guided briefings, FinTech teams will craft their proposals while Regulators prepare their oversight lens. The energy builds as proposals are pitched, regulators deliberate, and tough Q&A unfolds—culminating in real-time decisions that shape the fate of each innovation.\r\n\r\nThe session closes with an open reflection, inviting both sides to step back, share insights, and explore the balance between innovation, inclusion, and responsible regulation.\r\n\r\nFast. Interactive. Insightful. This is not just a session—it’s a front-row experience in the future of digital finance.\r\n\r\nWould you like me to make a shorter punchier version (2–3 sentences) that could be read out loud as an opening hook for the session?",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "El dilema del regulador es un juego de rol atractivo y basado en el debate que sitúa a los participantes en la compleja encrucijada de permitir la innovación financiera y garantizar al mismo tiempo la protección de los consumidores. Los jugadores interpretarán el papel de innovadores FinTech o equipos reguladores, simulando las tensiones reales a las que se enfrentan los responsables políticos. Los equipos debatirán... y finalmente decidirán: si aprobar, aprobar con condiciones o rechazar las tecnologías financieras emergentes. El juego está diseñado para promover un debate reflexivo, cuestionar estereotipos y sacar a la luz las compensaciones éticas y estructurales inherentes a la toma de decisiones reguladoras.\r\nFormato de la sesión: Laboratorio de aprendizaje\r\n\r\nDetalles de la sesión: \r\nPonte en los zapatos de innovadores y reguladores en esta simulación trepidante de 90 minutos. Los participantes formarán pequeños equipos, ya sea para presentar nuevas y audaces soluciones fintech o para formar parte de un panel regulador que debate, cuestiona y decide si estas ideas deben seguir adelante. Armados con tarjetas de innovación y sesiones informativas guiadas, los equipos FinTech elaborarán sus propuestas mientras los reguladores preparan su perspectiva de supervisión. La energía va en aumento a medida que se presentan las propuestas, los reguladores deliberan y se desarrollan duras sesiones de preguntas y respuestas, que culminan en decisiones en tiempo real que determinan el destino de cada innovación. La sesión concluye con una reflexión abierta, en la que se invita a ambas partes a dar un paso atrás, compartir ideas y explorar el equilibrio entre la innovación, la inclusión y la regulación responsable. Rápida. Interactiva. Perspicaz. No se trata solo de una sesión, sino de una experiencia inmersiva en el futuro de las finanzas digitales.\r\n",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "El dilema del regulador (sesión repetida)",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1037939",
+        "title": "The Regulator's Dilemma (repeat session)",
+        "description": "The Regulator’s Dilemma is an engaging, debate-driven role-playing game that places participants in the complex intersection of financial innovation and consumer protection. Players role-play as FinTech innovators or Regulatory Panels, simulating the real-world tensions faced by Policymakers and FinTechs in an emerging market. Teams debate whether to approve, conditionally approve, or reject emerging financial technologies. The game is designed to promote thoughtful discussion, challenge assumptions, and surface the ethical and structural trade-offs embedded in regulatory decision-making.",
+        "startsAt": "2025-11-06T15:15:00",
+        "endsAt": "2025-11-06T16:45:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "42e841a3-7a0b-4a96-86d1-cb0689c47382",
+            "name": "Nandini Harihareswara"
+          },
+          {
+            "id": "d35ddcb5-3563-4cca-b731-6845dc0d406f",
+            "name": "Rafe Mazer"
+          },
+          {
+            "id": "83cc3863-e48d-42e4-8055-86c53c9ef693",
+            "name": "Jeremiah Lee"
+          },
+          {
+            "id": "c6428e78-fd0c-4348-bca1-4a4d81b7e81f",
+            "name": "Pablo Antón Díaz"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383932,
+                "name": "Learning Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 388271,
+                "name": "Spanish"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69442,
+        "room": "Learn Together Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": "This will be a session organized as an unconference, a participant-driven slot. Participants will be able to propose and vote on session topics on the first day of the event, resulting in a dynamic agenda that reflects the collective wisdom and interests of those in attendance. The core idea is to create a collaborative, strengths-focused environment where anyone can contribute, share knowledge, and learn from others, and to address topics that were not in the formal agenda. ",
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "¿Alguna vez has querido proponer un tema en una conferencia porque sentías que faltaba o querías llamar la atención sobre él? ¡Ahora tienes la oportunidad! ¡Vamos a celebrar una sesión no convencional en la que todos podréis proponer y votar temas relacionados con el mundo Interledger!\r\n\r\nEsta sesión se organizará como una «no conferencia», es decir, un espacio impulsado por los participantes. Estos podrán proponer y votar temas para la sesión el primer día del evento, lo que dará lugar a una agenda dinámica que reflejará la sabiduría colectiva y los intereses de los asistentes. La idea central es crear un entorno colaborativo y centrado en las fortalezas, en el que cualquiera pueda contribuir, compartir conocimientos y aprender de los demás, así como abordar temas que no figuraban en la agenda formal.\r\n",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Pagos abiertos, micrófono abierto",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995909",
+        "title": "Open Payments, Open Mic",
+        "description": "Ever wanted to be able to propose a topic at a conference cause you felt it was missing or you wanted to bring it into attention? Now you have the chance! We are doing an unconference session where you all can propose and vote topics from all Interledger world! ",
+        "startsAt": "2025-11-06T15:15:00",
+        "endsAt": "2025-11-06T16:45:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "297fd54b-f93c-4996-89bc-f96b3b7f8258",
+            "name": "Ioana Chiorean"
+          },
+          {
+            "id": "b8c6942f-d96e-491b-bdef-0afc64456c9b",
+            "name": "Yiannis Giannelos"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383933,
+                "name": "Demo Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69443,
+        "room": "Demo Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": true
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "La inclusión financiera no comienza con una cuenta bancaria, sino con la posibilidad de que las personas puedan conectarse a Internet, confiar en lo que utilizan y mover sus ganancias en la moneda local sin intermediarios. Esta sesión aporta tres perspectivas complementarias a una conversación centrada en los financiadores: (1) tecnología de código abierto e infraestructura compartida que reducen el bloqueo y mantienen bajos los costes para las ONG; (2) enfoques de financiación de la ingeniería y la ciencia de interés público que dan prioridad a la interoperabilidad, la seguridad y el mantenimiento a largo plazo; y (3) la unión entre el lugar de trabajo y los pagos, donde las nóminas y los pagos de las plataformas se encuentran con las herramientas financieras y donde las prácticas de datos pueden ampliar o cerrar las puertas a la inclusión. Discutiremos la formación en equidad digital que se necesita para reducir los temores bien fundados en torno a las herramientas financieras, los nuevos estándares de datos y el cambio hacia pagos más pequeños y rápidos (incluidas las remesas y la ayuda mutua, pero también la gig-economización de más industrias). El objetivo de este panel es presentar una exploración equilibrada y en lenguaje sencillo de las posibles opciones de financiación para los próximos 12 meses: qué deben cofinanciar los financiadores, qué deben dejar de duplicar y cómo realizar un seguimiento del progreso sin incentivos perversos. ",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Derechos y vías: cómo la filantropía vincula el acceso, la capacidad y los sistemas de pago inclusivos",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "995876",
+        "title": "Rights & Rails: How Philanthropy Links Access, Capacity & Inclusive Payment Systems",
+        "description": "Financial inclusion doesn’t start with a bank account; it starts with people being able to get online, trust what they’re using, and move earnings in local currency without gatekeepers. This session brings three complementary lenses to a funder-focused conversation: (1) open source tech and shared infrastructure that reduce lock-in and keep costs low for NGOs; (2) public interest engineering and science funding approaches that prioritize interoperability, security, and long-term maintenance; and (3) the workplace/payments junction, where payroll and platform payouts meet financial tools and where data practices can either widen or close doors to inclusion. We’ll discuss the digital equity training that is needed to lower well-founded fears around financial tools, emerging data standards, and the shift toward smaller and faster payouts (including remittances and mutual aid, but also the gig-economification of more industries). The aim for this panel is to present a balanced, plain-language exploration of potential portfolio choices for the next 12 months: what funders should co-finance, what to stop duplicating, and how to track progress without perverse incentives.",
+        "startsAt": "2025-11-06T16:00:00",
+        "endsAt": "2025-11-06T16:45:00",
+        "isServiceSession": false,
+        "isPlenumSession": false,
+        "speakers": [
+          {
+            "id": "8c31891a-1b90-41c9-9419-cb79cdd7494e",
+            "name": "Chris Lawrence"
+          },
+          {
+            "id": "5897fd4a-a09b-4352-b7f8-d150bd4b0736",
+            "name": "Wilneida Negrón"
+          },
+          {
+            "id": "7f1a2e6f-e78e-4713-9e1c-83a396083805",
+            "name": "Amy Sample Ward"
+          },
+          {
+            "id": "ad86c689-2742-4fac-8d13-f38eb8a09312",
+            "name": "Afua Bruce"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [
+              {
+                "id": 383931,
+                "name": "Listening Lab"
+              }
+            ],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      },
+      {
+        "questionAnswers": [
+          {
+            "id": 106566,
+            "question": "Session Details",
+            "questionType": "Long_Text",
+            "answer": null,
+            "sort": 1,
+            "answerExtra": null
+          },
+          {
+            "id": 114099,
+            "question": "Descripción",
+            "questionType": "Long_Text",
+            "answer": "¡Acompáñanos en la sesión de clausura de la Summit Interledger del 2025! ",
+            "sort": 36,
+            "answerExtra": null
+          },
+          {
+            "id": 114105,
+            "question": "Título de la sesión",
+            "questionType": "Short_Text",
+            "answer": "Sesión Plenaria de clausura",
+            "sort": 35,
+            "answerExtra": null
+          }
+        ],
+        "id": "1031417",
+        "title": "Closing Plenary",
+        "description": "Join us in the closing session of the Interledger Summit 2025!",
+        "startsAt": "2025-11-06T17:00:00",
+        "endsAt": "2025-11-06T17:30:00",
+        "isServiceSession": false,
+        "isPlenumSession": true,
+        "speakers": [
+          {
+            "id": "daa019af-2d28-46a0-96b5-f98444e8a9f7",
+            "name": "Briana Marbury"
+          }
+        ],
+        "categories": [
+          {
+            "id": 106558,
+            "name": "Session format",
+            "categoryItems": [],
+            "sort": 0
+          },
+          {
+            "id": 107734,
+            "name": "Will this session be in Spanish, English or Both?",
+            "categoryItems": [
+              {
+                "id": 388270,
+                "name": "English"
+              },
+              {
+                "id": 402871,
+                "name": "Spanish Translation available"
+              }
+            ],
+            "sort": 7
+          }
+        ],
+        "roomId": 69441,
+        "room": "Listening Lab",
+        "liveUrl": null,
+        "recordingUrl": null,
+        "status": "Accepted",
+        "isInformed": true,
+        "isConfirmed": false
+      }
+    ],
+    "isDefault": false
+  }
+]


### PR DESCRIPTION
## Summary
This PR adds storage of Sessionize Summit data as JSON files. 

It includes both speaker and session information for the years 2022–2025, and saves them inside the `/src/data/sessionize` folder. 

## Related Issue
[INTORG-469: Store JSON files](https://linear.app/interledger/issue/INTORG-469/store-json-files)

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
