### PR TITLE
fix(styles): add list-style markers to prose content [INTORG-589]

### DIFF
--- a/src/styles/components/prose/base-typography.css
+++ b/src/styles/components/prose/base-typography.css
@@ -29,16 +29,23 @@
       line-height: 1.6;
     }
 
-    /* Lists: indented with spacing */
-    & ul,
+    /* Lists: indented with spacing and markers */
+    & ul {
+      margin-block-end: var(--spacing-space-s);
+      padding-inline-start: var(--spacing-space-m);
+      list-style-type: disc;
+    }
+
     & ol {
       margin-block-end: var(--spacing-space-s);
       padding-inline-start: var(--spacing-space-m);
+      list-style-type: decimal;
     }
 
-    /* List items: spaced */
+    /* List items: spaced, with line-height matching paragraphs */
     & li {
       margin-block-end: var(--spacing-space-xs);
+      line-height: 1.6;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `list-style-type: disc` for `<ul>` and `list-style-type: decimal` for `<ol>` inside prose content areas
- Tailwind's CSS reset strips default list markers, leaving bullet lists unstyled on pages like `/join-network/`
- Also adds `line-height: 1.6` on `<li>` to match paragraph readability

## Related Issue

Fixes INTORG-589

## Manual Test

1. Visit `/join-network/` on the preview deploy
2. Confirm unordered lists display disc bullet markers
3. Confirm ordered lists display decimal numbers
4. Check other prose pages (blog posts, foundation pages) for consistent list styling
<img width="913" height="479" alt="Screenshot 2026-04-08 at 12 07 54 PM" src="https://github.com/user-attachments/assets/282869c7-61f0-43a8-b9c8-1513a5385d3b" />


## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)