### PR TITLE
content(blog): replace EMBEDDED VIDEO links with VideoEmbed components

### DIFF
--- a/src/content/foundation-blog-posts/2024-05-08-digital-financial-inclusion-igniting-sustainable-development-goals.mdx
+++ b/src/content/foundation-blog-posts/2024-05-08-digital-financial-inclusion-igniting-sustainable-development-goals.mdx
@@ -35,7 +35,10 @@ At the Interledger Foundation, our focus in advancing our mission is to support 
 
 If you have not done so already, tune into this conversation with ILF’s **Chief Program Officer**, [Chris Lawrence](https://community.interledger.org/chrislarry) on the **Fintech4Good Podcast** as he underscores the significance of open source in driving innovation and invites listeners to engage with the foundation's efforts to reimagine digital financial inclusion.
 
-[EMBEDDED VIDEO: Breaking Banks Europe Podcast: Episode 221: Fintech4Good: Digital Financial Inclusion](https://youtu.be/N5BTy2xxRqQ)
+<VideoEmbed
+  url="https://youtu.be/N5BTy2xxRqQ"
+  title="Breaking Banks Europe Podcast: Episode 221: Fintech4Good: Digital Financial Inclusion"
+/>
 
 As it seeks to establish a global payments network for inclusive digital financial service providers, the **ILF recently launched its Digital Financial Services grant** and is now accepting applications for emerging financial services, products, and innovative solutions geared toward benefitting underserved and underrepresented communities.
 

--- a/src/content/foundation-blog-posts/2024-06-21-harnessing-future-insights-global-technology-retreat-digital-trust-and-inclusion.mdx
+++ b/src/content/foundation-blog-posts/2024-06-21-harnessing-future-insights-global-technology-retreat-digital-trust-and-inclusion.mdx
@@ -21,7 +21,10 @@ Last month, I participated in the Global Technology Retreat (GTR24) hosted by th
 
 During this conference, I took my first-ever driverless autonomous car ride in San Francisco. It was both eerie and fascinating, like something straight out of a science fiction movie. It amazed me how seamlessly advanced technology is integrated, with a user-friendly experience up front, sophisticated systems operating quietly in the background, policy and regulation catching up with it, and people trusting their lives with it!
 
-[EMBEDDED VIDEO: Waymo driverless autonomous car in San Francisco, California.](https://www.youtube.com/shorts/eZdmPsWU28U?feature=share)
+<VideoEmbed
+  url="https://www.youtube.com/shorts/eZdmPsWU28U?feature=share"
+  title="Waymo driverless autonomous car in San Francisco, California."
+/>
 
 > “Any sufficiently advanced technology is indistinguishable from magic.” <br />
 > —Arthur C. Clarke.

--- a/src/content/foundation-blog-posts/2025-04-29-exploring-community-based-identification-systems.mdx
+++ b/src/content/foundation-blog-posts/2025-04-29-exploring-community-based-identification-systems.mdx
@@ -57,6 +57,12 @@ As de Asis sums up: "Financial services are not just about transactions or econo
 
 Watch these talks from the Summit 2024 to learn more:
 
-[EMBEDDED VIDEO: 07 financial inclusion for undocumented communities from strategies to practices](https://youtu.be/gLh3vyjmYqc)
+<VideoEmbed
+  url="https://youtu.be/gLh3vyjmYqc"
+  title="07 financial inclusion for undocumented communities from strategies to practices"
+/>
 
-[EMBEDDED VIDEO: Meet the UN IGF Dynamic Coalition on Digital Financial Inclusion](https://youtu.be/MV2YUu0J5To)
+<VideoEmbed
+  url="https://youtu.be/MV2YUu0J5To"
+  title="Meet the UN IGF Dynamic Coalition on Digital Financial Inclusion"
+/>

--- a/src/content/foundation-blog-posts/2025-09-05-why-higher-education-institutions-worldwide-should-embrace-hackathons-catalysts-academic.mdx
+++ b/src/content/foundation-blog-posts/2025-09-05-why-higher-education-institutions-worldwide-should-embrace-hackathons-catalysts-academic.mdx
@@ -69,4 +69,7 @@ Hackathons offer a space where learning meets legacy. By integrating these event
 
 The Interledger Foundation’s [Higher Education Grant](https://submit.interledger.org/submit/319057/interledger-nextgen-higher-education-2025-call-for-loi) is open to institutions worldwide. Apply now or contact the Foundation to learn more about how your university can support student-led innovation and participate in shaping the future of open, inclusive financial systems.
 
-[EMBEDDED VIDEO: Experience an Interledger Student Hackathon](https://www.youtube.com/watch?v=drZfYz7Eafc)
+<VideoEmbed
+  url="https://www.youtube.com/watch?v=drZfYz7Eafc"
+  title="Experience an Interledger Student Hackathon"
+/>

--- a/src/content/foundation-blog-posts/2025-09-11-interledger-hackathon-intro-open-payments-live-qa-ilf-experts.mdx
+++ b/src/content/foundation-blog-posts/2025-09-11-interledger-hackathon-intro-open-payments-live-qa-ilf-experts.mdx
@@ -16,7 +16,10 @@ tags:
 
 _If you missed our live session, don’t worry! Here is all the information you need for the hackathon. Watch the recording below:_
 
-[EMBEDDED VIDEO: Interledger Hackathon An Intro to Open Payments + Live Q&A with ILF Experts](https://www.youtube.com/watch?v=ATO1d9PfD0g)
+<VideoEmbed
+  url="https://www.youtube.com/watch?v=ATO1d9PfD0g"
+  title="Interledger Hackathon An Intro to Open Payments + Live Q&A with ILF Experts"
+/>
 
 ## General Info
 


### PR DESCRIPTION
## Summary

Replace 6 broken `[EMBEDDED VIDEO: ...](url)` markdown links across 5 blog posts with `<VideoEmbed url="..." title="..." />` JSX components. These were previously embedded videos that became plain text links during the site migration.

### Affected posts
- `digital-financial-inclusion-igniting-sustainable-development-goals` (1 video)
- `harnessing-future-insights-global-technology-retreat-digital-trust-and-inclusion` (1 video)
- `exploring-community-based-identification-systems` (2 videos)
- `why-higher-education-institutions-worldwide-should-embrace-hackathons` (1 video)
- `interledger-hackathon-intro-open-payments-live-qa-ilf-experts` (1 video)

## Related Issue

Fixes INTORG-517

## Manual Test

1. `pnpm dev`
2. Navigate to any of the 5 blog posts listed above
3. Verify the YouTube video renders with a thumbnail + play button (facade pattern) instead of a text link

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused 
- [ ] Screenshots for UI changes (if applicable)