### PR TITLE
fix(cms): increase SEO meta description character limit

### DIFF
--- a/cms/src/components/shared/seo.json
+++ b/cms/src/components/shared/seo.json
@@ -19,7 +19,7 @@
     },
     "metaDescription": {
       "type": "text",
-      "maxLength": 160,
+      "maxLength": 300,
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/cms/types/generated/components.d.ts
+++ b/cms/types/generated/components.d.ts
@@ -692,7 +692,7 @@ export interface SharedSeo extends Struct.ComponentSchema {
         }
       }> &
       Schema.Attribute.SetMinMaxLength<{
-        maxLength: 160
+        maxLength: 300
       }>
     metaImage: Schema.Attribute.Media<'images'> &
       Schema.Attribute.SetPluginOptions<{


### PR DESCRIPTION
## Summary

The meta description `maxLength` in the shared SEO component was set to 160 characters, which was too restrictive for content editors. Bumped the limit to 300 characters to give editors more room while staying within commonly recommended SEO ranges.

Updated both the Strapi schema (`seo.json`) and the generated TypeScript types.

## Related Issue

Fixes INTORG-502

## Manual Test

1. Start Strapi locally
2. Open any content type with the SEO component
3. Confirm the meta description field now accepts up to 300 characters

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)