### PR TITLE
feat: add localization support for foundation-blog-posts

### DIFF
--- a/cms/src/api/foundation-blog-post/content-types/foundation-blog-post/schema.json
+++ b/cms/src/api/foundation-blog-post/content-types/foundation-blog-post/schema.json
@@ -126,19 +126,6 @@
       },
       "component": "shared.tags",
       "repeatable": true
-    },
-    "language": {
-      "type": "enumeration",
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "default": "en",
-      "enum": [
-        "en",
-        "es"
-      ]
     }
   }
 }

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -451,7 +451,7 @@ async function configureLayouts(strapi: StrapiInstance) {
     'api::foundation-blog-post.foundation-blog-post': [
       [
         { name: 'title', size: 6 },
-        { name: 'slug', size: 6 }
+        { name: 'pathSlug', size: 6 }
       ],
       [
         { name: 'date', size: 4 },

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -181,7 +181,7 @@ async function configureFieldLabels(strapi: StrapiInstance) {
   const contentTypeLabels: Record<string, Record<string, string>> = {
     'api::ambassador.ambassador': {
       name: 'Name',
-      slug: 'URL Slug',
+      pathSlug: 'URL Slug',
       description: 'Description',
       photo: 'Photo',
       linkedinUrl: 'LinkedIn URL',
@@ -202,7 +202,7 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     },
     'api::foundation-page.foundation-page': {
       title: 'Page Title',
-      slug: 'URL Slug',
+      pathSlug: 'URL Slug',
       path: 'Directory Structure',
       pageType: 'Brand Pillar',
       seo: 'SEO',
@@ -211,7 +211,7 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     },
     'api::summit-page.summit-page': {
       title: 'Title',
-      slug: 'URL Slug',
+      pathSlug: 'URL Slug',
       path: 'Directory Structure',
       pageType: 'Brand Pillar',
       seo: 'SEO',
@@ -470,7 +470,7 @@ async function configureLayouts(strapi: StrapiInstance) {
     'api::ambassador.ambassador': [
       [
         { name: 'name', size: 6 },
-        { name: 'slug', size: 6 }
+        { name: 'pathSlug', size: 6 }
       ],
       [
         { name: 'linkedinUrl', size: 6 },
@@ -485,7 +485,7 @@ async function configureLayouts(strapi: StrapiInstance) {
         { name: 'pageType', size: 6 }
       ],
       [
-        { name: 'slug', size: 6 },
+        { name: 'pathSlug', size: 6 },
         { name: 'path', size: 6 }
       ],
       [{ name: 'seo', size: 12 }],
@@ -498,7 +498,7 @@ async function configureLayouts(strapi: StrapiInstance) {
         { name: 'pageType', size: 6 }
       ],
       [
-        { name: 'slug', size: 6 },
+        { name: 'pathSlug', size: 6 },
         { name: 'path', size: 6 }
       ],
       [{ name: 'seo', size: 12 }],

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -16,7 +16,6 @@ interface BlogResult {
   publishedAt?: Date
   locale: string
   pillar: 'vision' | 'mission' | 'tech' | 'values'
-  language?: 'en' | 'es'
   featureImage?: {
     name: string
     alternativeText?: string
@@ -33,7 +32,7 @@ interface BlogResult {
     profileImage?: { url: string; name: string }
   }[]
   tags?: { tagValue: string }[]
-  localizations: string[]
+  localizations: { pathSlug: string }[]
 }
 
 interface BlogEvent {
@@ -100,7 +99,10 @@ function generateBlogMDX(post: BlogResult) {
         ? `tags: []`
         : `tags:${post.tags.map((tag) => `\n  - ${q(tag.tagValue)}`).join('')}`
       : null,
-    post.language ? `locale: ${q(post.language)}` : null
+    post.locale ? `locale: ${q(post.locale)}` : null,
+    post.locale && post.locale != 'en'
+      ? `localizes: ${post.localizations[0].pathSlug}`
+      : null
   ].filter(Boolean) as string[]
 
   const frontmatter = frontmatterLines.join('\n')
@@ -179,7 +181,18 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
       })
       scheduleGitSync(label)
     },
-
+    async afterUpdate(event: BlogEvent) {
+      if (shouldSkipMdxExport()) return
+      const { result } = event
+      if (!result || !result.publishedAt) return
+      const label = event.model.singularName
+      console.log(`📝 Updating ${label} MDX for: ${result.pathSlug}`)
+      await writeMDXFile({
+        outputPath: getOutputPath(result.locale),
+        post: result
+      })
+      scheduleGitSync(label)
+    },
     async afterDelete(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
       const { result } = event

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -100,7 +100,7 @@ function generateBlogMDX(post: BlogResult) {
         : `tags:${post.tags.map((tag) => `\n  - ${q(tag.tagValue)}`).join('')}`
       : null,
     post.locale ? `locale: ${q(post.locale)}` : null,
-    post.locale && post.locale != 'en'
+    post.localizations?.[0]?.pathSlug
       ? `localizes: ${post.localizations[0].pathSlug}`
       : null
   ].filter(Boolean) as string[]

--- a/cms/src/utils/flatContentLifecycle.ts
+++ b/cms/src/utils/flatContentLifecycle.ts
@@ -159,7 +159,16 @@ export function createFlatLocaleMdxLifecycle<
       await exportAllLocales(result.documentId)
       scheduleGitSync(label)
     },
-
+    async afterUpdate(event: { result?: T }) {
+      const { result } = event
+      if (shouldSkipMdxExport()) return
+      if (!result?.documentId || !result.publishedAt) return
+      console.log(
+        `📝 Updating ${label} MDX for all locales: ${result.pathSlug}`
+      )
+      await exportAllLocales(result.documentId)
+      scheduleGitSync(label)
+    },
     async afterDelete(event: { result?: T }) {
       const { result } = event
       if (shouldSkipMdxExport()) return

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -263,7 +263,17 @@ export function createPageLifecycle(config: PageLifecycleConfig) {
       await exportAllLocales(config, result.documentId)
       scheduleGitSync(label)
     },
-
+    async afterUpdate(event: Event) {
+      const { result } = event
+      if (!result) return
+      if (shouldSkipMdxExport()) return
+      const label = uidToLogLabel(config.contentTypeUid)
+      console.log(
+        `📝 Updating ${label} MDX for all locales: ${result.pathSlug}`
+      )
+      await exportAllLocales(config, result.documentId)
+      scheduleGitSync(label)
+    },
     async afterDelete(event: Event) {
       const { result } = event
       if (!result) return

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -571,13 +571,6 @@ export interface ApiFoundationBlogPostFoundationBlogPost
           localized: true
         }
       }>
-    language: Schema.Attribute.Enumeration<['en', 'es']> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true
-        }
-      }> &
-      Schema.Attribute.DefaultTo<'en'>
     locale: Schema.Attribute.String
     localizations: Schema.Attribute.Relation<
       'oneToMany',


### PR DESCRIPTION
## Summary
This PR:
- adds localization support for foundation-blog-posts
- removes `language` field from Strapi Admin ui for Blog post (redundant, we already use `locale`)
- adds back `afterUpdate` hooks in lifecycles (after switching off `draft`s for content, the lifecycles have changed they behaviour)

## Related Issue
Blog - add support for localization([INTORG-295](https://linear.app/interledger/issue/INTORG-495/blog-add-support-for-localization))

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [ ] `pnpm run format`
- [ ] `pnpm run lint`

## PR Checklist

- [ ] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
