### PR TITLE
feat(cms): split image uploads into git-tracked originals and jon/intorg-497

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 .netlify
 
 presentations/
+
+# Strapi-generated responsive images (regenerated locally from originals; see cms/docs/IMAGES.md)
+public/uploads/img/optimized/

--- a/cms/config/plugins.ts
+++ b/cms/config/plugins.ts
@@ -1,4 +1,10 @@
 export default () => ({
+  upload: {
+    config: {
+      // Images → optimized/ (gitignored). Admin uploads also copy masters to img/original/ (overwrite by slugged name). Use pnpm sync:images to bulk re-import from original/.
+      provider: '@interledger/strapi-upload-local-split'
+    }
+  },
   ckeditor: {
     enabled: true
   },

--- a/cms/package.json
+++ b/cms/package.json
@@ -17,6 +17,7 @@
     "sync:all:dry-run": "pnpm run sync:mdx:dry-run && pnpm run sync:navigation:dry-run",
     "sync:delete-all": "tsx scripts/sync-delete-all.ts",
     "sync:delete-all:dry-run": "tsx scripts/sync-delete-all.ts --dry-run",
+    "sync:images": "tsx scripts/sync-images.ts",
     "test:sync-mdx": "vitest run scripts/sync-mdx",
     "test:serializers": "vitest run src/serializers"
   },
@@ -24,6 +25,7 @@
     "uuid": "d5c8f4e2-9a1b-4c3d-8e7f-6a5b4c3d2e1f"
   },
   "dependencies": {
+    "@interledger/strapi-upload-local-split": "file:./providers/strapi-upload-local-split",
     "@_sh/strapi-plugin-ckeditor": "^7.1.0",
     "@ckeditor/strapi-plugin-ckeditor": "^1.1.1",
     "@notum-cz/strapi-plugin-record-locking": "^2.1.0",

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@ckeditor/strapi-plugin-ckeditor':
         specifier: ^1.1.1
         version: 1.1.2(@strapi/strapi@5.41.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.17)(@emotion/is-prop-valid@1.4.0)(@swc/helpers@0.5.19)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@25.4.0)(@types/react@19.2.14)(better-sqlite3@12.8.0)(codemirror@5.65.21)(esbuild@0.27.3)(koa@2.16.4)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(type-fest@4.41.0))(ckeditor5@47.4.0)(react@18.3.1)
+      '@interledger/strapi-upload-local-split':
+        specifier: file:./providers/strapi-upload-local-split
+        version: file:providers/strapi-upload-local-split
       '@notum-cz/strapi-plugin-record-locking':
         specifier: ^2.1.0
         version: 2.1.1(6829809b0650e99ce61605174693c5ef)
@@ -1442,6 +1445,9 @@ packages:
   '@inquirer/figures@1.0.15':
     resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
     engines: {node: '>=18'}
+
+  '@interledger/strapi-upload-local-split@file:providers/strapi-upload-local-split':
+    resolution: {directory: providers/strapi-upload-local-split, type: directory}
 
   '@internationalized/date@3.5.4':
     resolution: {integrity: sha512-qoVJVro+O0rBaw+8HPjUB1iH8Ihf8oziEnqMnvhJUSuVIrHOuZ6eNLHNvzXJKUvAtaDiqMnRlg8Z2mgh09BlUw==}
@@ -7933,6 +7939,8 @@ snapshots:
       '@ckeditor/ckeditor5-core': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-code-block@47.4.0':
     dependencies:
@@ -8002,6 +8010,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-editor-multi-root@47.4.0':
     dependencies:
@@ -8032,8 +8042,6 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-utils': 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-enter@47.4.0':
     dependencies:
@@ -8142,8 +8150,6 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-icons@47.4.0': {}
 
@@ -8326,6 +8332,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-restricted-editing@47.4.0':
     dependencies:
@@ -8453,8 +8461,6 @@ snapshots:
       '@ckeditor/ckeditor5-engine': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-widget@47.4.0':
     dependencies:
@@ -9140,6 +9146,8 @@ snapshots:
       '@types/node': 25.4.0
 
   '@inquirer/figures@1.0.15': {}
+
+  '@interledger/strapi-upload-local-split@file:providers/strapi-upload-local-split': {}
 
   '@internationalized/date@3.5.4':
     dependencies:
@@ -10134,7 +10142,7 @@ snapshots:
       '@strapi/design-system': 2.2.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.17)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/permissions': 5.41.1
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/typescript-utils': 5.41.1
       '@strapi/utils': 5.41.1
       '@testing-library/dom': 10.4.1
@@ -10333,7 +10341,7 @@ snapshots:
       '@strapi/database': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)
       '@strapi/design-system': 2.2.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.17)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/utils': 5.41.1
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
@@ -10434,7 +10442,7 @@ snapshots:
       '@strapi/generators': 5.41.1(@types/node@25.4.0)
       '@strapi/logger': 5.41.1
       '@strapi/permissions': 5.41.1
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/typescript-utils': 5.41.1
       '@strapi/utils': 5.41.1
       '@vercel/stega': 0.1.2
@@ -10862,7 +10870,7 @@ snapshots:
       '@strapi/openapi': 5.41.1
       '@strapi/permissions': 5.41.1
       '@strapi/review-workflows': 5.41.1(6d9d4bf50717dda097ab439406d5332a)
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/typescript-utils': 5.41.1
       '@strapi/upload': 5.41.1(875d5a09f0e66a339eb16219cd5704cd)
       '@strapi/utils': 5.41.1
@@ -10963,6 +10971,36 @@ snapshots:
       - webpack-cli
       - webpack-dev-server
       - webpack-plugin-serve
+
+  '@strapi/types@5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)':
+    dependencies:
+      '@casl/ability': 6.7.5
+      '@koa/cors': 5.0.0
+      '@koa/router': 12.0.2
+      '@strapi/database': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)
+      '@strapi/logger': 5.41.1
+      '@strapi/permissions': 5.41.1
+      '@strapi/utils': 5.41.1
+      commander: 8.3.0
+      json-logic-js: 2.0.5
+      koa: 2.16.4
+      koa-body: 6.0.1
+      node-schedule: 2.1.1
+      typedoc: 0.25.10(typescript@5.4.4)
+      typedoc-github-wiki-theme: 1.1.0(typedoc-plugin-markdown@3.17.1(typedoc@0.25.10(typescript@5.9.3)))(typedoc@0.25.10(typescript@5.9.3))
+      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.10(typescript@5.9.3))
+      zod: 3.25.67
+    transitivePeerDependencies:
+      - '@types/node'
+      - better-sqlite3
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+      - typescript
 
   '@strapi/types@5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)':
     dependencies:
@@ -16225,6 +16263,14 @@ snapshots:
     dependencies:
       handlebars: 4.7.8
       typedoc: 0.25.10(typescript@5.9.3)
+
+  typedoc@0.25.10(typescript@5.4.4):
+    dependencies:
+      lunr: 2.3.9
+      marked: 4.3.0
+      minimatch: 9.0.9
+      shiki: 0.14.7
+      typescript: 5.4.4
 
   typedoc@0.25.10(typescript@5.9.3):
     dependencies:

