### PR TITLE
fix: remove unused value from interface definition

### DIFF
--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -89,8 +89,6 @@ export interface PageLifecycleConfig {
   contentTypeUid: string
   /** English output path relative to project root, e.g. 'src/content/foundation-pages' */
   outputDir: string
-  /** Directory name used inside src/content/{locale}/, e.g. 'foundation-pages' */
-  localizedOutputDir: string
 }
 
 function getOutputDir(config: PageLifecycleConfig, locale: string): string {


### PR DESCRIPTION
## Summary
Remove unused value from interface definition

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
