### PR TITLE
feat(cms): add hero call-to-action buttons managed via Strapi INTORG-588

### DIFF
--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -18,6 +18,7 @@ import type { foundationBlogFrontmatterSchema } from '../../../src/schemas/conte
 import { parseMdxToBlocks, type ParserContext } from './mdxBlockParser'
 import { MdxParserError } from './parserErrors'
 import { normalizeInlineImages } from './normalizeImages'
+import type { HeroCta } from '../../src/utils/mdx'
 import fs from 'fs/promises'
 import path from 'path'
 import { getTargetRepoRoot } from '@/utils/gitSync'
@@ -138,6 +139,45 @@ async function getImageFromStrapi(
   }
 }
 
+interface StrapiHeroPayload {
+  title: string
+  description: string
+  hero_call_to_action?: Array<{
+    text: string
+    link: string
+    style: string
+    external: boolean
+    analytics_event_label?: string
+  }>
+}
+
+function buildHeroPayload(
+  heroTitle: string | undefined,
+  heroDescription: string | undefined,
+  fallbackTitle: string,
+  ctas: HeroCta[] | undefined
+): StrapiHeroPayload {
+  const hero: StrapiHeroPayload = {
+    title: heroTitle || fallbackTitle,
+    description: heroDescription || ''
+  }
+
+  const validCtas = ctas?.filter((c) => c.text && c.link)
+  if (validCtas && validCtas.length > 0) {
+    hero.hero_call_to_action = validCtas.map((c) => ({
+      text: c.text!,
+      link: c.link!,
+      style: c.style ?? 'primary',
+      external: c.external ?? false,
+      ...(c.analytics_event_label
+        ? { analytics_event_label: c.analytics_event_label }
+        : {})
+    }))
+  }
+
+  return hero
+}
+
 /**
  * Builds a Strapi payload for a page-type MDX file.
  *
@@ -174,35 +214,14 @@ export async function buildPagePayload(
     ...(parsed.pillar ? { pillar: parsed.pillar } : {})
   }
 
-  // Handle hero section
-  // If hero fields exist in frontmatter, use them
-  // Otherwise, preserve existing hero data if updating an entry
+  // Handle hero section — use frontmatter fields if present, otherwise preserve existing
   if (parsed.heroTitle || parsed.heroDescription) {
-    const hero: Record<string, unknown> = {
-      title: parsed.heroTitle || parsed.title,
-      description: parsed.heroDescription || ''
-    }
-    const heroCtas = parsed.heroCtas as
-      | Array<{
-          text: string
-          link: string
-          style?: string
-          external?: boolean
-          analytics_event_label?: string
-        }>
-      | undefined
-    if (heroCtas && heroCtas.length > 0) {
-      hero.hero_call_to_action = heroCtas.map((c) => ({
-        text: c.text,
-        link: c.link,
-        style: c.style ?? 'primary',
-        external: c.external ?? false,
-        ...(c.analytics_event_label
-          ? { analytics_event_label: c.analytics_event_label }
-          : {})
-      }))
-    }
-    data.hero = hero
+    data.hero = buildHeroPayload(
+      parsed.heroTitle as string | undefined,
+      parsed.heroDescription as string | undefined,
+      parsed.title as string,
+      parsed.heroCtas as HeroCta[] | undefined
+    )
   } else {
     const existingHero = getEntryField(existingEntry, 'hero')
     if (existingHero) {

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -178,10 +178,31 @@ export async function buildPagePayload(
   // If hero fields exist in frontmatter, use them
   // Otherwise, preserve existing hero data if updating an entry
   if (parsed.heroTitle || parsed.heroDescription) {
-    data.hero = {
+    const hero: Record<string, unknown> = {
       title: parsed.heroTitle || parsed.title,
       description: parsed.heroDescription || ''
     }
+    const heroCtas = parsed.heroCtas as
+      | Array<{
+          text: string
+          link: string
+          style?: string
+          external?: boolean
+          analytics_event_label?: string
+        }>
+      | undefined
+    if (heroCtas && heroCtas.length > 0) {
+      hero.hero_call_to_action = heroCtas.map((c) => ({
+        text: c.text,
+        link: c.link,
+        style: c.style ?? 'primary',
+        external: c.external ?? false,
+        ...(c.analytics_event_label
+          ? { analytics_event_label: c.analytics_event_label }
+          : {})
+      }))
+    }
+    data.hero = hero
   } else {
     const existingHero = getEntryField(existingEntry, 'hero')
     if (existingHero) {

--- a/cms/src/components/shared/hero.json
+++ b/cms/src/components/shared/hero.json
@@ -33,6 +33,16 @@
           "localized": true
         }
       }
+    },
+    "hero_call_to_action": {
+      "type": "component",
+      "component": "shared.cta-link",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     }
   }
 }

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -546,7 +546,8 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     'shared.hero': {
       title: 'Hero Title',
       description: 'Hero Description',
-      backgroundImage: 'Background Image'
+      backgroundImage: 'Background Image',
+      hero_call_to_action: 'Call-to-action Buttons'
     },
     'shared.seo': {
       metaDescription: 'Meta Description'
@@ -874,7 +875,8 @@ async function configureLayouts(strapi: StrapiInstance) {
       [
         { name: 'description', size: 6 },
         { name: 'backgroundImage', size: 6 }
-      ]
+      ],
+      [{ name: 'hero_call_to_action', size: 12 }]
     ],
     'shared.seo': [[{ name: 'metaDescription', size: 12 }]]
   }

--- a/cms/src/utils/mdx.ts
+++ b/cms/src/utils/mdx.ts
@@ -138,16 +138,25 @@ export function getPreservedFields(filepath: string): Record<string, unknown> {
   }
 }
 
+interface HeroCta {
+  text?: string
+  link?: string
+  style?: 'primary' | 'secondary'
+  external?: boolean
+  analytics_event_label?: string
+}
+
+interface HeroData {
+  title?: string
+  description?: string
+  backgroundImage?: { url?: string }
+  hero_call_to_action?: HeroCta[]
+}
+
 export function heroFrontmatter(
-  hero:
-    | {
-        title?: string
-        description?: string
-        backgroundImage?: { url?: string }
-      }
-    | undefined
-): Record<string, string> {
-  const data: Record<string, string> = {}
+  hero: HeroData | undefined
+): Record<string, unknown> {
+  const data: Record<string, unknown> = {}
   if (!hero) return data
   if (hero.title) {
     data.heroTitle = hero.title
@@ -158,6 +167,18 @@ export function heroFrontmatter(
   const heroImage = getImageUrl(hero.backgroundImage)
   if (heroImage) {
     data.heroImage = heroImage
+  }
+  const ctas = hero.hero_call_to_action?.filter((c) => c.text && c.link)
+  if (ctas && ctas.length > 0) {
+    data.heroCtas = ctas.map((c) => ({
+      text: c.text!,
+      link: c.link!,
+      ...(c.style && c.style !== 'primary' ? { style: c.style } : {}),
+      ...(c.external ? { external: true } : {}),
+      ...(c.analytics_event_label
+        ? { analytics_event_label: c.analytics_event_label }
+        : {})
+    }))
   }
   return data
 }

--- a/cms/src/utils/mdx.ts
+++ b/cms/src/utils/mdx.ts
@@ -138,7 +138,7 @@ export function getPreservedFields(filepath: string): Record<string, unknown> {
   }
 }
 
-interface HeroCta {
+export interface HeroCta {
   text?: string
   link?: string
   style?: 'primary' | 'secondary'

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -39,6 +39,13 @@ interface PageData {
     title?: string
     description?: string
     backgroundImage?: { url?: string }
+    hero_call_to_action?: Array<{
+      text?: string
+      link?: string
+      style?: 'primary' | 'secondary'
+      external?: boolean
+      analytics_event_label?: string
+    }>
   }
   seo?: {
     metaDescription?: string
@@ -155,7 +162,12 @@ export function generateMDX(
   }
 
   // Explicitly remove Strapi-managed fields that are no longer set (e.g. deleted image)
-  const heroManagedKeys = ['heroTitle', 'heroDescription', 'heroImage'] as const
+  const heroManagedKeys = [
+    'heroTitle',
+    'heroDescription',
+    'heroImage',
+    'heroCtas'
+  ] as const
   for (const key of heroManagedKeys) {
     if (!(key in heroData)) delete frontmatterData[key]
   }
@@ -217,7 +229,7 @@ async function fetchPublished(
       locale,
       status: 'published',
       populate: {
-        hero: { populate: '*' },
+        hero: { populate: { backgroundImage: true, hero_call_to_action: true } },
         seo: { populate: '*' },
         content: FOUNDATION_PAGE_CONTENT_POPULATE
       }

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -229,7 +229,9 @@ async function fetchPublished(
       locale,
       status: 'published',
       populate: {
-        hero: { populate: { backgroundImage: true, hero_call_to_action: true } },
+        hero: {
+          populate: { backgroundImage: true, hero_call_to_action: true }
+        },
         seo: { populate: '*' },
         content: FOUNDATION_PAGE_CONTENT_POPULATE
       }

--- a/cms/types/generated/components.d.ts
+++ b/cms/types/generated/components.d.ts
@@ -596,6 +596,12 @@ export interface SharedHero extends Struct.ComponentSchema {
           localized: true
         }
       }>
+    hero_call_to_action: Schema.Attribute.Component<'shared.cta-link', true> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
     title: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.SetPluginOptions<{

--- a/src/components/pages/FoundationContentPage.astro
+++ b/src/components/pages/FoundationContentPage.astro
@@ -77,11 +77,12 @@ if (isNotFound) return Astro.redirect('/404')
                 </p>
               )}
               {heroCtas.length > 0 && (
-                <div class="flex flex-wrap gap-space-s">
+                <div class="flex flex-wrap gap-space-s mt-space-s">
                   {heroCtas.map((cta) => (
                     <Link
                       href={cta.link}
                       style={cta.style}
+                      variant="hero"
                       umami={cta.analytics_event_label}
                       external={cta.external}
                       text={cta.text}

--- a/src/components/pages/FoundationContentPage.astro
+++ b/src/components/pages/FoundationContentPage.astro
@@ -11,6 +11,7 @@ import PdfEmbed from '@/components/PdfEmbed.astro'
 import VideoEmbed from '@/components/blocks/VideoEmbed.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import { getHeroSectionStyle } from '@/utils/heroSectionStyle'
+import Link from '@/components/shared/Link.astro'
 
 interface Props {
   slug: string
@@ -39,6 +40,7 @@ const canonicalURL = mdxData?.canonicalUrl || undefined
 const mdxHeroTitle = mdxData?.heroTitle || mdxData?.title || ''
 const mdxHeroDescription = mdxData?.heroDescription || ''
 const heroSectionStyle = getHeroSectionStyle(mdxData?.heroImage)
+const heroCtas = mdxData?.heroCtas ?? []
 const pillar = mdxData?.pillar || undefined
 const isNotFound = !MdxContent
 
@@ -73,6 +75,19 @@ if (isNotFound) return Astro.redirect('/404')
                 <p class="mb-space-m text-[1.125rem] max-w-[600px]">
                   {mdxHeroDescription}
                 </p>
+              )}
+              {heroCtas.length > 0 && (
+                <div class="flex flex-wrap gap-space-s">
+                  {heroCtas.map((cta) => (
+                    <Link
+                      href={cta.link}
+                      style={cta.style}
+                      umami={cta.analytics_event_label}
+                      external={cta.external}
+                      text={cta.text}
+                    />
+                  ))}
+                </div>
               )}
             </div>
           </div>

--- a/src/components/pages/SummitContentPage.astro
+++ b/src/components/pages/SummitContentPage.astro
@@ -11,6 +11,7 @@ import CalloutText from '@/components/callout/CalloutText.astro'
 import PdfEmbed from '@/components/PdfEmbed.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import { getHeroSectionStyle } from '@/utils/heroSectionStyle'
+import Link from '@/components/shared/Link.astro'
 
 interface Props {
   slug: string
@@ -39,6 +40,7 @@ const canonicalURL = mdxData?.canonicalUrl || undefined
 const mdxHeroTitle = mdxData?.heroTitle || mdxData?.title || ''
 const mdxHeroDescription = mdxData?.heroDescription || ''
 const heroSectionStyle = getHeroSectionStyle(mdxData?.heroImage)
+const heroCtas = mdxData?.heroCtas ?? []
 const gradient =
   (mdxData as { gradient?: string } | undefined)?.gradient || 'option1'
 ---
@@ -74,6 +76,19 @@ const gradient =
                 <p class="mb-space-m text-[1.125rem] max-w-[600px]">
                   {mdxHeroDescription}
                 </p>
+              )}
+              {heroCtas.length > 0 && (
+                <div class="flex flex-wrap gap-space-s">
+                  {heroCtas.map((cta) => (
+                    <Link
+                      href={cta.link}
+                      style={cta.style}
+                      umami={cta.analytics_event_label}
+                      external={cta.external}
+                      text={cta.text}
+                    />
+                  ))}
+                </div>
               )}
             </div>
           </div>

--- a/src/components/pages/SummitContentPage.astro
+++ b/src/components/pages/SummitContentPage.astro
@@ -78,11 +78,12 @@ const gradient =
                 </p>
               )}
               {heroCtas.length > 0 && (
-                <div class="flex flex-wrap gap-space-s">
+                <div class="flex flex-wrap gap-space-s mt-space-s">
                   {heroCtas.map((cta) => (
                     <Link
                       href={cta.link}
                       style={cta.style}
+                      variant="hero"
                       umami={cta.analytics_event_label}
                       external={cta.external}
                       text={cta.text}

--- a/src/components/shared/HeroSection.astro
+++ b/src/components/shared/HeroSection.astro
@@ -1,5 +1,20 @@
 ---
 import Link from './Link.astro'
+
+interface CtaLink {
+  link: string
+  text: string
+  style?: string
+  external?: boolean
+  analytics_event_label?: string
+}
+
+interface Props {
+  title?: string
+  content?: string
+  ctas?: CtaLink[]
+}
+
 const { title, content, ctas } = Astro.props
 ---
 
@@ -16,19 +31,20 @@ const { title, content, ctas } = Astro.props
       <p class="max-w-[50em] text-[1.125rem] leading-relaxed mb-space-xs">
         {content ?? ''}
       </p>
-      <div class="flex gap-8">
-        {
-          ctas?.map((link) => (
+      {ctas && ctas.length > 0 && (
+        <div class="flex flex-wrap gap-space-s mt-space-s">
+          {ctas.map((link) => (
             <Link
               href={link.link}
               style={link.style}
+              variant="hero"
               umami={link.analytics_event_label}
               external={link.external}
               text={link.text}
             />
-          ))
-        }
-      </div>
+          ))}
+        </div>
+      )}
     </div>
   </div>
 </section>

--- a/src/components/shared/HeroSection.astro
+++ b/src/components/shared/HeroSection.astro
@@ -31,20 +31,22 @@ const { title, content, ctas } = Astro.props
       <p class="max-w-[50em] text-[1.125rem] leading-relaxed mb-space-xs">
         {content ?? ''}
       </p>
-      {ctas && ctas.length > 0 && (
-        <div class="flex flex-wrap gap-space-s mt-space-s">
-          {ctas.map((link) => (
-            <Link
-              href={link.link}
-              style={link.style}
-              variant="hero"
-              umami={link.analytics_event_label}
-              external={link.external}
-              text={link.text}
-            />
-          ))}
-        </div>
-      )}
+      {
+        ctas && ctas.length > 0 && (
+          <div class="flex flex-wrap gap-space-s mt-space-s">
+            {ctas.map((link) => (
+              <Link
+                href={link.link}
+                style={link.style}
+                variant="hero"
+                umami={link.analytics_event_label}
+                external={link.external}
+                text={link.text}
+              />
+            ))}
+          </div>
+        )
+      }
     </div>
   </div>
 </section>

--- a/src/components/shared/Link.astro
+++ b/src/components/shared/Link.astro
@@ -1,13 +1,31 @@
 ---
-const { href, style, umami, external, text } = Astro.props
+const { href, style, umami, external, text, variant } = Astro.props
+
+const classes: Record<string, string> = {
+  'hero-primary':
+    'inline-block w-fit rounded-pill bg-white text-primary font-semibold no-underline transition-colors hover:bg-white/90',
+  'hero-secondary':
+    'inline-block w-fit rounded-pill border-2 border-white text-white font-semibold no-underline transition-colors hover:bg-white/15',
+  secondary:
+    'inline-block w-fit rounded-pill bg-white/70 text-primary no-underline transition-colors hover:bg-white/90',
+  primary:
+    'inline-block w-fit rounded-pill bg-primary text-white no-underline transition-colors hover:bg-primary-hover'
+}
+
+const key =
+  variant === 'hero'
+    ? style === 'secondary'
+      ? 'hero-secondary'
+      : 'hero-primary'
+    : style === 'secondary'
+      ? 'secondary'
+      : 'primary'
 ---
 
 <a
   href={href ?? ''}
-  class={style === 'secondary'
-    ? 'inline-block w-fit rounded-button bg-white/70 text-primary transition-colors hover:bg-white/90'
-    : 'inline-block w-fit rounded-button bg-primary text-white transition-colors hover:bg-primary-hover'}
-  style={`padding: clamp(0.875rem, 0.7772rem + 0.4348vi, 1.125rem) clamp(1.6875rem, 1.4674rem + 0.9783vi, 2.25rem);`}
+  class={classes[key]}
+  style={`padding: clamp(0.625rem, 0.56rem + 0.29vi, 0.8rem) clamp(1.25rem, 1.1rem + 0.65vi, 1.6rem);`}
   data-umami-event={umami ?? ''}
   {...external && {
     target: '_blank',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,11 +62,12 @@ const heroSectionStyle = getHeroSectionStyle(heroImage)
           </p>
           {
             heroCtas && heroCtas.length > 0 && (
-              <div class="flex flex-wrap gap-space-s">
+              <div class="flex flex-wrap gap-space-s mt-space-s">
                 {heroCtas.map((cta) => (
                   <Link
                     href={cta.link}
                     style={cta.style}
+                    variant="hero"
                     umami={cta.analytics_event_label}
                     external={cta.external}
                     text={cta.text}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import Paragraph from '../components/blocks/Paragraph.astro'
 import { type Locale } from '@/utils/i18'
 import { HOME_SLUG } from '@/utils/routes'
 import { getHeroSectionStyle } from '@/utils/heroSectionStyle'
+import Link from '@/components/shared/Link.astro'
 
 const pageLang: Locale = 'en'
 
@@ -25,7 +26,8 @@ const {
   canonicalUrl,
   heroTitle,
   heroDescription,
-  heroImage
+  heroImage,
+  heroCtas
 } = homePage.data
 const pageTitle = title || 'Interledger Foundation'
 const pageDescription = metaDescription || undefined
@@ -58,6 +60,19 @@ const heroSectionStyle = getHeroSectionStyle(heroImage)
           <p class="mb-space-m text-[1.25rem] max-w-[600px]">
             {heroDescription}
           </p>
+          {heroCtas && heroCtas.length > 0 && (
+            <div class="flex flex-wrap gap-space-s">
+              {heroCtas.map((cta) => (
+                <Link
+                  href={cta.link}
+                  style={cta.style}
+                  umami={cta.analytics_event_label}
+                  external={cta.external}
+                  text={cta.text}
+                />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,19 +60,21 @@ const heroSectionStyle = getHeroSectionStyle(heroImage)
           <p class="mb-space-m text-[1.25rem] max-w-[600px]">
             {heroDescription}
           </p>
-          {heroCtas && heroCtas.length > 0 && (
-            <div class="flex flex-wrap gap-space-s">
-              {heroCtas.map((cta) => (
-                <Link
-                  href={cta.link}
-                  style={cta.style}
-                  umami={cta.analytics_event_label}
-                  external={cta.external}
-                  text={cta.text}
-                />
-              ))}
-            </div>
-          )}
+          {
+            heroCtas && heroCtas.length > 0 && (
+              <div class="flex flex-wrap gap-space-s">
+                {heroCtas.map((cta) => (
+                  <Link
+                    href={cta.link}
+                    style={cta.style}
+                    umami={cta.analytics_event_label}
+                    external={cta.external}
+                    text={cta.text}
+                  />
+                ))}
+              </div>
+            )
+          }
         </div>
       </div>
     </section>

--- a/src/pages/page-preview.astro
+++ b/src/pages/page-preview.astro
@@ -6,6 +6,7 @@
  */
 import BaseLayout from '@/layouts/BaseLayout.astro'
 import DynamicZone from '@/components/blocks/DynamicZone.astro'
