### PR TITLE
fix(cms): target preview aside by nth-child instead of last-of-type

### DIFF
--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -110,7 +110,7 @@ export default {
       /* TEMP UI Fix: minimum textarea height */
       textarea { min-height: 140px !important; }
       /* TEMP UI Fix: hide only the Preview aside (last one), not the one above */
-      aside[aria-labelledby="additional-information"]:last-of-type { display: none !important; }
+      aside[aria-labelledby="additional-information"]:nth-child(2) { display: none !important; }
     `
     document.head.appendChild(style)
 


### PR DESCRIPTION
## Summary

The CSS selector hiding the Preview aside was matching the wrong element after a Strapi UI update. Switched from `:last-of-type` to `:nth-child(2)` to reliably target only the preview aside.

## Related Issue

<!-- Fixes INTORG-??? -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
