### PR TITLE
chore: added summit page handling

### DIFF
--- a/src/content/summit-pages/es/home.mdx
+++ b/src/content/summit-pages/es/home.mdx
@@ -1,0 +1,58 @@
+---
+pathSlug: 'home'
+title: 'Cumbre 2025'
+heroTitle: 'Interledger Summit Ciudad de Mexico'
+locale: 'es'
+localizes: 'home'
+---
+
+<Paragraph>
+
+Te damos la bienvenida para ver virtualmente la transmision en vivo por YouTube.
+
+Desde paneles que invitan a reflexionar hasta demostraciones en tiempo real, tendras un asiento en primera fila para conocer las ideas e innovaciones que impulsan a la comunidad de Interledger.
+
+Transmitiremos dos espacios clave durante ambos dias:
+
+## Listening Lab (Escenario Principal)
+
+Conectate todos los dias a las 10:00 a. m. hora estandar del centro (CST) para escuchar charlas y conversaciones inspiradoras con lideres globales en finanzas abiertas, inclusion digital y sistemas interoperables.
+
+Listening Lab miercoles 5 de noviembre
+Listening Lab jueves 6 de noviembre
+
+## Demo Lab
+
+Disfruta demostraciones en vivo de tecnologias y proyectos de vanguardia a partir de las 11:30 a. m. CST cada dia.
+
+Demo Lab miercoles 5 de noviembre
+Demo Lab jueves 6 de noviembre
+Dejanos tus comentarios en el chat de YouTube.
+
+## Conectando la infraestructura financiera global
+
+Interledger Summit reune a las personas, plataformas y politicas que impulsan el futuro de la interoperabilidad financiera. A medida que los sistemas de pago siguen evolucionando, Interledger aporta la capa de conexion que permite que el dinero se mueva con la misma libertad, apertura e inmediatez que la informacion.
+
+En el centro de este trabajo se encuentra el Protocolo Interledger, una red financiera global en la que cualquier persona, en cualquier lugar, puede acceder y beneficiarse de pagos inclusivos y sin fronteras, sin importar su geografia, ingresos o infraestructura.
+
+## Que esperar en 2025
+
+La Summit de este ano ofrecera dos dias de sesiones de alto impacto, aprendizaje practico y colaboracion profunda, disenados para acelerar el progreso entre sectores.
+
+## Labs de la Summit
+
+Un panel de ponentes de la Summit conversando en el escenario
+
+### Listening Lab
+
+Escucha directamente a usuarios, defensores y responsables de politicas publicas. Basa tu trabajo en experiencias reales y ayuda a dar forma a sistemas que funcionen para todas las personas.
+
+### Learn Together Lab
+
+Colabora en desafios del mundo real. Desarrolla habilidades practicas, comparte herramientas y crea en conjunto soluciones que impulsen la innovacion financiera inclusiva.
+
+### Demo Lab
+
+Mira Interledger en accion. Explora demostraciones en vivo de integraciones de wallets, pagos en streaming y tecnologia abierta resolviendo problemas reales.
+
+</Paragraph>

--- a/src/pages/es/summit/[...page].astro
+++ b/src/pages/es/summit/[...page].astro
@@ -1,9 +1,12 @@
 ---
 import SummitContentPage from '@/components/pages/SummitContentPage.astro'
 import { getLocalizedPaths } from '@/utils/static-paths'
+import { HOME_SLUG } from '@/utils/routes'
 
 export async function getStaticPaths() {
-  return getLocalizedPaths('summit-pages', 'es', 'page')
+  return getLocalizedPaths('summit-pages', 'es', 'page', {
+    excludeSlug: HOME_SLUG
+  })
 }
 
 const { slug, locale: contentLocale } = Astro.props

--- a/src/pages/es/summit/index.astro
+++ b/src/pages/es/summit/index.astro
@@ -1,0 +1,9 @@
+---
+import SummitContentPage from '@/components/pages/SummitContentPage.astro'
+import { HOME_SLUG } from '@/utils/routes'
+import { type Locale } from '@/utils/i18'
+
+const pageLang: Locale = 'es'
+---
+
+<SummitContentPage slug={HOME_SLUG} contentLocale={pageLang} />

--- a/src/pages/summit/[...page].astro
+++ b/src/pages/summit/[...page].astro
@@ -1,9 +1,12 @@
 ---
 import SummitContentPage from '@/components/pages/SummitContentPage.astro'
 import { getLocalizedPaths } from '@/utils/static-paths'
+import { HOME_SLUG } from '@/utils/routes'
 
 export async function getStaticPaths() {
-  return getLocalizedPaths('summit-pages', 'en', 'page')
+  return getLocalizedPaths('summit-pages', 'en', 'page', {
+    excludeSlug: HOME_SLUG
+  })
 }
 
 const { slug, locale: contentLocale } = Astro.props

--- a/src/pages/summit/index.astro
+++ b/src/pages/summit/index.astro
@@ -1,0 +1,9 @@
+---
+import SummitContentPage from '@/components/pages/SummitContentPage.astro'
+import { HOME_SLUG } from '@/utils/routes'
+import { type Locale } from '@/utils/i18'
+
+const pageLang: Locale = 'en'
+---
+
+<SummitContentPage slug={HOME_SLUG} contentLocale={pageLang} />


### PR DESCRIPTION
## Summary
<!-- What changed and why -->
The home page needs special handling which was missing for the summit home. 

This change makes Summit follow the same pattern as Foundation:

src/content/summit-pages/home.mdx now represents the Summit homepage.
/summit and /es/summit render that content through dedicated index routes.
The catch-all Summit routes exclude the home slug so it is not exposed as /summit/home.

## Related Issue
<!-- Fixes INTORG-123 -->

## Manual Test
<!-- Reviewer steps (only if needed) -->
visit /summit and /es/summit

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
