### PR TITLE
fix(cms): Astro HERO: background image + remove secondary CTA btns INTORG-572 INTORG-573

### DIFF
--- a/cms/src/components/shared/hero.json
+++ b/cms/src/components/shared/hero.json
@@ -3,7 +3,7 @@
   "info": {
     "displayName": "Hero",
     "icon": "star",
-    "description": "Hero section with title, description and CTAs"
+    "description": "Hero section with title, description and background image"
   },
   "options": {},
   "attributes": {
@@ -28,16 +28,6 @@
       "type": "media",
       "multiple": false,
       "allowedTypes": ["images"],
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
-    },
-    "secondaryCtas": {
-      "type": "component",
-      "repeatable": true,
-      "component": "shared.cta-link",
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -254,8 +254,7 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     'shared.hero': {
       title: 'Hero Title',
       description: 'Hero Description',
-      backgroundImage: 'Background Image',
-      secondaryCtas: 'Secondary Buttons'
+      backgroundImage: 'Background Image'
     },
     'shared.seo': {
       metaDescription: 'Meta Description'
@@ -559,8 +558,7 @@ async function configureLayouts(strapi: StrapiInstance) {
       [
         { name: 'description', size: 6 },
         { name: 'backgroundImage', size: 6 }
-      ],
-      [{ name: 'secondaryCtas', size: 12 }]
+      ]
     ],
     'shared.seo': [[{ name: 'metaDescription', size: 12 }]]
   }