--- a/cms/providers/strapi-upload-local-split/index.js
+++ b/cms/providers/strapi-upload-local-split/index.js
@@ -1,0 +1,159 @@
+'use strict'
+
+/**
+ * Local upload provider: images → uploads/img/optimized/ (hashed names, gitignored),
+ * other files → uploads/ (same layout as default local provider).
+ *
+ * Strapi static root is repo ../public (see config/server.ts).
+ */
+const fs = require('fs')
+const path = require('path')
+const stream = require('stream')
+const fse = require('fs-extra')
+const utils = require('@strapi/utils')
+const layoutPaths = require('./layout-paths')
+
+const { PayloadTooLargeError } = utils.errors
+const { kbytesToBytes, bytesToHumanReadable } = utils.file
+
+const UPLOADS_FOLDER_NAME = 'uploads'
+
+function isImageMime(mime) {
+  return typeof mime === 'string' && mime.startsWith('image/')
+}
+
+function relativePathFor(file) {
+  if (isImageMime(file.mime)) {
+    const posixRel = layoutPaths.optimizedUploadsRelFromStorageName(
+      file.name,
+      file.hash,
+      file.ext
+    )
+    return path.join(...posixRel.split('/'))
+  }
+  return `${file.hash}${file.ext}`
+}
+
+function urlFromRelative(rel) {
+  const posix = rel.split(path.sep).join('/')
+  return `/${UPLOADS_FOLDER_NAME}/${posix}`
+}
+
+/** Thumbnail / breakpoint uploads keep optimized URLs; only the main asset uses img/original. */
+function isDerivativeImageUpload(file) {
+  return /^(thumbnail|large|medium|small|xlarge)_/i.test(file.name || '')
+}
+
+function stablePublicUrlForMasterImage(file) {
+  const rel = layoutPaths.originalMasterUploadsRelFromStorageName(
+    file.name || 'image'
+  )
+  return urlFromRelative(rel)
+}
+
+module.exports = {
+  init({ sizeLimit: providerOptionsSizeLimit } = {}) {
+    if (providerOptionsSizeLimit) {
+      process.emitWarning(
+        '[deprecated] In future versions, "sizeLimit" argument will be ignored from upload.config.providerOptions. Move it to upload.config'
+      )
+    }
+
+    const uploadRoot = path.resolve(
+      strapi.dirs.static.public,
+      UPLOADS_FOLDER_NAME
+    )
+    if (!fse.pathExistsSync(uploadRoot)) {
+      throw new Error(
+        `The upload folder (${uploadRoot}) doesn't exist or is not accessible. Please make sure it exists.`
+      )
+    }
+
+    return {
+      checkFileSize(file, options) {
+        const { sizeLimit } = options ?? {}
+        if (providerOptionsSizeLimit) {
+          if (kbytesToBytes(file.size) > providerOptionsSizeLimit) {
+            throw new PayloadTooLargeError(
+              `${file.name} exceeds size limit of ${bytesToHumanReadable(providerOptionsSizeLimit)}.`
+            )
+          }
+        } else if (sizeLimit) {
+          if (kbytesToBytes(file.size) > sizeLimit) {
+            throw new PayloadTooLargeError(
+              `${file.name} exceeds size limit of ${bytesToHumanReadable(sizeLimit)}.`
+            )
+          }
+        }
+      },
+
+      uploadStream(file) {
+        if (!file.stream) {
+          return Promise.reject(new Error('Missing file stream'))
+        }
+        const rel = relativePathFor(file)
+        const dest = path.join(uploadRoot, rel)
+        return fse.ensureDir(path.dirname(dest)).then(
+          () =>
+            new Promise((resolve, reject) => {
+              stream.pipeline(
+                file.stream,
+                fs.createWriteStream(dest),
+                (err) => {
+                  if (err) reject(err)
+                  else {
+                    file.url =
+                      isImageMime(file.mime) && !isDerivativeImageUpload(file)
+                        ? stablePublicUrlForMasterImage(file)
+                        : urlFromRelative(rel)
+                    resolve()
+                  }
+                }
+              )
+            })
+        )
+      },
+
+      upload(file) {
+        if (!file.buffer) {
+          return Promise.reject(new Error('Missing file buffer'))
+        }
+        const rel = relativePathFor(file)
+        const dest = path.join(uploadRoot, rel)
+        return fse.ensureDir(path.dirname(dest)).then(
+          () =>
+            new Promise((resolve, reject) => {
+              fs.writeFile(dest, file.buffer, (err) => {
+                if (err) reject(err)
+                else {
+                  file.url =
+                    isImageMime(file.mime) && !isDerivativeImageUpload(file)
+                      ? stablePublicUrlForMasterImage(file)
+                      : urlFromRelative(rel)
+                  resolve()
+                }
+              })
+            })
+        )
+      },
+
+      delete(file) {
+        // Only remove provider-managed derivatives under optimized/ (or hashed non-image files).
+        // Never delete img/original/: those are git-tracked masters and may be the source for
+        // `sync:images`; Strapi media delete / replace must not unlink them.
+        const rel = relativePathFor(file)
+        const filePath = path.join(uploadRoot, rel)
+        return new Promise((resolve, reject) => {
+          if (!fs.existsSync(filePath)) {
+            resolve("File doesn't exist")
+            return
+          }
+          fs.unlink(filePath, (err) => {
+            if (err) reject(err)
+            else resolve()
+          })
+        })
+      }
+    }
+  }
+}

--- a/cms/providers/strapi-upload-local-split/layout-paths.js
+++ b/cms/providers/strapi-upload-local-split/layout-paths.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Mirrors cms/src/utils/imageLayoutPaths.ts (plain JS for the upload provider).
+ * All originals are flat under img/original/<slug>.<ext> — no subdirectories.
+ */
+const path = require('path')
+const { strings } = require('@strapi/utils')
+
+function slugBase(filenameWithExt) {
+  const ext = path.extname(filenameWithExt)
+  const base = path.basename(filenameWithExt, ext)
+  return strings.nameToSlug(base, { separator: '_', lowercase: false })
+}
+
+function originalMasterUploadsRelFromStorageName(storageOrStrapiName) {
+  const fileWithExt = path.posix.basename(storageOrStrapiName)
+  const ext = path.extname(fileWithExt) || '.bin'
+  const slug = slugBase(fileWithExt)
+  return path.posix.join('img', 'original', `${slug}${ext}`)
+}
+
+function optimizedUploadsRelFromStorageName(storageOrStrapiName, hash, ext) {
+  const dotExt = ext && ext.startsWith('.') ? ext : `.${ext || 'bin'}`
+  return path.posix.join('img', 'optimized', `${hash}${dotExt}`)
+}
+
+module.exports = {
+  originalMasterUploadsRelFromStorageName,
+  optimizedUploadsRelFromStorageName
+}

--- a/cms/providers/strapi-upload-local-split/package.json
+++ b/cms/providers/strapi-upload-local-split/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@interledger/strapi-upload-local-split",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/cms/scripts/sync-images.ts
+++ b/cms/scripts/sync-images.ts
@@ -8,10 +8,13 @@
  *
  * Flow (admin uploads also copy masters to img/original/; this script bulk re-imports):
  * 1. Recursively walk public/uploads/img/original/; filenames are the slugged basename only
- *    (e.g. blog/hero.jpg → storageName hero.jpg). Delete existing media with that name
- *    (optional; default on) so DB + disk stay aligned.
+ *    (e.g. blog/hero.jpg → storageName hero.jpg). Delete **all** Strapi media rows with that
+ *    `name` (optional; default on) so DB + disk stay aligned — then POST /api/upload replaces them.
  * 2. Remove public/uploads/img/optimized/ (optional; default on).
  * 3. Upload each original via POST /api/upload; optimized derivatives go under img/optimized/.
+ *
+ * `--no-replace`: do **not** delete existing media; **skip upload** for names already in Strapi
+ * (only imports files that are missing). Use this to avoid re-adding duplicates on every run.
  *
  * Requires .env at repo root: STRAPI_URL, STRAPI_API_TOKEN (full access to upload API).
  *
@@ -173,6 +176,7 @@ async function main(): Promise<void> {
 
   const dryRun = process.argv.includes('--dry-run')
   const noWipe = process.argv.includes('--no-wipe')
+  /** When set: never delete existing uploads; skip upload if that filename already exists. */
   const noReplace = process.argv.includes('--no-replace')
   const force = process.argv.includes('--force')
 
@@ -241,24 +245,24 @@ async function main(): Promise<void> {
     token: STRAPI_TOKEN
   })
 
