### PR TITLE
chore: add analytics for summit data pages

### DIFF
--- a/src/components/blog/DevelopersBlogListingPage.astro
+++ b/src/components/blog/DevelopersBlogListingPage.astro
@@ -3,7 +3,7 @@ import type { Page } from 'astro'
 import FoundationPageLayout from '@/layouts/FoundationPageLayout.astro'
 import Breadcrumbs from '@/components/shared/Breadcrumbs.astro'
 import BlogIndexDevelopers from '@/components/blog/BlogIndexDevelopers.astro'
-import Pagination from '@/components/blog/Pagination.astro'
+import Pagination from '@/components/shared/Pagination.astro'
 import stripPagination from '@/utils/stripPagination'
 
 interface Props {
@@ -72,6 +72,7 @@ if (selectedTag) {
         prevUrl={page.url.prev}
         nextUrl={page.url.next}
         lastUrl={page.url.last}
+        label={title}
       />
     </div>
   </main>

--- a/src/components/blog/FoundationBlogListingPage.astro
+++ b/src/components/blog/FoundationBlogListingPage.astro
@@ -2,7 +2,7 @@
 import type { Page } from 'astro'
 import FoundationPageLayout from '@/layouts/FoundationPageLayout.astro'
 import BlogIndexFoundation from '@/components/blog/BlogIndexFoundation.astro'
-import Pagination from '@/components/blog/Pagination.astro'
+import Pagination from '@/components/shared/Pagination.astro'
 import stripPagination from '@/utils/stripPagination'
 
 interface Props {
@@ -46,6 +46,7 @@ const developersBlogPath = blogPath.replace(/\/blog$/, '/developers/blog')
         prevUrl={page.url.prev}
         nextUrl={page.url.next}
         lastUrl={page.url.last}
+        label={title}
       />
     </div>
   </main>

--- a/src/components/shared/Pagination.astro
+++ b/src/components/shared/Pagination.astro
@@ -1,16 +1,24 @@
 ---
-const { baseUrl, length, currentPage, firstUrl, prevUrl, nextUrl, lastUrl } =
-  Astro.props
+const {
+  baseUrl,
+  length,
+  currentPage,
+  firstUrl,
+  prevUrl,
+  nextUrl,
+  lastUrl,
+  label
+} = Astro.props
 const paginationList = Array.from({ length }, (_, i) => i + 1)
 ---
 
-<nav aria-label="Blog pages" class="flex justify-center my-space-m">
+<nav aria-label={`${label} pages`} class="flex justify-center my-space-m">
   {
     firstUrl ? (
       <a
         href={`${firstUrl}`}
         class="px-space-s py-space-xs"
-        data-umami-event="Blog pagination - first"
+        data-umami-event={`${label} pagination - first`}
       >
         &#171;
       </a>
@@ -26,7 +34,7 @@ const paginationList = Array.from({ length }, (_, i) => i + 1)
       <a
         href={`${prevUrl}`}
         class="px-space-s py-space-xs"
-        data-umami-event="Blog pagination - prev"
+        data-umami-event={`${label} pagination - prev`}
       >
         &#8249;
       </a>
@@ -42,7 +50,7 @@ const paginationList = Array.from({ length }, (_, i) => i + 1)
       <a
         href={`${baseUrl}${num == 1 ? '' : '/' + num}`}
         class={`px-space-s py-space-xs ${currentPage == num ? 'text-primary-fallback pointer-events-none' : ''}`}
-        data-umami-event={`Blog pagination - ${num}`}
+        data-umami-event={`${label} pagination - ${num}`}
       >
         {num}
       </a>
@@ -58,7 +66,7 @@ const paginationList = Array.from({ length }, (_, i) => i + 1)
       <a
         href={`${nextUrl}`}
         class="px-space-s py-space-xs"
-        data-umami-event="Blog pagination - next"
+        data-umami-event={`${label} pagination - next`}
       >
         &#8250;
       </a>
@@ -70,7 +78,7 @@ const paginationList = Array.from({ length }, (_, i) => i + 1)
       <a
         href={`${lastUrl}`}
         class="px-space-s py-space-xs"
-        data-umami-event="Blog pagination - last"
+        data-umami-event={`${label} pagination - last`}
       >
         &#187;
       </a>

--- a/src/components/summit/SessionCard.astro
+++ b/src/components/summit/SessionCard.astro
@@ -7,9 +7,10 @@ import SessionSubheader from './SessionSubheader.astro'
 interface Props {
   talkPreview: TalkPreview
   basePath: string
+  year: string
 }
 
-const { talkPreview, basePath } = Astro.props
+const { talkPreview, basePath, year } = Astro.props
 const href = `${basePath}/${generateSlug(talkPreview.title)}`
 ---
 
@@ -24,7 +25,11 @@ const href = `${basePath}/${generateSlug(talkPreview.title)}`
   />
   <div class="[&_p]:text-step--1">
     <h2 class="text-[var(--color-primary)]">
-      <a href={href}>{talkPreview.title}</a>
+      <a
+        href={href}
+        data-umami-event={`${year} Summit Sessions - Session: ${talkPreview.title}`}
+        >{talkPreview.title}</a
+      >
     </h2>
     <SessionSubheader talk={talkPreview} showRecordingLabel={true} lang="en" />
     {talkPreview.description && <p>{truncateText(talkPreview.description)}</p>}

--- a/src/components/summit/SessionDetailPage.astro
+++ b/src/components/summit/SessionDetailPage.astro
@@ -69,6 +69,7 @@ const breadcrumbs = [
             speakers={speakers}
             basePath={speakersBasePath}
             extraClass="flex-col"
+            year={year}
           />
         </aside>
       </div>

--- a/src/components/summit/SessionsList.astro
+++ b/src/components/summit/SessionsList.astro
@@ -6,8 +6,9 @@ import { truncateText } from '@/utils/text'
 interface Props {
   sessions: Talk[]
   sessionBaseHref: string
+  year: string
 }
-const { sessions, sessionBaseHref } = Astro.props
+const { sessions, sessionBaseHref, year } = Astro.props
 const sessionsWithLinks = sessions.map((session) => ({
   ...session,
   href: `${sessionBaseHref}/${generateSlug(session.title)}`
@@ -20,7 +21,12 @@ const sessionsWithLinks = sessions.map((session) => ({
       <li>
         <article>
           <h2 class="text-teal-300">
-            <a href={session.href}>{session.title}</a>
+            <a
+              href={session.href}
+              data-umami-event={`${year} Speaker page - Session: ${session.title}`}
+            >
+              {session.title}
+            </a>
           </h2>
           {session.description && <p>{truncateText(session.description)}</p>}
         </article>

--- a/src/components/summit/SessionsListPage.astro
+++ b/src/components/summit/SessionsListPage.astro
@@ -1,6 +1,6 @@
 ---
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
-import Pagination from '@/components/blog/Pagination.astro'
+import Pagination from '@/components/shared/Pagination.astro'
 import SessionCard from './SessionCard.astro'
 import type { TalkPreview } from '@/types/summit'
 import type { Page } from 'astro'
@@ -14,6 +14,7 @@ interface Props {
 }
 const { talkPreviews, basePath, title, page, year } = Astro.props
 const sessionBasePath = basePath.replace(/\/talks\/?$/, '/talk')
+const label = `${year} Summit Talks`
 ---
 
 <SummitPageLayout title={title}>
@@ -47,6 +48,7 @@ const sessionBasePath = basePath.replace(/\/talks\/?$/, '/talk')
           prevUrl={page.url.prev}
           nextUrl={page.url.next}
           lastUrl={page.url.last}
+          label={label}
         />
       )
     }

--- a/src/components/summit/SessionsListPage.astro
+++ b/src/components/summit/SessionsListPage.astro
@@ -10,8 +10,9 @@ interface Props {
   basePath: string
   title: string
   page: Page
+  year: string
 }
-const { talkPreviews, basePath, title, page } = Astro.props
+const { talkPreviews, basePath, title, page, year } = Astro.props
 const sessionBasePath = basePath.replace(/\/talks\/?$/, '/talk')
 ---
 
@@ -23,7 +24,11 @@ const sessionBasePath = basePath.replace(/\/talks\/?$/, '/talk')
         talkPreviews.length > 0 ? (
           <ul class="flex flex-col gap-4">
             {talkPreviews.map((talk) => (
-              <SessionCard talkPreview={talk} basePath={sessionBasePath} />
+              <SessionCard
+                talkPreview={talk}
+                basePath={sessionBasePath}
+                year={year}
+              />
             ))}
           </ul>
         ) : (

--- a/src/components/summit/SpeakerCard.astro
+++ b/src/components/summit/SpeakerCard.astro
@@ -5,14 +5,18 @@ import { generateSlug } from '@/utils/slug'
 interface Props {
   speaker: Speaker
   basePath: string
+  year: string
 }
 
-const { speaker, basePath } = Astro.props
+const { speaker, basePath, year } = Astro.props
 const href = `${basePath}/${generateSlug(speaker.name)}`
 ---
 
 <li class="flex-1 min-w-[8em]">
-  <a href={href}>
+  <a
+    href={href}
+    data-umami-event={`${year} Speaker Card - Speaker: ${speaker.name}`}
+  >
     <img
       src={speaker.profilePicture}
       alt={speaker.name}

--- a/src/components/summit/SpeakerDetailPage.astro
+++ b/src/components/summit/SpeakerDetailPage.astro
@@ -45,6 +45,7 @@ const bio = lang === 'es' && entry.es?.bio ? entry.es.bio : entry.bio
             <SessionsList
               sessions={sessions}
               sessionBaseHref={sessionBaseHref}
+              year={year}
             />
           </section>
         )

--- a/src/components/summit/SpeakersList.astro
+++ b/src/components/summit/SpeakersList.astro
@@ -5,10 +5,11 @@ import SpeakerCard from './SpeakerCard.astro'
 interface Props {
   speakers: Speaker[]
   basePath: string
+  year: string
   extraClass?: string
 }
 
-const { speakers, basePath, extraClass } = Astro.props
+const { speakers, basePath, year, extraClass } = Astro.props
 const listClass = `flex flex-wrap gap-space-s ${extraClass ?? ''}`.trim()
 ---
 
@@ -16,7 +17,7 @@ const listClass = `flex flex-wrap gap-space-s ${extraClass ?? ''}`.trim()
   speakers.length > 0 ? (
     <ul class={listClass}>
       {speakers.map((speaker) => (
-        <SpeakerCard speaker={speaker} basePath={basePath} />
+        <SpeakerCard speaker={speaker} basePath={basePath} year={year} />
       ))}
     </ul>
   ) : (

--- a/src/components/summit/SpeakersListPage.astro
+++ b/src/components/summit/SpeakersListPage.astro
@@ -10,9 +10,10 @@ interface Props {
   basePath: string
   title: string
   page: Page
+  year: string
 }
 
-const { speakers, basePath, title, page } = Astro.props
+const { speakers, basePath, title, page, year } = Astro.props
 const speakerBasePath = basePath.replace(/\/speakers\/?$/, '/speaker')
 ---
 
@@ -20,7 +21,11 @@ const speakerBasePath = basePath.replace(/\/speakers\/?$/, '/speaker')
   <main class="p-4 max-w-275 m-auto">
     <h1>{title}</h1>
     <section aria-label="Speakers">
-      <SpeakersList speakers={speakers} basePath={speakerBasePath} />
+      <SpeakersList
+        speakers={speakers}
+        basePath={speakerBasePath}
+        year={year}
+      />
     </section>
 
     {

--- a/src/components/summit/SpeakersListPage.astro
+++ b/src/components/summit/SpeakersListPage.astro
@@ -1,7 +1,7 @@
 ---
 import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
 import SpeakersList from './SpeakersList.astro'
-import Pagination from '@/components/blog/Pagination.astro'
+import Pagination from '@/components/shared/Pagination.astro'
 import type { Page } from 'astro'
 import type { Speaker } from '@/types/summit'
 
@@ -15,6 +15,7 @@ interface Props {
 
 const { speakers, basePath, title, page, year } = Astro.props
 const speakerBasePath = basePath.replace(/\/speakers\/?$/, '/speaker')
+const label = `${year} Summit Speakers`
 ---
 
 <SummitPageLayout title={title}>
@@ -38,6 +39,7 @@ const speakerBasePath = basePath.replace(/\/speakers\/?$/, '/speaker')
           prevUrl={page.url.prev}
           nextUrl={page.url.next}
           lastUrl={page.url.last}
+          label={label}
         />
       )
     }

--- a/src/pages/es/summit/[year]/speakers/[...page].astro
+++ b/src/pages/es/summit/[year]/speakers/[...page].astro
@@ -16,6 +16,12 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { year } = Astro.params
 const { page } = Astro.props
+if (!year) {
+  throw new Error('Year param is required')
+}
+if (!page) {
+  return Astro.redirect('/404')
+}
 const speakers: Speaker[] = page.data
 const basePath = stripPagination(Astro.url.pathname)
 const title = `Oradores de la Cumbre ${year}`
@@ -26,4 +32,5 @@ const title = `Oradores de la Cumbre ${year}`
   basePath={basePath}
   title={title}
   page={page}
+  year={year}
 />

--- a/src/pages/es/summit/[year]/talks/[...page].astro
+++ b/src/pages/es/summit/[year]/talks/[...page].astro
@@ -16,6 +16,12 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { year } = Astro.params
 const { page } = Astro.props
+if (!year) {
+  throw new Error('Year param is required')
+}
+if (!page) {
+  return Astro.redirect('/404')
+}
 const talkPreviews: TalkPreview[] = page.data
 const basePath = stripPagination(Astro.url.pathname)
 const title = `Sesiones de la Cumbre ${year}`
@@ -26,4 +32,5 @@ const title = `Sesiones de la Cumbre ${year}`
   basePath={basePath}
   title={title}
   page={page}
+  year={year}
 />

--- a/src/pages/summit/[year]/speakers/[...page].astro
+++ b/src/pages/summit/[year]/speakers/[...page].astro
@@ -16,6 +16,12 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { year } = Astro.params
 const { page } = Astro.props
+if (!year) {
+  throw new Error('Year param is required')
+}
+if (!page) {
+  return Astro.redirect('/404')
+}
 const speakers: Speaker[] = page.data
 const basePath = stripPagination(Astro.url.pathname)
 const title = `${year} Summit Speakers`
@@ -26,4 +32,5 @@ const title = `${year} Summit Speakers`
   basePath={basePath}
   title={title}
   page={page}
+  year={year}
 />

--- a/src/pages/summit/[year]/talks/[...page].astro
+++ b/src/pages/summit/[year]/talks/[...page].astro
@@ -16,6 +16,12 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { year } = Astro.params
 const { page } = Astro.props
+if (!year) {
+  throw new Error('Year param is required')
+}
+if (!page) {
+  return Astro.redirect('/404')
+}
 const talkPreviews: TalkPreview[] = page.data
 const basePath = stripPagination(Astro.url.pathname)
 const title = `${year} Summit Sessions`
@@ -26,4 +32,5 @@ const title = `${year} Summit Sessions`
   basePath={basePath}
   title={title}
   page={page}
+  year={year}
 />


### PR DESCRIPTION
## Summary
- Add `data-umami-events` for links on Summit Speakers / Talks pages 
- Move the `Pagination` component from `blog` to `shared`, and make it configurable via props to support both Blog and Summit pages

## Related Issue
Fixes [INTORG-558](https://linear.app/interledger/issue/INTORG-558/summit-speakers-talks-analytics)

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
