### PR TITLE
feat(cms): brand pillar foundation pages updates INTORG-569 INTORG-568

### DIFF
--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -111,6 +111,8 @@ export default {
       textarea { min-height: 140px !important; }
       /* TEMP UI Fix: hide only the Preview aside (last one), not the one above */
       aside[aria-labelledby="additional-information"]:nth-child(2) { display: none !important; }
+      /* TEMP UI Fix: enum dropdowns should show all options without scrolling */
+      [role="listbox"] { max-height: none !important; }
     `
     document.head.appendChild(style)
 

--- a/cms/src/api/foundation-page/content-types/foundation-page/schema.json
+++ b/cms/src/api/foundation-page/content-types/foundation-page/schema.json
@@ -5,7 +5,7 @@
     "singularName": "foundation-page",
     "pluralName": "foundation-pages",
     "displayName": "Foundation Page",
-    "description": "Website pages with dynamic content blocks. Page type (Grant, Policy, Developer) defines layout. Full path slug sets the URL and file location."
+    "description": "Website pages with dynamic content blocks. Full path slug sets the URL and file location."
   },
   "options": {
     "draftAndPublish": false
@@ -27,13 +27,6 @@
       "unique": true,
       "pluginOptions": { "i18n": { "localized": true } },
       "description": "Path relative to the site root (/). Examples: about-us → /about-us; grant/grant-for-web → /grant/grant-for-web. No leading slash."
-    },
-    "pageType": {
-      "type": "enumeration",
-      "enum": ["grant", "policy", "developer"],
-      "default": "grant",
-      "pluginOptions": { "i18n": { "localized": false } },
-      "description": "Grant Page, Policy Page, or Developer Page"
     },
     "pillar": {
       "type": "enumeration",

--- a/cms/src/api/summit-page/content-types/summit-page/schema.json
+++ b/cms/src/api/summit-page/content-types/summit-page/schema.json
@@ -5,7 +5,7 @@
     "singularName": "summit-page",
     "pluralName": "summit-pages",
     "displayName": "Summit Page",
-    "description": "Summit pages with dark theme. Page type (Hackathon, Hackathon Resource) defines layout. Full path slug sets the URL and file location."
+    "description": "Summit pages with dark theme. Full path slug sets the URL and file location."
   },
   "options": {
     "draftAndPublish": false
@@ -27,13 +27,6 @@
       "unique": true,
       "pluginOptions": { "i18n": { "localized": true } },
       "description": "Path relative to /summit/. Examples: faq → /summit/faq; schedule → /summit/schedule. Do not include /summit/ or a leading slash."
-    },
-    "pageType": {
-      "type": "enumeration",
-      "enum": ["hackathon", "hackathon-resource"],
-      "default": "hackathon",
-      "pluginOptions": { "i18n": { "localized": false } },
-      "description": "Hackathon or Hackathon Resource"
     },
     "seo": {
       "type": "component",

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -197,7 +197,8 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     'api::foundation-page.foundation-page': {
       title: 'Page Title',
       pathSlug: 'Full Path Slug',
-      pageType: 'Brand Pillar',
+      pageType: 'Page Type',
+      pillar: 'Brand Pillar',
       seo: 'SEO',
       hero: 'Hero',
       content: 'Page Content'
@@ -205,7 +206,7 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     'api::summit-page.summit-page': {
       title: 'Title',
       pathSlug: 'Full Path Slug',
-      pageType: 'Brand Pillar',
+      pageType: 'Page Type',
       seo: 'SEO',
       hero: 'Hero',
       content: 'Content'
@@ -473,8 +474,9 @@ async function configureLayouts(strapi: StrapiInstance) {
     ],
     'api::foundation-page.foundation-page': [
       [
-        { name: 'title', size: 6 },
-        { name: 'pageType', size: 6 }
+        { name: 'title', size: 4 },
+        { name: 'pageType', size: 4 },
+        { name: 'pillar', size: 4 }
       ],
       [{ name: 'pathSlug', size: 12 }],
       [{ name: 'seo', size: 12 }],

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -197,7 +197,6 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     'api::foundation-page.foundation-page': {
       title: 'Page Title',
       pathSlug: 'Full Path Slug',
-      pageType: 'Page Type',
       pillar: 'Brand Pillar',
       seo: 'SEO',
       hero: 'Hero',
@@ -206,7 +205,6 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     'api::summit-page.summit-page': {
       title: 'Title',
       pathSlug: 'Full Path Slug',
-      pageType: 'Page Type',
       seo: 'SEO',
       hero: 'Hero',
       content: 'Content'
@@ -474,9 +472,8 @@ async function configureLayouts(strapi: StrapiInstance) {
     ],
     'api::foundation-page.foundation-page': [
       [
-        { name: 'title', size: 4 },
-        { name: 'pageType', size: 4 },
-        { name: 'pillar', size: 4 }
+        { name: 'title', size: 6 },
+        { name: 'pillar', size: 6 }
       ],
       [{ name: 'pathSlug', size: 12 }],
       [{ name: 'seo', size: 12 }],
@@ -484,10 +481,7 @@ async function configureLayouts(strapi: StrapiInstance) {
       [{ name: 'content', size: 12 }]
     ],
     'api::summit-page.summit-page': [
-      [
-        { name: 'title', size: 6 },
-        { name: 'pageType', size: 6 }
-      ],
+      [{ name: 'title', size: 12 }],
       [{ name: 'pathSlug', size: 12 }],
       [{ name: 'seo', size: 12 }],
       [{ name: 'hero', size: 12 }],

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -415,7 +415,7 @@ export function createPageLifecycle(config: PageLifecycleConfig) {
               .replace(/^\/+|\/+$/g, '')
               .trim()
       if (!slug) {
-        strapi.log.warn(
+        console.warn(
           `[${label}] Skipping MDX delete: pathSlug missing on deleted document (documentId=${result.documentId})`
         )
         scheduleGitSync(label)

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -651,7 +651,7 @@ export interface ApiFoundationPageFoundationPage
   extends Struct.CollectionTypeSchema {
   collectionName: 'foundation-pages'
   info: {
-    description: 'Website pages with dynamic content blocks. Page type (Grant, Policy, Developer) defines layout. Full path slug sets the URL and file location.'
+    description: 'Website pages with dynamic content blocks. Full path slug sets the URL and file location.'
     displayName: 'Foundation Page'
     pluralName: 'foundation-pages'
     singularName: 'foundation-page'
@@ -695,13 +695,6 @@ export interface ApiFoundationPageFoundationPage
       'oneToMany',
       'api::foundation-page.foundation-page'
     >
-    pageType: Schema.Attribute.Enumeration<['grant', 'policy', 'developer']> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: false
-        }
-      }> &
-      Schema.Attribute.DefaultTo<'grant'>
     pathSlug: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.Unique &
@@ -772,7 +765,7 @@ export interface ApiSummitNavigationSummitNavigation
 export interface ApiSummitPageSummitPage extends Struct.CollectionTypeSchema {
   collectionName: 'summit_pages'
   info: {
-    description: 'Summit pages with dark theme. Page type (Hackathon, Hackathon Resource) defines layout. Full path slug sets the URL and file location.'
+    description: 'Summit pages with dark theme. Full path slug sets the URL and file location.'
     displayName: 'Summit Page'
     pluralName: 'summit-pages'
     singularName: 'summit-page'
@@ -816,15 +809,6 @@ export interface ApiSummitPageSummitPage extends Struct.CollectionTypeSchema {
       'oneToMany',
       'api::summit-page.summit-page'
     >
-    pageType: Schema.Attribute.Enumeration<
-      ['hackathon', 'hackathon-resource']
-    > &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: false
-        }
-      }> &
-      Schema.Attribute.DefaultTo<'hackathon'>
     pathSlug: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.Unique &

--- a/src/content/foundation-pages/developers.mdx
+++ b/src/content/foundation-pages/developers.mdx
@@ -7,5 +7,6 @@ locale: 'en'
 ---
 
 <CalloutText>
-We welcome contributions to our open-source repositories on GitHub. If you find them valuable, please give us a star. Your support makes a difference!
+  We welcome contributions to our open-source repositories on GitHub. If you
+  find them valuable, please give us a star. Your support makes a difference!
 </CalloutText>

--- a/src/content/foundation-pages/interledger.mdx
+++ b/src/content/foundation-pages/interledger.mdx
@@ -6,12 +6,13 @@ locale: 'en'
 ---
 
 <CalloutText>
-Interledger is the global payments network for inclusive financial service providers.
+  Interledger is the global payments network for inclusive financial service
+  providers.
 </CalloutText>
 
 <Paragraph>
 
-The Interledger network connects financial services that have implemented the Interledger Protocol (ILP) and helps make payments easier, faster and cheaper. 
+The Interledger network connects financial services that have implemented the Interledger Protocol (ILP) and helps make payments easier, faster and cheaper.
 
 Traditional payment networks operate independently from each other. Sending money is easy only if the sender and recipient have accounts on the same network, but it can be slow and expensive if they have accounts on different networks.
 
@@ -20,12 +21,13 @@ Interledger makes it easy and inexpensive to send payments in whatever currency 
 </Paragraph>
 
 <Blockquote source="Adrian Hope-Baylis, CEO at Fynbos">
-  “Interledger is unique in its approach to making payments accessible to anyone around the world..”
+  “Interledger is unique in its approach to making payments accessible to anyone
+  around the world..”
 </Blockquote>
 
 <Paragraph>
 
-Built on modern technologies, Interledger can handle up to 1 million transactions per second per participant. The reduced cost of transactions, and increased throughput when compared to traditional payment networks, allows Interledger-enabled financial services to explore new use-cases currently impossible in traditional financial systems. 
+Built on modern technologies, Interledger can handle up to 1 million transactions per second per participant. The reduced cost of transactions, and increased throughput when compared to traditional payment networks, allows Interledger-enabled financial services to explore new use-cases currently impossible in traditional financial systems.
 
 Micro transactions, as low as the 100th part of a cent, streaming payments and currency exchange during network traversal are all-new use-cases enabled by implementing the Interledger Protocol and joining the Interledger network.
 
@@ -37,13 +39,13 @@ The latest version of ILP (ILPv4) defines a set of rules that describes how ledg
 
 ILPv4 can be integrated with any type of ledger, including those not built for interoperability, and it is designed to be used with a variety of higher-level protocols, like Open Payments, that implement features ranging from quoting to sending larger amounts of value with chunked payments and delegated access into accounts.
 
-Like the internet, connectors route packets of money across inter-connected nodes.  ILPv4 is a request/response protocol, where requests and responses are ILPv4 packets. Typically, a single aggregate payment from sender to receiver is split into multiple ILP packets. Each ILP packet contains transaction information, which is private to the ledgers participating in the transaction.
+Like the internet, connectors route packets of money across inter-connected nodes. ILPv4 is a request/response protocol, where requests and responses are ILPv4 packets. Typically, a single aggregate payment from sender to receiver is split into multiple ILP packets. Each ILP packet contains transaction information, which is private to the ledgers participating in the transaction.
 
 ## ILP is not tied to a single company, payment network, or currency.
 
 The open architecture and minimal protocol enable interoperability for any digital financial service.
 
-Interledger enables secure, multi-hop payments using Hashed Timelock Agreements. As of ILPv4, these conditions are not enforced by the ledger, as it would be too costly and slow. Instead, participants in the network use these hashlocks to perform accounting with their connected nodes. 
+Interledger enables secure, multi-hop payments using Hashed Timelock Agreements. As of ILPv4, these conditions are not enforced by the ledger, as it would be too costly and slow. Instead, participants in the network use these hashlocks to perform accounting with their connected nodes.
 
 Accounting is used to determine in-flight balances, which are periodically settled. Because the Settlement phase is completely outside the Interledger Protocol, it enables ILP to have much faster messaging and clearing of a payment than any traditional financial system.
 

--- a/src/content/foundation-pages/media.mdx
+++ b/src/content/foundation-pages/media.mdx
@@ -6,7 +6,8 @@ locale: 'en'
 ---
 
 <CalloutText>
-We are passionate about sharing stories around open-source, digital financial inclusion, and how we are revolutionizing digital payments.
+  We are passionate about sharing stories around open-source, digital financial
+  inclusion, and how we are revolutionizing digital payments.
 </CalloutText>
 
 <Paragraph>
@@ -20,6 +21,7 @@ If you’re interested in learning more about our mission to create an open, int
 For any media inquiries, contact press@interledger.org.
 
 ## In the press
+
 - Interledger Steps Up to Foster Cross-Border Payments in 130 Countries | PaymentsJournal
 - Interledger Commits $4Million to Remove Financial Roadblock to Implementing Instant Payments | The Fintech Times
 - BankThink Cross-border payments don't need to be so complicated and expensive | American Banker

--- a/src/content/foundation-pages/open-payments.mdx
+++ b/src/content/foundation-pages/open-payments.mdx
@@ -7,7 +7,8 @@ locale: 'en'
 ---
 
 <CalloutText>
-Sending a payment should be as easy as sending an email. The Open Payments standard brings this vision to life.
+  Sending a payment should be as easy as sending an email. The Open Payments
+  standard brings this vision to life.
 </CalloutText>
 
 <Paragraph>
@@ -35,24 +36,24 @@ Your provider then maps the alias (your wallet address) to your actual account b
 
 ## A Better Way to Pay Online
 
--  Simplicity: All you need to send a payment online is your wallet address.
--  Enhanced Privacy and Security: Wallet addresses don’t reveal sensitive financial information, minimizing the risk of it falling into the wrong hands or being misused.
--  Transparency: You approve transactions directly with your account provider, gaining full visibility of fees and currency conversions in your local currency.
--  Control: You decide how much money is accessible, who can access it, for how long, and how often.
+- Simplicity: All you need to send a payment online is your wallet address.
+- Enhanced Privacy and Security: Wallet addresses don’t reveal sensitive financial information, minimizing the risk of it falling into the wrong hands or being misused.
+- Transparency: You approve transactions directly with your account provider, gaining full visibility of fees and currency conversions in your local currency.
+- Control: You decide how much money is accessible, who can access it, for how long, and how often.
 
 ## The Payment Journey
 
 1. The App Talks to Both Wallets
-3. The application sends a request to both the sender's and recipient's wallet addresses. This allows it to contact each account provider directly to coordinate the transaction.
-5. The Recipient’s Provider Is Notified
-7. The app starts by telling the recipient’s account provider that money is expected.
-9. A Quote Is Requested from Your Provider
-11. Your provider calculates a quote, including all applicable fees and currency conversions — and shows the total in your currency, so you know exactly what you’re agreeing to.
-13. You Approve the Payment
-    iBefore anything happens, you’re asked to approve:
-    i. On mobile, your payment app might send you a push notification asking for confirmation.
-    ii. On the web, you may be redirected to your account provider’s website to log in and approve.
-19. This step ensures the integrity of your account —it's a conversation between you and your account provider, who can verify your identity (with a password, fingerprint, etc.). No one can access your account without your knowledge or permission.
+2. The application sends a request to both the sender's and recipient's wallet addresses. This allows it to contact each account provider directly to coordinate the transaction.
+3. The Recipient’s Provider Is Notified
+4. The app starts by telling the recipient’s account provider that money is expected.
+5. A Quote Is Requested from Your Provider
+6. Your provider calculates a quote, including all applicable fees and currency conversions — and shows the total in your currency, so you know exactly what you’re agreeing to.
+7. You Approve the Payment
+   iBefore anything happens, you’re asked to approve:
+   i. On mobile, your payment app might send you a push notification asking for confirmation.
+   ii. On the web, you may be redirected to your account provider’s website to log in and approve.
+8. This step ensures the integrity of your account —it's a conversation between you and your account provider, who can verify your identity (with a password, fingerprint, etc.). No one can access your account without your knowledge or permission.
 
 ## The Final Step: How the Money Moves
 

--- a/src/content/foundation-pages/open-standards.mdx
+++ b/src/content/foundation-pages/open-standards.mdx
@@ -6,7 +6,8 @@ locale: 'en'
 ---
 
 <CalloutText>
-Our technology is always open, accessible, and shared with the global community.
+  Our technology is always open, accessible, and shared with the global
+  community.
 </CalloutText>
 
 <Paragraph>
@@ -16,7 +17,8 @@ We believe that payment networks should be interoperable to remove barriers to p
 </Paragraph>
 
 <Blockquote source="Christina Kinney, Head of Payment Operations">
-  “Interledger gives us the ability to grow and adapt. The way they have built it is such that it really can democratize the movement of money.”
+  “Interledger gives us the ability to grow and adapt. The way they have built
+  it is such that it really can democratize the movement of money.”
 </Blockquote>
 
 <Paragraph>
@@ -31,7 +33,7 @@ Discover more about the faster, easier and more efficient way to send money here
 
 ## Open Payments is a standard that enables digital financial services to allow delegated access into their Interledger-enabled accounts.
 
-When digital financial service providers implement the standard,  their customers’ financial accounts gain the ability to share transaction history and certain account details with applications. This allows applications to issue instructions for sending and receiving payments on their user’s behalf.
+When digital financial service providers implement the standard, their customers’ financial accounts gain the ability to share transaction history and certain account details with applications. This allows applications to issue instructions for sending and receiving payments on their user’s behalf.
 
 Evolve your offer through open payments, find out more here.
 
@@ -40,7 +42,5 @@ Evolve your offer through open payments, find out more here.
 Until recently, there hasn't been an open, neutral, and cost-efficient way of transferring money on the Internet. Interledger and the Open Payment APIs provide a simple, interoperable, and currency-agnostic method for the transfer of small amounts of money.
 
 Be part of the next wave of web monetization work here.
-
-
 
 </Paragraph>

--- a/src/content/foundation-pages/policy-and-advocacy.mdx
+++ b/src/content/foundation-pages/policy-and-advocacy.mdx
@@ -6,7 +6,8 @@ locale: 'en'
 ---
 
 <CalloutText>
-$21 million awarded in grants | 271 projects supported to date | 42 countries represented globally
+  $21 million awarded in grants | 271 projects supported to date | 42 countries
+  represented globally
 </CalloutText>
 
 <Paragraph>

--- a/src/content/foundation-pages/team.mdx
+++ b/src/content/foundation-pages/team.mdx
@@ -9,6 +9,7 @@ locale: 'en'
 The Interledger Foundation is comprised of a dynamic team of individuals across various backgrounds, countries and skillsets, contributing to our overall vision of making payments as easy as sending an email.
 
 ## ILF Leadership Team
+
 Briana Marbury
 President & CEO
 
@@ -18,7 +19,7 @@ Alex Shin
 Chief Operating Officer
 
 Alex joined the Interledger Foundation in September 2025 as a Chief Operating Officer, where he leads strategic planning and oversees the foundation’s global operations, partnerships, and financial stewardship. Prior to this role, Alex spent several years as a Certified Public Accountant and auditor with national public accounting firms, serving a range of respected nonprofit organizations. His expertise in nonprofit finance and operations has made him a sought-after speaker and published contributor in the sector. As COO, Alex drives organizational alignment, ensures operational continuity, including but not limited to, finance, HR, and compliance.
- 
+
 Alex Lakatos
 Chief Technical Officer
 
@@ -39,6 +40,7 @@ Communications Director
 Anna has a background working with open standards. As Communications Manager at Interledger Foundation she helps to connect technical capabilities with human impact stories. She is passionate about sharing stories of the transformative nature of open payments and the importance of inclusive, open working practices.
 
 ## Board of Directors
+
 - Briana Marbury, President & CEO of Interledger Foundation
 - Stefan Thomas, Chairperson of Interledger Foundation, Co-creator of ILP
 - Evan Schwartz, Co-creator of ILP

--- a/src/content/foundation-pages/web-monetization.mdx
+++ b/src/content/foundation-pages/web-monetization.mdx
@@ -6,5 +6,6 @@ locale: 'en'
 ---
 
 <CalloutText>
-Web Monetization allows websites to automatically and passively receive payments from visitors.
+  Web Monetization allows websites to automatically and passively receive
+  payments from visitors.
 </CalloutText>

--- a/src/content/summit-pages/es/hackathon.mdx
+++ b/src/content/summit-pages/es/hackathon.mdx
@@ -15,7 +15,6 @@ View the schedule
 
 Interledger is happy to partner with FinnoSummit, one of the leading events in the Fintech ecosystem of Mexico and Latin America.
 
-
 ## Win amazing prizes!
 
 Your ideas can make the internet more open and inclusive for everyone. Build with purpose — and earn prizes that celebrate real-world impact.
@@ -56,8 +55,8 @@ Receive insights and guidance from the Interledger team to build your best solut
 Ideation sessions**
 Participate in a facilitated ideation session to help refine your innovative solutions.
 
-
 ## Participation requirements
+
 - You must be 18 or older to participate
 - Teams of 1 to 4 participants can enter
 - This hackathon will take place in English and Spanish


### PR DESCRIPTION
## Summary
- Updates CMS admin UI to separate `pageType` ("Page Type") and `pillar` ("Brand Pillar") into distinct fields, with a 3-column layout in the Strapi admin
- Fixes a `strapi.log.warn(` call bug in `pageLifecycle.ts` (missing closing paren — replaced with `console.warn`)

## Related Issue

Fixes INTORG-569

## Manual Test

1. Open Strapi admin → Foundation Pages — confirm the new Brand Pillar field appears alongside Page Type in the layout
2. Check that all 9 brand pillar pages are present under `src/content/foundation-pages/`
3. Verify the pages render correctly in the Astro site

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)

no more brand pillar on summit pages
<img width="2070" height="1162" alt="image" src="https://github.com/user-attachments/assets/acf9468d-d38c-4857-860c-d310c6f68f22" />

and new values for foundation pages ( note my DB is stale and 'VALUES' doesnt show up here... hopefully it does when you test it )
<img width="724" height="470" alt="image" src="https://github.com/user-attachments/assets/bd7c53c5-cc89-42ab-8df1-c18efe61b63b" />
