### PR TITLE
feat: Create list pages for Summit talks and speakers

### DIFF
--- a/src/components/summit/SessionCard.astro
+++ b/src/components/summit/SessionCard.astro
@@ -1,4 +1,6 @@
 ---
+// NOTE: This component is a temporary placeholder component.
+// It contains minimal markup for now and will be fully implemented in a follow-up PR.
 import type { Talk } from '@/utils/summit-talks-speakers.ts'
 
 interface Props {

--- a/src/components/summit/SessionCard.astro
+++ b/src/components/summit/SessionCard.astro
@@ -1,0 +1,13 @@
+---
+import type { Talk } from '@/utils/summit-talks-speakers.ts'
+
+interface Props {
+  talk: Talk
+}
+
+const { talk } = Astro.props
+---
+
+<li class="min-h-[200px] bg-black/10">
+  <h2>{talk.title}</h2>
+</li>

--- a/src/components/summit/SessionCard.astro
+++ b/src/components/summit/SessionCard.astro
@@ -1,7 +1,7 @@
 ---
 // NOTE: This component is a temporary placeholder component.
 // It contains minimal markup for now and will be fully implemented in a follow-up PR.
-import type { Talk } from '@/utils/summit-talks-speakers.ts'
+import type { Talk } from '@/utils/summit-talks-speakers'
 
 interface Props {
   talk: Talk

--- a/src/components/summit/SessionCard.astro
+++ b/src/components/summit/SessionCard.astro
@@ -8,6 +8,6 @@ interface Props {
 const { talk } = Astro.props
 ---
 
-<li class="min-h-[200px] bg-black/10">
+<li class="min-h-50 bg-black/10">
   <h2>{talk.title}</h2>
 </li>

--- a/src/components/summit/SessionsListPage.astro
+++ b/src/components/summit/SessionsListPage.astro
@@ -1,6 +1,6 @@
 ---
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
-import Pagination from '../blog/Pagination.astro'
+import Pagination from '@/components/blog/Pagination.astro'
 import SessionCard from './SessionCard.astro'
 import type { Talk } from '@/utils/summit-talks-speakers'
 import type { Page } from 'astro'

--- a/src/components/summit/SessionsListPage.astro
+++ b/src/components/summit/SessionsListPage.astro
@@ -1,0 +1,48 @@
+---
+import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
+import Pagination from '../blog/Pagination.astro'
+import SessionCard from './SessionCard.astro'
+import type { Talk } from '@/utils/summit-talks-speakers.ts'
+import type { Page } from 'astro'
+
+interface Props {
+  talks: Talk[]
+  basePath: string
+  title: string
+  page: Page
+}
+const { talks, basePath, title, page } = Astro.props
+---
+
+<SummitPageLayout title={title}>
+  <main class="p-4 max-w-275 m-auto">
+    <h1>{title}</h1>
+    <section>
+      {
+        talks.length > 0 ? (
+          <ul class="flex flex-col gap-4">
+            {talks.map((talk) => (
+              <SessionCard talk={talk} />
+            ))}
+          </ul>
+        ) : (
+          <p>No data available for {title}</p>
+        )
+      }
+    </section>
+
+    {
+      page.lastPage && page.lastPage > 1 && (
+        <Pagination
+          baseUrl={basePath}
+          length={page.lastPage}
+          currentPage={page.currentPage}
+          firstUrl={page.url.first}
+          prevUrl={page.url.prev}
+          nextUrl={page.url.next}
+          lastUrl={page.url.last}
+        />
+      )
+    }
+  </main>
+</SummitPageLayout>

--- a/src/components/summit/SessionsListPage.astro
+++ b/src/components/summit/SessionsListPage.astro
@@ -2,7 +2,7 @@
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
 import Pagination from '../blog/Pagination.astro'
 import SessionCard from './SessionCard.astro'
-import type { Talk } from '@/utils/summit-talks-speakers.ts'
+import type { Talk } from '@/utils/summit-talks-speakers'
 import type { Page } from 'astro'
 
 interface Props {

--- a/src/components/summit/SpeakerCard.astro
+++ b/src/components/summit/SpeakerCard.astro
@@ -1,0 +1,13 @@
+---
+import type { Speaker } from '@/utils/summit-talks-speakers.ts'
+
+interface Props {
+  speaker: Speaker
+}
+
+const { speaker } = Astro.props
+---
+
+<li class="min-h-50 w-50 bg-black/10">
+  <h2>{speaker.name}</h2>
+</li>

--- a/src/components/summit/SpeakerCard.astro
+++ b/src/components/summit/SpeakerCard.astro
@@ -1,7 +1,7 @@
 ---
 // NOTE: This component is a temporary placeholder component.
 // It contains minimal markup for now and will be fully implemented in a follow-up PR.
-import type { Speaker } from '@/utils/summit-talks-speakers.ts'
+import type { Speaker } from '@/utils/summit-talks-speakers'
 
 interface Props {
   speaker: Speaker

--- a/src/components/summit/SpeakerCard.astro
+++ b/src/components/summit/SpeakerCard.astro
@@ -1,4 +1,6 @@
 ---
+// NOTE: This component is a temporary placeholder component.
+// It contains minimal markup for now and will be fully implemented in a follow-up PR.
 import type { Speaker } from '@/utils/summit-talks-speakers.ts'
 
 interface Props {

--- a/src/components/summit/SpeakersListPage.astro
+++ b/src/components/summit/SpeakersListPage.astro
@@ -4,6 +4,7 @@ import SpeakerCard from '@/components/summit/SpeakerCard.astro'
 import Pagination from '@/components/blog/Pagination.astro'
 import type { Page } from 'astro'
 import type { Speaker } from '@/utils/summit-talks-speakers'
+
 interface Props {
   speakers: Speaker[]
   basePath: string

--- a/src/components/summit/SpeakersListPage.astro
+++ b/src/components/summit/SpeakersListPage.astro
@@ -1,0 +1,48 @@
+---
+import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
+import SpeakerCard from '@/components/summit/SpeakerCard.astro'
+import Pagination from '@/components/blog/Pagination.astro'
+import type { Page } from 'astro'
+import type { Speaker } from '@/utils/summit-talks-speakers'
+interface Props {
+  speakers: Speaker[]
+  basePath: string
+  title: string
+  page: Page
+}
+
+const { speakers, basePath, title, page } = Astro.props
+---
+
+<SummitPageLayout title={title}>
+  <main class="p-4 max-w-275 m-auto">
+    <h1>{title}</h1>
+    <section>
+      {
+        speakers.length > 0 ? (
+          <ul class="flex flex-wrap gap-4">
+            {speakers.map((speaker) => (
+              <SpeakerCard speaker={speaker} />
+            ))}
+          </ul>
+        ) : (
+          <p>No data available for {title}</p>
+        )
+      }
+    </section>
+
+    {
+      page.lastPage && page.lastPage > 1 && (
+        <Pagination
+          baseUrl={basePath}
+          length={page.lastPage}
+          currentPage={page.currentPage}
+          firstUrl={page.url.first}
+          prevUrl={page.url.prev}
+          nextUrl={page.url.next}
+          lastUrl={page.url.last}
+        />
+      )
+    }
+  </main>
+</SummitPageLayout>

--- a/src/pages/es/summit/[year]/speakers/[...page].astro
+++ b/src/pages/es/summit/[year]/speakers/[...page].astro
@@ -1,11 +1,9 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import { paginateSummitSpeakers } from '@/utils/summit-talks-speakers.ts'
 import type { Speaker } from '@/utils/summit-talks-speakers.ts'
+import { paginateSummitSpeakers } from '@/utils/summit-talks-speakers.ts'
 import stripPagination from '@/utils/stripPagination'
-import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
-import SpeakerCard from '@/components/summit/SpeakerCard.astro'
-import Pagination from '@/components/blog/Pagination.astro'
+import SpeakersListPage from '@/components/summit/SpeakersListPage.astro'
 
 type Props = {
   page: Page
@@ -20,30 +18,12 @@ const { year } = Astro.params
 const { page } = Astro.props
 const speakers: Speaker[] = page.data
 const basePath = stripPagination(Astro.url.pathname)
-const title = `${year} Summit Speakers`
+const title = `Oradores de la Cumbre ${year}`
 ---
 
-<SummitPageLayout title={title}>
-  <main class="p-4 max-w-275 m-auto">
-    <h1>{title}</h1>
-    <section>
-      <ul class="flex flex-wrap gap-4">
-        {speakers.map((speaker) => <SpeakerCard speaker={speaker} />)}
-      </ul>
-    </section>
-
-    {
-      page.lastPage && page.lastPage > 1 && (
-        <Pagination
-          baseUrl={basePath}
-          length={page.lastPage}
-          currentPage={page.currentPage}
-          firstUrl={page.url.first}
-          prevUrl={page.url.prev}
-          nextUrl={page.url.next}
-          lastUrl={page.url.last}
-        />
-      )
-    }
-  </main>
-</SummitPageLayout>
+<SpeakersListPage
+  speakers={speakers}
+  basePath={basePath}
+  title={title}
+  page={page}
+/>

--- a/src/pages/es/summit/[year]/speakers/[...page].astro
+++ b/src/pages/es/summit/[year]/speakers/[...page].astro
@@ -1,7 +1,7 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import type { Speaker } from '@/utils/summit-talks-speakers.ts'
-import { paginateSummitSpeakers } from '@/utils/summit-talks-speakers.ts'
+import type { Speaker } from '@/utils/summit-talks-speakers'
+import { paginateSummitSpeakers } from '@/utils/summit-talks-speakers'
 import stripPagination from '@/utils/stripPagination'
 import SpeakersListPage from '@/components/summit/SpeakersListPage.astro'
 

--- a/src/pages/es/summit/[year]/speakers/[...page].astro
+++ b/src/pages/es/summit/[year]/speakers/[...page].astro
@@ -1,10 +1,10 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import { paginateSummitTalks } from '@/utils/summit-talks-speakers.ts'
-import type { Talk } from '@/utils/summit-talks-speakers.ts'
+import { paginateSummitSpeakers } from '@/utils/summit-talks-speakers.ts'
+import type { Speaker } from '@/utils/summit-talks-speakers.ts'
 import stripPagination from '@/utils/stripPagination'
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
-import SessionCard from '@/components/summit/SessionCard.astro'
+import SpeakerCard from '@/components/summit/SpeakerCard.astro'
 import Pagination from '@/components/blog/Pagination.astro'
 
 type Props = {
@@ -12,23 +12,23 @@ type Props = {
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-  const paths = await paginateSummitTalks(paginate, 'en')
+  const paths = await paginateSummitSpeakers(paginate, 'es')
   return paths
 }
 
 const { year } = Astro.params
 const { page } = Astro.props
-const talks: Talk[] = page.data
+const speakers: Speaker[] = page.data
 const basePath = stripPagination(Astro.url.pathname)
-const title = `${year} Summit Sessions`
+const title = `${year} Summit Speakers`
 ---
 
 <SummitPageLayout title={title}>
   <main class="p-4 max-w-275 m-auto">
     <h1>{title}</h1>
     <section>
-      <ul class="flex flex-col gap-4">
-        {talks.map((talk) => <SessionCard talk={talk} />)}
+      <ul class="flex flex-wrap gap-4">
+        {speakers.map((speaker) => <SpeakerCard speaker={speaker} />)}
       </ul>
     </section>
 

--- a/src/pages/es/summit/[year]/talks/[...page].astro
+++ b/src/pages/es/summit/[year]/talks/[...page].astro
@@ -1,11 +1,9 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import { paginateSummitTalks } from '@/utils/summit-talks-speakers.ts'
 import type { Talk } from '@/utils/summit-talks-speakers.ts'
+import { paginateSummitTalks } from '@/utils/summit-talks-speakers.ts'
 import stripPagination from '@/utils/stripPagination'
-import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
-import SessionCard from '@/components/summit/SessionCard.astro'
-import Pagination from '@/components/blog/Pagination.astro'
+import SessionsListPage from '@/components/summit/SessionsListPage.astro'
 
 type Props = {
   page: Page
@@ -20,30 +18,7 @@ const { year } = Astro.params
 const { page } = Astro.props
 const talks: Talk[] = page.data
 const basePath = stripPagination(Astro.url.pathname)
-const title = `${year} Summit Sessions`
+const title = `Sesiones de la Cumbre ${year}`
 ---
 
-<SummitPageLayout title={title}>
-  <main class="p-4 max-w-275 m-auto">
-    <h1>{title}</h1>
-    <section>
-      <ul class="flex flex-col gap-4">
-        {talks.map((talk) => <SessionCard talk={talk} />)}
-      </ul>
-    </section>
-
-    {
-      page.lastPage && page.lastPage > 1 && (
-        <Pagination
-          baseUrl={basePath}
-          length={page.lastPage}
-          currentPage={page.currentPage}
-          firstUrl={page.url.first}
-          prevUrl={page.url.prev}
-          nextUrl={page.url.next}
-          lastUrl={page.url.last}
-        />
-      )
-    }
-  </main>
-</SummitPageLayout>
+<SessionsListPage talks={talks} basePath={basePath} title={title} page={page} />

--- a/src/pages/es/summit/[year]/talks/[...page].astro
+++ b/src/pages/es/summit/[year]/talks/[...page].astro
@@ -1,7 +1,7 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import type { Talk } from '@/utils/summit-talks-speakers.ts'
-import { paginateSummitTalks } from '@/utils/summit-talks-speakers.ts'
+import type { Talk } from '@/utils/summit-talks-speakers'
+import { paginateSummitTalks } from '@/utils/summit-talks-speakers'
 import stripPagination from '@/utils/stripPagination'
 import SessionsListPage from '@/components/summit/SessionsListPage.astro'
 

--- a/src/pages/es/summit/[year]/talks/[...page].astro
+++ b/src/pages/es/summit/[year]/talks/[...page].astro
@@ -12,7 +12,7 @@ type Props = {
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-  const paths = await paginateSummitTalks(paginate, 'en')
+  const paths = await paginateSummitTalks(paginate, 'es')
   return paths
 }
 

--- a/src/pages/summit/[year]/speakers/[...page].astro
+++ b/src/pages/summit/[year]/speakers/[...page].astro
@@ -1,10 +1,10 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import { paginateSummitTalks } from '@/utils/summit-talks-speakers.ts'
-import type { Talk } from '@/utils/summit-talks-speakers.ts'
+import { paginateSummitSpeakers } from '@/utils/summit-talks-speakers.ts'
+import type { Speaker } from '@/utils/summit-talks-speakers.ts'
 import stripPagination from '@/utils/stripPagination'
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
-import SessionCard from '@/components/summit/SessionCard.astro'
+import SpeakerCard from '@/components/summit/SpeakerCard.astro'
 import Pagination from '@/components/blog/Pagination.astro'
 
 type Props = {
@@ -12,23 +12,23 @@ type Props = {
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-  const paths = await paginateSummitTalks(paginate)
+  const paths = await paginateSummitSpeakers(paginate)
   return paths
 }
 
 const { year } = Astro.params
 const { page } = Astro.props
-const talks: Talk[] = page.data
+const speakers: Speaker[] = page.data
 const basePath = stripPagination(Astro.url.pathname)
-const title = `${year} Summit Sessions`
+const title = `${year} Summit Speakers`
 ---
 
 <SummitPageLayout title={title}>
   <main class="p-4 max-w-275 m-auto">
     <h1>{title}</h1>
     <section>
-      <ul class="flex flex-col gap-4">
-        {talks.map((talk) => <SessionCard talk={talk} />)}
+      <ul class="flex flex-wrap gap-4">
+        {speakers.map((speaker) => <SpeakerCard speaker={speaker} />)}
       </ul>
     </section>
 

--- a/src/pages/summit/[year]/speakers/[...page].astro
+++ b/src/pages/summit/[year]/speakers/[...page].astro
@@ -1,7 +1,7 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import type { Speaker } from '@/utils/summit-talks-speakers.ts'
-import { paginateSummitSpeakers } from '@/utils/summit-talks-speakers.ts'
+import type { Speaker } from '@/utils/summit-talks-speakers'
+import { paginateSummitSpeakers } from '@/utils/summit-talks-speakers'
 import stripPagination from '@/utils/stripPagination'
 import SpeakersListPage from '@/components/summit/SpeakersListPage.astro'
 

--- a/src/pages/summit/[year]/speakers/[...page].astro
+++ b/src/pages/summit/[year]/speakers/[...page].astro
@@ -1,11 +1,9 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import { paginateSummitSpeakers } from '@/utils/summit-talks-speakers.ts'
 import type { Speaker } from '@/utils/summit-talks-speakers.ts'
+import { paginateSummitSpeakers } from '@/utils/summit-talks-speakers.ts'
 import stripPagination from '@/utils/stripPagination'
-import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
-import SpeakerCard from '@/components/summit/SpeakerCard.astro'
-import Pagination from '@/components/blog/Pagination.astro'
+import SpeakersListPage from '@/components/summit/SpeakersListPage.astro'
 
 type Props = {
   page: Page
@@ -23,27 +21,9 @@ const basePath = stripPagination(Astro.url.pathname)
 const title = `${year} Summit Speakers`
 ---
 
-<SummitPageLayout title={title}>
-  <main class="p-4 max-w-275 m-auto">
-    <h1>{title}</h1>
-    <section>
-      <ul class="flex flex-wrap gap-4">
-        {speakers.map((speaker) => <SpeakerCard speaker={speaker} />)}
-      </ul>
-    </section>
-
-    {
-      page.lastPage && page.lastPage > 1 && (
-        <Pagination
-          baseUrl={basePath}
-          length={page.lastPage}
-          currentPage={page.currentPage}
-          firstUrl={page.url.first}
-          prevUrl={page.url.prev}
-          nextUrl={page.url.next}
-          lastUrl={page.url.last}
-        />
-      )
-    }
-  </main>
-</SummitPageLayout>
+<SpeakersListPage
+  speakers={speakers}
+  basePath={basePath}
+  title={title}
+  page={page}
+/>

--- a/src/pages/summit/[year]/speakers/[...page].astro
+++ b/src/pages/summit/[year]/speakers/[...page].astro
@@ -12,7 +12,7 @@ type Props = {
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-  const paths = await paginateSummitSpeakers(paginate)
+  const paths = await paginateSummitSpeakers(paginate, 'en')
   return paths
 }
 

--- a/src/pages/summit/[year]/talks/[...page].astro
+++ b/src/pages/summit/[year]/talks/[...page].astro
@@ -1,0 +1,49 @@
+---
+import type { Page, GetStaticPaths } from 'astro'
+import { paginateSummitTalks } from '@/utils/summit-talks-speakers.ts'
+import type { Talk } from '@/utils/summit-talks-speakers.ts'
+import Pagination from '@/components/blog/Pagination.astro'
+import stripPagination from '@/utils/stripPagination'
+
+type Props = {
+  page: Page
+}
+
+export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
+  const paths = await paginateSummitTalks(paginate)
+  return paths
+}
+
+const { year } = Astro.params
+const { page } = Astro.props
+const talks: Talk[] | undefined = page.data
+const basePath = stripPagination(Astro.url.pathname)
+---
+
+<div>
+  <div>This is summit TALKS page for the year: {year}</div>
+
+  <ul>
+    {
+      talks.map((talk) => (
+        <li>
+          <h2>{talk.title}</h2>
+        </li>
+      ))
+    }
+  </ul>
+
+  {
+    page.lastPage && page.lastPage > 1 && (
+      <Pagination
+        baseUrl={basePath}
+        length={page.lastPage}
+        currentPage={page.currentPage}
+        firstUrl={page.url.first}
+        prevUrl={page.url.prev}
+        nextUrl={page.url.next}
+        lastUrl={page.url.last}
+      />
+    )
+  }
+</div>

--- a/src/pages/summit/[year]/talks/[...page].astro
+++ b/src/pages/summit/[year]/talks/[...page].astro
@@ -2,8 +2,10 @@
 import type { Page, GetStaticPaths } from 'astro'
 import { paginateSummitTalks } from '@/utils/summit-talks-speakers.ts'
 import type { Talk } from '@/utils/summit-talks-speakers.ts'
-import Pagination from '@/components/blog/Pagination.astro'
 import stripPagination from '@/utils/stripPagination'
+import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
+import SessionCard from '@/components/summit/SessionCard.astro'
+import Pagination from '@/components/blog/Pagination.astro'
 
 type Props = {
   page: Page
@@ -18,32 +20,33 @@ const { year } = Astro.params
 const { page } = Astro.props
 const talks: Talk[] | undefined = page.data
 const basePath = stripPagination(Astro.url.pathname)
+const title = `${year} Summit Sessions`
 ---
 
-<div>
-  <div>This is summit TALKS page for the year: {year}</div>
+<SummitPageLayout
+  title={title}
+  description="The Interledger Foundation is a global nonprofit grantmaking foundation, leading the next revolution in payments through Interledger, the global network for inclusive digital financial service providers."
+>
+  <main class="p-4">
+    <h1>{title}</h1>
+    <section>
+      <ul class="flex flex-col gap-4">
+        {talks.map((talk) => <SessionCard talk={talk} />)}
+      </ul>
+    </section>
 
-  <ul>
     {
-      talks.map((talk) => (
-        <li>
-          <h2>{talk.title}</h2>
-        </li>
-      ))
+      page.lastPage && page.lastPage > 1 && (
+        <Pagination
+          baseUrl={basePath}
+          length={page.lastPage}
+          currentPage={page.currentPage}
+          firstUrl={page.url.first}
+          prevUrl={page.url.prev}
+          nextUrl={page.url.next}
+          lastUrl={page.url.last}
+        />
+      )
     }
-  </ul>
-
-  {
-    page.lastPage && page.lastPage > 1 && (
-      <Pagination
-        baseUrl={basePath}
-        length={page.lastPage}
-        currentPage={page.currentPage}
-        firstUrl={page.url.first}
-        prevUrl={page.url.prev}
-        nextUrl={page.url.next}
-        lastUrl={page.url.last}
-      />
-    )
-  }
-</div>
+  </main>
+</SummitPageLayout>

--- a/src/pages/summit/[year]/talks/[...page].astro
+++ b/src/pages/summit/[year]/talks/[...page].astro
@@ -1,11 +1,9 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import { paginateSummitTalks } from '@/utils/summit-talks-speakers.ts'
 import type { Talk } from '@/utils/summit-talks-speakers.ts'
+import { paginateSummitTalks } from '@/utils/summit-talks-speakers.ts'
 import stripPagination from '@/utils/stripPagination'
-import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
-import SessionCard from '@/components/summit/SessionCard.astro'
-import Pagination from '@/components/blog/Pagination.astro'
+import SessionsListPage from '@/components/summit/SessionsListPage.astro'
 
 type Props = {
   page: Page
@@ -23,27 +21,4 @@ const basePath = stripPagination(Astro.url.pathname)
 const title = `${year} Summit Sessions`
 ---
 
-<SummitPageLayout title={title}>
-  <main class="p-4 max-w-275 m-auto">
-    <h1>{title}</h1>
-    <section>
-      <ul class="flex flex-col gap-4">
-        {talks.map((talk) => <SessionCard talk={talk} />)}
-      </ul>
-    </section>
-
-    {
-      page.lastPage && page.lastPage > 1 && (
-        <Pagination
-          baseUrl={basePath}
-          length={page.lastPage}
-          currentPage={page.currentPage}
-          firstUrl={page.url.first}
-          prevUrl={page.url.prev}
-          nextUrl={page.url.next}
-          lastUrl={page.url.last}
-        />
-      )
-    }
-  </main>
-</SummitPageLayout>
+<SessionsListPage talks={talks} basePath={basePath} title={title} page={page} />

--- a/src/pages/summit/[year]/talks/[...page].astro
+++ b/src/pages/summit/[year]/talks/[...page].astro
@@ -1,7 +1,7 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import type { Talk } from '@/utils/summit-talks-speakers.ts'
-import { paginateSummitTalks } from '@/utils/summit-talks-speakers.ts'
+import type { Talk } from '@/utils/summit-talks-speakers'
+import { paginateSummitTalks } from '@/utils/summit-talks-speakers'
 import stripPagination from '@/utils/stripPagination'
 import SessionsListPage from '@/components/summit/SessionsListPage.astro'
 

--- a/src/utils/summit-talks-speakers.ts
+++ b/src/utils/summit-talks-speakers.ts
@@ -1,5 +1,6 @@
 import type { PaginateFunction } from 'astro'
 
+export type Language = 'en' | 'es'
 export interface Talk {
   id: string
   title: string
@@ -11,7 +12,8 @@ export interface Speaker {
 
 export const YEARS = ['2022', '2023', '2024', '2025']
 
-export function getSpeakers(year: string, lang: string): Speaker[] {
+//Dummy function - ignore this for now, will be implemented in a follow up PR
+export function getSpeakers(year: string, lang: Language): Speaker[] {
   const baseSpeakers: Speaker[] = [
     {
       id: '370w173',
@@ -49,8 +51,8 @@ export function getSpeakers(year: string, lang: string): Speaker[] {
       return []
   }
 }
-
-export function getTalks(year: string, lang): Talk[] {
+//Dummy function - ignore this for now, will be implemented in a follow up PR
+export function getTalks(year: string, lang: Language): Talk[] {
   const baseSessions: Talk[] = [
     {
       id: '370173',
@@ -93,7 +95,7 @@ export function getTalks(year: string, lang): Talk[] {
 
 export async function paginateSummitTalks(
   paginate: PaginateFunction,
-  lang: string
+  lang: Language
 ) {
   return YEARS.flatMap((year) => {
     const talksForYear = getTalks(year, lang)
@@ -106,7 +108,7 @@ export async function paginateSummitTalks(
 
 export async function paginateSummitSpeakers(
   paginate: PaginateFunction,
-  lang: string
+  lang: Language
 ) {
   return YEARS.flatMap((year) => {
     const speakersForYear = getSpeakers(year, lang)

--- a/src/utils/summit-talks-speakers.ts
+++ b/src/utils/summit-talks-speakers.ts
@@ -1,0 +1,53 @@
+import type { PaginateFunction } from 'astro'
+
+export interface Talk {
+  id: string
+  title: string
+}
+
+export function getAllTalks(year: string): Talk[] {
+  const sessions2022 = [
+    {
+      id: '370173',
+      title: `2022 State of Interledger`
+    },
+    {
+      id: '385579',
+      title:
+        ' 2022 TigerBeetle, a Financial Accounting Database for Interledger'
+    }
+  ]
+  const sessions2023 = [
+    {
+      id: '370173',
+      title: `2023 State of Interledger`
+    },
+    {
+      id: '385579',
+      title:
+        ' 2023 TigerBeetle, a Financial Accounting Database for Interledger'
+    }
+  ]
+  // let sessionsToReturn : Talk[] ;
+  switch (year) {
+    case '2022':
+      return sessions2022
+    case '2023':
+      return sessions2023
+    default:
+      console.error('Year is not correct or we do not have data for that year')
+      return []
+  }
+}
+
+export async function paginateSummitTalks(paginate: PaginateFunction) {
+  const years = ['2022', '2023', '2024', '2025']
+
+  return years.flatMap((year) => {
+    const talksForYear = getAllTalks(year)
+    return paginate(talksForYear, {
+      params: { year },
+      pageSize: 10
+    })
+  })
+}

--- a/src/utils/summit-talks-speakers.ts
+++ b/src/utils/summit-talks-speakers.ts
@@ -28,14 +28,15 @@ export function getAllTalks(year: string): Talk[] {
         ' 2023 TigerBeetle, a Financial Accounting Database for Interledger'
     }
   ]
-  // let sessionsToReturn : Talk[] ;
   switch (year) {
     case '2022':
       return sessions2022
     case '2023':
       return sessions2023
     default:
-      console.error('Year is not correct or we do not have data for that year')
+      console.error(
+        'Year is not correct or data is not available for that year'
+      )
       return []
   }
 }

--- a/src/utils/summit-talks-speakers.ts
+++ b/src/utils/summit-talks-speakers.ts
@@ -11,7 +11,7 @@ export interface Speaker {
 
 export const YEARS = ['2022', '2023', '2024', '2025']
 
-export function getSpeakers(year: string): Speaker[] {
+export function getSpeakers(year: string, lang: string): Speaker[] {
   const baseSpeakers: Speaker[] = [
     {
       id: '370w173',
@@ -22,11 +22,26 @@ export function getSpeakers(year: string): Speaker[] {
       name: 'Ioana Chiorean'
     }
   ]
+  const baseSpanishSpeakers: Speaker[] = [
+    {
+      id: '12342',
+      name: 'Lupita'
+    },
+    {
+      id: '020231',
+      name: 'Jose Armando'
+    }
+  ]
   //get 22 speakers to see pagination
   const speakers2022 = Array.from({ length: 11 }).flatMap(() => baseSpeakers)
-  switch (year) {
-    case '2022':
+  const spanishSpeakers2022 = Array.from({ length: 5 }).flatMap(
+    () => baseSpanishSpeakers
+  )
+  switch (true) {
+    case year === '2022' && lang === 'en':
       return speakers2022
+    case year === '2022' && lang === 'es':
+      return spanishSpeakers2022
     default:
       console.error(
         'Year is not correct or speakers data is not available for that year'
@@ -35,7 +50,7 @@ export function getSpeakers(year: string): Speaker[] {
   }
 }
 
-export function getTalks(year: string): Talk[] {
+export function getTalks(year: string, lang): Talk[] {
   const baseSessions: Talk[] = [
     {
       id: '370173',
@@ -46,12 +61,27 @@ export function getTalks(year: string): Talk[] {
       title: `${year} TigerBeetle, a Financial Accounting Database for Interledger`
     }
   ]
+  const baseSpanishSessions: Talk[] = [
+    {
+      id: '3da173',
+      title: `${year} En espagnol: State of Interledger`
+    },
+    {
+      id: '38ad79',
+      title: `${year} En espagnol: TigerBeetle, a Financial Accounting Database for Interledger`
+    }
+  ]
   const sessions2022 = Array.from({ length: 10 }).flatMap(() => baseSessions)
+  const spanishSessions2022 = Array.from({ length: 6 }).flatMap(
+    () => baseSpanishSessions
+  )
   const sessions2023 = Array.from({ length: 3 }).flatMap(() => baseSessions)
-  switch (year) {
-    case '2022':
+  switch (true) {
+    case year === '2022' && lang === 'en':
       return sessions2022
-    case '2023':
+    case year === '2022' && lang === 'es':
+      return spanishSessions2022
+    case year === '2023' && lang === 'en':
       return sessions2023
     default:
       console.error(
@@ -61,9 +91,12 @@ export function getTalks(year: string): Talk[] {
   }
 }
 
-export async function paginateSummitTalks(paginate: PaginateFunction) {
+export async function paginateSummitTalks(
+  paginate: PaginateFunction,
+  lang: string
+) {
   return YEARS.flatMap((year) => {
-    const talksForYear = getTalks(year)
+    const talksForYear = getTalks(year, lang)
     return paginate(talksForYear, {
       params: { year },
       pageSize: 10
@@ -71,9 +104,12 @@ export async function paginateSummitTalks(paginate: PaginateFunction) {
   })
 }
 
-export async function paginateSummitSpeakers(paginate: PaginateFunction) {
+export async function paginateSummitSpeakers(
+  paginate: PaginateFunction,
+  lang: string
+) {
   return YEARS.flatMap((year) => {
-    const speakersForYear = getSpeakers(year)
+    const speakersForYear = getSpeakers(year, lang)
     return paginate(speakersForYear, {
       params: { year },
       pageSize: 20

--- a/src/utils/summit-talks-speakers.ts
+++ b/src/utils/summit-talks-speakers.ts
@@ -66,11 +66,11 @@ export function getTalks(year: string, lang: Language): Talk[] {
   const baseSpanishSessions: Talk[] = [
     {
       id: '3da173',
-      title: `${year} En espagnol: State of Interledger`
+      title: `${year} En español: State of Interledger`
     },
     {
       id: '38ad79',
-      title: `${year} En espagnol: TigerBeetle, a Financial Accounting Database for Interledger`
+      title: `${year} En español: TigerBeetle, a Financial Accounting Database for Interledger`
     }
   ]
   const sessions2022 = Array.from({ length: 10 }).flatMap(() => baseSessions)

--- a/src/utils/summit-talks-speakers.ts
+++ b/src/utils/summit-talks-speakers.ts
@@ -4,30 +4,50 @@ export interface Talk {
   id: string
   title: string
 }
+export interface Speaker {
+  id: string
+  name: string
+}
 
-export function getAllTalks(year: string): Talk[] {
-  const sessions2022 = [
+export const YEARS = ['2022', '2023', '2024', '2025']
+
+export function getSpeakers(year: string): Speaker[] {
+  const baseSpeakers: Speaker[] = [
+    {
+      id: '370w173',
+      name: 'Ayden Férdeline'
+    },
+    {
+      id: '38w5579',
+      name: 'Ioana Chiorean'
+    }
+  ]
+  //get 22 speakers to see pagination
+  const speakers2022 = Array.from({ length: 11 }).flatMap(() => baseSpeakers)
+  switch (year) {
+    case '2022':
+      return speakers2022
+    default:
+      console.error(
+        'Year is not correct or speakers data is not available for that year'
+      )
+      return []
+  }
+}
+
+export function getTalks(year: string): Talk[] {
+  const baseSessions: Talk[] = [
     {
       id: '370173',
-      title: `2022 State of Interledger`
+      title: `${year} State of Interledger`
     },
     {
       id: '385579',
-      title:
-        ' 2022 TigerBeetle, a Financial Accounting Database for Interledger'
+      title: `${year} TigerBeetle, a Financial Accounting Database for Interledger`
     }
   ]
-  const sessions2023 = [
-    {
-      id: '370173',
-      title: `2023 State of Interledger`
-    },
-    {
-      id: '385579',
-      title:
-        ' 2023 TigerBeetle, a Financial Accounting Database for Interledger'
-    }
-  ]
+  const sessions2022 = Array.from({ length: 10 }).flatMap(() => baseSessions)
+  const sessions2023 = Array.from({ length: 3 }).flatMap(() => baseSessions)
   switch (year) {
     case '2022':
       return sessions2022
@@ -35,20 +55,28 @@ export function getAllTalks(year: string): Talk[] {
       return sessions2023
     default:
       console.error(
-        'Year is not correct or data is not available for that year'
+        'Year is not correct or sessions data is not available for that year'
       )
       return []
   }
 }
 
 export async function paginateSummitTalks(paginate: PaginateFunction) {
-  const years = ['2022', '2023', '2024', '2025']
-
-  return years.flatMap((year) => {
-    const talksForYear = getAllTalks(year)
+  return YEARS.flatMap((year) => {
+    const talksForYear = getTalks(year)
     return paginate(talksForYear, {
       params: { year },
       pageSize: 10
+    })
+  })
+}
+
+export async function paginateSummitSpeakers(paginate: PaginateFunction) {
+  return YEARS.flatMap((year) => {
+    const speakersForYear = getSpeakers(year)
+    return paginate(speakersForYear, {
+      params: { year },
+      pageSize: 20
     })
   })
 }


### PR DESCRIPTION
## Summary
This PR creates the list pages pages for `speakers` and `sessions` for all the years of **summit**, EN and ES. 

NOTES: 
- The components in this PR (`SessionCard`, `SpeakerCard` ) are temporary placeholders. <br>They contains minimal markup for now and will be fully implemented in a follow-up PR.

- The `getSpeakers` and `getTalks` are dummy functions - they will also be implemented in a follow-up PR


## Related Issue
Summit - [Create the list pages - INTORG-470](https://linear.app/interledger/issue/INTORG-470/create-the-list-pages)

## Manual Test
- Navigate to `/summit/[year]/talks`, respectively to `es/summit/[year]/talks` for spanish version <br> 
For EN: 2022 version should have pagination, 2023 should have entries, but no pagination; 2024-2025 have no data 
For ES: 2022 has data, the rest have no data
- Navigate to `summit/[year]/speakers`,  respectively to `es/summit/[year]/speakers` for spanish version <br> 
For EN: 2022 version should have pagination, 2023-2025 have no data 
For ES: 2022 has data, but no pagination, the rest have no data

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
