### PR TITLE
fix(cms): ensure uploads folder exists before Strapi registers

### DIFF
--- a/cms/config/server.ts
+++ b/cms/config/server.ts
@@ -1,16 +1,41 @@
+import fs from 'fs'
 import path from 'path'
 
-export default ({ env }) => ({
-  host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
-  // Point Strapi's public directory at the repo root's /public so uploads land in /public/uploads
-  dirs: {
-    public: env('STRAPI_PUBLIC_DIR', path.resolve(process.cwd(), '../public'))
-  },
-  app: {
-    keys: env.array('APP_KEYS')
-  },
-  webhooks: {
-    populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false)
+/**
+ * Local upload provider requires `public/uploads` to exist before the upload
+ * plugin registers (app `register` runs too late). Create it when this config loads.
+ */
+function ensureUploadsFolder(publicDir: string): void {
+  const uploadsDir = path.join(publicDir, 'uploads')
+  try {
+    if (!fs.existsSync(uploadsDir)) {
+      fs.mkdirSync(uploadsDir, { recursive: true })
+      console.log(`✅ Created Strapi upload folder: ${uploadsDir}`)
+    }
+  } catch (err) {
+    console.warn('[Strapi] Could not ensure upload folder exists:', err)
   }
-})
+}
+
+export default ({ env }) => {
+  const publicDir = env(
+    'STRAPI_PUBLIC_DIR',
+    path.resolve(process.cwd(), '../public')
+  )
+  ensureUploadsFolder(publicDir)
+
+  return {
+    host: env('HOST', '0.0.0.0'),
+    port: env.int('PORT', 1337),
+    // Point Strapi's public directory at the repo root's /public so uploads land in /public/uploads
+    dirs: {
+      public: publicDir
+    },
+    app: {
+      keys: env.array('APP_KEYS')
+    },
+    webhooks: {
+      populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Strapi's local upload provider expects `public/uploads` to exist before the upload plugin registers during startup. On fresh clones the folder doesn't exist, causing upload failures. This eagerly creates it in the server config so startup never fails.

## Related Issue

Fixes INTORG-531

## Manual Test

1. Delete `public/uploads/` if it exists
2. Start Strapi (`pnpm develop`)
3. Verify the folder is created and uploads work

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
