### PR TITLE
feat(analytics): add Umami event tracking to remaining components

### DIFF
--- a/src/components/blocks/CtaBanner.astro
+++ b/src/components/blocks/CtaBanner.astro
@@ -68,6 +68,7 @@ const secondaryButtonClasses = {
             <a
               href={primaryButtonLink}
               class={primaryButtonClasses[backgroundColor]}
+              data-umami-event={`CTA Banner - ${primaryButtonText}`}
             >
               {primaryButtonText}
             </a>
@@ -76,6 +77,7 @@ const secondaryButtonClasses = {
             <a
               href={secondaryButtonLink}
               class={secondaryButtonClasses[backgroundColor]}
+              data-umami-event={`CTA Banner - ${secondaryButtonText}`}
             >
               {secondaryButtonText}
             </a>

--- a/src/components/blocks/VideoEmbed.astro
+++ b/src/components/blocks/VideoEmbed.astro
@@ -22,7 +22,12 @@ const provider = detectVideoProvider(url)
       <Vimeo id={url} playlabel={title} />
     </div>
   ) : (
-    <a href={url} target="_blank" rel="noopener noreferrer">
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      data-umami-event={`Video link - ${title}`}
+    >
       {title}
     </a>
   )

--- a/src/components/blog/BlogIndexDevelopers.astro
+++ b/src/components/blog/BlogIndexDevelopers.astro
@@ -51,6 +51,7 @@ const {
                   <a
                     href={postPath}
                     class="text-black font-semibold underline decoration-transparent transition-all duration-300 hover:text-primary hover:decoration-inherit"
+                    data-umami-event={`Blog - ${blogPostEntry.data.date.toISOString().slice(0, 10)} (title)`}
                   >
                     {blogPostEntry.data.title}
                   </a>
@@ -67,6 +68,7 @@ const {
                 <a
                   href={postPath}
                   class="text-black font-semibold underline decoration-transparent transition-all duration-300 hover:text-primary hover:decoration-inherit"
+                  data-umami-event={`Blog - ${blogPostEntry.data.date.toISOString().slice(0, 10)} (title)`}
                 >
                   {blogPostEntry.data.title}
                 </a>

--- a/src/components/blog/BlogIndexFoundation.astro
+++ b/src/components/blog/BlogIndexFoundation.astro
@@ -55,6 +55,7 @@ const {
               <a
                 href={postPath}
                 class="text-black font-bold underline decoration-transparent transition-all duration-300 hover:underline hover:decoration-inherit"
+                data-umami-event={`Blog - ${blogPostEntry.data.date.toISOString().slice(0, 10)} (title)`}
               >
                 {blogPostEntry.data.title}
               </a>
@@ -72,7 +73,8 @@ const {
             </p>
             <a
               href={postPath}
-              class="group self-start flex gap-space-2xs text-step--1 underline decoration-transparent transition-all duration-300 hover:underline hover:text-inherit hover:decoration-inherit "
+              class="group self-start flex gap-space-2xs text-step--1 underline decoration-transparent transition-all duration-300 hover:underline hover:text-inherit hover:decoration-inherit"
+              data-umami-event={`Blog - ${blogPostEntry.data.date.toISOString().slice(0, 10)} (read more)`}
             >
               Read more
               <svg

--- a/src/components/blog/BlogIndexHeader.astro
+++ b/src/components/blog/BlogIndexHeader.astro
@@ -16,6 +16,7 @@ const { title, href, message, imgHref, imgAlt } = Astro.props
   <a
     class="group flex items-center gap-space-s rounded bg-white px-space-2xs py-space-3xs shadow text-step--1 no-underline"
     href={href}
+    data-umami-event={`Blog link - ${message}`}
   >
     <p
       class="underline decoration-transparent transition-[text-decoration-color] duration-300 group-hover:decoration-current"

--- a/src/components/blog/CommunityLinksDevelopers.astro
+++ b/src/components/blog/CommunityLinksDevelopers.astro
@@ -6,20 +6,22 @@
 
 <p class="italic">
   As we are open source, you can easily check our work on <a
-    href="https://github.com/interledger/">GitHub</a
+    href="https://github.com/interledger/"
+    data-umami-event="Blog Developers - GitHub">GitHub</a
   >. If the work mentioned here inspired you, we welcome your contributions. You
   can join our <a
     href="https://communityinviter.com/apps/interledger/interledger-working-groups-slack"
-    >community slack</a
+    data-umami-event="Blog Developers - Community Slack">community slack</a
   > or participate in the next <a
     href="https://docs.google.com/document/d/1T_Q_eRZtL8GluJR9rVADd7fvkB8mPluMk-d96LM4vlg/edit?usp=sharing"
-    >community call</a
+    data-umami-event="Blog Developers - Community Call">community call</a
   >, which takes place each second Wednesday of the month.
 </p>
 
 <p class="italic">
   If you want to stay updated with all open opportunities and news from the
   Interledger Foundation, you can subscribe to our <a
-    href="https://interledger.org/subscribe">newsletter</a
+    href="https://interledger.org/subscribe"
+    data-umami-event="Blog Developers - Newsletter">newsletter</a
   >.
 </p>

--- a/src/components/blog/CommunityLinksFoundation.astro
+++ b/src/components/blog/CommunityLinksFoundation.astro
@@ -7,12 +7,13 @@
 <p class="italic">
   If you want to stay updated with all open opportunities and news from the
   Interledger Foundation, you can subscribe to our <a
-    href="https://interledger.org/subscribe">newsletter</a
+    href="https://interledger.org/subscribe"
+    data-umami-event="Blog Foundation - Newsletter">newsletter</a
   >. We also welcome you to join our <a
     href="https://communityinviter.com/apps/interledger/interledger-working-groups-slack"
-    >community slack</a
+    data-umami-event="Blog Foundation - Community Slack">community slack</a
   > or participate in the next <a
     href="https://docs.google.com/document/d/1T_Q_eRZtL8GluJR9rVADd7fvkB8mPluMk-d96LM4vlg/edit?usp=sharing"
-    >community call</a
+    data-umami-event="Blog Foundation - Community Call">community call</a
   >, which takes place each second Wednesday of the month.
 </p>

--- a/src/components/blog/Pagination.astro
+++ b/src/components/blog/Pagination.astro
@@ -7,7 +7,11 @@ const paginationList = Array.from({ length }, (_, i) => i + 1)
 <nav aria-label="Blog pages" class="flex justify-center my-space-m">
   {
     firstUrl ? (
-      <a href={`${firstUrl}`} class="px-space-s py-space-xs">
+      <a
+        href={`${firstUrl}`}
+        class="px-space-s py-space-xs"
+        data-umami-event="Blog pagination - first"
+      >
         &#171;
       </a>
     ) : (
@@ -19,7 +23,11 @@ const paginationList = Array.from({ length }, (_, i) => i + 1)
 
   {
     prevUrl ? (
-      <a href={`${prevUrl}`} class="px-space-s py-space-xs">
+      <a
+        href={`${prevUrl}`}
+        class="px-space-s py-space-xs"
+        data-umami-event="Blog pagination - prev"
+      >
         &#8249;
       </a>
     ) : (
@@ -34,6 +42,7 @@ const paginationList = Array.from({ length }, (_, i) => i + 1)
       <a
         href={`${baseUrl}${num == 1 ? '' : '/' + num}`}
         class={`px-space-s py-space-xs ${currentPage == num ? 'text-primary-fallback pointer-events-none' : ''}`}
+        data-umami-event={`Blog pagination - ${num}`}
       >
         {num}
       </a>
@@ -46,7 +55,11 @@ const paginationList = Array.from({ length }, (_, i) => i + 1)
         &#8250;
       </span>
     ) : (
-      <a href={`${nextUrl}`} class="px-space-s py-space-xs">
+      <a
+        href={`${nextUrl}`}
+        class="px-space-s py-space-xs"
+        data-umami-event="Blog pagination - next"
+      >
         &#8250;
       </a>
     )
@@ -54,7 +67,11 @@ const paginationList = Array.from({ length }, (_, i) => i + 1)
 
   {
     lastUrl ? (
-      <a href={`${lastUrl}`} class="px-space-s py-space-xs">
+      <a
+        href={`${lastUrl}`}
+        class="px-space-s py-space-xs"
+        data-umami-event="Blog pagination - last"
+      >
         &#187;
       </a>
     ) : (

--- a/src/components/pages/Footer.astro
+++ b/src/components/pages/Footer.astro
@@ -7,7 +7,10 @@ const currentYear = new Date().getFullYear()
 >
   <ul class="list-none flex gap-6 justify-center p-0 mt-space-2xs xs:mt-0">
     <li>
-      <a href="https://interledger.social/@Interledger">
+      <a
+        href="https://interledger.social/@Interledger"
+        data-umami-event="Footer - Mastadon"
+      >
         <img
           src="/img/lander/icon-fediverse.svg"
           alt="Mastadon"
@@ -16,24 +19,31 @@ const currentYear = new Date().getFullYear()
       </a>
     </li>
     <li>
-      <a href="https://twitter.com/interledger">
+      <a href="https://twitter.com/interledger" data-umami-event="Footer - X">
         <img src="/img/lander/icon-twitter.svg" alt="Twitter" class="w-6 h-6" />
       </a>
     </li>
     <li>
       <a
         href="https://communityinviter.com/apps/interledger/interledger-working-groups-slack"
+        data-umami-event="Footer - Slack"
       >
         <img src="/img/lander/icon-slack.svg" alt="Slack" class="w-6 h-6" />
       </a>
     </li>
     <li>
-      <a href="https://github.com/interledger">
+      <a
+        href="https://github.com/interledger"
+        data-umami-event="Footer - GitHub"
+      >
         <img src="/img/lander/icon-github.svg" alt="Github" class="w-6 h-6" />
       </a>
     </li>
     <li>
-      <a href="https://www.linkedin.com/company/interledger-foundation/">
+      <a
+        href="https://www.linkedin.com/company/interledger-foundation/"
+        data-umami-event="Footer - LinkedIn"
+      >
         <img
           src="/img/lander/icon-linkedin.svg"
           alt="Linkedin"

--- a/src/components/pages/LanderHeader.astro
+++ b/src/components/pages/LanderHeader.astro
@@ -6,12 +6,17 @@ import DevelopersLogo from '../logos/DevelopersLogo.astro'
   <div
     class="flex justify-between items-center max-w-[95rem] mx-auto gap-space-s"
   >
-    <a href="/" class="flex items-center gap-space-xs flex-none">
+    <a
+      href="/"
+      class="flex items-center gap-space-xs flex-none"
+      data-umami-event="Devs Nav - Logo"
+    >
       <DevelopersLogo class="w-[7em] flex-none text-[var(--color-text)]" />
     </a>
     <a
       href="/"
       class="ml-auto inline-flex h-[1.5em] max-w-full flex-wrap overflow-hidden whitespace-nowrap text-step--1"
+      data-umami-event="Devs Nav - ILF"
     >
       <span
         class="block w-0 flex-auto overflow-hidden text-ellipsis text-right"
@@ -22,7 +27,11 @@ import DevelopersLogo from '../logos/DevelopersLogo.astro'
       </span>
       <span class="inline flex-[0_1_100%]"> Interledger Foundation </span>
     </a>
-    <a href="https://github.com/interledger" class="h-[1.25em] w-[1.25em]">
+    <a
+      href="https://github.com/interledger"
+      class="h-[1.25em] w-[1.25em]"
+      data-umami-event="Devs Nav - GitHub"
+    >
       <img
         src="/img/lander/icon-github.svg"
         alt="Interledger Github"


### PR DESCRIPTION
## Summary

- Add `data-umami-event` attributes to 8 components that were missing click tracking
- Event names follow the existing taxonomy from v4 and the production Umami dashboard
- Components tracked: CtaBanner, Lander Footer, LanderHeader, VideoEmbed fallback, BlogIndexFoundation, BlogIndexDevelopers, BlogIndexHeader, Pagination

## Related Issue

Closes INTORG-360

## Manual Test

1. Run `pnpm build` and confirm it succeeds
2. Open the Foundation blog listing page and inspect a post title link -- verify it has `data-umami-event="Blog - YYYY-MM-DD (title)"`
3. Open the Developers blog listing page and verify the same
4. Check the Lander footer social links have `data-umami-event="Footer - {Platform}"`
5. Check the Lander header logo has `data-umami-event="Devs Nav - Logo"`
6. On a page with a CtaBanner block, verify the CTA buttons have `data-umami-event="CTA Banner - {buttonText}"`

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable) -- no visual changes, attributes only