### PR TITLE
feat(cms): add helper text for blog post tags field [INTORG-570]

### DIFF
--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -433,7 +433,12 @@ async function configureFieldLabels(strapi: StrapiInstance) {
         strapi.log.debug(`Component ${uid} not found, skipping labels`)
         continue
       }
-      await applyLabels(componentService, uid, labels, componentDescriptions[uid])
+      await applyLabels(
+        componentService,
+        uid,
+        labels,
+        componentDescriptions[uid]
+      )
     } catch (error) {
       strapi.log.debug(
         `Could not update labels for ${uid}: ${(error as Error).message}`

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -340,6 +340,16 @@ async function configureFieldLabels(strapi: StrapiInstance) {
       image: 'Image',
       imagePosition: 'Image Position',
       attribution: 'Image Attribution'
+    },
+    'shared.tags': {
+      tagValue: 'Tag'
+    }
+  }
+
+  const componentDescriptions: Record<string, Record<string, string>> = {
+    'shared.tags': {
+      tagValue:
+        'You can select multiple tags — click "+ Add an entry" for each tag'
     }
   }
 
@@ -423,7 +433,7 @@ async function configureFieldLabels(strapi: StrapiInstance) {
         strapi.log.debug(`Component ${uid} not found, skipping labels`)
         continue
       }
-      await applyLabels(componentService, uid, labels)
+      await applyLabels(componentService, uid, labels, componentDescriptions[uid])
     } catch (error) {
       strapi.log.debug(
         `Could not update labels for ${uid}: ${(error as Error).message}`


### PR DESCRIPTION
## Summary

Add helper text to the blog post tags field in the Strapi admin panel, indicating that multiple tags can be selected. Uses the existing `applyLabels` infrastructure to set a description on the `tagValue` field inside the `shared.tags` component.

## Related Issue

Fixes INTORG-570

## Manual Test

1. Start Strapi locally (`pnpm --dir cms develop`)
2. Open a Foundation Blog Post entry
3. Scroll to the Tags section
4. Verify helper text "You can select multiple tags — click "+ Add an entry" for each tag" appears below the Tag dropdown
5. 
<img width="845" height="256" alt="Screenshot 2026-04-08 at 1 08 11 PM" src="https://github.com/user-attachments/assets/6d9191b0-ac46-4bfb-91d8-04dc220fbc2e" />


## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)