### PR TITLE
fix(cms): add afterUpdate hook to navigation lifecycle

### DIFF
--- a/cms/src/utils/navigationLifecycle.ts
+++ b/cms/src/utils/navigationLifecycle.ts
@@ -138,23 +138,33 @@ async function deleteNavigationFile(
   }
 }
 
+async function exportAndCommitNavigation(
+  config: NavigationLifecycleConfig,
+  action: string
+): Promise<void> {
+  if (shouldSkipMdxExport()) return
+  const label = uidToLogLabel(config.contentTypeUid)
+  console.log(`📝 ${action} ${label} JSON`)
+  const navigation = await fetchPublishedNavigation(config)
+  if (!navigation) {
+    console.log(`⏭️  No published ${label} navigation`)
+    return
+  }
+  const outputPath = writeNavigationFile(config, navigation)
+  await gitCommitAndPush(
+    [outputPath],
+    `${label}: ${action.toLowerCase()} navigation`
+  )
+}
+
 export function createNavigationLifecycle(config: NavigationLifecycleConfig) {
   return {
     async afterCreate(_event: Event) {
-      if (shouldSkipMdxExport()) return
-      console.log(`📝 Creating ${uidToLogLabel(config.contentTypeUid)} JSON`)
-      const navigation = await fetchPublishedNavigation(config)
-      if (!navigation) {
-        console.log(
-          `⏭️  No published ${uidToLogLabel(config.contentTypeUid)} navigation`
-        )
-        return
-      }
-      const outputPath = writeNavigationFile(config, navigation)
-      await gitCommitAndPush(
-        [outputPath],
-        `${uidToLogLabel(config.contentTypeUid)}: update navigation`
-      )
+      await exportAndCommitNavigation(config, 'Create')
+    },
+
+    async afterUpdate(_event: Event) {
+      await exportAndCommitNavigation(config, 'Update')
     },
 
     async afterDelete(_event: Event) {


### PR DESCRIPTION
## Summary

Add missing `afterUpdate` lifecycle hook to the navigation content types. 

## Related Issue

Fixes INTORG-586

## Manual Test

1. Start Strapi (`pnpm run dev` in `cms/`)
2. Open **Foundation Navigation** (single type)
3. Edit a menu item label or add a new menu group
4. Click **Save**
5. Verify a git commit appears on staging with message `foundation-navigation: update navigation`
6. Check `src/config/foundation-navigation.json` reflects the change
7. Repeat for **Summit Navigation**
8. Run `pnpm run build` in Astro root → verify header renders the updated menu

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)