### PR TITLE
feat(parser): implement paragraph merging in parseMdxToBlocks

### DIFF
--- a/cms/scripts/sync-mdx/mdxBlockParser.test.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.test.ts
@@ -97,27 +97,126 @@ describe('parseMdxToBlocks', () => {
 
   // --- Markdown node fallback ---
 
-  it('converts markdown nodes to paragraph blocks', async () => {
+  it('merges consecutive markdown nodes into a single paragraph block', async () => {
     const blocks = await parseMdxToBlocks('## Hello\n\nSome text here.', ctx)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toEqual({
+      __component: 'blocks.paragraph',
+      content: '## Hello\n\nSome text here.'
+    })
+  })
+
+  it('merges thematic breaks with surrounding markdown', async () => {
+    const blocks = await parseMdxToBlocks('Hello\n\n---\n\nWorld', ctx)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].__component).toBe('blocks.paragraph')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Paragraph merging
+// ---------------------------------------------------------------------------
+
+describe('paragraph merging', () => {
+  const ctx = { locale: 'en' }
+
+  it('splits on JSX component: markdown before and after', async () => {
+    const mdx = [
+      'Intro paragraph.',
+      '',
+      '<Paragraph>Rich content.</Paragraph>',
+      '',
+      'Outro paragraph.'
+    ].join('\n')
+
+    const blocks = await parseMdxToBlocks(mdx, ctx)
+
+    expect(blocks).toHaveLength(3)
+    expect(blocks[0]).toEqual({
+      __component: 'blocks.paragraph',
+      content: 'Intro paragraph.'
+    })
+    expect(blocks[1]).toMatchObject({ __component: 'blocks.paragraph' })
+    expect((blocks[1] as { content: string }).content).toBe('Rich content.')
+    expect(blocks[2]).toEqual({
+      __component: 'blocks.paragraph',
+      content: 'Outro paragraph.'
+    })
+  })
+
+  it('merges heading + paragraph + list into one block', async () => {
+    const mdx = [
+      '## Section title',
+      '',
+      'A paragraph of text.',
+      '',
+      '- item one',
+      '- item two'
+    ].join('\n')
+
+    const blocks = await parseMdxToBlocks(mdx, ctx)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].__component).toBe('blocks.paragraph')
+    const content = (blocks[0] as { content: string }).content
+    expect(content).toContain('## Section title')
+    expect(content).toContain('A paragraph of text.')
+    expect(content).toContain('- item one')
+  })
+
+  it('handles markdown only at the end (trailing flush)', async () => {
+    const mdx = [
+      '<Paragraph>First block.</Paragraph>',
+      '',
+      'Trailing markdown.'
+    ].join('\n')
+
+    const blocks = await parseMdxToBlocks(mdx, ctx)
+
+    expect(blocks).toHaveLength(2)
+    expect(blocks[1]).toEqual({
+      __component: 'blocks.paragraph',
+      content: 'Trailing markdown.'
+    })
+  })
+
+  it('handles markdown only at the start (flush before JSX)', async () => {
+    const mdx = [
+      'Leading markdown.',
+      '',
+      '<Paragraph>Second block.</Paragraph>'
+    ].join('\n')
+
+    const blocks = await parseMdxToBlocks(mdx, ctx)
 
     expect(blocks).toHaveLength(2)
     expect(blocks[0]).toEqual({
       __component: 'blocks.paragraph',
-      content: '## Hello'
-    })
-    expect(blocks[1]).toEqual({
-      __component: 'blocks.paragraph',
-      content: 'Some text here.'
+      content: 'Leading markdown.'
     })
   })
 
-  it('skips whitespace-only markdown nodes', async () => {
-    // A thematic break (---) produces a node with no textual content,
-    // but it still has non-whitespace source so it should be kept
-    const blocks = await parseMdxToBlocks('Hello\n\n---\n\nWorld', ctx)
+  it('produces one block for a long post with no JSX', async () => {
+    const mdx = [
+      '# Title',
+      '',
+      'Paragraph one.',
+      '',
+      'Paragraph two.',
+      '',
+      '## Subtitle',
+      '',
+      '- list item',
+      '',
+      'Final paragraph.'
+    ].join('\n')
 
-    expect(blocks.length).toBeGreaterThanOrEqual(2)
-    expect(blocks.every((b) => b.__component === 'blocks.paragraph')).toBe(true)
+    const blocks = await parseMdxToBlocks(mdx, ctx)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].__component).toBe('blocks.paragraph')
   })
 })
 

--- a/cms/scripts/sync-mdx/mdxBlockParser.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.ts
@@ -174,6 +174,20 @@ export async function parseMdxToBlocks(
 
   const blocks: ParsedBlock[] = []
 
+  // Buffer for consecutive markdown nodes. Flushed as a single
+  // blocks.paragraph when a JSX component interrupts or EOF is reached.
+  // This prevents a post with 80 markdown nodes from producing 80 blocks.
+  const pendingMarkdown: string[] = []
+
+  function flushPending(): void {
+    if (pendingMarkdown.length === 0) return
+    const merged = pendingMarkdown.join('\n\n')
+    if (merged.trim()) {
+      blocks.push({ __component: 'blocks.paragraph' as const, content: merged })
+    }
+    pendingMarkdown.length = 0
+  }
+
   // Walk top-level AST nodes
   for (const node of tree.children) {
     // Check for JSX — either a top-level flow element (tags on separate
@@ -183,6 +197,9 @@ export async function parseMdxToBlocks(
       node.type === 'mdxJsxFlowElement' ? node : unwrapTextElement(node)
 
     if (jsxNode) {
+      // Flush accumulated markdown before handling the JSX component
+      flushPending()
+
       const componentName = jsxNode.name
 
       if (!componentName) {
@@ -239,8 +256,8 @@ export async function parseMdxToBlocks(
     }
 
     // Markdown nodes (paragraph, heading, thematic break, etc.) —
-    // extract source text and wrap as a paragraph block. Will be
-    // replaced by a dedicated Paragraph component handler.
+    // accumulate source text into the pending buffer. Will be flushed
+    // as a single blocks.paragraph when a JSX node or EOF interrupts.
     if (
       node.position &&
       node.position.start.offset != null &&
@@ -251,10 +268,13 @@ export async function parseMdxToBlocks(
         node.position.end.offset
       )
       if (raw.trim()) {
-        blocks.push({ __component: 'blocks.paragraph' as const, content: raw })
+        pendingMarkdown.push(raw)
       }
     }
   }
+
+  // Flush any trailing markdown after the last node
+  flushPending()
 
   return blocks
 }

--- a/cms/vitest.config.ts
+++ b/cms/vitest.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@site': path.resolve(__dirname, '../src')
+      '@site': path.resolve(__dirname, '../src'),
+      '@': path.resolve(__dirname, 'src')
     }
   }
 })


### PR DESCRIPTION
## Summary

Consecutive markdown nodes (paragraphs, headings, lists, tables) are now accumulated into a single `blocks.paragraph`, split only when a JSX component interrupts or EOF is reached. A blog post with 80 markdown nodes now produces 1 block instead of 80. without this, `serializeContent()` would wrap every node in a separate `<Paragraph>` component.

Also fixes a missing `@` path alias in `cms/vitest.config.ts` that was causing `mdxTransformer.test.ts` to fail.

## Related Issue

Fixes INTORG-514

## Manual Test

1. Run `pnpm --dir cms test:sync-mdx`
2. Verify merging: `## Hello\n\nSome text here.` produces 1 block, not 2
3. Verify splitting: markdown → `<Paragraph>JSX</Paragraph>` → markdown produces 3 blocks

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused 
- [ ] Screenshots for UI changes (if applicable)