### PR TITLE
ci: trigger sync on navigation changes and run sync:all jm/intorg-493-syncall

### DIFF
--- a/.github/workflows/playground-merge.yml
+++ b/.github/workflows/playground-merge.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       cms_changed: ${{ steps.detect_changes.outputs.cms_changed }}
       content_changed: ${{ steps.detect_changes.outputs.content_changed }}
+      navigation_changed: ${{ steps.detect_changes.outputs.navigation_changed }}
     
     steps:
       - name: Validate manual trigger is on playground branch
@@ -44,6 +45,7 @@ jobs:
         with:
           script: |
             const contentPattern = /^src\/content\/(?:(?:foundation-pages|summit-pages|foundation-blog-posts|ambassadors)\/|[^/]+\/(?:foundation-pages|summit-pages|foundation-blog-posts|ambassadors)\/).+\.(md|mdx)$/
+            const navigationPattern = /^src\/config\/(?:foundation-navigation|summit-navigation)\.json$/
             const zeroSha = '0000000000000000000000000000000000000000'
 
             if (context.eventName === 'workflow_dispatch') {
@@ -159,6 +161,8 @@ jobs:
               changedFiles.some((file) => file.startsWith('cms/'))
             const contentChanged =
               changedFiles.some((file) => contentPattern.test(file))
+            const navigationChanged =
+              changedFiles.some((file) => navigationPattern.test(file))
 
             if (cmsChanged) {
               core.info('CMS changes detected')
@@ -168,8 +172,13 @@ jobs:
               core.info('Content changes detected')
             }
 
+            if (navigationChanged) {
+              core.info('Navigation changes detected')
+            }
+
             core.setOutput('cms_changed', String(cmsChanged))
             core.setOutput('content_changed', String(contentChanged))
+            core.setOutput('navigation_changed', String(navigationChanged))
 
   rebuild-strapi:
     needs: detect-changes
@@ -234,11 +243,11 @@ jobs:
           sleep 5
           sudo systemctl status strapi.service
 
-  sync-mdx-to-strapi:
+  sync-to-strapi:
     needs: [detect-changes, rebuild-strapi]
     if: |
       (needs.rebuild-strapi.result == 'success' || needs.rebuild-strapi.result == 'skipped') &&
-      needs.detect-changes.outputs.content_changed == 'true'
+      (needs.detect-changes.outputs.content_changed == 'true' || needs.detect-changes.outputs.navigation_changed == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -256,16 +265,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Sync MDX to Strapi
+      - name: Sync MDX and navigation to Strapi
         working-directory: cms
         env:
           STRAPI_URL: ${{ secrets.STRAPI_URL }}
           STRAPI_API_TOKEN: ${{ secrets.STRAPI_API_TOKEN }}
-        run: pnpm run sync:mdx
+        run: pnpm run sync:all
 
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [detect-changes, rebuild-strapi, sync-mdx-to-strapi]
+    needs: [detect-changes, rebuild-strapi, sync-to-strapi]
     if: ${{ always() && failure() }}
     steps:
       - name: Notify Slack on failure

--- a/.github/workflows/playground-merge.yml
+++ b/.github/workflows/playground-merge.yml
@@ -49,9 +49,10 @@ jobs:
             const zeroSha = '0000000000000000000000000000000000000000'
 
             if (context.eventName === 'workflow_dispatch') {
-              core.info('Manual trigger - will rebuild CMS and sync content')
+              core.info('Manual trigger - will rebuild CMS and sync content and navigation')
               core.setOutput('cms_changed', 'true')
               core.setOutput('content_changed', 'true')
+              core.setOutput('navigation_changed', 'true')
               return
             }
 
@@ -125,10 +126,11 @@ jobs:
                 if (tooManyFilesFlag || filesLikelyTruncated) {
                   core.warning(
                     'GitHub compareCommitsWithBasehead response may be truncated due to too many changed files; ' +
-                      'treating CMS and content as changed to avoid missing updates.'
+                      'treating CMS, content, and navigation as changed to avoid missing updates.'
                   )
                   core.setOutput('cms_changed', 'true')
                   core.setOutput('content_changed', 'true')
+                  core.setOutput('navigation_changed', 'true')
                   return
                 }
 
@@ -140,6 +142,7 @@ jobs:
                 // On API failure, err on the side of caution and assume relevant changes occurred.
                 core.setOutput('cms_changed', 'true')
                 core.setOutput('content_changed', 'true')
+                core.setOutput('navigation_changed', 'true')
                 return
               }
             }

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -49,9 +49,10 @@ jobs:
             const zeroSha = '0000000000000000000000000000000000000000'
 
             if (context.eventName === 'workflow_dispatch') {
-              core.info('Manual trigger - will rebuild CMS and sync content')
+              core.info('Manual trigger - will rebuild CMS and sync content and navigation')
               core.setOutput('cms_changed', 'true')
               core.setOutput('content_changed', 'true')
+              core.setOutput('navigation_changed', 'true')
               return
             }
 
