### PR TITLE
feat(parser): register VideoEmbed handler in parseMdxToBlocks

### DIFF
--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -19,6 +19,7 @@ import './blockquoteHandler'
 import './calloutTextHandler'
 import './paragraphHandler'
 import './pdfEmbedHandler'
+import './videoEmbedHandler'
 import { createRelationResolver } from './ambassadorHandler'
 import { MdxParserError, ParserErrorCode } from './parserErrors'
 

--- a/cms/scripts/sync-mdx/types.blocks.ts
+++ b/cms/scripts/sync-mdx/types.blocks.ts
@@ -80,6 +80,13 @@ export interface PdfEmbedBlock extends StrapiBlockBase {
   analyticsEvent: string
 }
 
+/** blocks.video-embed — embedded YouTube or Vimeo video. */
+export interface VideoEmbedBlock extends StrapiBlockBase {
+  __component: 'blocks.video-embed'
+  url: string
+  title: string
+}
+
 // ---------------------------------------------------------------------------
 // Union
 // ---------------------------------------------------------------------------
@@ -92,3 +99,4 @@ export type ParsedBlock =
   | BlockquoteBlock
   | CalloutTextBlock
   | PdfEmbedBlock
+  | VideoEmbedBlock

--- a/cms/scripts/sync-mdx/videoEmbedHandler.test.ts
+++ b/cms/scripts/sync-mdx/videoEmbedHandler.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { parseMdxToBlocks } from './mdxBlockParser'
+import { ParserErrorCode } from './parserErrors'
+
+// Side-effect import: registers VideoEmbed handler
+import './videoEmbedHandler'
+
+const ctx = { locale: 'en' }
+
+// ---------------------------------------------------------------------------
+// Happy paths
+// ---------------------------------------------------------------------------
+
+describe('VideoEmbed handler', () => {
+  it('parses YouTube URL with title', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<VideoEmbed url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" title="Never Gonna Give You Up" />',
+      ctx
+    )
+
+    expect(blocks).toEqual([
+      {
+        __component: 'blocks.video-embed',
+        url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        title: 'Never Gonna Give You Up'
+      }
+    ])
+  })
+
+  it('parses Vimeo URL with title', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<VideoEmbed url="https://vimeo.com/123456789" title="Sample Video" />',
+      ctx
+    )
+
+    expect(blocks).toEqual([
+      {
+        __component: 'blocks.video-embed',
+        url: 'https://vimeo.com/123456789',
+        title: 'Sample Video'
+      }
+    ])
+  })
+
+  it('parses youtu.be short URL', async () => {
+    const blocks = await parseMdxToBlocks(
+      '<VideoEmbed url="https://youtu.be/N5BTy2xxRqQ" title="Short URL" />',
+      ctx
+    )
+
+    expect(blocks[0]).toMatchObject({
+      url: 'https://youtu.be/N5BTy2xxRqQ',
+      title: 'Short URL'
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe('VideoEmbed handler — errors', () => {
+  it('throws MISSING_REQUIRED_PROP when url is missing', async () => {
+    await expect(
+      parseMdxToBlocks('<VideoEmbed title="No URL" />', ctx)
+    ).rejects.toMatchObject({ code: ParserErrorCode.MISSING_REQUIRED_PROP })
+  })
+
+  it('throws MISSING_REQUIRED_PROP when title is missing', async () => {
+    await expect(
+      parseMdxToBlocks(
+        '<VideoEmbed url="https://www.youtube.com/watch?v=abc" />',
+        ctx
+      )
+    ).rejects.toMatchObject({ code: ParserErrorCode.MISSING_REQUIRED_PROP })
+  })
+
+  it('throws DYNAMIC_EXPRESSION when url is a dynamic expression', async () => {
+    await expect(
+      parseMdxToBlocks('<VideoEmbed url={someVar} title="Test" />', ctx)
+    ).rejects.toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
+  })
+
+  it('throws DYNAMIC_EXPRESSION when title is a dynamic expression', async () => {
+    await expect(
+      parseMdxToBlocks(
+        '<VideoEmbed url="https://youtube.com/watch?v=abc" title={someVar} />',
+        ctx
+      )
+    ).rejects.toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: mixed markdown + <VideoEmbed> ordering
+// ---------------------------------------------------------------------------
+
+describe('VideoEmbed handler — mixed content', () => {
+  it('preserves document order with surrounding markdown', async () => {
+    const mdx = [
+      'Watch the recording below:',
+      '',
+      '<VideoEmbed url="https://www.youtube.com/watch?v=ATO1d9PfD0g" title="Hackathon Recording" />',
+      '',
+      'More content after the video.'
+    ].join('\n')
+
+    const blocks = await parseMdxToBlocks(mdx, ctx)
+
+    expect(blocks).toHaveLength(3)
+    expect(blocks[0]).toMatchObject({ __component: 'blocks.paragraph' })
+    expect(blocks[1]).toEqual({
+      __component: 'blocks.video-embed',
+      url: 'https://www.youtube.com/watch?v=ATO1d9PfD0g',
+      title: 'Hackathon Recording'
+    })
+    expect(blocks[2]).toMatchObject({ __component: 'blocks.paragraph' })
+  })
+})

--- a/cms/scripts/sync-mdx/videoEmbedHandler.ts
+++ b/cms/scripts/sync-mdx/videoEmbedHandler.ts
@@ -1,0 +1,22 @@
+import type { ParsedBlock, VideoEmbedBlock } from './types.blocks'
+import { getStringAttr } from './jsxExtract'
+import { registerComponentHandler, type ParserContext } from './mdxBlockParser'
+import type { JsxBlockNode } from './mdxBlockParser'
+
+async function handleVideoEmbed(
+  node: JsxBlockNode,
+  _ctx: ParserContext
+): Promise<ParsedBlock[]> {
+  const url = getStringAttr(node, 'url', { required: true })
+  const title = getStringAttr(node, 'title', { required: true })
+
+  const block: VideoEmbedBlock = {
+    __component: 'blocks.video-embed',
+    url,
+    title
+  }
+
+  return [block]
+}
+
+registerComponentHandler('VideoEmbed', handleVideoEmbed)

--- a/cms/vitest.config.ts
+++ b/cms/vitest.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@site': path.resolve(__dirname, '../src')
+      '@site': path.resolve(__dirname, '../src'),
+      '@': path.resolve(__dirname, 'src')
     }
   }
 })


### PR DESCRIPTION
## Summary

Wire a `VideoEmbed` handler into the MDX block parser so `<VideoEmbed url="..." title="..." />` in MDX files maps to a `blocks.video-embed` Strapi payload during sync.

- Add `VideoEmbedBlock` interface to `types.blocks.ts` + `ParsedBlock` union
- Create `videoEmbedHandler.ts`, extracts `url` and `title` via `getStringAttr`, emits `blocks.video-embed`
- Register handler via side-effect import in `config.ts`

**Stacked on PR #148** (intorg-513: VideoEmbed component + Strapi schema)

## Related Issue

Fixes INTORG-516

## Manual Test

1. `pnpm --dir cms test:sync-mdx` 

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused 
- [ ] Screenshots for UI changes (if applicable)