### PR TITLE
ci: will now do dryrun as part of PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,6 +25,7 @@ jobs:
 
   build-and-dryrun:
     runs-on: ubuntu-latest
+    environment: strapi-staging
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,9 +1,9 @@
-name: Lint and Build
+name: PR Checks
 
 on:
   pull_request:
-  push:
-    branches: [main]
+      branches:
+        - staging
 
 jobs:
   lint:
@@ -23,7 +23,7 @@ jobs:
 
       - run: pnpm run lint
 
-  build:
+  build-and-dryrun:
     runs-on: ubuntu-latest
 
     steps:
@@ -36,6 +36,14 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
-
-      - run: pnpm run build
+      - name: Build and Dry Run
+        env:
+          STRAPI_API_TOKEN: ${{ secrets.STRAPI_API_TOKEN }}
+          STRAPI_URL: ${{ secrets.STRAPI_URL }}
+        run: |
+          pnpm install --frozen-lockfile      
+          pnpm run build
+          cd cms
+          pnpm install --frozen-lockfile
+          pnpm run build
+          pnpm run sync:mdx:dry-run

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build and Dry Run
         env:
-          STRAPI_API_TOKEN: ${{ secrets.STRAPI_API_TOKEN }}
+          STRAPI_API_TOKEN: ${{ secrets.STRAPI_TOKEN_DRY_RUN }}
           STRAPI_URL: ${{ secrets.STRAPI_URL }}
         run: |
           pnpm install --frozen-lockfile      

--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -45,7 +45,8 @@ export interface ContentTypeConfig {
   buildPayload: (
     mdx: MDXFile,
     strapi: StrapiClient,
-    existing: StrapiEntry | null
+    existing: StrapiEntry | null,
+    dryRun: boolean
   ) => Promise<Record<string, unknown>>
 }
 