--- a/cms/src/utils/pageLifecycle.test.ts
+++ b/cms/src/utils/pageLifecycle.test.ts
@@ -20,7 +20,11 @@ describe('generateMDX — clears deleted Strapi-managed fields', () => {
       title: 'Test Page',
       pathSlug: 'test',
       locale: 'en',
-      hero: { title: 'Hero Title', description: undefined, backgroundImage: undefined }
+      hero: {
+        title: 'Hero Title',
+        description: undefined,
+        backgroundImage: undefined
+      }
     }
     const preservedFields = {
       heroImage: 'https://example.com/old-image.jpg',

--- a/cms/src/utils/pageLifecycle.test.ts
+++ b/cms/src/utils/pageLifecycle.test.ts
@@ -1,7 +1,69 @@
 import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defaultLang } from './mdx'
-import { readLocaleFromUpdateEvent, resolvePageFilepath } from './pageLifecycle'
+import {
+  generateMDX,
+  readLocaleFromUpdateEvent,
+  resolvePageFilepath
+} from './pageLifecycle'
+
+const testConfig = {
+  contentTypeUid: 'api::foundation-page.foundation-page',
+  outputDir: 'src/content/foundation-pages'
+}
+
+describe('generateMDX — clears deleted Strapi-managed fields', () => {
+  it('removes heroImage from frontmatter when backgroundImage is deleted in Strapi', () => {
+    const page = {
+      id: 1,
+      documentId: 'doc1',
+      title: 'Test Page',
+      pathSlug: 'test',
+      locale: 'en',
+      hero: { title: 'Hero Title', description: undefined, backgroundImage: undefined }
+    }
+    const preservedFields = {
+      heroImage: 'https://example.com/old-image.jpg',
+      heroTitle: 'Preserved Title'
+    }
+
+    const result = generateMDX(testConfig, page, preservedFields)
+
+    expect(result).not.toContain('heroImage')
+  })
+
+  it('removes metaDescription from frontmatter when seo.metaDescription is deleted in Strapi', () => {
+    const page = {
+      id: 1,
+      documentId: 'doc1',
+      title: 'Test Page',
+      pathSlug: 'test',
+      locale: 'en',
+      seo: { metaDescription: undefined }
+    }
+    const preservedFields = { metaDescription: 'Old description' }
+
+    const result = generateMDX(testConfig, page, preservedFields)
+
+    expect(result).not.toContain('metaDescription')
+  })
+
+  it('keeps heroImage in frontmatter when backgroundImage is present', () => {
+    const page = {
+      id: 1,
+      documentId: 'doc1',
+      title: 'Test Page',
+      pathSlug: 'test',
+      locale: 'en',
+      hero: { backgroundImage: { url: 'https://example.com/image.jpg' } }
+    }
+
+    const result = generateMDX(testConfig, page)
+
+    expect(result).toContain('heroImage')
+    expect(result).toContain('https://example.com/image.jpg')
+  })
+})
 
 describe('resolvePageFilepath', () => {
   const outputDir = path.join('/repo', 'src', 'content', 'foundation-pages')

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -115,7 +115,7 @@ function getOutputDir(config: PageLifecycleConfig): string {
   return path.join(projectRoot, config.outputDir)
 }
 
-function generateMDX(
+export function generateMDX(
   config: PageLifecycleConfig,
   page: PageData,
   preservedFields: Record<string, unknown> = {},
@@ -128,17 +128,27 @@ function generateMDX(
   const localizesValue =
     (isLocalized && englishSlug ? englishSlug : undefined) || localizes
 
+  const heroData = heroFrontmatter(page.hero)
+  const seoData = seoFrontmatter(page.seo)
+
   // Spread preserved fields first, then Strapi-managed fields overwrite
   const frontmatterData: Record<string, unknown> = {
     ...restPreserved,
     pathSlug: page.pathSlug,
     title: page.title,
     ...(page.pillar ? { pillar: page.pillar } : {}),
-    ...heroFrontmatter(page.hero),
-    ...seoFrontmatter(page.seo),
+    ...heroData,
+    ...seoData,
     ...(localizesValue ? { localizes: localizesValue } : {}),
     locale
   }
+
+  // Explicitly remove Strapi-managed fields that are no longer set (e.g. deleted image)
+  const heroManagedKeys = ['heroTitle', 'heroDescription', 'heroImage'] as const
+  for (const key of heroManagedKeys) {
+    if (!(key in heroData)) delete frontmatterData[key]
+  }
+  if (!('metaDescription' in seoData)) delete frontmatterData.metaDescription
 
   const content = serializeContent(page.content)
 

--- a/cms/types/generated/components.d.ts
+++ b/cms/types/generated/components.d.ts
@@ -578,7 +578,7 @@ export interface SharedCtaLink extends Struct.ComponentSchema {
 export interface SharedHero extends Struct.ComponentSchema {
   collectionName: 'components_shared_heroes'
   info: {
-    description: 'Hero section with title, description and CTAs'
+    description: 'Hero section with title, description and background image'
     displayName: 'Hero'
     icon: 'star'
   }
@@ -590,12 +590,6 @@ export interface SharedHero extends Struct.ComponentSchema {
         }
       }>
     description: Schema.Attribute.Text &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true
-        }
-      }>
-    secondaryCtas: Schema.Attribute.Component<'shared.cta-link', true> &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true

--- a/src/components/pages/FoundationContentPage.astro
+++ b/src/components/pages/FoundationContentPage.astro
@@ -9,6 +9,7 @@ import CalloutText from '@/components/callout/CalloutText.astro'
 import Paragraph from '@/components/blocks/Paragraph.astro'
 import PdfEmbed from '@/components/PdfEmbed.astro'
 import VideoEmbed from '@/components/blocks/VideoEmbed.astro'
+import { getHeroSectionStyle } from '@/utils/heroSectionStyle'
 
 interface Props {
   slug: string
@@ -35,6 +36,7 @@ const ogImageUrl = mdxData?.metaImage || undefined
 const canonicalURL = mdxData?.canonicalUrl || undefined
 const mdxHeroTitle = mdxData?.heroTitle || mdxData?.title || ''
 const mdxHeroDescription = mdxData?.heroDescription || ''
+const heroSectionStyle = getHeroSectionStyle(mdxData?.heroImage)
 const pillar = mdxData?.pillar || undefined
 const isNotFound = !MdxContent
 
@@ -50,7 +52,15 @@ if (isNotFound) return Astro.redirect('/404')
   <main class="pb-space-l" data-pillar={pillar}>
     {
       mdxHeroTitle && (
-        <section class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[40vh] py-space-xl text-white flex items-center">
+        <section
+          class:list={[
+            'min-h-[40vh] py-space-xl text-white flex items-center',
+            heroSectionStyle
+              ? 'bg-no-repeat bg-cover bg-center'
+              : 'bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right]'
+          ]}
+          style={heroSectionStyle}
+        >
           <div class="mx-auto w-full max-w-wide px-space-m">
             <div class="max-w-narrow">
               <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-space-xs text-[clamp(2rem,5vw,3rem)]">

--- a/src/components/pages/SummitContentPage.astro
+++ b/src/components/pages/SummitContentPage.astro
@@ -9,6 +9,7 @@ import VideoEmbed from '@/components/blocks/VideoEmbed.astro'
 import Ambassador from '@/components/ambassadors/Ambassador.astro'
 import CalloutText from '@/components/callout/CalloutText.astro'
 import PdfEmbed from '@/components/PdfEmbed.astro'
+import { getHeroSectionStyle } from '@/utils/heroSectionStyle'
 
 interface Props {
   slug: string
@@ -35,7 +36,9 @@ const ogImageUrl = mdxData?.metaImage || undefined
 const canonicalURL = mdxData?.canonicalUrl || undefined
 const mdxHeroTitle = mdxData?.heroTitle || mdxData?.title || ''
 const mdxHeroDescription = mdxData?.heroDescription || ''
-const gradient = mdxData?.gradient || 'option1'
+const heroSectionStyle = getHeroSectionStyle(mdxData?.heroImage)
+const gradient =
+  (mdxData as { gradient?: string } | undefined)?.gradient || 'option1'
 ---
 
 <SummitPageLayout
@@ -50,7 +53,15 @@ const gradient = mdxData?.gradient || 'option1'
   >
     {
       mdxHeroTitle && (
-        <section class="min-h-[40vh] py-space-xl flex items-center text-white">
+        <section
+          class:list={[
+            'min-h-[40vh] py-space-xl flex items-center text-white',
+            heroSectionStyle
+              ? 'bg-no-repeat bg-cover bg-center'
+              : 'bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right]'
+          ]}
+          style={heroSectionStyle}
+        >
           <div class="mx-auto w-full max-w-wide px-space-m">
             <div class="max-w-narrow">
               <h1 class="max-w-[14em] leading-[1.2] font-semibold mb-space-xs text-[clamp(2rem,5vw,3rem)]">

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -4,6 +4,7 @@ import FoundationPageLayout from '../../layouts/FoundationPageLayout.astro'
 import Paragraph from '../../components/blocks/Paragraph.astro'
 import { type Locale } from '@/utils/i18'
 import { HOME_SLUG } from '@/utils/routes'
+import { getHeroSectionStyle } from '@/utils/heroSectionStyle'
 
 const pageLang: Locale = 'es'
 
@@ -23,10 +24,12 @@ const {
   metaImage,
   canonicalUrl,
   heroTitle,
-  heroDescription
+  heroDescription,
+  heroImage
 } = homePage.data
 const pageTitle = title || 'Interledger Foundation'
 const pageDescription = metaDescription || undefined
+const heroSectionStyle = getHeroSectionStyle(heroImage)
 ---
 
 <FoundationPageLayout
@@ -37,7 +40,13 @@ const pageDescription = metaDescription || undefined
 >
   <main class="pb-space-l">
     <section
-      class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[50vh] py-space-xl text-white flex items-center"
+      class:list={[
+        'min-h-[50vh] py-space-xl text-white flex items-center',
+        heroSectionStyle
+          ? 'bg-no-repeat bg-cover bg-center'
+          : 'bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right]'
+      ]}
+      style={heroSectionStyle}
     >
       <div class="mx-auto w-full max-w-wide px-space-m">
         <div class="max-w-narrow">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import FoundationPageLayout from '../layouts/FoundationPageLayout.astro'
 import Paragraph from '../components/blocks/Paragraph.astro'
 import { type Locale } from '@/utils/i18'
 import { HOME_SLUG } from '@/utils/routes'
+import { getHeroSectionStyle } from '@/utils/heroSectionStyle'
 
 const pageLang: Locale = 'en'
 
@@ -23,10 +24,12 @@ const {
   metaImage,
   canonicalUrl,
   heroTitle,
-  heroDescription
+  heroDescription,
+  heroImage
 } = homePage.data
 const pageTitle = title || 'Interledger Foundation'
 const pageDescription = metaDescription || undefined
+const heroSectionStyle = getHeroSectionStyle(heroImage)
 ---
 
 <FoundationPageLayout
@@ -37,7 +40,13 @@ const pageDescription = metaDescription || undefined
 >
   <main class="pb-space-l">
     <section
-      class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[50vh] py-space-xl text-white flex items-center"
+      class:list={[
+        'min-h-[50vh] py-space-xl text-white flex items-center',
+        heroSectionStyle
+          ? 'bg-no-repeat bg-cover bg-center'
+          : 'bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right]'
+      ]}
+      style={heroSectionStyle}
     >
       <div class="mx-auto w-full max-w-wide px-space-m">
         <div class="max-w-narrow">

--- a/src/utils/heroSectionStyle.ts
+++ b/src/utils/heroSectionStyle.ts
@@ -1,0 +1,13 @@
+export function getHeroSectionStyle(
+  heroImage?: string
+): Record<string, string> | undefined {
+  const safeHeroImageUrl = heroImage?.trim()
+    ? encodeURI(heroImage.trim())
+    : undefined
+
+  return safeHeroImageUrl
+    ? {
+        backgroundImage: `url('${safeHeroImageUrl}')`
+      }
+    : undefined
+}


### PR DESCRIPTION
## Summary

- Adds a `backgroundImage` field to the Strapi `shared.hero` component, replacing the old secondary CTA buttons
- When set, renders the image as the hero section background; falls back to the existing gradient when absent
- Fixes a bug where deleting an image (or any hero/SEO field) in Strapi left the stale value in the MDX frontmatter

## Related Issue

Fixes INTORG-573

## Manual Test

1. In Strapi admin, open any Foundation or Summit page
2. Upload a background image in the Hero > Background Image field and publish — verify it renders on the page
3. Delete the image and publish — verify the gradient fallback renders and `heroImage` is gone from the MDX file

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused
