### PR TITLE
feat: handle translations for summit data

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,18 @@ The following IDs are hardcoded in `src/utils/extractSessionize.ts`:
 
 When importing data for a new summit, verify that these IDs have not changed in the Sessionize export. If they have, update the constants in `extractSessionize.ts` accordingly.
 
+#### Adding Support for a New Language
+
+To add a new language to the Sessionize data pipeline:
+
+1. Add the locale code to `SESSIONIZE_SUPPORTED_LOCALES` in `src/types/summit.ts`:
+
+```typescript
+export const SESSIONIZE_SUPPORTED_LOCALES = ['es', 'fr'] as const
+```
+
+2. Update the utility functions in `src/utils/extractSessionize.ts` to extract the new language's fields from `questionAnswers`, following the same pattern used for Spanish. Each function should add a new key to the returned translations object (e.g. `fr: { title, description }`) alongside the existing `es: {}` entry. You will also need to add the corresponding Sessionize question IDs as constants (same as `SPANISH_TITLE_ID`, `SPANISH_DESC_ID`, etc.).
+
 ### Image Handling
 
 - Speaker images are downloaded locally during sync

--- a/src/components/shared/TranslationDisclaimer.astro
+++ b/src/components/shared/TranslationDisclaimer.astro
@@ -1,0 +1,7 @@
+---
+
+---
+
+<p class="p-space-xs italic text-step-0">
+  Esta página aún no está disponible en español
+</p>

--- a/src/components/shared/TranslationDisclaimer.astro
+++ b/src/components/shared/TranslationDisclaimer.astro
@@ -1,7 +1,0 @@
----
-
----
-
-<p class="p-space-xs italic text-step-0">
-  Esta página aún no está disponible en español
-</p>

--- a/src/components/summit/SessionCard.astro
+++ b/src/components/summit/SessionCard.astro
@@ -1,9 +1,10 @@
 ---
-import type { SessionizeSupportedLocale, TalkPreview } from '@/types/summit'
+import type { TalkPreview } from '@/types/summit'
 import { generateSlug } from '@/utils/slug'
 import { truncateText } from '@/utils/text'
 import SessionSubheader from './SessionSubheader.astro'
