### PR TITLE
feat(cms): route uploads to img/original and disable image variants

### DIFF
--- a/cms/config/plugins.ts
+++ b/cms/config/plugins.ts
@@ -8,5 +8,11 @@ export default () => ({
       showTakeoverButton: true,
       transports: ['websocket']
     }
+  },
+  upload: {
+    config: {
+      provider: 'local',
+      breakpoints: {}
+    }
   }
 })

--- a/cms/config/server.ts
+++ b/cms/config/server.ts
@@ -16,7 +16,10 @@ function ensureUploadDirs(publicDir: string): void {
         console.log(`✅ Created upload folder: ${dir}`)
       }
     } catch (err) {
-      console.warn(`[Strapi] Could not ensure upload folder exists: ${dir}`, err)
+      console.warn(
+        `[Strapi] Could not ensure upload folder exists: ${dir}`,
+        err
+      )
     }
   }
 }

--- a/cms/config/server.ts
+++ b/cms/config/server.ts
@@ -2,18 +2,22 @@ import fs from 'fs'
 import path from 'path'
 
 /**
- * Local upload provider requires `public/uploads` to exist before the upload
- * plugin registers (app `register` runs too late). Create it when this config loads.
+ * Strapi's local upload provider writes to `<public>/uploads/`. We need that
+ * directory to exist before the provider initialises (its `init` throws otherwise).
+ * We also pre-create the `img/original/` subdirectory where our bootstrap
+ * override actually stores files.
  */
-function ensureUploadsFolder(publicDir: string): void {
-  const uploadsDir = path.join(publicDir, 'uploads')
-  try {
-    if (!fs.existsSync(uploadsDir)) {
-      fs.mkdirSync(uploadsDir, { recursive: true })
-      console.log(`✅ Created Strapi upload folder: ${uploadsDir}`)
+function ensureUploadDirs(publicDir: string): void {
+  for (const sub of ['uploads', 'uploads/img/original']) {
+    const dir = path.join(publicDir, sub)
+    try {
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true })
+        console.log(`✅ Created upload folder: ${dir}`)
+      }
+    } catch (err) {
+      console.warn(`[Strapi] Could not ensure upload folder exists: ${dir}`, err)
     }
-  } catch (err) {
-    console.warn('[Strapi] Could not ensure upload folder exists:', err)
   }
 }
 
@@ -22,12 +26,11 @@ export default ({ env }) => {
     'STRAPI_PUBLIC_DIR',
     path.resolve(process.cwd(), '../public')
   )