-  // 1) Remove existing Strapi rows that share the same media `name` (and their files)
+  // 1) Remove every Strapi row with the same media `name` (clears accidental duplicates too)
   if (!noReplace) {
     for (const { relPosix } of originals) {
       const storageName = storageNameFromRelativeImagePath(relPosix)
       if (dryRun) {
-        const existing = await strapi.findUploadByName(storageName)
-        if (existing != null) {
+        const ids = await strapi.findUploadIdsByName(storageName)
+        for (const id of ids) {
           console.log(
-            `  [dry-run] would delete Strapi upload id=${existing} (${storageName})`
+            `  [dry-run] would delete Strapi upload id=${id} (${storageName})`
           )
         }
         continue
       }
-      const existing = await strapi.findUploadByName(storageName)
-      if (existing != null) {
-        await strapi.deleteUploadFile(existing)
+      const ids = await strapi.findUploadIdsByName(storageName)
+      for (const id of ids) {
+        await strapi.deleteUploadFile(id)
         console.log(
-          `🗑️  Deleted existing Strapi media id=${existing} (${storageName})`
+          `🗑️  Deleted existing Strapi media id=${id} (${storageName})`
         )
       }
     }
@@ -274,8 +278,20 @@ async function main(): Promise<void> {
   // 3) Upload each original (Strapi writes to img/optimized/ via custom provider)
   let uploaded = 0
   let failed = 0
+  let skippedExisting = 0
   for (const { abs, relPosix } of originals) {
     const storageName = storageNameFromRelativeImagePath(relPosix)
+    if (noReplace) {
+      const existingId = await strapi.findUploadByName(storageName)
+      if (existingId != null) {
+        skippedExisting += 1
+        const suffix = dryRun ? ' [dry-run]' : ''
+        console.log(
+          `⏭️  Skipping ${relPosix} (${storageName}) — already in Strapi${suffix}`
+        )
+        continue
+      }
+    }
     try {
       const result = await uploadOriginal({
         filePath: abs,
@@ -305,10 +321,17 @@ async function main(): Promise<void> {
   }
 
   console.log('='.repeat(50))
+  const summaryParts = [
+    dryRun ? `${uploaded} file(s) would be uploaded` : `${uploaded} uploaded`,
+    failed > 0 ? `${failed} failed` : null,
+    skippedExisting > 0
+      ? `${skippedExisting} skipped (already in Strapi)`
+      : null
+  ].filter(Boolean)
   console.log(
     dryRun
-      ? `Done (dry-run). ${originals.length} file(s) would be uploaded.`
-      : `Done. ${uploaded} ok, ${failed} failed.`
+      ? `Done (dry-run). ${summaryParts.join(', ')}.`
+      : `Done. ${summaryParts.join(', ')}.`
   )
   if (failed > 0) process.exit(1)
 }

--- a/cms/scripts/sync-images.ts
+++ b/cms/scripts/sync-images.ts
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+/**
+ * Regenerate Strapi image derivatives from git-tracked originals.
+ *
+ * Run from cms/ with Strapi running:
+ *   pnpm sync:images --dry-run
+ *   pnpm sync:images
+ *
+ * Flow (admin uploads also copy masters to img/original/; this script bulk re-imports):
+ * 1. Recursively walk public/uploads/img/original/; filenames are the slugged basename only
+ *    (e.g. blog/hero.jpg → storageName hero.jpg). Delete existing media with that name
+ *    (optional; default on) so DB + disk stay aligned.
+ * 2. Remove public/uploads/img/optimized/ (optional; default on).
+ * 3. Upload each original via POST /api/upload; optimized derivatives go under img/optimized/.
+ *
+ * Requires .env at repo root: STRAPI_URL, STRAPI_API_TOKEN (full access to upload API).
+ *
+ * Caveat: Replacing media changes file ids/URLs. Entries in Strapi that pointed at old
+ * uploads may need re-linking unless names/URLs match your usage. Prefer on a dev DB or
+ * after coordinating content updates.
+ *
+ * See cms/docs/IMAGES.md
+ */
+
+import fs from 'fs/promises'
+import fsSync from 'fs'
+import path from 'path'
+import { spawnSync } from 'child_process'
+import dotenv from 'dotenv'
+import mime from 'mime-types'
+import { getProjectRoot } from '@/utils/paths'
+import { storageNameFromRelativeImagePath } from '@/utils/imageLayoutPaths'
+import { createStrapiClient } from './sync-mdx/strapiClient'
+
+const IMAGE_EXT = new Set([
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.webp',
+  '.gif',
+  '.svg',
+  '.avif',
+  '.tiff',
+  '.tif',
+  '.bmp'
+])
+
+function isImageFile(filename: string): boolean {
+  return IMAGE_EXT.has(path.extname(filename).toLowerCase())
+}
+
+type OriginalEntry = { abs: string; relPosix: string }
+
+/** Recursively collect images under original/; `relPosix` is relative to originalDir. */
+async function collectOriginalImages(
+  originalDir: string
+): Promise<OriginalEntry[]> {
+  if (!fsSync.existsSync(originalDir)) return []
+  const out: OriginalEntry[] = []
+
+  async function walk(currentAbs: string): Promise<void> {
+    const entries = await fs.readdir(currentAbs, { withFileTypes: true })
+    for (const e of entries) {
+      if (e.name === '.gitkeep' || e.name.startsWith('.')) continue
+      const abs = path.join(currentAbs, e.name)
+      if (e.isDirectory()) {
+        await walk(abs)
+      } else if (isImageFile(e.name)) {
+        const rel = path.relative(originalDir, abs)
+        const relPosix = rel.split(path.sep).join('/')
+        out.push({ abs, relPosix })
+      }
+    }
+  }
+
+  await walk(originalDir)
+  return out.sort((a, b) => a.relPosix.localeCompare(b.relPosix))
+}
+
+async function wipeOptimized(
+  optimizedDir: string,
+  dryRun: boolean
+): Promise<void> {
+  if (!fsSync.existsSync(optimizedDir)) {
+    if (!dryRun) {
+      await fs.mkdir(optimizedDir, { recursive: true })
+    }
+    console.log(
+      `📁 ${dryRun ? '[dry-run] would create' : 'created'} ${optimizedDir}`
+    )
+    return
+  }
+  if (dryRun) {
+    const entries = await fs.readdir(optimizedDir)
+    for (const e of entries) {
+      console.log(`  [dry-run] would remove ${path.join(optimizedDir, e)}`)
+    }
+    return
+  }
+  await fs.rm(optimizedDir, { recursive: true, force: true })
+  await fs.mkdir(optimizedDir, { recursive: true })
+  console.log(`🗑️  Emptied and recreated ${optimizedDir}`)
+}
+
+async function uploadOriginal(args: {
+  filePath: string
+  storageName: string
+  baseUrl: string
+  token: string
+  dryRun: boolean
+}): Promise<{ id?: number; url?: string; documentId?: string } | null> {
+  const { filePath, storageName, baseUrl, token, dryRun } = args
+  const mimeType = mime.lookup(filePath) || 'application/octet-stream'
+
+  if (dryRun) {
+    console.log(`  [dry-run] would upload ${storageName} (${mimeType})`)
+    return null
+  }
+
+  const buffer = await fs.readFile(filePath)
+  const blob = new Blob([buffer], { type: mimeType })
+  const formData = new FormData()
+  formData.append('files', blob, storageName)
+  formData.append(
+    'fileInfo',
+    JSON.stringify({
+      name: storageName,
+      alternativeText: null,
+      caption: null
+    })
+  )
+
+  const res = await fetch(`${baseUrl}/api/upload`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'x-skip-mdx-export': 'true'
+    },
+    body: formData
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Upload failed (${res.status}): ${text}`)
+  }
+
+  const data: unknown = await res.json()
+  const row = Array.isArray(data)
+    ? (data as Record<string, unknown>[])[0]
+    : (data as { data?: Record<string, unknown>[] })?.data?.[0]
+
+  if (!row || typeof row !== 'object') return null
+  const id =
+    typeof row.id === 'number'
+      ? row.id
+      : typeof row.id === 'string'
+        ? parseInt(row.id, 10)
+        : undefined
+  const url = typeof row.url === 'string' ? row.url : undefined
+  const documentId =
+    typeof row.documentId === 'string' ? row.documentId : undefined
+
+  return {
+    id: Number.isFinite(id) ? id : undefined,
+    url,
+    documentId
+  }
+}
+
+async function main(): Promise<void> {
+  console.log('🖼️  sync:images — originals → Strapi → optimized')
+  console.log('='.repeat(50))
+
+  const dryRun = process.argv.includes('--dry-run')
+  const noWipe = process.argv.includes('--no-wipe')
+  const noReplace = process.argv.includes('--no-replace')
+  const force = process.argv.includes('--force')
+
+  const projectRoot = getProjectRoot()
+
+  if (!dryRun && !force) {
+    const branch = spawnSync('git', ['branch', '--show-current'], {
+      encoding: 'utf-8',
+      cwd: projectRoot
+    })
+    const currentBranch = branch.stdout?.trim()
+    const allowed = ['main', 'staging']
+    if (!allowed.includes(currentBranch || '')) {
+      console.error(
+        `❌ Refusing to run outside ${allowed.join('/')} (use --dry-run or --force)`
+      )
+      console.error(`   Current branch: ${currentBranch || '(unknown)'}`)
+      process.exit(1)
+    }
+  }
+
+  const envPath = path.join(projectRoot, '.env')
+  if (fsSync.existsSync(envPath)) {
+    dotenv.config({ path: envPath })
+  }
+
+  const STRAPI_URL = process.env.STRAPI_URL?.replace(/\/$/, '')
+  const STRAPI_TOKEN = process.env.STRAPI_API_TOKEN
+
+  if (!STRAPI_URL) {
+    console.error('❌ STRAPI_URL missing in .env')
+    process.exit(1)
+  }
+  if (!STRAPI_TOKEN) {
+    console.error('❌ STRAPI_API_TOKEN missing in .env')
+    process.exit(1)
+  }
+
+  const originalDir = path.join(
+    projectRoot,
+    'public',
+    'uploads',
+    'img',
+    'original'
+  )
+  const optimizedDir = path.join(
+    projectRoot,
+    'public',
+    'uploads',
+    'img',
+    'optimized'
+  )
+
+  const originals = await collectOriginalImages(originalDir)
+  if (originals.length === 0) {
+    console.log(`No images found under ${originalDir} (recursive)`)
+    process.exit(0)
+  }
+
+  console.log(`🔗 Strapi: ${STRAPI_URL}`)
+  console.log(`📂 ${originals.length} image(s) under original/ (recursive)`)
+  if (dryRun) console.log('🔍 DRY-RUN — no API calls that mutate data\n')
+
+  const strapi = createStrapiClient({
+    baseUrl: STRAPI_URL,
+    token: STRAPI_TOKEN
+  })
+
+  // 1) Remove existing Strapi rows that share the same media `name` (and their files)
+  if (!noReplace) {
+    for (const { relPosix } of originals) {
+      const storageName = storageNameFromRelativeImagePath(relPosix)
+      if (dryRun) {
+        const existing = await strapi.findUploadByName(storageName)
+        if (existing != null) {
+          console.log(
+            `  [dry-run] would delete Strapi upload id=${existing} (${storageName})`
+          )
+        }
+        continue
+      }
+      const existing = await strapi.findUploadByName(storageName)
+      if (existing != null) {
+        await strapi.deleteUploadFile(existing)
+        console.log(
+          `🗑️  Deleted existing Strapi media id=${existing} (${storageName})`
+        )
+      }
+    }
+  }
+
+  // 2) Wipe optimized folder on disk (orphans + clean slate)
+  if (!noWipe) {
+    await wipeOptimized(optimizedDir, dryRun)
+  } else {
+    console.log('⏭️  Skipped wiping optimized/ (--no-wipe)')
+  }
+
+  // 3) Upload each original (Strapi writes to img/optimized/ via custom provider)
+  let uploaded = 0
+  let failed = 0
+  for (const { abs, relPosix } of originals) {
+    const storageName = storageNameFromRelativeImagePath(relPosix)
+    try {
+      const result = await uploadOriginal({
+        filePath: abs,
+        storageName,
+        baseUrl: STRAPI_URL,
+        token: STRAPI_TOKEN,
+        dryRun
+      })
+      if (!dryRun && result) {
+        const idPart =
+          result.id != null
+            ? `id=${result.id}`
+            : result.documentId
+              ? `documentId=${result.documentId}`
+              : 'id=?'
+        console.log(
+          `✅ ${relPosix} (${storageName}) → ${idPart} url=${result.url ?? '?'}`
+        )
+      }
+      uploaded += 1
+    } catch (e) {
+      failed += 1
+      console.error(
+        `❌ ${relPosix}: ${e instanceof Error ? e.message : String(e)}`
+      )
+    }
+  }
+
+  console.log('='.repeat(50))
+  console.log(
+    dryRun
+      ? `Done (dry-run). ${originals.length} file(s) would be uploaded.`
+      : `Done. ${uploaded} ok, ${failed} failed.`
+  )
+  if (failed > 0) process.exit(1)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/cms/scripts/sync-images.ts
+++ b/cms/scripts/sync-images.ts
@@ -32,7 +32,10 @@ import { spawnSync } from 'child_process'
 import dotenv from 'dotenv'
 import mime from 'mime-types'
 import { getProjectRoot } from '@/utils/paths'
-import { storageNameFromRelativeImagePath } from '@/utils/imageLayoutPaths'
+import {
+  storageNameFromRelativeImagePath,
+  originalMasterUploadsRelFromStorageName
+} from '@/utils/imageLayoutPaths'
 import { createStrapiClient } from './sync-mdx/strapiClient'
 
 const IMAGE_EXT = new Set([
@@ -77,7 +80,29 @@ async function collectOriginalImages(
   }
 
   await walk(originalDir)
-  return out.sort((a, b) => a.relPosix.localeCompare(b.relPosix))
+  out.sort((a, b) => a.relPosix.localeCompare(b.relPosix))
+
+  // Deduplicate by canonical slug URL. Two files (e.g. a legacy subdir file and a
+  // flat copy created by the upload hook) may map to the same img/original/<slug>.ext
+  // target. Keep the flat root-level file when there's a collision — it's the
+  // canonical form. If no flat file exists, keep whichever was found first.
+  const seen = new Map<string, OriginalEntry>()
+  for (const entry of out) {
+    const storageName = storageNameFromRelativeImagePath(entry.relPosix)
+    const canonicalUrl = originalMasterUploadsRelFromStorageName(storageName)
+    const existing = seen.get(canonicalUrl)
+    if (!existing) {
+      seen.set(canonicalUrl, entry)
+    } else {
+      // Prefer the flat file (no `/` in relPosix) over a subdir file
+      const entryIsFlat = !entry.relPosix.includes('/')
+      if (entryIsFlat) {
+        seen.set(canonicalUrl, entry)
+      }
+      // else keep existing
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.relPosix.localeCompare(b.relPosix))
 }
 
 async function wipeOptimized(

--- a/cms/scripts/sync-mdx/strapiClient.ts
+++ b/cms/scripts/sync-mdx/strapiClient.ts
@@ -18,6 +18,8 @@ export interface StrapiClient {
   /** Update the alternativeText (alt text) on a Strapi upload file record. */
   updateUploadAlt: (id: number, alternativeText: string) => Promise<void>
   findUploadByName: (name: string) => Promise<number | null>
+  /** Remove a media library file by numeric id (also deletes files on disk via upload provider). */
+  deleteUploadFile: (id: number) => Promise<void>
   createLocalization: (
     apiId: string,
     documentId: string,
@@ -284,12 +286,29 @@ export function createStrapiClient({
   }
 
   async function findUploadByName(name: string) {
-    const result = await request(`upload/files?filters[name][$eq]=${name}`)
+    const result = await request(
+      `upload/files?filters[name][$eq]=${encodeURIComponent(name)}`
+    )
     const files = Array.isArray(result)
       ? (result as { id: number }[])
       : ((result as { data?: { id: number }[] })?.data ?? [])
 
     return files.length > 0 ? files[0].id : null
+  }
+
+  async function deleteUploadFile(id: number): Promise<void> {
+    const url = `${baseUrl}/api/upload/files/${id}`
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-skip-mdx-export': 'true'
+      }
+    })
+    if (!response.ok && response.status !== 404) {
+      const text = await response.text()
+      throw new Error(`Strapi API error (${response.status}): ${text}`)
+    }
   }
 
   async function deleteLocalization(
@@ -309,6 +328,7 @@ export function createStrapiClient({
     findUploadByUrl,
     updateUploadAlt,
     findUploadByName,
+    deleteUploadFile,
     createLocalization,
     updateLocalization,
     createEntry,

--- a/cms/scripts/sync-mdx/strapiClient.ts
+++ b/cms/scripts/sync-mdx/strapiClient.ts
@@ -18,6 +18,8 @@ export interface StrapiClient {
   /** Update the alternativeText (alt text) on a Strapi upload file record. */
   updateUploadAlt: (id: number, alternativeText: string) => Promise<void>
   findUploadByName: (name: string) => Promise<number | null>
+  /** All upload file ids whose `name` matches (pagination-safe; use for bulk delete before re-import). */
+  findUploadIdsByName: (name: string) => Promise<number[]>
   /** Remove a media library file by numeric id (also deletes files on disk via upload provider). */
   deleteUploadFile: (id: number) => Promise<void>
   createLocalization: (
@@ -54,6 +56,23 @@ export interface StrapiClient {
 interface StrapiClientOptions {
   baseUrl: string
   token: string
+}
+
+function parseUploadFilesList(result: unknown): { id: number }[] {
+  const rows: unknown[] = Array.isArray(result)
+    ? result
+    : result &&
+        typeof result === 'object' &&
+        'data' in result &&
+        Array.isArray((result as { data: unknown }).data)
+      ? ((result as { data: unknown[] }).data as unknown[])
+      : []
+  return rows.filter(
+    (r): r is { id: number } =>
+      r !== null &&
+      typeof r === 'object' &&
+      typeof (r as { id: unknown }).id === 'number'
+  )
 }
 
 export function createStrapiClient({
@@ -278,21 +297,45 @@ export function createStrapiClient({
     const result = await request(
       `upload/files?filters[url][$eq]=${encodeURIComponent(lookupUrl)}`
     )
-    // Strapi Upload API returns a plain array, not { data: [] }
-    const files = Array.isArray(result)
-      ? (result as { id: number }[])
-      : ((result as { data?: { id: number }[] })?.data ?? [])
+    const files = parseUploadFilesList(result)
     return files.length > 0 ? files[0].id : null
+  }
+
+  async function findUploadIdsByName(name: string): Promise<number[]> {
+    const encoded = encodeURIComponent(name)
+    const ids: number[] = []
+    let page = 1
+    const pageSize = 100
+    for (;;) {
+      const result = await request(
+        `upload/files?filters[name][$eq]=${encoded}&pagination[page]=${page}&pagination[pageSize]=${pageSize}`
+      )
+      const files = parseUploadFilesList(result)
+      for (const f of files) {
+        ids.push(f.id)
+      }
+      if (files.length === 0) break
+      const pagination = (
+        result as {
+          meta?: { pagination?: { page?: number; pageCount?: number } }
+        }
+      )?.meta?.pagination
+      const pageCount = pagination?.pageCount
+      if (pageCount != null) {
+        if (page >= pageCount) break
+      } else if (files.length < pageSize) {
+        break
+      }
+      page += 1
+    }
+    return ids
   }
 
   async function findUploadByName(name: string) {
     const result = await request(
-      `upload/files?filters[name][$eq]=${encodeURIComponent(name)}`
+      `upload/files?filters[name][$eq]=${encodeURIComponent(name)}&pagination[pageSize]=1`
     )
-    const files = Array.isArray(result)
-      ? (result as { id: number }[])
-      : ((result as { data?: { id: number }[] })?.data ?? [])
-
+    const files = parseUploadFilesList(result)
     return files.length > 0 ? files[0].id : null
   }
 
@@ -328,6 +371,7 @@ export function createStrapiClient({
     findUploadByUrl,
     updateUploadAlt,
     findUploadByName,
+    findUploadIdsByName,
     deleteUploadFile,
     createLocalization,
     updateLocalization,

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -2,6 +2,9 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { validateGitSyncRepoOnStartup } from './utils/gitSync'
 import { validateNoNestedJsx } from './utils/contentValidation'
+import { patchUploadServiceForOriginalImages } from './utils/uploadSplitImages'
+import { registerUploadFileStableUrlLifecycle } from './utils/uploadFileStableUrlLifecycle'
+import { sanitizeStrapiImageUploadResponseForCke } from './utils/ckeditorUploadResponseSanitizer'
 import { LOCALES } from './utils/mdx'
 
 function copySchemas() {
@@ -613,9 +616,22 @@ export default {
    *
    * This gives you an opportunity to extend code.
    */
-  register(/* { strapi } */) {
+  register({ strapi }: { strapi: { server: { use: (fn: unknown) => void } } }) {
     // Copy schema JSON files after TypeScript compilation
     copySchemas()
+
+    // CKEditor upload adapter builds srcset from formats[]; strip formats on this response
+    // when the main file uses img/original/ so the editor does not request fake original/thumbnail_* URLs.
+    strapi.server.use(
+      async (
+        ctx: { status?: number; body?: unknown },
+        next: () => Promise<void>
+      ) => {
+        await next()
+        if (ctx.status != null && ctx.status >= 400) return
+        sanitizeStrapiImageUploadResponseForCke(ctx.body)
+      }
+    )
   },
 
   /**
@@ -696,6 +712,11 @@ export default {
 
     // Ensure git sync points at a valid staging clone before handling content events
     await validateGitSyncRepoOnStartup()
+
+    // Save incoming image bytes to public/uploads/img/original/ (overwrite same slugged name)
+    patchUploadServiceForOriginalImages(strapi)
+    // Point media library `url` at original/ so MDX + sync:mdx stay stable (also covers replace)
+    registerUploadFileStableUrlLifecycle(strapi)
 
     // Ensure required locales (en, es) are installed
     await ensureLocales(strapi)

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -4,7 +4,10 @@ import { validateGitSyncRepoOnStartup } from './utils/gitSync'
 import { validateNoNestedJsx } from './utils/contentValidation'
 import { patchUploadServiceForOriginalImages } from './utils/uploadSplitImages'
 import { registerUploadFileStableUrlLifecycle } from './utils/uploadFileStableUrlLifecycle'
-import { sanitizeStrapiImageUploadResponseForCke } from './utils/ckeditorUploadResponseSanitizer'
+import {
+  sanitizeStrapiImageUploadResponseForCke,
+  deepNormalizeUploadsUrls
+} from './utils/ckeditorUploadResponseSanitizer'
 import { LOCALES } from './utils/mdx'
 
 function copySchemas() {
@@ -39,9 +42,15 @@ function copySchemas() {
 }
 
 // Strapi instance type for lifecycle functions
-interface StrapiDocumentService {
-  findMany: (options: Record<string, unknown>) => Promise<unknown[]>
-  create: (options: { data: Record<string, unknown> }) => Promise<unknown>
+interface StrapiEntityService {
+  findMany: (
+    uid: string,
+    options: Record<string, unknown>
+  ) => Promise<unknown[]>
+  create: (
+    uid: string,
+    options: { data: Record<string, unknown> }
+  ) => Promise<unknown>
 }
 
 interface StrapiLogger {
@@ -98,15 +107,19 @@ interface CmComponentsService {
 }
 
 interface StrapiInstance {
-  documents: (uid: string) => StrapiDocumentService
+  dirs: { static: { public: string } }
+  entityService: StrapiEntityService
   log: StrapiLogger
-  plugin: (name: string) =>
-    | {
-        service: (
-          name: string
-        ) => CmContentTypesService | CmComponentsService | undefined
-      }
-    | undefined
+  db: {
+    lifecycles: { subscribe: (sub: Record<string, unknown>) => void }
+    query: (uid: string) => {
+      update: (args: {
+        where: { id: number }
+        data: Record<string, unknown>
+      }) => Promise<unknown>
+    }
+  }
+  plugin: (name: string) => { service: (name: string) => unknown } | undefined
 }
 
 /**
@@ -122,12 +135,13 @@ async function ensureLocales(strapi: StrapiInstance) {
   for (const localeCode of LOCALES) {
     try {
       // Check if locale already exists
-      const existingLocales = await strapi
-        .documents('plugin::i18n.locale')
-        .findMany({
+      const existingLocales = await strapi.entityService.findMany(
+        'plugin::i18n.locale',
+        {
           filters: { code: localeCode },
           limit: 1
-        })
+        }
+      )
 
       if (existingLocales && existingLocales.length > 0) {
         strapi.log.debug(`✅ Locale ${localeCode} already exists`)
@@ -138,7 +152,7 @@ async function ensureLocales(strapi: StrapiInstance) {
       const displayName =
         localeConfigs[localeCode] ||
         `${localeCode.toUpperCase()} (${localeCode})`
-      await strapi.documents('plugin::i18n.locale').create({
+      await strapi.entityService.create('plugin::i18n.locale', {
         data: {
           code: localeCode,
           name: displayName
@@ -667,6 +681,7 @@ export default {
           (ctx.method === 'PUT' || ctx.method === 'POST') &&
           CONTENT_MANAGER_PATTERN.test(ctx.url ?? '')
         ) {
+          deepNormalizeUploadsUrls(ctx.request?.body)
           try {
             validateNoNestedJsx(ctx.request?.body?.content)
           } catch (err: unknown) {

--- a/cms/src/serializers/blocks/callout-text.serializer.test.ts
+++ b/cms/src/serializers/blocks/callout-text.serializer.test.ts
@@ -34,4 +34,14 @@ describe('callout-text serializer', () => {
     expect(result).toContain('Informacion importante.')
     expect(result).toContain('</CalloutText>')
   })
+
+  it('strips Strapi host from inline image URLs', () => {
+    const result = serialize({
+      content:
+        'See ![diagram](http://localhost:1337/uploads/img/original/diagram.png) above.'
+    })
+
+    expect(result).toContain('/uploads/img/original/diagram.png')
+    expect(result).not.toContain('http://localhost:1337')
+  })
 })

--- a/cms/src/serializers/blocks/callout-text.serializer.ts
+++ b/cms/src/serializers/blocks/callout-text.serializer.ts
@@ -1,15 +1,15 @@
 import isHtml from 'is-html'
-import { htmlToMarkdown } from '../../utils/mdx'
+import { htmlToMarkdown, normalizeUploadsUrls } from '../../utils/mdx'
 
 export function serialize(block: { content: string }): string {
   if (!block.content) return ''
 
-  const content = (
-    isHtml(block.content) ? htmlToMarkdown(block.content) : block.content
+  const content = normalizeUploadsUrls(
+    (isHtml(block.content) ? htmlToMarkdown(block.content) : block.content)
+      .trim()
+      .replace(/\{/g, '\\{')
+      .replace(/\}/g, '\\}')
   )
-    .trim()
-    .replace(/\{/g, '\\{')
-    .replace(/\}/g, '\\}')
 
   return `<CalloutText>\n${content}\n</CalloutText>`
 }

--- a/cms/src/serializers/blocks/paragraph.serializer.test.ts
+++ b/cms/src/serializers/blocks/paragraph.serializer.test.ts
@@ -28,8 +28,7 @@ describe('paragraph serializer', () => {
 
   it('strips https host from inline image URLs', () => {
     const result = serialize({
-      content:
-        '![img](https://cms.example.com/uploads/img/original/foo.png)'
+      content: '![img](https://cms.example.com/uploads/img/original/foo.png)'
     })
     expect(result).toContain('/uploads/img/original/foo.png')
     expect(result).not.toContain('https://cms.example.com')

--- a/cms/src/serializers/blocks/paragraph.serializer.test.ts
+++ b/cms/src/serializers/blocks/paragraph.serializer.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { serialize } from './paragraph.serializer'
+
+describe('paragraph serializer', () => {
+  it('serializes plain content', () => {
+    const result = serialize({ content: 'Hello world.' })
+    expect(result).toBe('<Paragraph>\n\nHello world.\n\n</Paragraph>')
+  })
+
+  it('adds alignment attribute when not left', () => {
+    const result = serialize({ content: 'Centered.', alignment: 'center' })
+    expect(result).toContain('alignment="center"')
+  })
+
+  it('omits alignment attribute for left alignment', () => {
+    const result = serialize({ content: 'Left.', alignment: 'left' })
+    expect(result).not.toContain('alignment=')
+  })
+
+  it('strips Strapi host from inline image URLs', () => {
+    const result = serialize({
+      content:
+        'See ![chart](http://localhost:1337/uploads/img/original/chart.png) here.'
+    })
+    expect(result).toContain('/uploads/img/original/chart.png')
+    expect(result).not.toContain('http://localhost:1337')
+  })
+
+  it('strips https host from inline image URLs', () => {
+    const result = serialize({
+      content:
+        '![img](https://cms.example.com/uploads/img/original/foo.png)'
+    })
+    expect(result).toContain('/uploads/img/original/foo.png')
+    expect(result).not.toContain('https://cms.example.com')
+  })
+})

--- a/cms/src/serializers/blocks/paragraph.serializer.ts
+++ b/cms/src/serializers/blocks/paragraph.serializer.ts
@@ -1,3 +1,5 @@
+import { normalizeUploadsUrls } from '../../utils/mdx'
+
 export function serialize(block: {
   content: string
   alignment?: string
@@ -6,5 +8,6 @@ export function serialize(block: {
     block.alignment && block.alignment !== 'left'
       ? ` alignment="${block.alignment}"`
       : ''
-  return `<Paragraph${alignmentAttr}>\n\n${block.content}\n\n</Paragraph>`
+  const content = normalizeUploadsUrls(block.content)
+  return `<Paragraph${alignmentAttr}>\n\n${content}\n\n</Paragraph>`
 }

--- a/cms/src/utils/ckeditorUploadResponseSanitizer.ts
+++ b/cms/src/utils/ckeditorUploadResponseSanitizer.ts
@@ -1,0 +1,38 @@
+/**
+ * CKEditor (@_sh/strapi-plugin-ckeditor) builds `srcset` from `formats[].width` + `formats[].url`
+ * on the upload XHR response. Our main `url` is under `img/original/` (masters) while
+ * Strapi derivatives normally live under `img/optimized/`. If `formats[].url` incorrectly
+ * points at `.../original/thumbnail_*` etc., the browser prefers `srcset` → 404 → broken
+ * in-editor preview until reload (saved HTML often has no `srcset`).
+ *
+ * When we detect that mismatch, drop `formats` from this **response body only** so the
+ * adapter sends CKEditor `{ default: mainUrl }` and preview uses `src`. Correct optimized
+ * `formats` (if ever present) are left intact.
+ */
+const DERIVATIVE_UNDER_ORIGINAL =
+  /\/img\/original\/(thumbnail|small|medium|large|xlarge)_/i
+
+export function sanitizeStrapiImageUploadResponseForCke(body: unknown): void {
+  if (!Array.isArray(body) || body.length === 0) return
+
+  for (const item of body) {
+    if (!item || typeof item !== 'object') continue
+    const file = item as Record<string, unknown>
+    const mime = typeof file.mime === 'string' ? file.mime : ''
+    const url = typeof file.url === 'string' ? file.url : ''
+    if (!mime.startsWith('image/')) continue
+    if (!url.includes('/img/original/')) continue
+    const formats = file.formats
+    if (!formats || typeof formats !== 'object') continue
+
+    const hasBadDerivativeUrl = Object.keys(formats as object).some((key) => {
+      const fmt = (formats as Record<string, { url?: string }>)[key]
+      const u = typeof fmt?.url === 'string' ? fmt.url : ''
+      return u.length > 0 && DERIVATIVE_UNDER_ORIGINAL.test(u)
+    })
+
+    if (hasBadDerivativeUrl) {
+      delete file.formats
+    }
+  }
+}

--- a/cms/src/utils/ckeditorUploadResponseSanitizer.ts
+++ b/cms/src/utils/ckeditorUploadResponseSanitizer.ts
@@ -1,3 +1,52 @@
+import path from 'path'
+import { originalMasterPublicUrlFromStorageName } from './imageLayoutPaths'
+
+/** Strip Strapi hash suffix from basename (same idea as upload lifecycle). */
+function cleanedStorageName(strapiName: string): string {
+  const ext = path.extname(strapiName) || '.bin'
+  const base = path.basename(strapiName, ext)
+  const cleanedBase = base.replace(/_[a-f0-9]{10}$/i, '')
+  return `${cleanedBase}${ext}`
+}
+
+/**
+ * Rewrite `/uploads/img/optimized/...` URLs in nested request bodies to stable
+ * `/uploads/img/original/...` so saved content matches media library URLs.
+ */
+export function deepNormalizeUploadsUrls(body: unknown): void {
+  if (body === null || body === undefined) return
+  if (typeof body === 'string') return
+  if (Array.isArray(body)) {
+    for (let i = 0; i < body.length; i++) {
+      const v = body[i]
+      if (typeof v === 'string') {
+        body[i] = normalizeOptimizedUrlsInString(v)
+      } else if (v && typeof v === 'object') {
+        deepNormalizeUploadsUrls(v)
+      }
+    }
+    return
+  }
+  if (typeof body === 'object') {
+    const o = body as Record<string, unknown>
+    for (const k of Object.keys(o)) {
+      const v = o[k]
+      if (typeof v === 'string') {
+        o[k] = normalizeOptimizedUrlsInString(v)
+      } else if (v && typeof v === 'object') {
+        deepNormalizeUploadsUrls(v)
+      }
+    }
+  }
+}
+
+function normalizeOptimizedUrlsInString(s: string): string {
+  const re = /\/uploads\/img\/optimized\/([^/?#'"\s<>]+)/g
+  return s.replace(re, (_match, filename: string) =>
+    originalMasterPublicUrlFromStorageName(cleanedStorageName(filename))
+  )
+}
+
 /**
  * CKEditor (@_sh/strapi-plugin-ckeditor) builds `srcset` from `formats[].width` + `formats[].url`
  * on the upload XHR response. Our main `url` is under `img/original/` (masters) while

--- a/cms/src/utils/ckeditorUploadResponseSanitizer.ts
+++ b/cms/src/utils/ckeditorUploadResponseSanitizer.ts
@@ -48,18 +48,54 @@ function normalizeOptimizedUrlsInString(s: string): string {
 }
 
 /**
- * CKEditor (@_sh/strapi-plugin-ckeditor) builds `srcset` from `formats[].width` + `formats[].url`
- * on the upload XHR response. Our main `url` is under `img/original/` (masters) while
- * Strapi derivatives normally live under `img/optimized/`. If `formats[].url` incorrectly
- * points at `.../original/thumbnail_*` etc., the browser prefers `srcset` → 404 → broken
- * in-editor preview until reload (saved HTML often has no `srcset`).
+ * Sanitizes Strapi upload API responses before they reach CKEditor.
  *
- * When we detect that mismatch, drop `formats` from this **response body only** so the
- * adapter sends CKEditor `{ default: mainUrl }` and preview uses `src`. Correct optimized
- * `formats` (if ever present) are left intact.
+ * 1. Strips the host from absolute `url` fields so CKEditor inserts root-relative
+ *    paths (`/uploads/...`) instead of `http://localhost:1337/uploads/...`. This
+ *    keeps the stored content portable across environments.
+ *
+ * 2. CKEditor builds `srcset` from `formats[].width` + `formats[].url`. Our main
+ *    `url` is under `img/original/` while derivatives live under `img/optimized/`.
+ *    If `formats[].url` incorrectly points at `.../original/thumbnail_*` etc., the
+ *    browser prefers `srcset` → 404 → broken in-editor preview. When that mismatch
+ *    is detected, drop `formats` so the adapter sends `{ default: mainUrl }` only.
  */
 const DERIVATIVE_UNDER_ORIGINAL =
   /\/img\/original\/(thumbnail|small|medium|large|xlarge)_/i
+
+function toRelativeUploadsUrl(url: string): string {
+  if (!url.startsWith('http')) return url
+  // Strip scheme + host, keep path from /uploads/ onward
+  return url.replace(/^https?:\/\/[^/]+(?=\/uploads\/)/, '')
+}
+
+/**
+ * Recursively walk a request body object and normalize any absolute Strapi
+ * upload URL found in a string value to a root-relative path.
+ *
+ * CKEditor constructs `http://localhost:1337/uploads/...` in the browser before
+ * the content is sent to the server. Normalizing on write ensures the DB always
+ * stores root-relative paths, regardless of which host the admin was accessed from.
+ */
+export function deepNormalizeUploadsUrls(obj: unknown): void {
+  if (!obj || typeof obj !== 'object') return
+  if (Array.isArray(obj)) {
+    for (const item of obj) deepNormalizeUploadsUrls(item)
+    return
+  }
+  const record = obj as Record<string, unknown>
+  for (const key of Object.keys(record)) {
+    const value = record[key]
+    if (typeof value === 'string') {
+      record[key] = value.replace(
+        /https?:\/\/[^/\s"']+\/uploads\//g,
+        '/uploads/'
+      )
+    } else {
+      deepNormalizeUploadsUrls(value)
+    }
+  }
+}
 
 export function sanitizeStrapiImageUploadResponseForCke(body: unknown): void {
   if (!Array.isArray(body) || body.length === 0) return
@@ -70,6 +106,11 @@ export function sanitizeStrapiImageUploadResponseForCke(body: unknown): void {
     const mime = typeof file.mime === 'string' ? file.mime : ''
     const url = typeof file.url === 'string' ? file.url : ''
     if (!mime.startsWith('image/')) continue
+    if (!url.includes('/uploads/')) continue
+
+    // Normalize main URL to root-relative
+    file.url = toRelativeUploadsUrl(url)
+
     if (!url.includes('/img/original/')) continue
     const formats = file.formats
     if (!formats || typeof formats !== 'object') continue

--- a/cms/src/utils/imageLayoutPaths.ts
+++ b/cms/src/utils/imageLayoutPaths.ts
@@ -15,7 +15,8 @@ function slugBase(filenameWithExt: string): string {
 export function storageNameFromRelativeImagePath(
   relativePosix: string
 ): string {
-  const basename = relativePosix.split('/').filter(Boolean).pop() ?? relativePosix
+  const basename =
+    relativePosix.split('/').filter(Boolean).pop() ?? relativePosix
   return basename
 }
 

--- a/cms/src/utils/imageLayoutPaths.ts
+++ b/cms/src/utils/imageLayoutPaths.ts
@@ -1,0 +1,48 @@
+/**
+ * All originals live flat under `img/original/<slug>.<ext>` — no subdirectories.
+ * Strapi multipart filenames are just the slugged basename; no path encoding needed.
+ */
+import path from 'path'
+import { strings as strapiStrings } from '@strapi/utils'
+
+function slugBase(filenameWithExt: string): string {
+  const ext = path.extname(filenameWithExt)
+  const base = path.basename(filenameWithExt, ext)
+  return strapiStrings.nameToSlug(base, { separator: '_', lowercase: false })
+}
+
+/** `a/b/x.jpg` → `x.jpg`; `x.jpg` → `x.jpg` (drop directory, just slugged basename) */
+export function storageNameFromRelativeImagePath(
+  relativePosix: string
+): string {
+  const basename = relativePosix.split('/').filter(Boolean).pop() ?? relativePosix
+  return basename
+}
+
+/** Posix path under `uploads/` (no leading slash): `img/original/<slug>.<ext>` */
+export function originalMasterUploadsRelFromStorageName(
+  storageOrStrapiName: string
+): string {
+  const fileWithExt = path.posix.basename(storageOrStrapiName)
+  const ext = path.extname(fileWithExt) || '.bin'
+  const slug = slugBase(fileWithExt)
+  return path.posix.join('img', 'original', `${slug}${ext}`)
+}
+
+/** `/uploads/img/original/<slug>.<ext>` */
+export function originalMasterPublicUrlFromStorageName(
+  storageOrStrapiName: string
+): string {
+  const rel = originalMasterUploadsRelFromStorageName(storageOrStrapiName)
+  return `/uploads/${rel}`
+}
+
+/** Posix path under `uploads/` for optimized main file: `img/optimized/<hash><ext>` */
+export function optimizedUploadsRelFromStorageName(
+  _storageOrStrapiName: string,
+  hash: string,
+  ext: string
+): string {
+  const dotExt = ext.startsWith('.') ? ext : `.${ext}`
+  return path.posix.join('img', 'optimized', `${hash}${dotExt}`)
+}

--- a/cms/src/utils/mdx.ts
+++ b/cms/src/utils/mdx.ts
@@ -98,6 +98,18 @@ export function htmlToMarkdown(html: string): string {
   return turndown.turndown(html.replace(/&nbsp;/gi, ' '))
 }
 
+/**
+ * Strip the Strapi host from any `/uploads/` URL in a content string.
+ *
+ * CKEditor (running inside the Strapi admin) inserts absolute image URLs like
+ * `http://localhost:1337/uploads/img/original/foo.png`. This normalizes them
+ * to root-relative paths (`/uploads/img/original/foo.png`) so the exported
+ * MDX works consistently across dev, staging, and production environments.
+ */
+export function normalizeUploadsUrls(content: string): string {
+  return content.replace(/https?:\/\/[^/\s"']+\/uploads\//g, '/uploads/')
+}
+
 // ── Text helpers ─────────────────────────────────────────────────────────────
 
 export function markdownToHtml(markdown: string): string {

--- a/cms/src/utils/mdx.ts
+++ b/cms/src/utils/mdx.ts
@@ -67,8 +67,10 @@ export function yamlSingleQuoteScalar(
 
 /**
  * Gets the resolved URL for a Strapi media field.
- * Pass `preferredFormat` to try a specific image format first (e.g. 'thumbnail'),
- * falling back to the original URL if that format is unavailable.
+ *
+ * For library images, `media.url` is the stable master path (`/uploads/img/original/...`).
+ * Pass `preferredFormat` only when you explicitly want a derivative under `img/optimized/`
+ * (e.g. admin previews); prefer the default for MDX export so sync/re-import keeps working.
  */
 export function getImageUrl(
   media: MediaLike | undefined | null,

--- a/cms/src/utils/uploadFileStableUrlLifecycle.ts
+++ b/cms/src/utils/uploadFileStableUrlLifecycle.ts
@@ -1,0 +1,82 @@
+/**
+ * Fallback: rewrite `url` if it still points at `img/optimized/` (e.g. legacy rows or edge cases).
+ * The upload provider sets `file.url` to `img/original/...` immediately after writing optimized
+ * bytes so CKEditor gets the correct URL in the first API response — this lifecycle is not
+ * sufficient on its own for inserts.
+ *
+ * Also covers **replace** flows that might persist an optimized URL before a follow-up read.
+ */
+import path from 'path'
+import { originalPublicUrlFromOriginalFilename } from './uploadSplitImages'
+
+const FILE_UID = 'plugin::upload.file' as const
+
+type UploadFileRow = {
+  id: number
+  name: string
+  mime?: string | null
+  url?: string | null
+}
+
+function shouldPointAtOriginalMaster(file: UploadFileRow): boolean {
+  if (
+    !file.mime?.startsWith('image/') ||
+    !file.url?.includes('/uploads/img/optimized/')
+  ) {
+    return false
+  }
+  // Thumbnails / breakpoints keep optimized URLs
+  if (/^(thumbnail|large|medium|small|xlarge)_/i.test(file.name || '')) {
+    return false
+  }
+  return true
+}
+
+/** Strip Strapi hash suffix from basename. */
+function cleanedStorageName(strapiName: string): string {
+  const ext = path.extname(strapiName) || '.bin'
+  const base = path.basename(strapiName, ext)
+  const cleanedBase = base.replace(/_[a-f0-9]{10}$/i, '')
+  return `${cleanedBase}${ext}`
+}
+
+export function registerUploadFileStableUrlLifecycle(strapi: {
+  db: {
+    lifecycles: { subscribe: (sub: Record<string, unknown>) => void }
+    query: (uid: string) => {
+      update: (args: {
+        where: { id: number }
+        data: Record<string, unknown>
+      }) => Promise<unknown>
+    }
+  }
+  log?: { warn: (msg: string) => void }
+}): void {
+  async function rewriteIfNeeded(result: UploadFileRow): Promise<void> {
+    if (!result?.id || !shouldPointAtOriginalMaster(result)) return
+    const url = originalPublicUrlFromOriginalFilename(
+      cleanedStorageName(result.name)
+    )
+    if (url === result.url) return
+    try {
+      await strapi.db.query(FILE_UID).update({
+        where: { id: result.id },
+        data: { url }
+      })
+    } catch (e) {
+      strapi.log?.warn(
+        `[upload] Could not set stable original URL for file id=${result.id}: ${e instanceof Error ? e.message : String(e)}`
+      )
+    }
+  }
+
+  strapi.db.lifecycles.subscribe({
+    models: [FILE_UID],
+    async afterCreate(event) {
+      await rewriteIfNeeded(event.result as UploadFileRow)
+    },
+    async afterUpdate(event) {
+      await rewriteIfNeeded(event.result as UploadFileRow)
+    }
+  })
+}

--- a/cms/src/utils/uploadFileStableUrlLifecycle.ts
+++ b/cms/src/utils/uploadFileStableUrlLifecycle.ts
@@ -5,9 +5,15 @@
  * sufficient on its own for inserts.
  *
  * Also covers **replace** flows that might persist an optimized URL before a follow-up read.
+ *
+ * On delete: removes the corresponding original from disk and schedules a git sync so that
+ * sync:images does not re-import it on the next run.
  */
+import fs from 'fs'
 import path from 'path'
 import { originalPublicUrlFromOriginalFilename } from './uploadSplitImages'
+import { originalMasterUploadsRelFromStorageName } from './imageLayoutPaths'
+import { scheduleGitSync } from './gitSync'
 
 const FILE_UID = 'plugin::upload.file' as const
 
@@ -18,18 +24,15 @@ type UploadFileRow = {
   url?: string | null
 }
 
+function isMainImage(file: UploadFileRow): boolean {
+  return (
+    !!file.mime?.startsWith('image/') &&
+    !/^(thumbnail|large|medium|small|xlarge)_/i.test(file.name || '')
+  )
+}
+
 function shouldPointAtOriginalMaster(file: UploadFileRow): boolean {
-  if (
-    !file.mime?.startsWith('image/') ||
-    !file.url?.includes('/uploads/img/optimized/')
-  ) {
-    return false
-  }
-  // Thumbnails / breakpoints keep optimized URLs
-  if (/^(thumbnail|large|medium|small|xlarge)_/i.test(file.name || '')) {
-    return false
-  }
-  return true
+  return isMainImage(file) && !!file.url?.includes('/uploads/img/optimized/')
 }
 
 /** Strip Strapi hash suffix from basename. */
@@ -41,6 +44,7 @@ function cleanedStorageName(strapiName: string): string {
 }
 
 export function registerUploadFileStableUrlLifecycle(strapi: {
+  dirs: { static: { public: string } }
   db: {
     lifecycles: { subscribe: (sub: Record<string, unknown>) => void }
     query: (uid: string) => {
@@ -70,6 +74,27 @@ export function registerUploadFileStableUrlLifecycle(strapi: {
     }
   }
 
+  function deleteOriginalIfExists(result: UploadFileRow): void {
+    if (!isMainImage(result)) return
+    const rel = originalMasterUploadsRelFromStorageName(
+      cleanedStorageName(result.name)
+    )
+    const filePath = path.join(
+      strapi.dirs.static.public,
+      'uploads',
+      ...rel.split('/').filter(Boolean)
+    )
+    if (!fs.existsSync(filePath)) return
+    try {
+      fs.unlinkSync(filePath)
+      scheduleGitSync(`media: delete ${result.name}`)
+    } catch (e) {
+      strapi.log?.warn(
+        `[upload] Could not delete original for ${result.name}: ${e instanceof Error ? e.message : String(e)}`
+      )
+    }
+  }
+
   strapi.db.lifecycles.subscribe({
     models: [FILE_UID],
     async afterCreate(event) {
@@ -77,6 +102,9 @@ export function registerUploadFileStableUrlLifecycle(strapi: {
     },
     async afterUpdate(event) {
       await rewriteIfNeeded(event.result as UploadFileRow)
+    },
+    afterDelete(event) {
+      deleteOriginalIfExists(event.result as UploadFileRow)
     }
   })
 }

--- a/cms/src/utils/uploadSplitImages.ts
+++ b/cms/src/utils/uploadSplitImages.ts
@@ -70,11 +70,7 @@ type UploadPayload = {
 
 type StrapiForUploadSplit = {
   dirs: { static: { public: string } }
-  plugin: (name: string) => {
-    service: (name: string) => {
-      upload: (payload: UploadPayload, opts?: unknown) => Promise<unknown>
-    }
-  }
+  plugin: (name: string) => { service: (name: string) => unknown }
 }
 
 export function patchUploadServiceForOriginalImages(

--- a/cms/src/utils/uploadSplitImages.ts
+++ b/cms/src/utils/uploadSplitImages.ts
@@ -1,0 +1,105 @@
+/**
+ * When an image is uploaded via Strapi, copy the **incoming** multipart file to
+ * public/uploads/img/original/ so git can track masters alongside optimized/ derivatives.
+ *
+ * Uses one filename per slugged basename (overwrite on re-upload — no _1, _2 suffixes).
+ */
+import fs from 'fs'
+import path from 'path'
+import { promisify } from 'util'
+import { originalMasterUploadsRelFromStorageName } from './imageLayoutPaths'
+
+const copyFile = promisify(fs.copyFile)
+const access = promisify(fs.access)
+
+function isImageMime(mimetype: string | undefined): boolean {
+  return typeof mimetype === 'string' && mimetype.startsWith('image/')
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, fs.constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Public `/uploads/...` URL for the git-tracked master file — same path as
+ * {@link copyIncomingImageOriginal} writes under `img/original/`.
+ */
+export function originalPublicUrlFromOriginalFilename(
+  originalFilename: string
+): string {
+  const rel = originalMasterUploadsRelFromStorageName(
+    originalFilename || 'image'
+  )
+  return `/uploads/${rel.replace(/\\/g, '/')}`
+}
+
+export async function copyIncomingImageOriginal(
+  strapi: { dirs: { static: { public: string } } },
+  incoming: {
+    filepath?: string
+    mimetype?: string
+    originalFilename?: string
+  }
+): Promise<void> {
+  if (!incoming.filepath || !isImageMime(incoming.mimetype)) return
+
+  const src = incoming.filepath
+  if (!(await pathExists(src))) return
+
+  const relUnderUploads = originalMasterUploadsRelFromStorageName(
+    incoming.originalFilename || 'image'
+  )
+  const dest = path.join(
+    strapi.dirs.static.public,
+    'uploads',
+    ...relUnderUploads.split('/').filter(Boolean)
+  )
+  await fs.promises.mkdir(path.dirname(dest), { recursive: true })
+
+  await copyFile(src, dest)
+}
+
+type UploadPayload = {
+  files: unknown
+}
+
+type StrapiForUploadSplit = {
+  dirs: { static: { public: string } }
+  plugin: (name: string) => {
+    service: (name: string) => {
+      upload: (payload: UploadPayload, opts?: unknown) => Promise<unknown>
+    }
+  }
+}
+
+export function patchUploadServiceForOriginalImages(
+  strapi: StrapiForUploadSplit
+): void {
+  const uploadService = strapi.plugin('upload').service('upload') as {
+    upload: (payload: UploadPayload, opts?: unknown) => Promise<unknown>
+  }
+  const originalUpload = uploadService.upload.bind(uploadService)
+
+  uploadService.upload = async (payload: UploadPayload, opts?: unknown) => {
+    const files = payload.files
+    const list = Array.isArray(files) ? files : [files]
+    for (const f of list) {
+      if (f && typeof f === 'object' && 'filepath' in f) {
+        await copyIncomingImageOriginal(
+          strapi,
+          f as {
+            filepath?: string
+            mimetype?: string
+            originalFilename?: string
+          }
+        )
+      }
+    }
+    return originalUpload(payload, opts)
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,5 +53,14 @@ export default defineConfig([
       '@typescript-eslint/no-require-imports': 'off'
     }
   },
+  {
+    files: ['cms/providers/strapi-upload-local-split/**/*.js'],
+    languageOptions: {
+      globals: { strapi: 'readonly' }
+    },
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off'
+    }
+  },
   eslintConfigPrettier
 ])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@ckeditor/strapi-plugin-ckeditor':
         specifier: ^1.1.1
         version: 1.1.2(@strapi/strapi@5.41.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(@emotion/is-prop-valid@1.4.0)(@swc/helpers@0.5.18)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@25.4.0)(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(codemirror@5.65.21)(esbuild@0.27.3)(koa@2.16.4)(lightningcss@1.31.1)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(type-fest@4.41.0))(ckeditor5@47.4.0)(react@18.3.1)
+      '@interledger/strapi-upload-local-split':
+        specifier: file:./providers/strapi-upload-local-split
+        version: file:cms/providers/strapi-upload-local-split
       '@notum-cz/strapi-plugin-record-locking':
         specifier: ^2.1.0
         version: 2.1.1(de708430221f0573ada5f739484fb3a3)
@@ -2037,6 +2040,9 @@ packages:
 
   '@interledger/docs-design-system@0.11.0':
     resolution: {integrity: sha512-gcHZEI7qnzu7O4e2DZiyQUfO+wkLQ7XB/y3igKB5Eow2+/kKTMUJFI2Y277Kw2imhqD5mBBtGFOOiahy6y0qkA==}
+
+  '@interledger/strapi-upload-local-split@file:cms/providers/strapi-upload-local-split':
+    resolution: {directory: cms/providers/strapi-upload-local-split, type: directory}
 
   '@internationalized/date@3.5.4':
     resolution: {integrity: sha512-qoVJVro+O0rBaw+8HPjUB1iH8Ihf8oziEnqMnvhJUSuVIrHOuZ6eNLHNvzXJKUvAtaDiqMnRlg8Z2mgh09BlUw==}
@@ -12117,8 +12123,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-table@47.4.0':
     dependencies:
@@ -13163,6 +13167,8 @@ snapshots:
   '@interledger/docs-design-system@0.11.0':
     dependencies:
       mermaid: 11.12.3
+
+  '@interledger/strapi-upload-local-split@file:cms/providers/strapi-upload-local-split': {}
 
   '@internationalized/date@3.5.4':
     dependencies:


### PR DESCRIPTION
## Summary

- **Recursive `sync:images`** under `public/uploads/img/original/`; nested paths are encoded as `__` in Strapi `name` (Strapi disallows `/` in multipart filenames).
- **Shared layout rules** (`imageLayoutPaths.ts` + `layout-paths.js`) for original vs optimized paths and subfolders.
- **Custom Strapi upload provider** (`strapi-upload-local-split`): main image `url` → `img/original/…`; derivatives → `img/optimized/…` (mirrored subdirs); **do not delete** `img/original/` when Strapi deletes an upload.
- **`uploadSplitImages`** copies masters into nested `original/…` using `originalMasterUploadsRelFromStorageName`.
- **`uploadFileStableUrlLifecycle`**: skip thumbnail/breakpoint rows; normalize `__` names / hash suffix.
- **CKEditor upload response**: `ckeditorUploadResponseSanitizer` + middleware in `cms/src/index.ts` strips `formats` when derivative URLs incorrectly sit under `img/original/` (fixes broken **srcset** / preview before reload).
- **ESLint**: override for `cms/providers/strapi-upload-local-split/**/*.js` (`strapi` global, allow `require`); removed unused code in provider and `uploadSplitImages.ts`.

## Related Issue

Fixes INTORG-497

## Manual Test

1. Run Strapi locally; upload an image in Media Library and confirm files land under `uploads/img/original/` (and optimized variants under `uploads/img/optimized/` as applicable).
2. In the rich text editor (CKEditor), insert/upload an image and confirm preview works immediately (no 404 on `srcset`).
3. Run `pnpm --filter cms run sync:images` (or your usual sync) against a tree with nested folders under `img/original/` and confirm Strapi receives expected entries.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable) — **N/A** (CMS/upload pipeline only; add screenshots if you document Media Library/CKEditor behavior)
