### PR TITLE
chore: exclude preview pages from seo

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -154,7 +154,7 @@ export default defineConfig({
     }),
     mdx(),
     sitemap({
-      filter: (url) => !new URL(url).pathname.startsWith('/blog/preview')
+      filter: (url) => !new URL(url).pathname.includes('/preview')
     })
   ],
   vite: {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Disallow: /blog/preview
+Disallow: /developers/blog/preview
+Disallow: /preview/
 Sitemap: https://interledger.org/sitemap-index.xml


### PR DESCRIPTION
## Summary
updates robots and astro config to exclude preview pages from seo

## Related Issue
<!-- Fixes INTORG-123 -->

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [ ] `pnpm run format`
- [ ] `pnpm run lint`

## PR Checklist

- [ ] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