@@ -95,19 +96,20 @@ export function buildContentTypes(
       dir: getContentPath(projectRoot, 'ambassadors'),
       apiId: 'ambassadors',
       schema: ambassadorFrontmatterSchema,
-      buildPayload: (mdx, strapi, _existing) =>
+      buildPayload: (mdx, strapi, _existing, dryRun) =>
         buildAmbassadorPayload(
           ambassadorFrontmatterSchema,
           mdx,
           strapi,
-          ambassadorAltIds
+          ambassadorAltIds,
+          dryRun
         )
     },
     'foundation-pages': {
       dir: getContentPath(projectRoot, 'foundationPages'),
       apiId: 'foundation-pages',
       schema: foundationPageFrontmatterSchema,
-      buildPayload: (mdx, strapi, existing) =>
+      buildPayload: (mdx, strapi, existing, _dryRun) =>
         buildParsedPagePayload(
           foundationPageFrontmatterSchema,
           mdx,
@@ -119,7 +121,7 @@ export function buildContentTypes(
       dir: getContentPath(projectRoot, 'summitPages'),
       apiId: 'summit-pages',
       schema: summitPageFrontmatterSchema,
-      buildPayload: (mdx, strapi, existing) =>
+      buildPayload: (mdx, strapi, existing, _dryRun) =>
         buildParsedPagePayload(
           summitPageFrontmatterSchema,
           mdx,
@@ -131,11 +133,12 @@ export function buildContentTypes(
       dir: getContentPath(projectRoot, 'blog'),
       apiId: 'foundation-blog-posts',
       schema: foundationBlogFrontmatterSchema,
-      buildPayload: async (mdx, strapi, _existing) => {
+      buildPayload: async (mdx, strapi, _existing, dryRun) => {
         const uploadContext: StrapiUploadContext = {
           strapi,
           STRAPI_URL: strapiUrl,
-          STRAPI_TOKEN: strapiToken
+          STRAPI_TOKEN: strapiToken,
+          dryRun
         }
         const locale = mdx.locale || 'en'
         const parserCtx: ParserContext = {
@@ -157,7 +160,8 @@ export function buildContentTypes(
           mdx,
           uploadContext,
           blogAltIds,
-          parserCtx
+          parserCtx,
+          dryRun
         )
       }
     }

--- a/cms/scripts/sync-mdx/index.ts
+++ b/cms/scripts/sync-mdx/index.ts
@@ -70,7 +70,8 @@ async function main() {
   const contentTypes = buildContentTypes(projectRoot, STRAPI_URL, STRAPI_TOKEN)
   const strapi = createStrapiClient({
     baseUrl: STRAPI_URL,
-    token: STRAPI_TOKEN
+    token: STRAPI_TOKEN,
+    dryRun: DRY_RUN
   })
 
   const results = await syncAll(

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -27,6 +27,7 @@ export interface StrapiUploadContext {
   strapi: StrapiClient
   STRAPI_URL: string
   STRAPI_TOKEN: string
+  dryRun: boolean
 }
 
 /**
@@ -103,7 +104,7 @@ async function uploadImageToStrapi(
 
 // Returns existing Strapi image ID or uploads a new image
 async function getImageFromStrapi(
-  { strapi, STRAPI_URL, STRAPI_TOKEN }: StrapiUploadContext,
+  { strapi, STRAPI_URL, STRAPI_TOKEN, dryRun }: StrapiUploadContext,
   { image, alt }: { image: string | undefined; alt: string | undefined }
 ): Promise<number | null> {
   const photoUrl = nullOrValue(image)
@@ -116,6 +117,14 @@ async function getImageFromStrapi(
     if (existing) {
       return existing
     }
+
+    if (dryRun) {
+      console.log(
+        `   🖼️  [DRY-RUN] Missing upload for "${photoUrl}"; skipping upload.`
+      )
+      return null
+    }
+
     const uploaded = await uploadImageToStrapi(STRAPI_URL, STRAPI_TOKEN, {
       filePath: photoUrl,
       name,
@@ -240,7 +249,8 @@ async function updateUploadAltOnce(
   id: number,
   alt: string,
   updatedAltIds: Map<number, string>,
-  pathSlug: string
+  pathSlug: string,
+  dryRun: boolean
 ): Promise<void> {
   const existing = updatedAltIds.get(id)
   if (existing !== undefined) {
@@ -251,6 +261,15 @@ async function updateUploadAltOnce(
     }
     return
   }
+
+  if (dryRun) {
+    console.log(
+      `   🏷️  [DRY-RUN] Would update alt text for upload #${id} from "${pathSlug}".`
+    )
+    updatedAltIds.set(id, alt)
+    return
+  }
+
   await strapi.updateUploadAlt(id, alt)
   updatedAltIds.set(id, alt)
 }
@@ -271,7 +290,8 @@ export async function buildAmbassadorPayload(
   schema: FrontmatterSchema,
   mdx: MDXFile,
   strapi: StrapiClient,
-  updatedAltIds: Map<number, string> = new Map()
+  updatedAltIds: Map<number, string> = new Map(),
+  dryRun = false
 ): Promise<Record<string, unknown>> {
   schema.parse({ ...mdx.frontmatter, pathSlug: mdx.pathSlug })
 
@@ -291,7 +311,8 @@ export async function buildAmbassadorPayload(
         photoId,
         photoAlt,
         updatedAltIds,
-        mdx.pathSlug
+        mdx.pathSlug,
+        dryRun
       )
     }
   }
@@ -326,7 +347,8 @@ export async function buildBlogPayload(
   mdx: MDXFile,
   strapiUploadContext: StrapiUploadContext,
   updatedAltIds: Map<number, string> = new Map(),
-  parserCtx?: ParserContext
+  parserCtx?: ParserContext,
+  dryRun = false
 ): Promise<Record<string, unknown>> {
   let parsed
   try {
@@ -371,7 +393,8 @@ export async function buildBlogPayload(
       featureImage,
       parsed.featureImageAlt,
       updatedAltIds,
-      mdx.pathSlug
+      mdx.pathSlug,
+      dryRun
     )
   }
   if (thumbnailImage && parsed.thumbnailImageAlt) {
@@ -380,7 +403,8 @@ export async function buildBlogPayload(
       thumbnailImage,
       parsed.thumbnailImageAlt,
       updatedAltIds,
-      mdx.pathSlug
+      mdx.pathSlug,
+      dryRun
     )
   }
 

--- a/cms/scripts/sync-mdx/strapiClient.ts
+++ b/cms/scripts/sync-mdx/strapiClient.ts
@@ -52,11 +52,13 @@ export interface StrapiClient {
 interface StrapiClientOptions {
   baseUrl: string
   token: string
+  dryRun?: boolean
 }
 
 export function createStrapiClient({
   baseUrl,
-  token
+  token,
+  dryRun = false
 }: StrapiClientOptions): StrapiClient {
   const apiRoot = `${baseUrl.replace(/\/+$/, '')}/api`
 
@@ -64,6 +66,13 @@ export function createStrapiClient({
     endpoint: string,
     options: RequestInit = {}
   ): Promise<unknown> {
+    const method = (options.method || 'GET').toUpperCase()
+    if (dryRun && ['POST', 'PUT', 'DELETE', 'PATCH'].includes(method)) {
+      throw new Error(
+        `Dry-run mutation blocked: ${method} ${endpoint.replace(/^\/+/, '')}`
+      )
+    }
+
     const url = `${apiRoot}/${endpoint.replace(/^\/+/, '')}`
     const response = await fetch(url, {
       ...options,

--- a/cms/scripts/sync-mdx/syncOperations.ts
+++ b/cms/scripts/sync-mdx/syncOperations.ts
@@ -33,7 +33,8 @@ export async function syncEnglishEntry(
   const englishData = await config.buildPayload(
     englishMdx,
     ctx.strapi,
-    existingByIdentifier ?? null
+    existingByIdentifier ?? null,
+    dryRun
   )
 
   if (existingByIdentifier) {
@@ -88,7 +89,8 @@ export async function syncLocaleEntry(
   const localeData = await config.buildPayload(
     localeMdx,
     ctx.strapi,
-    existingLocale ?? null
+    existingLocale ?? null,
+    dryRun
   )
 
   if (existingLocale) {


### PR DESCRIPTION
## Summary
Reworked lint and build pipeline to be a generic PR check pipeline. It will now not only perform the appropriate linting and builds, but it will also perform a dry run of the mdx-sync against the staging environment.

- Note that we are migrating to use github environments
- Will now use a RO strapi token
- Had to refactor mdx dry run process because it was still doing some mutations

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)