+import Link from '@/components/shared/Link.astro'
 import { applyPreviewNoStore } from '@/utils/cache'
 import { fetchStrapi } from '@/utils/fetchStrapi'
 
@@ -49,6 +50,13 @@ const title = page.title || 'Preview'
 const description = page.seo?.metaDescription || undefined
 const heroTitle = page.hero?.title || page.title
 const heroDescription = page.hero?.description
+const heroCtas = (page.hero?.hero_call_to_action ?? []) as Array<{
+  text?: string
+  link?: string
+  style?: string
+  external?: boolean
+  analytics_event_label?: string
+}>
 const content = page.content || []
 ---
 
@@ -71,6 +79,19 @@ const content = page.content || []
                 <p class="mb-space-m text-[1.125rem] max-w-[600px]">
                   {heroDescription}
                 </p>
+              )}
+              {heroCtas.length > 0 && (
+                <div class="flex flex-wrap gap-space-s">
+                  {heroCtas.map((cta) => (
+                    <Link
+                      href={cta.link}
+                      style={cta.style}
+                      umami={cta.analytics_event_label}
+                      external={cta.external}
+                      text={cta.text}
+                    />
+                  ))}
+                </div>
               )}
             </div>
           </div>

--- a/src/pages/page-preview.astro
+++ b/src/pages/page-preview.astro
@@ -81,11 +81,12 @@ const content = page.content || []
                 </p>
               )}
               {heroCtas.length > 0 && (
-                <div class="flex flex-wrap gap-space-s">
+                <div class="flex flex-wrap gap-space-s mt-space-s">
                   {heroCtas.map((cta) => (
                     <Link
                       href={cta.link}
                       style={cta.style}
+                      variant="hero"
                       umami={cta.analytics_event_label}
                       external={cta.external}
                       text={cta.text}

--- a/src/pages/preview/page-preview.astro
+++ b/src/pages/preview/page-preview.astro
@@ -83,11 +83,12 @@ const content = page.content || []
                 </p>
               )}
               {heroCtas.length > 0 && (
-                <div class="flex flex-wrap gap-space-s">
+                <div class="flex flex-wrap gap-space-s mt-space-s">
                   {heroCtas.map((cta) => (
                     <Link
                       href={cta.link}
                       style={cta.style}
+                      variant="hero"
                       umami={cta.analytics_event_label}
                       external={cta.external}
                       text={cta.text}

--- a/src/pages/preview/page-preview.astro
+++ b/src/pages/preview/page-preview.astro
@@ -6,6 +6,7 @@
  */
 import BaseLayout from '@/layouts/BaseLayout.astro'
 import DynamicZone from '@/components/blocks/DynamicZone.astro'
+import Link from '@/components/shared/Link.astro'
 import { applyPreviewNoStore } from '@/utils/cache'
 import { fetchStrapi } from '@/utils/fetchStrapi'
 
@@ -51,6 +52,13 @@ const title = page.title || 'Preview'
 const description = page.seo?.metaDescription || undefined
 const heroTitle = page.hero?.title || page.title
 const heroDescription = page.hero?.description
+const heroCtas = (page.hero?.hero_call_to_action ?? []) as Array<{
+  text?: string
+  link?: string
+  style?: string
+  external?: boolean
+  analytics_event_label?: string
+}>
 const content = page.content || []
 ---
 
@@ -73,6 +81,19 @@ const content = page.content || []
                 <p class="mb-space-m text-[1.125rem] max-w-[600px]">
                   {heroDescription}
                 </p>
+              )}
+              {heroCtas.length > 0 && (
+                <div class="flex flex-wrap gap-space-s">
+                  {heroCtas.map((cta) => (
+                    <Link
+                      href={cta.link}
+                      style={cta.style}
+                      umami={cta.analytics_event_label}
+                      external={cta.external}
+                      text={cta.text}
+                    />
+                  ))}
+                </div>
               )}
             </div>
           </div>

--- a/src/schemas/content.ts
+++ b/src/schemas/content.ts
@@ -1,5 +1,13 @@
 import { z } from 'zod'
 
+const heroCtaSchema = z.object({
+  text: z.string(),
+  link: z.string(),
+  style: z.enum(['primary', 'secondary']).optional(),
+  external: z.boolean().optional(),
+  analytics_event_label: z.string().optional()
+})
+
 // Normalizes pathSlug by stripping any leading or trailing slashes so that
 // "grants/web-grant", "/grants/web-grant", "grants/web-grant/", and
 // "/grants/web-grant/" all resolve to the same route.
@@ -82,6 +90,7 @@ export const foundationPageFrontmatterSchema = z.object({
   heroTitle: z.string().optional(),
   heroDescription: z.string().optional(),
   heroImage: z.string().optional(),
+  heroCtas: z.array(heroCtaSchema).optional(),
   metaDescription: z.string().optional(),
   metaImage: z.string().optional(),
   canonicalUrl: z.string().optional(),
@@ -112,6 +121,7 @@ export const summitPageFrontmatterSchema = z.object({
   heroTitle: z.string().optional(),
   heroDescription: z.string().optional(),
   heroImage: z.string().optional(),
+  heroCtas: z.array(heroCtaSchema).optional(),
   metaDescription: z.string().optional(),
   metaImage: z.string().optional(),
   canonicalUrl: z.string().optional(),


### PR DESCRIPTION
## Summary

Add hero call-to-action buttons as a Strapi-managed field on the Hero component.  commit and push changes

- Strapi schema (`shared.hero`) gains a repeatable `cta-link` component
- `heroFrontmatter()` serializes CTAs into `heroCtas` frontmatter field
- Astro page components and preview pages render CTAs using the existing `Link` component
- `sync:mdx` round-trips CTAs back into Strapi's `hero.hero_call_to_action`
- Admin layout and labels configured so the field appears in the Hero section

## Related Issue

Fixes INTORG-588

## Manual Test

1. Start Strapi (`pnpm run dev` in `cms/`)
2. Open any **Foundation Page** → expand **Hero** section
3. Verify **"Call-to-action Buttons"** repeatable field appears below Background Image
4. Add a CTA with text "Get Started" and link "/get-started", set style to "primary"
5. Add a second CTA with text "Learn More", link "/about", style "secondary"
6. Click **Publish** → verify a git commit is created on staging with the page slug in the message
7. Open the corresponding MDX file → confirm `heroCtas` array appears in frontmatter
8. Run `pnpm run build` in the Astro root → verify no build errors
9. Check the rendered page → CTA buttons appear in the hero section
10. Remove all CTAs in Strapi → Publish → verify `heroCtas` is removed from frontmatter
11. Repeat steps 3-6 for a **Summit Page**

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)