-import { defaultLocale, type Locale } from '@/utils/i18'
+import { type Locale } from '@/utils/i18'
+import { getTranslation } from '@/utils/summit-talks-speakers'
 
 interface Props {
   talkPreview: TalkPreview
@@ -13,10 +14,7 @@ interface Props {
 
 const { talkPreview, basePath, lang } = Astro.props
 const href = `${basePath}/${generateSlug(talkPreview.title)}`
-const needsTranslation = lang !== defaultLocale
-const translation = needsTranslation
-  ? talkPreview[lang as SessionizeSupportedLocale]
-  : null
+const translation = getTranslation(talkPreview, lang)
 const description = translation?.description ?? talkPreview.description
 const title = translation?.title ?? talkPreview.title
 ---

--- a/src/components/summit/SessionCard.astro
+++ b/src/components/summit/SessionCard.astro
@@ -3,14 +3,22 @@ import type { TalkPreview } from '@/types/summit'
 import { generateSlug } from '@/utils/slug'
 import { truncateText } from '@/utils/text'
 import SessionSubheader from './SessionSubheader.astro'
+import { defaultLocale, type Locale } from '@/utils/i18'
 
 interface Props {
   talkPreview: TalkPreview
   basePath: string
+  lang: Locale
 }
 
-const { talkPreview, basePath } = Astro.props
+const { talkPreview, basePath, lang } = Astro.props
 const href = `${basePath}/${generateSlug(talkPreview.title)}`
+const needsTranslation = lang !== defaultLocale
+const description =
+  (needsTranslation && talkPreview[lang]?.description) ||
+  talkPreview.description
+const title =
+  (needsTranslation && talkPreview[lang]?.title) || talkPreview.title
 ---
 
 <li class="flex flex-col gap-space-m mb-6 md:flex-row">
@@ -24,9 +32,13 @@ const href = `${basePath}/${generateSlug(talkPreview.title)}`
   />
   <div class="[&_p]:text-step--1">
     <h2 class="text-[var(--color-primary)]">
-      <a href={href}>{talkPreview.title}</a>
+      <a href={href}>{title}</a>
     </h2>
-    <SessionSubheader talk={talkPreview} showRecordingLabel={true} lang="en" />
-    {talkPreview.description && <p>{truncateText(talkPreview.description)}</p>}
+    <SessionSubheader
+      talk={talkPreview}
+      showRecordingLabel={true}
+      lang={lang}
+    />
+    {description && <p>{truncateText(description)}</p>}
   </div>
 </li>

--- a/src/components/summit/SessionCard.astro
+++ b/src/components/summit/SessionCard.astro
@@ -1,5 +1,5 @@
 ---
-import type { TalkPreview } from '@/types/summit'
+import type { SessionizeSupportedLocale, TalkPreview } from '@/types/summit'
 import { generateSlug } from '@/utils/slug'
 import { truncateText } from '@/utils/text'
 import SessionSubheader from './SessionSubheader.astro'
@@ -14,11 +14,11 @@ interface Props {
 const { talkPreview, basePath, lang } = Astro.props
 const href = `${basePath}/${generateSlug(talkPreview.title)}`
 const needsTranslation = lang !== defaultLocale
-const description =
-  (needsTranslation && talkPreview[lang]?.description) ||
-  talkPreview.description
-const title =
-  (needsTranslation && talkPreview[lang]?.title) || talkPreview.title
+const translation = needsTranslation
+  ? talkPreview[lang as SessionizeSupportedLocale]
+  : null
+const description = translation?.description ?? talkPreview.description
+const title = translation?.title ?? talkPreview.title
 ---
 
 <li class="flex flex-col gap-space-m mb-6 md:flex-row">

--- a/src/components/summit/SessionDetailPage.astro
+++ b/src/components/summit/SessionDetailPage.astro
@@ -5,7 +5,6 @@ import { currentSummitYear } from '@/utils/sessionize'
 import { getSpeakers } from '@/utils/extractSessionize'
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
 import Breadcrumbs from '@/components/shared/Breadcrumbs.astro'
-import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import SpeakersList from './SpeakersList.astro'
 import SessionSubheader from './SessionSubheader.astro'
 import TextParagraphs from './TextParagraphs.astro'
@@ -32,7 +31,6 @@ const needsTranslation = lang !== defaultLocale
 const translation = needsTranslation
   ? entry[lang as SessionizeSupportedLocale]
   : null
-const hasTranslation = !!(translation?.title || translation?.description)
 const title = translation?.title ?? entry.title
 const description = translation?.description ?? entry.description
 
@@ -52,7 +50,6 @@ const breadcrumbs = [
 
 <SummitPageLayout title={entry.title}>
   <main class="max-w-275 m-auto p-4">
-    {needsTranslation && !hasTranslation && <TranslationDisclaimer />}
     <Breadcrumbs breadcrumbs={breadcrumbs} />
     <article>
       <header class="mb-8">

--- a/src/components/summit/SessionDetailPage.astro
+++ b/src/components/summit/SessionDetailPage.astro
@@ -5,6 +5,7 @@ import { currentSummitYear } from '@/utils/sessionize'
 import { getSpeakers } from '@/utils/extractSessionize'
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
 import Breadcrumbs from '@/components/shared/Breadcrumbs.astro'
+import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import SpeakersList from './SpeakersList.astro'
 import SessionSubheader from './SessionSubheader.astro'
 import TextParagraphs from './TextParagraphs.astro'
@@ -28,6 +29,7 @@ const sessionsHref = `${baseHref}/${year}/talks`
 const speakersBasePath = `${baseHref}/${year}/speaker`
 
 const needsTranslation = lang !== defaultLocale
+const hasTranslation = !!(entry[lang]?.title || entry[lang]?.description)
 const title = (needsTranslation && entry[lang]?.title) || entry.title
 const description =
   (needsTranslation && entry[lang]?.description) || entry.description
@@ -48,6 +50,7 @@ const breadcrumbs = [
 
 <SummitPageLayout title={entry.title}>
   <main class="max-w-275 m-auto p-4">
+    {needsTranslation && !hasTranslation && <TranslationDisclaimer />}
     <Breadcrumbs breadcrumbs={breadcrumbs} />
     <article>
       <header class="mb-8">

--- a/src/components/summit/SessionDetailPage.astro
+++ b/src/components/summit/SessionDetailPage.astro
@@ -1,6 +1,7 @@
 ---
 import { defaultLocale } from '@/utils/i18'
-import type { SessionizeSupportedLocale, Talk } from '@/types/summit'
+import type { Talk } from '@/types/summit'
+import { getTranslation } from '@/utils/summit-talks-speakers'
 import { currentSummitYear } from '@/utils/sessionize'
 import { getSpeakers } from '@/utils/extractSessionize'
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
@@ -27,10 +28,7 @@ const summitHref = isCurrentYear ? baseHref : `${baseHref}/${year}`
 const sessionsHref = `${baseHref}/${year}/talks`
 const speakersBasePath = `${baseHref}/${year}/speaker`
 
-const needsTranslation = lang !== defaultLocale
-const translation = needsTranslation
-  ? entry[lang as SessionizeSupportedLocale]
-  : null
+const translation = getTranslation(entry, lang)
 const title = translation?.title ?? entry.title
 const description = translation?.description ?? entry.description
 

--- a/src/components/summit/SessionDetailPage.astro
+++ b/src/components/summit/SessionDetailPage.astro
@@ -1,6 +1,6 @@
 ---
 import { defaultLocale } from '@/utils/i18'
-import type { Talk } from '@/types/summit'
+import type { SessionizeSupportedLocale, Talk } from '@/types/summit'
 import { currentSummitYear } from '@/utils/sessionize'
 import { getSpeakers } from '@/utils/extractSessionize'
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
@@ -29,10 +29,12 @@ const sessionsHref = `${baseHref}/${year}/talks`
 const speakersBasePath = `${baseHref}/${year}/speaker`
 
 const needsTranslation = lang !== defaultLocale
-const hasTranslation = !!(entry[lang]?.title || entry[lang]?.description)
-const title = (needsTranslation && entry[lang]?.title) || entry.title
-const description =
-  (needsTranslation && entry[lang]?.description) || entry.description
+const translation = needsTranslation
+  ? entry[lang as SessionizeSupportedLocale]
+  : null
+const hasTranslation = !!(translation?.title || translation?.description)
+const title = translation?.title ?? entry.title
+const description = translation?.description ?? entry.description
 
 const breadcrumbs = [
   {

--- a/src/components/summit/SessionDetailPage.astro
+++ b/src/components/summit/SessionDetailPage.astro
@@ -1,5 +1,5 @@
 ---
-import { defaultLocale, type Locale } from '@/utils/i18'
+import { defaultLocale } from '@/utils/i18'
 import type { Talk } from '@/types/summit'
 import { currentSummitYear } from '@/utils/sessionize'
 import { getSpeakers } from '@/utils/extractSessionize'
@@ -13,24 +13,25 @@ import VideoEmbed from '../blocks/VideoEmbed.astro'
 interface Props {
   entry: Talk
   year: string
-  lang: Locale
 }
 
-const { entry, year, lang } = Astro.props
+const { routeLocale: lang, currentBasePath } = Astro.locals
+const { entry, year } = Astro.props
 const speakers = await getSpeakers(year, entry.id)
 
-const isCurrentYear = currentSummitYear === year
+// the path for current summit is /summit, instead of /summit/{year}
 const langPrefix = lang === defaultLocale ? '' : `/${lang}`
-const baseHref = `${langPrefix}/summit`
+const baseHref = `${langPrefix}${currentBasePath}`
+const isCurrentYear = currentSummitYear === year
 const summitHref = isCurrentYear ? baseHref : `${baseHref}/${year}`
 const sessionsHref = `${baseHref}/${year}/talks`
 const speakersBasePath = `${baseHref}/${year}/speaker`
 
-const title = lang == 'es' ? (entry.es?.title ?? entry.title) : entry.title
+const needsTranslation = lang !== defaultLocale
+const title = (needsTranslation && entry[lang]?.title) || entry.title
 const description =
-  lang == 'es'
-    ? (entry.es?.description ?? entry.description)
-    : entry.description
+  (needsTranslation && entry[lang]?.description) || entry.description
+
 const breadcrumbs = [
   {
     name: `${year} Summit`,

--- a/src/components/summit/SessionsList.astro
+++ b/src/components/summit/SessionsList.astro
@@ -1,5 +1,5 @@
 ---
-import { type Talk } from '@/types/summit'
+import { type Talk, type SessionizeSupportedLocale } from '@/types/summit'
 import { defaultLocale, type Locale } from '@/utils/i18'
 import { generateSlug } from '@/utils/slug'
 import { truncateText } from '@/utils/text'
@@ -13,10 +13,11 @@ const { sessions, sessionBaseHref, lang } = Astro.props
 const needsTranslation = lang !== defaultLocale
 
 const sessionsWithLinks = sessions.map((session) => {
-  const title: string =
-    (needsTranslation && session[lang]?.title) || session.title
-  const description: string =
-    (needsTranslation && session[lang]?.description) || session.description
+  const translation = needsTranslation
+    ? session[lang as SessionizeSupportedLocale]
+    : null
+  const title = translation?.title ?? session.title
+  const description = translation?.description ?? session.description
   return {
     ...session,
     title,

--- a/src/components/summit/SessionsList.astro
+++ b/src/components/summit/SessionsList.astro
@@ -1,17 +1,29 @@
 ---
 import { type Talk } from '@/types/summit'
+import { defaultLocale, type Locale } from '@/utils/i18'
 import { generateSlug } from '@/utils/slug'
 import { truncateText } from '@/utils/text'
 
 interface Props {
   sessions: Talk[]
   sessionBaseHref: string
+  lang: Locale
 }
-const { sessions, sessionBaseHref } = Astro.props
-const sessionsWithLinks = sessions.map((session) => ({
-  ...session,
-  href: `${sessionBaseHref}/${generateSlug(session.title)}`
-}))
+const { sessions, sessionBaseHref, lang } = Astro.props
+const needsTranslation = lang !== defaultLocale
+
+const sessionsWithLinks = sessions.map((session) => {
+  const title: string =
+    (needsTranslation && session[lang]?.title) || session.title
+  const description: string =
+    (needsTranslation && session[lang]?.description) || session.description
+  return {
+    ...session,
+    title,
+    description,
+    href: `${sessionBaseHref}/${generateSlug(session.title)}`
+  }
+})
 ---
 
 <ul>

--- a/src/components/summit/SessionsList.astro
+++ b/src/components/summit/SessionsList.astro
@@ -1,8 +1,9 @@
 ---
-import { type Talk, type SessionizeSupportedLocale } from '@/types/summit'
-import { defaultLocale, type Locale } from '@/utils/i18'
+import { type Talk } from '@/types/summit'
+import { type Locale } from '@/utils/i18'
 import { generateSlug } from '@/utils/slug'
 import { truncateText } from '@/utils/text'
+import { getTranslation } from '@/utils/summit-talks-speakers'
 
 interface Props {
   sessions: Talk[]
@@ -10,12 +11,9 @@ interface Props {
   lang: Locale
 }
 const { sessions, sessionBaseHref, lang } = Astro.props
-const needsTranslation = lang !== defaultLocale
 
 const sessionsWithLinks = sessions.map((session) => {
-  const translation = needsTranslation
-    ? session[lang as SessionizeSupportedLocale]
-    : null
+  const translation = getTranslation(session, lang)
   const title = translation?.title ?? session.title
   const description = translation?.description ?? session.description
   return {

--- a/src/components/summit/SessionsListPage.astro
+++ b/src/components/summit/SessionsListPage.astro
@@ -1,17 +1,19 @@
 ---
+import type { Page } from 'astro'
+import type { TalkPreview } from '@/types/summit'
+import stripPagination from '@/utils/stripPagination'
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
 import Pagination from '@/components/blog/Pagination.astro'
 import SessionCard from './SessionCard.astro'
-import type { TalkPreview } from '@/types/summit'
-import type { Page } from 'astro'
 
 interface Props {
   talkPreviews: TalkPreview[]
-  basePath: string
   title: string
   page: Page
 }
-const { talkPreviews, basePath, title, page } = Astro.props
+const { routeLocale: lang } = Astro.locals
+const { talkPreviews, title, page } = Astro.props
+const basePath = stripPagination(Astro.url.pathname)
 const sessionBasePath = basePath.replace(/\/talks\/?$/, '/talk')
 ---
 
@@ -23,7 +25,11 @@ const sessionBasePath = basePath.replace(/\/talks\/?$/, '/talk')
         talkPreviews.length > 0 ? (
           <ul class="flex flex-col gap-4">
             {talkPreviews.map((talk) => (
-              <SessionCard talkPreview={talk} basePath={sessionBasePath} />
+              <SessionCard
+                talkPreview={talk}
+                basePath={sessionBasePath}
+                lang={lang}
+              />
             ))}
           </ul>
         ) : (

--- a/src/components/summit/SessionsListPage.astro
+++ b/src/components/summit/SessionsListPage.astro
@@ -28,12 +28,9 @@ const label = `${year} Summit Talks`
           <ul class="flex flex-col gap-4">
             {talkPreviews.map((talk) => (
               <SessionCard
-               
                 talkPreview={talk}
-               
                 basePath={sessionBasePath}
                 lang={lang}
-             
                 year={year}
               />
             ))}

--- a/src/components/summit/SpeakerDetailPage.astro
+++ b/src/components/summit/SpeakerDetailPage.astro
@@ -1,7 +1,8 @@
 ---
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
 import { defaultLocale } from '@/utils/i18'
-import type { Speaker, SessionizeSupportedLocale } from '@/types/summit'
+import type { Speaker } from '@/types/summit'
+import { getTranslation } from '@/utils/summit-talks-speakers'
 import { getTalks } from '@/utils/extractSessionize'
 import TextParagraphs from './TextParagraphs.astro'
 import SessionsList from './SessionsList.astro'
@@ -16,10 +17,7 @@ const { routeLocale: lang } = Astro.locals
 const langPrefix = lang !== defaultLocale ? `/${lang}` : ''
 const sessionBaseHref = `${langPrefix}/summit/${year}/talk`
 const sessions = await getTalks(year, entry.id)
-const needsTranslation = lang !== defaultLocale
-const translation = needsTranslation
-  ? entry[lang as SessionizeSupportedLocale]
-  : null
+const translation = getTranslation(entry, lang)
 const bio = translation?.bio ?? entry.bio
 ---
 

--- a/src/components/summit/SpeakerDetailPage.astro
+++ b/src/components/summit/SpeakerDetailPage.astro
@@ -5,6 +5,7 @@ import type { Speaker } from '@/types/summit'
 import { getTalks } from '@/utils/extractSessionize'
 import TextParagraphs from './TextParagraphs.astro'
 import SessionsList from './SessionsList.astro'
+import TranslationDisclaimer from '../shared/TranslationDisclaimer.astro'
 
 interface Props {
   entry: Speaker
@@ -16,11 +17,13 @@ interface Props {
 const { entry, year, sessionBaseHref, lang } = Astro.props
 const sessions = await getTalks(year, entry.id)
 const needsTranslation = lang !== defaultLocale
-const bio = (needsTranslation && entry.es?.bio) || entry.bio
+const hasTranslation = !!entry[lang]?.bio
+const bio = (needsTranslation && entry[lang]?.bio) || entry.bio
 ---
 
 <SummitPageLayout title={entry.name}>
   <main>
+    {needsTranslation && !hasTranslation && <TranslationDisclaimer />}
     <header class="bg-black/20">
       <div class="max-w-250 m-auto flex justify-between mb-4 items-end">
         <div>

--- a/src/components/summit/SpeakerDetailPage.astro
+++ b/src/components/summit/SpeakerDetailPage.astro
@@ -5,7 +5,6 @@ import type { Speaker, SessionizeSupportedLocale } from '@/types/summit'
 import { getTalks } from '@/utils/extractSessionize'
 import TextParagraphs from './TextParagraphs.astro'
 import SessionsList from './SessionsList.astro'
-import TranslationDisclaimer from '../shared/TranslationDisclaimer.astro'
 
 interface Props {
   entry: Speaker
@@ -21,13 +20,11 @@ const needsTranslation = lang !== defaultLocale
 const translation = needsTranslation
   ? entry[lang as SessionizeSupportedLocale]
   : null
-const hasTranslation = !!translation?.bio
 const bio = translation?.bio ?? entry.bio
 ---
 
 <SummitPageLayout title={entry.name}>
   <main>
-    {needsTranslation && !hasTranslation && <TranslationDisclaimer />}
     <header class="bg-black/20">
       <div class="max-w-250 m-auto flex justify-between mb-4 items-end">
         <div>

--- a/src/components/summit/SpeakerDetailPage.astro
+++ b/src/components/summit/SpeakerDetailPage.astro
@@ -1,6 +1,6 @@
 ---
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
-import type { Locale } from '@/utils/i18'
+import { defaultLocale, type Locale } from '@/utils/i18'
 import type { Speaker } from '@/types/summit'
 import { getTalks } from '@/utils/extractSessionize'
 import TextParagraphs from './TextParagraphs.astro'
@@ -15,7 +15,8 @@ interface Props {
 
 const { entry, year, sessionBaseHref, lang } = Astro.props
 const sessions = await getTalks(year, entry.id)
-const bio = lang === 'es' && entry.es?.bio ? entry.es.bio : entry.bio
+const needsTranslation = lang !== defaultLocale
+const bio = (needsTranslation && entry.es?.bio) || entry.bio
 ---
 
 <SummitPageLayout title={entry.name}>
@@ -45,6 +46,7 @@ const bio = lang === 'es' && entry.es?.bio ? entry.es.bio : entry.bio
             <SessionsList
               sessions={sessions}
               sessionBaseHref={sessionBaseHref}
+              lang={lang}
             />
           </section>
         )

--- a/src/components/summit/SpeakerDetailPage.astro
+++ b/src/components/summit/SpeakerDetailPage.astro
@@ -13,9 +13,10 @@ interface Props {
 }
 
 const { entry, year } = Astro.props
-const { routeLocale: lang } = Astro.locals
-const langPrefix = lang !== defaultLocale ? `/${lang}` : ''
-const sessionBaseHref = `${langPrefix}/summit/${year}/talk`
+const { routeLocale: lang, currentBasePath } = Astro.locals
+const langPrefix = lang === defaultLocale ? '' : `/${lang}`
+const baseHref = `${langPrefix}${currentBasePath}`
+const sessionBaseHref = `${baseHref}/${year}/talk`
 const sessions = await getTalks(year, entry.id)
 const translation = getTranslation(entry, lang)
 const bio = translation?.bio ?? entry.bio

--- a/src/components/summit/SpeakerDetailPage.astro
+++ b/src/components/summit/SpeakerDetailPage.astro
@@ -1,7 +1,7 @@
 ---
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
-import { defaultLocale, type Locale } from '@/utils/i18'
-import type { Speaker } from '@/types/summit'
+import { defaultLocale } from '@/utils/i18'
+import type { Speaker, SessionizeSupportedLocale } from '@/types/summit'
 import { getTalks } from '@/utils/extractSessionize'
 import TextParagraphs from './TextParagraphs.astro'
 import SessionsList from './SessionsList.astro'
@@ -10,15 +10,19 @@ import TranslationDisclaimer from '../shared/TranslationDisclaimer.astro'
 interface Props {
   entry: Speaker
   year: string
-  sessionBaseHref: string
-  lang: Locale
 }
 
-const { entry, year, sessionBaseHref, lang } = Astro.props
+const { entry, year } = Astro.props
+const { routeLocale: lang } = Astro.locals
+const langPrefix = lang !== defaultLocale ? `/${lang}` : ''
+const sessionBaseHref = `${langPrefix}/summit/${year}/talk`
 const sessions = await getTalks(year, entry.id)
 const needsTranslation = lang !== defaultLocale
-const hasTranslation = !!entry[lang]?.bio
-const bio = (needsTranslation && entry[lang]?.bio) || entry.bio
+const translation = needsTranslation
+  ? entry[lang as SessionizeSupportedLocale]
+  : null
+const hasTranslation = !!translation?.bio
+const bio = translation?.bio ?? entry.bio
 ---
 
 <SummitPageLayout title={entry.name}>

--- a/src/pages/es/summit/[year]/speaker/[id].astro
+++ b/src/pages/es/summit/[year]/speaker/[id].astro
@@ -2,7 +2,6 @@
 import type { GetStaticPaths } from 'astro'
 import { getSpeakerPages } from '@/utils/summit-talks-speakers'
 import SpeakerDetailPage from '@/components/summit/SpeakerDetailPage.astro'
-import type { Locale } from '@/utils/i18'
 import type { Speaker } from '@/types/summit'
 
 interface Props {
@@ -14,7 +13,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
   return entries
 }
 
-const lang: Locale = 'es'
 const { year } = Astro.params
 const { entry } = Astro.props
 if (!year) {
@@ -23,12 +21,6 @@ if (!year) {
 if (!entry) {
   return Astro.redirect('/404')
 }
-const sessionBaseHref = `/${lang}/summit/${year}/talk`
 ---
 
-<SpeakerDetailPage
-  entry={entry}
-  year={year}
-  sessionBaseHref={sessionBaseHref}
-  lang={lang}
-/>
+<SpeakerDetailPage entry={entry} year={year} />

--- a/src/pages/es/summit/[year]/talk/[id].astro
+++ b/src/pages/es/summit/[year]/talk/[id].astro
@@ -8,7 +8,6 @@ interface Props {
   entry: Talk
 }
 
-const lang = 'es'
 export const getStaticPaths: GetStaticPaths = async () => {
   const entries = await getSessionPages()
   return entries
@@ -24,4 +23,4 @@ if (!entry) {
 }
 ---
 
-<SessionDetailPage entry={entry} year={year} lang={lang} />
+<SessionDetailPage entry={entry} year={year} />

--- a/src/pages/es/summit/[year]/talks/[...page].astro
+++ b/src/pages/es/summit/[year]/talks/[...page].astro
@@ -25,5 +25,9 @@ const talkPreviews: TalkPreview[] = page.data
 const title = `Sesiones de la Cumbre ${year}`
 ---
 
-<SessionsListPage talkPreviews={talkPreviews} title={title} page={page}   year={year}
+<SessionsListPage
+  talkPreviews={talkPreviews}
+  title={title}
+  page={page}
+  year={year}
 />

--- a/src/pages/es/summit/[year]/talks/[...page].astro
+++ b/src/pages/es/summit/[year]/talks/[...page].astro
@@ -2,7 +2,6 @@
 import type { Page, GetStaticPaths } from 'astro'
 import type { TalkPreview } from '@/types/summit'
 import { paginateSummitTalks } from '@/utils/summit-talks-speakers'
-import stripPagination from '@/utils/stripPagination'
 import SessionsListPage from '@/components/summit/SessionsListPage.astro'
 
 type Props = {
@@ -17,13 +16,7 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 const { year } = Astro.params
 const { page } = Astro.props
 const talkPreviews: TalkPreview[] = page.data
-const basePath = stripPagination(Astro.url.pathname)
 const title = `Sesiones de la Cumbre ${year}`
 ---
 
-<SessionsListPage
-  talkPreviews={talkPreviews}
-  basePath={basePath}
-  title={title}
-  page={page}
-/>
+<SessionsListPage talkPreviews={talkPreviews} title={title} page={page} />

--- a/src/pages/summit/[year]/speaker/[id].astro
+++ b/src/pages/summit/[year]/speaker/[id].astro
@@ -2,7 +2,6 @@
 import type { GetStaticPaths } from 'astro'
 import { getSpeakerPages } from '@/utils/summit-talks-speakers'
 import SpeakerDetailPage from '@/components/summit/SpeakerDetailPage.astro'
-import type { Locale } from '@/utils/i18'
 import type { Speaker } from '@/types/summit'
 
 interface Props {
@@ -14,7 +13,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
   return entries
 }
 
-const lang: Locale = 'en'
 const { year } = Astro.params
 const { entry } = Astro.props
 if (!year) {
@@ -23,13 +21,6 @@ if (!year) {
 if (!entry) {
   return Astro.redirect('/404')
 }
-
-const sessionBaseHref = `/summit/${year}/talk`
 ---
 
-<SpeakerDetailPage
-  entry={entry}
-  year={year}
-  sessionBaseHref={sessionBaseHref}
-  lang={lang}
-/>
+<SpeakerDetailPage entry={entry} year={year} />

--- a/src/pages/summit/[year]/talk/[id].astro
+++ b/src/pages/summit/[year]/talk/[id].astro
@@ -8,7 +8,6 @@ interface Props {
   entry: Talk
 }
 
-const lang = 'en'
 export const getStaticPaths: GetStaticPaths = async () => {
   const entries = await getSessionPages()
   return entries
@@ -24,4 +23,4 @@ if (!entry) {
 }
 ---
 
-<SessionDetailPage entry={entry} year={year} lang={lang} />
+<SessionDetailPage entry={entry} year={year} />

--- a/src/pages/summit/[year]/talks/[...page].astro
+++ b/src/pages/summit/[year]/talks/[...page].astro
@@ -2,7 +2,6 @@
 import type { Page, GetStaticPaths } from 'astro'
 import type { TalkPreview } from '@/types/summit'
 import { paginateSummitTalks } from '@/utils/summit-talks-speakers'
-import stripPagination from '@/utils/stripPagination'
 import SessionsListPage from '@/components/summit/SessionsListPage.astro'
 
 type Props = {
@@ -17,13 +16,7 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 const { year } = Astro.params
 const { page } = Astro.props
 const talkPreviews: TalkPreview[] = page.data
-const basePath = stripPagination(Astro.url.pathname)
 const title = `${year} Summit Sessions`
 ---
 
-<SessionsListPage
-  talkPreviews={talkPreviews}
-  basePath={basePath}
-  title={title}
-  page={page}
-/>
+<SessionsListPage talkPreviews={talkPreviews} title={title} page={page} />

--- a/src/pages/summit/[year]/talks/[...page].astro
+++ b/src/pages/summit/[year]/talks/[...page].astro
@@ -25,5 +25,9 @@ const talkPreviews: TalkPreview[] = page.data
 const title = `${year} Summit Sessions`
 ---
 
-<SessionsListPage talkPreviews={talkPreviews} title={title} page={page}   year={year}
+<SessionsListPage
+  talkPreviews={talkPreviews}
+  title={title}
+  page={page}
+  year={year}
 />

--- a/src/types/summit.ts
+++ b/src/types/summit.ts
@@ -1,3 +1,5 @@
+export type SessionizeSupportedLocale = 'es'
+
 export interface Talk {
   id: string
   title: string

--- a/src/types/summit.ts
+++ b/src/types/summit.ts
@@ -1,4 +1,7 @@
-export type SessionizeSupportedLocale = 'es'
+export const SESSIONIZE_SUPPORTED_LOCALES = ['es'] as const
+
+export type SessionizeSupportedLocale =
+  (typeof SESSIONIZE_SUPPORTED_LOCALES)[number]
 
 export interface Talk {
   id: string

--- a/src/utils/sessionize.ts
+++ b/src/utils/sessionize.ts
@@ -1,6 +1,3 @@
-export const YEARS = ['2022', '2023', '2024', '2025'].sort()
-export const currentSummitYear = YEARS.at(-1)
-
 export const sessionizeApiMap: Record<
   string,
   { speakersUrl: string; talksUrl: string }
@@ -22,3 +19,6 @@ export const sessionizeApiMap: Record<
     talksUrl: 'https://sessionize.com/api/v2/lbapz770/view/Sessions'
   }
 }
+
+export const YEARS = Object.keys(sessionizeApiMap).sort()
+export const currentSummitYear = YEARS.at(-1)

--- a/src/utils/summit-talks-speakers.ts
+++ b/src/utils/summit-talks-speakers.ts
@@ -2,6 +2,22 @@ import type { PaginateFunction } from 'astro'
 import { getSpeakers, getTalks, getTalkPreviews } from './extractSessionize'
 import { generateSlug } from './slug'
 import { YEARS } from './sessionize'
+import {
+  type SessionizeSupportedLocale,
+  SESSIONIZE_SUPPORTED_LOCALES
+} from '@/types/summit'
+
+function isSessionizeSupportedLocale(
+  lang: string
+): lang is SessionizeSupportedLocale {
+  return (SESSIONIZE_SUPPORTED_LOCALES as readonly string[]).includes(lang)
+}
+
+export function getTranslation<
+  T extends Record<SessionizeSupportedLocale, unknown>
+>(entry: T, lang: string): T[SessionizeSupportedLocale] | null {
+  return isSessionizeSupportedLocale(lang) ? entry[lang] : null
+}
 
 export async function paginateSummitTalks(paginate: PaginateFunction) {
   const paths = await Promise.all(

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,8 +1,13 @@
-export function formatDate(iso: string, lang = 'en') {
+import { defaultLocale, type Locale } from './i18'
+export function formatDate(iso: string, lang = defaultLocale) {
   const date = new Date(iso)
   if (isNaN(date.getTime())) return ''
 
-  const locale = lang === 'es' ? 'es-ES' : 'en-GB'
+  const localeMap: Record<Locale, string> = {
+    es: 'es-ES',
+    en: 'en-GB'
+  }
+  const locale = localeMap[lang] ?? localeMap[defaultLocale]
 
   let formatted = new Intl.DateTimeFormat(locale, {
     weekday: 'short',

--- a/src/utils/translationMap.ts
+++ b/src/utils/translationMap.ts
@@ -1,6 +1,9 @@
 import { getCollection } from 'astro:content'
 import { defaultLocale, switcherLocales, type Locale } from '@/utils/i18'
 import { ROUTE_BASES, type RouteCollection } from '@/utils/routes'
+import { YEARS } from './sessionize'
+import { getTalks, getSpeakers } from './extractSessionize'
+import { generateSlug } from './slug'
 
 export type TranslationEntry = Record<Locale, string>
 
@@ -45,5 +48,26 @@ export async function buildMap(): Promise<Record<string, TranslationEntry>> {
     }
   }
 
+  // Create map entries for sessionize pages, as they are not part of the
+  // content collections and need to be added manually
+  // The pages will have the same slug across all locales
+  for (const year of YEARS) {
+    map[`${year}/talks`] = createFallbackEntry(`${year}/talks`)
+    map[`${year}/speakers`] = createFallbackEntry(`${year}/speakers`)
+
+    const talks = await getTalks(year)
+    for (const talk of talks) {
+      const id = generateSlug(talk.title)
+      map[`${year}/talk/${id}`] = createFallbackEntry(`${year}/talk/${id}`)
+    }
+
+    const speakers = await getSpeakers(year)
+    for (const speaker of speakers) {
+      const id = generateSlug(speaker.name)
+      map[`${year}/speaker/${id}`] = createFallbackEntry(
+        `${year}/speaker/${id}`
+      )
+    }
+  }
   return map
 }


### PR DESCRIPTION
## Summary

This PR adds translation support for dynamic Sessionize content (talks and speakers).

- **Populate `translationMap` with Sessionize data** — ensures the `LanguageSwitcher` correctly navigates between `en` and `es` pages for all summit talks and speakers
- **Fallback to En** — when no Spanish content is found, the pages fall back to English content 
- **update README** with info on Adding support for a new language

## Related Issue
Handle translations for summit data - Fixes [INTORG-475](https://linear.app/interledger/issue/INTORG-475/handle-translations-for-summit-data)

## Manual Test
1. Navigate to `/summit/{year}/talks` and use the **Language Switcher** to toggle between `en` and `es`. Repeat for `/summit/{year}/speakers`.
2. Click into individual talk pages (`/summit/{year}/talk/{talk-title}`) and speaker pages (`/summit/{year}/speaker/{speaker-name}`) and toggle languages on each.
3. On individual `es` pages, verify one of the following:
   - Spanish content is displayed, **or**
   - A disclaimer is shown if no translated content is available for that page.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
