### PR TITLE
feat: add /.well-known/security.txt

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:tech@interledger.org
+Expires: 2026-09-25T18:24:02+08:00
+Preferred-Languages: en-gb


### PR DESCRIPTION
## Summary

Adds a `security.txt` file at `/.well-known/security.txt` per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) for responsible vulnerability disclosure. The file is served as a static asset from `public/.well-known/`.

Contents:
- **Contact:** tech@interledger.org
- **Expires:** 2026-09-25
- **Preferred-Languages:** en-gb

## Related Issue

Fixes INTORG-525

## Manual Test

1. Run `pnpm dev`
2. Visit `http://localhost:4321/.well-known/security.txt`
3. Confirm the file is served with the correct contents

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)