-  ensureUploadsFolder(publicDir)
+  ensureUploadDirs(publicDir)
 
   return {
     host: env('HOST', '0.0.0.0'),
     port: env.int('PORT', 1337),
-    // Point Strapi's public directory at the repo root's /public so uploads land in /public/uploads
     dirs: {
       public: publicDir
     },

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -1,8 +1,12 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import { validateGitSyncRepoOnStartup } from './utils/gitSync'
+import {
+  scheduleGitSync,
+  validateGitSyncRepoOnStartup
+} from './utils/gitSync'
 import { validateNoNestedJsx } from './utils/contentValidation'
 import { LOCALES } from './utils/mdx'
+import { shouldSkipMdxExport } from './utils/pageLifecycle'
 
 function copySchemas() {
   const srcDir = path.join(__dirname, '../../src')
@@ -97,6 +101,15 @@ interface CmComponentsService {
 interface StrapiInstance {
   documents: (uid: string) => StrapiDocumentService
   log: StrapiLogger
+  db?: {
+    lifecycles?: {
+      subscribe: (subscription: {
+        models: string[]
+        afterCreate?: (event: { result?: Record<string, unknown> }) => void
+        afterDelete?: (event: { result?: Record<string, unknown> }) => void
+      }) => void
+    }
+  }
   plugin: (name: string) =>
     | {
         service: (
@@ -104,6 +117,30 @@ interface StrapiInstance {
         ) => CmContentTypesService | CmComponentsService | undefined
       }
     | undefined
+}
+
+function registerUploadGitSyncLifecycle(strapi: StrapiInstance): void {
+  strapi.db?.lifecycles?.subscribe({
+    models: ['plugin::upload.file'],
+    afterCreate(event) {
+      if (shouldSkipMdxExport()) return
+
+      const mime = event.result?.mime
+      if (typeof mime === 'string' && !mime.startsWith('image/')) return
+
+      console.log('🖼️  Upload created, scheduling git sync')
+      scheduleGitSync('upload')
+    },
+    afterDelete(event) {
+      if (shouldSkipMdxExport()) return
+
+      const mime = event.result?.mime
+      if (typeof mime === 'string' && !mime.startsWith('image/')) return
+
+      console.log('🗑️  Upload deleted, scheduling git sync')
+      scheduleGitSync('upload')
+    }
+  })
 }
 
 /**
@@ -701,5 +738,8 @@ export default {
     // Configure pretty field labels for the admin panel
     await configureFieldLabels(strapi)
     await configureLayouts(strapi)
+
+    // Auto-commit uploaded image changes in public/uploads via git sync.
+    registerUploadGitSyncLifecycle(strapi)
   }
 }

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -1,10 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { pipeline } from 'stream/promises'
-import {
-  scheduleGitSync,
-  validateGitSyncRepoOnStartup
-} from './utils/gitSync'
+import { scheduleGitSync, validateGitSyncRepoOnStartup } from './utils/gitSync'
 import { validateNoNestedJsx } from './utils/contentValidation'
 import { LOCALES } from './utils/mdx'
 import { shouldSkipMdxExport } from './utils/pageLifecycle'
@@ -316,7 +313,9 @@ async function disableImageVariants(strapi: StrapiInstance): Promise<void> {
   if (imgService) {
     imgService.generateThumbnail = async () => null
     imgService.generateResponsiveFormats = async () => []
-    strapi.log.info('✅ Image manipulation: thumbnail & responsive formats disabled')
+    strapi.log.info(
+      '✅ Image manipulation: thumbnail & responsive formats disabled'
+    )
   }
 }
 

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
+import { pipeline } from 'stream/promises'
 import {
   scheduleGitSync,
   validateGitSyncRepoOnStartup
@@ -98,9 +99,57 @@ interface CmComponentsService {
   ) => Promise<void>
 }
 
+interface UploadSettings {
+  responsiveDimensions: boolean
+  sizeOptimization: boolean
+  autoOrientation: boolean
+  aiMetadata: boolean
+}
+
+interface UploadProvider {
+  upload: (file: UploadFile) => Promise<void>
+  uploadStream: (file: UploadFile) => Promise<void>
+  delete: (file: UploadFile) => Promise<void>
+  checkFileSize: (file: UploadFile, options?: unknown) => void
+}
+
+interface UploadFile {
+  hash: string
+  ext: string
+  url?: string
+  buffer?: Buffer
+  stream?: NodeJS.ReadableStream
+  getStream?: () => NodeJS.ReadableStream
+  [key: string]: unknown
+}
+
+interface UploadService {
+  getSettings: () => Promise<UploadSettings>
+  setSettings: (value: UploadSettings) => Promise<void>
+}
+
+interface ImageManipulationService {
+  generateThumbnail: (file: unknown) => Promise<unknown>
+  generateResponsiveFormats: (file: unknown) => Promise<unknown[]>
+  [key: string]: unknown
+}
+
+interface StrapiPlugin {
+  service: (
+    name: string
+  ) =>
+    | CmContentTypesService
+    | CmComponentsService
+    | UploadService
+    | ImageManipulationService
+    | undefined
+  provider?: UploadProvider
+}
+
 interface StrapiInstance {
   documents: (uid: string) => StrapiDocumentService
   log: StrapiLogger
+  dirs: { static: { public: string } }
   db?: {
     lifecycles?: {
       subscribe: (subscription: {
@@ -110,13 +159,7 @@ interface StrapiInstance {
       }) => void
     }
   }
-  plugin: (name: string) =>
-    | {
-        service: (
-          name: string
-        ) => CmContentTypesService | CmComponentsService | undefined
-      }
-    | undefined
+  plugin: (name: string) => StrapiPlugin | undefined
 }
 
 function registerUploadGitSyncLifecycle(strapi: StrapiInstance): void {
@@ -197,6 +240,83 @@ async function ensureLocales(strapi: StrapiInstance) {
         )
       }
     }
+  }
+}
+
+// ── Upload overrides ──────────────────────────────────────────────────────────
+const UPLOAD_SUBDIR = 'img/original'
+const UPLOAD_URL_PREFIX = `/uploads/${UPLOAD_SUBDIR}`
+
+/**
+ * Redirect the local upload provider so files land in
+ * `public/uploads/img/original/` and URLs reflect the new path.
+ */
+function overrideUploadProvider(strapi: StrapiInstance): void {
+  const uploadPlugin = strapi.plugin('upload')
+  if (!uploadPlugin?.provider) {
+    strapi.log.warn('⚠️  Upload plugin provider not found — skipping override')
+    return
+  }
+
+  const publicDir = strapi.dirs.static.public
+  const uploadPath = path.join(publicDir, 'uploads', UPLOAD_SUBDIR)
+  if (!fs.existsSync(uploadPath)) {
+    fs.mkdirSync(uploadPath, { recursive: true })
+  }
+
+  const provider = uploadPlugin.provider
+
+  provider.uploadStream = async (file: UploadFile) => {
+    const stream = file.stream ?? file.getStream?.()
+    if (!stream) throw new Error('Missing file stream')
+    const dest = path.join(uploadPath, `${file.hash}${file.ext}`)
+    await pipeline(stream, fs.createWriteStream(dest))
+    file.url = `${UPLOAD_URL_PREFIX}/${file.hash}${file.ext}`
+  }
+
+  provider.upload = async (file: UploadFile) => {
+    if (!file.buffer) throw new Error('Missing file buffer')
+    const dest = path.join(uploadPath, `${file.hash}${file.ext}`)
+    fs.writeFileSync(dest, file.buffer)
+    file.url = `${UPLOAD_URL_PREFIX}/${file.hash}${file.ext}`
+  }
+
+  provider.delete = async (file: UploadFile) => {
+    const dest = path.join(uploadPath, `${file.hash}${file.ext}`)
+    if (fs.existsSync(dest)) fs.unlinkSync(dest)
+  }
+
+  strapi.log.info(`✅ Upload provider redirected to ${uploadPath}`)
+}
+
+/**
+ * Disable all image variant generation (thumbnails, responsive formats,
+ * size optimization). Only the original file is kept.
+ */
+async function disableImageVariants(strapi: StrapiInstance): Promise<void> {
+  const uploadPlugin = strapi.plugin('upload')
+  if (!uploadPlugin) return
+
+  const uploadService = uploadPlugin.service('upload') as
+    | UploadService
+    | undefined
+  if (uploadService) {
+    await uploadService.setSettings({
+      responsiveDimensions: false,
+      sizeOptimization: false,
+      autoOrientation: false,
+      aiMetadata: false
+    })
+    strapi.log.info('✅ Upload settings: variants disabled')
+  }
+
+  const imgService = uploadPlugin.service('image-manipulation') as
+    | ImageManipulationService
+    | undefined
+  if (imgService) {
+    imgService.generateThumbnail = async () => null
+    imgService.generateResponsiveFormats = async () => []
+    strapi.log.info('✅ Image manipulation: thumbnail & responsive formats disabled')
   }
 }
 
@@ -731,6 +851,10 @@ export default {
 
     // Ensure git sync points at a valid staging clone before handling content events
     await validateGitSyncRepoOnStartup()
+
+    // Redirect uploads to public/uploads/img/original/ and disable image variants
+    overrideUploadProvider(strapi)
+    await disableImageVariants(strapi)
 
     // Ensure required locales (en, es) are installed
     await ensureLocales(strapi)

--- a/cms/src/utils/gitSync.ts
+++ b/cms/src/utils/gitSync.ts
@@ -7,7 +7,7 @@ import { getProjectRoot } from './paths'
 const STAGE_CANDIDATES = [
   'src/content/',
   'src/data/',
-  'public/uploads'
+  'public/uploads/img/original'
 ] as const
 const CONTENT_PATH_PREFIXES = ['src/content/', 'src/data/'] as const
 const DEBOUNCE_MS = 300
@@ -299,7 +299,7 @@ export async function gitCommitAndPush(
     .map((fp) => toGitPath(repoRoot, fp))
     .filter((p): p is string => Boolean(p))
 
-  const uploadsDir = path.join(repoRoot, 'public', 'uploads')
+  const uploadsDir = path.join(repoRoot, 'public', 'uploads', 'img', 'original')
   if (fs.existsSync(uploadsDir)) {
     const uploadsPath = toGitPath(repoRoot, uploadsDir)
     if (uploadsPath) normalizedPaths.push(uploadsPath)

--- a/cms/src/utils/paths.ts
+++ b/cms/src/utils/paths.ts
@@ -33,7 +33,7 @@ export function assertRunFromCms(): void {
 export const PATHS = {
   CONTENT_ROOT: 'src/content',
   CONFIG_ROOT: 'src/config',
-  UPLOADS: 'public/uploads',
+  UPLOADS: 'public/uploads/img/original',
   /** Content subdirs for each type (used under CONTENT_ROOT and CONTENT_ROOT/<type>/{locale}). */
   CONTENT: {
     ambassadors: 'ambassadors',


### PR DESCRIPTION
## Summary

Strapi's default upload plugin generates `thumbnail_`, `small_`, `medium_`, and `large_` variants for every uploaded image. This adds unnecessary files to the repo and bloats `public/uploads/`.

This PR:
- **Disables all image variant generation** — forces upload settings (`responsiveDimensions`, `sizeOptimization`, `autoOrientation`, `aiMetadata`) to `false` and monkey-patches `generateThumbnail` / `generateResponsiveFormats` to no-op, so only the original file is kept.
- **Redirects uploads to `public/uploads/img/original/`** — overrides the local upload provider's `upload`, `uploadStream`, and `delete` methods so files land in the new subdirectory and URLs are stored as `/uploads/img/original/<hash>.<ext>`.
- **Updates path references** — `PATHS.UPLOADS`, git sync stage candidates, and the explicit uploads dir in `gitCommitAndPush` all point to the new path.

## Related Issue

INTORG-594

## Manual Test

1. Start Strapi locally (`cd cms && pnpm develop`)
2. Upload an image via the Media Library
3. Confirm the file lands in `public/uploads/img/original/` (not `public/uploads/`)
4. Confirm no `thumbnail_`, `small_`, `medium_`, or `large_` prefixed files are created
5. Confirm the stored URL in the media entry is `/uploads/img/original/<hash>.<ext>`

## Checks

- [ ] `pnpm run format`
- [ ] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)