@@ -125,10 +126,11 @@ jobs:
                 if (tooManyFilesFlag || filesLikelyTruncated) {
                   core.warning(
                     'GitHub compareCommitsWithBasehead response may be truncated due to too many changed files; ' +
-                      'treating CMS and content as changed to avoid missing updates.'
+                      'treating CMS, content, and navigation as changed to avoid missing updates.'
                   )
                   core.setOutput('cms_changed', 'true')
                   core.setOutput('content_changed', 'true')
+                  core.setOutput('navigation_changed', 'true')
                   return
                 }
 
@@ -140,6 +142,7 @@ jobs:
                 // On API failure, err on the side of caution and assume relevant changes occurred.
                 core.setOutput('cms_changed', 'true')
                 core.setOutput('content_changed', 'true')
+                core.setOutput('navigation_changed', 'true')
                 return
               }
             }

--- a/.github/workflows/staging-merge.yml
+++ b/.github/workflows/staging-merge.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       cms_changed: ${{ steps.detect_changes.outputs.cms_changed }}
       content_changed: ${{ steps.detect_changes.outputs.content_changed }}
+      navigation_changed: ${{ steps.detect_changes.outputs.navigation_changed }}
     
     steps:
       - name: Validate manual trigger is on staging branch
@@ -44,6 +45,7 @@ jobs:
         with:
           script: |
             const contentPattern = /^src\/content\/(?:(?:foundation-pages|summit-pages|foundation-blog-posts|ambassadors)\/|[^/]+\/(?:foundation-pages|summit-pages|foundation-blog-posts|ambassadors)\/).+\.(md|mdx)$/
+            const navigationPattern = /^src\/config\/(?:foundation-navigation|summit-navigation)\.json$/
             const zeroSha = '0000000000000000000000000000000000000000'
 
             if (context.eventName === 'workflow_dispatch') {
@@ -159,6 +161,8 @@ jobs:
               changedFiles.some((file) => file.startsWith('cms/'))
             const contentChanged =
               changedFiles.some((file) => contentPattern.test(file))
+            const navigationChanged =
+              changedFiles.some((file) => navigationPattern.test(file))
 
             if (cmsChanged) {
               core.info('CMS changes detected')
@@ -168,8 +172,13 @@ jobs:
               core.info('Content changes detected')
             }
 
+            if (navigationChanged) {
+              core.info('Navigation changes detected')
+            }
+
             core.setOutput('cms_changed', String(cmsChanged))
             core.setOutput('content_changed', String(contentChanged))
+            core.setOutput('navigation_changed', String(navigationChanged))
 
   rebuild-strapi:
     needs: detect-changes
@@ -234,11 +243,11 @@ jobs:
           sleep 5
           sudo systemctl status strapi.service
 
-  sync-mdx-to-strapi:
+  sync-to-strapi:
     needs: [detect-changes, rebuild-strapi]
     if: |
       (needs.rebuild-strapi.result == 'success' || needs.rebuild-strapi.result == 'skipped') &&
-      needs.detect-changes.outputs.content_changed == 'true'
+      (needs.detect-changes.outputs.content_changed == 'true' || needs.detect-changes.outputs.navigation_changed == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -256,16 +265,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Sync MDX to Strapi
+      - name: Sync MDX and navigation to Strapi
         working-directory: cms
         env:
           STRAPI_URL: ${{ secrets.STRAPI_URL }}
           STRAPI_API_TOKEN: ${{ secrets.STRAPI_API_TOKEN }}
-        run: pnpm run sync:mdx
+        run: pnpm run sync:all
 
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [detect-changes, rebuild-strapi, sync-mdx-to-strapi]
+    needs: [detect-changes, rebuild-strapi, sync-to-strapi]
     if: ${{ always() && failure() }}
     steps:
       - name: Notify Slack on failure

--- a/cms/package.json
+++ b/cms/package.json
@@ -13,6 +13,8 @@
     "sync:mdx:dry-run": "tsx scripts/sync-mdx/index.ts --dry-run",
     "sync:navigation": "tsx scripts/sync-navigation.ts",
     "sync:navigation:dry-run": "tsx scripts/sync-navigation.ts --dry-run",
+    "sync:all": "pnpm run sync:mdx && pnpm run sync:navigation",
+    "sync:all:dry-run": "pnpm run sync:mdx:dry-run && pnpm run sync:navigation:dry-run",
     "test:sync-mdx": "vitest run scripts/sync-mdx",
     "test:serializers": "vitest run src/serializers"
   },


### PR DESCRIPTION
## Summary

Navigation changes now trigger the sync job, same as MDX content. Switched to `sync:all` to run both syncs together, and renamed the job to match.

## Related Issue

Fixes INTORG-493

## Manual Test

1. Merge a branch that only changes `foundation-navigation.json` or `summit-navigation.json` into playground/staging
2. Confirm the `sync-to-strapi` job runs (previously it would be skipped)

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
