### PR TITLE
style(prose): add visible underline to content links

### DIFF
--- a/src/layouts/DevelopersBlogLayout.astro
+++ b/src/layouts/DevelopersBlogLayout.astro
@@ -50,7 +50,7 @@ const rawHTMLString = `This article was originally published at <a href=${frontm
       [&_h3]:text-step-1 [&_h3]:font-bold [&_h3]:mb-space-xs
       [&_h4]:font-bold [&_h4]:mb-space-xs
       [&_h5]:font-bold [&_h5]:text-[0.83em]
-      [&_a]:text-primary [&_a]:no-underline [&_a:hover]:underline
+      [&_a]:text-primary [&_a]:underline [&_a]:transition-[text-decoration-color] [&_a]:duration-200 [&_a]:ease-in-out [&_a:hover]:decoration-transparent
       [&_figcaption]:text-step--1 [&_figcaption]:italic
       [&_table]:table [&_table]:w-full [&_table]:border-collapse [&_table]:rounded [&_table]:shadow [&_table]:mb-space-m [&_th]:text-left [&_th]:py-space-3xs [&_th]:px-space-2xs [&_td]:py-space-3xs [&_td]:px-space-2xs [&_thead_tr]:bg-[var(--color-table-stripe)] [&_thead_tr:first-of-type_th:first-of-type]:rounded-ss [&_thead_tr:first-of-type_th:last-of-type]:rounded-se [&_thead+tbody_tr:nth-child(2n)]:bg-[var(--color-table-stripe)] [&_tbody_tr:first-of-type_th:first-child]:rounded-ss [&_tbody_tr:first-of-type_td:first-child]:rounded-ss [&_tbody_tr:first-of-type_th:last-child]:rounded-se [&_tbody_tr:first-of-type_td:last-child]:rounded-se [&_tbody_tr:last-of-type_th:first-child]:rounded-es [&_tbody_tr:last-of-type_td:first-child]:rounded-es [&_tbody_tr:last-of-type_th:last-child]:rounded-ee [&_tbody_tr:last-of-type_td:last-child]:rounded-ee
       [&_.expressive-code]:mb-space-s [&_:not(pre)>code]:rounded [&_:not(pre)>code]:text-step--1 [&_:not(pre)>code]:bg-[var(--color-bg-inline-code)] [&_:not(pre)>code]:px-[0.375rem] [&_:not(pre)>code]:py-[0.125rem] [&_:not(pre)>code]:[overflow-wrap:anywhere]

--- a/src/styles/components/prose/blog.css
+++ b/src/styles/components/prose/blog.css
@@ -17,13 +17,15 @@
       font-size: 0.83em;
     }
 
-    /* === Links: no underline by default, underline on hover === */
+    /* === Links: underline by default for discoverability === */
     & a {
       color: var(--color-primary);
-      text-decoration-line: none;
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
+      transition: text-decoration-color 200ms ease-in-out;
     }
     & a:hover {
-      text-decoration-line: underline;
+      text-decoration-color: transparent;
     }
 
     /* === Extended element spacing === */

--- a/src/styles/components/prose/default.css
+++ b/src/styles/components/prose/default.css
@@ -6,15 +6,15 @@
 
 @layer components {
   main {
-    /* Links: hidden underline that reveals on hover */
+    /* Links: visible underline, accent color on hover */
     & a {
       color: var(--color-primary);
-      text-decoration-color: transparent;
       text-decoration-line: underline;
+      text-decoration-color: currentColor;
       transition: text-decoration-color 200ms ease-in-out;
     }
     & a:hover {
-      text-decoration-color: currentColor;
+      text-decoration-color: transparent;
     }
 
     /* Paragraphs: tighter line-height for body text */

--- a/src/styles/components/prose/foundation.css
+++ b/src/styles/components/prose/foundation.css
@@ -7,5 +7,11 @@
 @layer components {
   [data-prose] a {
     color: var(--color-primary);
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    transition: text-decoration-color 200ms ease-in-out;
+  }
+  [data-prose] a:hover {
+    text-decoration-color: transparent;
   }
 }

--- a/src/styles/components/prose/summit.css
+++ b/src/styles/components/prose/summit.css
@@ -9,6 +9,16 @@
 
 @layer components {
   [data-prose-summit] {
+    & a {
+      color: var(--color-primary);
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
+      transition: text-decoration-color 200ms ease-in-out;
+    }
+    & a:hover {
+      text-decoration-color: transparent;
+    }
+
     & h1 { font-size: var(--text-step-4); }
 
     & h2,


### PR DESCRIPTION
## Summary

Links in prose content areas were missing visible underlines, making them hard to identify as clickable. This adds a default underline to links across all three prose variants (default, blog, foundation) with a smooth fade-out on hover. Navigation links are unaffected.

Fixes INTORG-598

## Manual Test

1. Visit `/about-us` : links in body content should be underlined
3. Hover over a link: underline should fade out smoothly
4. Navigation links in header/footer should **not** have underlines

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)