### PR TITLE
refactor(404): reuse shared 404 page instead of inline not-found sect…

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,6 +30,7 @@ export default defineConfig({
     starlight({
       title: 'Interledger',
       description: 'Enable seamless exchange of value across payment networks.',
+      disable404Route: true,
       customCss: [
         './node_modules/@interledger/docs-design-system/src/styles/teal-theme.css',
         './node_modules/@interledger/docs-design-system/src/styles/ilf-docs.css',

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -49,38 +49,38 @@ if (isNotFound) return Astro.redirect('/404')
   canonicalURL={canonicalURL}
 >
   <main class="pb-space-l" data-pillar={pillar}>
-    <>
-          {mdxHeroTitle && (
-            <section class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[40vh] py-space-xl text-white flex items-center">
-              <div class="mx-auto w-full max-w-wide px-space-m">
-                <div class="max-w-narrow">
-                  <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-space-xs text-[clamp(2rem,5vw,3rem)]">
-                    {mdxHeroTitle}
-                  </h1>
-                  {mdxHeroDescription && (
-                    <p class="mb-space-m text-[1.125rem] max-w-[600px]">
-                      {mdxHeroDescription}
-                    </p>
-                  )}
-                </div>
-              </div>
-            </section>
-          )}
-          <section class="py-space-xl">
-            <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
-              <div data-prose class="mx-auto max-w-narrow">
-                <MdxContent
-                  components={{
-                    Ambassador,
-                    AmbassadorGrid,
-                    Blockquote,
-                    CalloutText,
-                    Paragraph
-                  }}
-                />
-              </div>
+    {
+      mdxHeroTitle && (
+        <section class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[40vh] py-space-xl text-white flex items-center">
+          <div class="mx-auto w-full max-w-wide px-space-m">
+            <div class="max-w-narrow">
+              <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-space-xs text-[clamp(2rem,5vw,3rem)]">
+                {mdxHeroTitle}
+              </h1>
+              {mdxHeroDescription && (
+                <p class="mb-space-m text-[1.125rem] max-w-[600px]">
+                  {mdxHeroDescription}
+                </p>
+              )}
             </div>
-          </section>
-    </>
+          </div>
+        </section>
+      )
+    }
+    <section class="py-space-xl">
+      <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
+        <div data-prose class="mx-auto max-w-narrow">
+          <MdxContent
+            components={{
+              Ambassador,
+              AmbassadorGrid,
+              Blockquote,
+              CalloutText,
+              Paragraph
+            }}
+          />
+        </div>
+      </div>
+    </section>
   </main>
 </FoundationPageLayout>

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -39,7 +39,7 @@ const mdxHeroTitle = mdxData?.heroTitle || mdxData?.title || ''
 const mdxHeroDescription = mdxData?.heroDescription || ''
 const pillar = mdxData?.pillar || undefined
 const isNotFound = !MdxContent
-if (isNotFound) Astro.response.status = 404
+if (isNotFound) return Astro.redirect('/404')
 ---
 
 <FoundationPageLayout
@@ -49,21 +49,7 @@ if (isNotFound) Astro.response.status = 404
   canonicalURL={canonicalURL}
 >
   <main class="pb-space-l" data-pillar={pillar}>
-    {
-      isNotFound ? (
-        <section class="min-h-[50vh] flex items-center justify-center text-center">
-          <div class="mx-auto w-full max-w-wide px-space-m">
-            <h1 class="text-2xl font-semibold text-primary mb-space-s">404</h1>
-            <p class="text-[var(--sl-color-gray-2)] mb-space-m">
-              The page you requested could not be found.
-            </p>
-            <a href="/" class="text-primary underline hover:no-underline">
-              ← Back to home
-            </a>
-          </div>
-        </section>
-      ) : (
-        <>
+    <>
           {mdxHeroTitle && (
             <section class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[40vh] py-space-xl text-white flex items-center">
               <div class="mx-auto w-full max-w-wide px-space-m">
@@ -95,8 +81,6 @@ if (isNotFound) Astro.response.status = 404
               </div>
             </div>
           </section>
-        </>
-      )
-    }
+    </>
   </main>
 </FoundationPageLayout>

--- a/src/pages/summit/[...page].astro
+++ b/src/pages/summit/[...page].astro
@@ -39,7 +39,7 @@ const mdxHeroTitle = mdxData?.heroTitle || mdxData?.title || ''
 const mdxHeroDescription = mdxData?.heroDescription || ''
 const gradient = mdxData?.gradient || 'option1'
 const isNotFound = !MdxContent
-if (isNotFound) Astro.response.status = 404
+if (isNotFound) return Astro.redirect('/404')
 ---
 
 <SummitPageLayout
@@ -52,21 +52,7 @@ if (isNotFound) Astro.response.status = 404
   <main
     class="relative z-0 pb-space-l before:content-[''] before:fixed before:inset-0 before:-z-10 before:bg-[url('/img/bg-swirl.svg')] before:bg-repeat before:bg-[length:100%] before:opacity-25 before:blur-[150px] before:transform before:translate-x-0 before:translate-y-0"
   >
-    {
-      isNotFound ? (
-        <section class="min-h-[50vh] flex items-center justify-center text-center">
-          <div class="mx-auto w-full max-w-wide px-space-m">
-            <h1 class="text-2xl font-semibold mb-space-s text-white">404</h1>
-            <p class="mb-space-m text-white/80">
-              The page you requested could not be found.
-            </p>
-            <a href="/" class="text-white underline hover:no-underline">
-              ← Back to home
-            </a>
-          </div>
-        </section>
-      ) : (
-        <>
+    <>
           {mdxHeroTitle && (
             <section class="min-h-[40vh] py-space-xl flex items-center text-white">
               <div class="mx-auto w-full max-w-wide px-space-m">
@@ -92,8 +78,6 @@ if (isNotFound) Astro.response.status = 404
               </div>
             </div>
           </section>
-        </>
-      )
-    }
+    </>
   </main>
 </SummitPageLayout>

--- a/src/pages/summit/[...page].astro
+++ b/src/pages/summit/[...page].astro
@@ -52,32 +52,32 @@ if (isNotFound) return Astro.redirect('/404')
   <main
     class="relative z-0 pb-space-l before:content-[''] before:fixed before:inset-0 before:-z-10 before:bg-[url('/img/bg-swirl.svg')] before:bg-repeat before:bg-[length:100%] before:opacity-25 before:blur-[150px] before:transform before:translate-x-0 before:translate-y-0"
   >
-    <>
-          {mdxHeroTitle && (
-            <section class="min-h-[40vh] py-space-xl flex items-center text-white">
-              <div class="mx-auto w-full max-w-wide px-space-m">
-                <div class="max-w-narrow">
-                  <h1 class="max-w-[14em] leading-[1.2] font-semibold mb-space-xs text-[clamp(2rem,5vw,3rem)]">
-                    {mdxHeroTitle}
-                  </h1>
-                  {mdxHeroDescription && (
-                    <p class="mb-space-m text-[1.125rem] max-w-[600px]">
-                      {mdxHeroDescription}
-                    </p>
-                  )}
-                </div>
-              </div>
-            </section>
-          )}
-          <section class="py-space-xl">
-            <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
-              <div class="mx-auto max-w-narrow [&_h2]:mt-space-l [&_h2]:mb-space-s [&_h2]:text-[1.75rem] [&_h2]:font-semibold [&_h3]:mt-space-m [&_h3]:mb-space-xs [&_h3]:text-[1.25rem] [&_h3]:font-semibold [&_p]:mb-space-s [&_p]:leading-[1.6] [&_ul]:mb-space-s [&_ul]:ps-space-m [&_li]:mb-space-xs [&_a]:underline [&_a:hover]:no-underline">
-                <MdxContent
-                  components={{ AmbassadorGrid, Blockquote, Paragraph }}
-                />
-              </div>
+    {
+      mdxHeroTitle && (
+        <section class="min-h-[40vh] py-space-xl flex items-center text-white">
+          <div class="mx-auto w-full max-w-wide px-space-m">
+            <div class="max-w-narrow">
+              <h1 class="max-w-[14em] leading-[1.2] font-semibold mb-space-xs text-[clamp(2rem,5vw,3rem)]">
+                {mdxHeroTitle}
+              </h1>
+              {mdxHeroDescription && (
+                <p class="mb-space-m text-[1.125rem] max-w-[600px]">
+                  {mdxHeroDescription}
+                </p>
+              )}
             </div>
-          </section>
-    </>
+          </div>
+        </section>
+      )
+    }
+    <section class="py-space-xl">
+      <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
+        <div
+          class="mx-auto max-w-narrow [&_h2]:mt-space-l [&_h2]:mb-space-s [&_h2]:text-[1.75rem] [&_h2]:font-semibold [&_h3]:mt-space-m [&_h3]:mb-space-xs [&_h3]:text-[1.25rem] [&_h3]:font-semibold [&_p]:mb-space-s [&_p]:leading-[1.6] [&_ul]:mb-space-s [&_ul]:ps-space-m [&_li]:mb-space-xs [&_a]:underline [&_a:hover]:no-underline"
+        >
+          <MdxContent components={{ AmbassadorGrid, Blockquote, Paragraph }} />
+        </div>
+      </div>
+    </section>
   </main>
 </SummitPageLayout>


### PR DESCRIPTION
## Summary

Replace inline 404 markup in `[...page].astro` and `summit/[...page].astro` with redirects to `/404`, and disable Starlight's built-in 404 route. Previously each catch-all route rendered its own styled not-found section, meaning 404 UI was duplicated and inconsistent across the site. Now all not-found cases funnel through a single shared `/404` page.

## Related Issue

Fixes INTORG-496

## Manual Test

1. Visit a non-existent foundation page (e.g. `/does-not-exist`) — should redirect to `/404`
2. Visit a non-existent summit page (e.g. `/summit/does-not-exist`) — should redirect to `/404`
3. Confirm the shared 404 page renders correctly in both cases

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
