### PR TITLE
fix(cms): restrict ambassador description editor to supported options [INTORG-567]

### DIFF
--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -45,6 +45,38 @@ interface CKEditor {
 const DOC_ID_PATTERN = /^[a-z0-9]{20,26}$/
 const DOC_ID_TITLE_PATTERN = /^[a-z0-9]{20,26}\s*\|/
 
+function cleanGoogleDocsOnPaste(editor: CKEditor) {
+  const clipboardPlugin = editor.plugins.get('ClipboardPipeline')
+
+  clipboardPlugin.on(
+    'contentInsertion',
+    (evt: unknown, data: CKEditorInsertionData) => {
+      const htmlContent = data.dataTransfer.getData('text/html')
+
+      if (
+        htmlContent &&
+        (htmlContent.includes('docs-internal-guid') ||
+          htmlContent.includes('google-docs'))
+      ) {
+        const cleanedHtml = htmlContent
+          // Remove only the Google Docs wrapper <b> tag with font-weight:normal - is this too fragile?
+          .replace(/<b[^>]*font-weight:\s*normal[^>]*>/gi, '')
+          .replace(/<\/b>(?=<br class="Apple-interchange-newline">)/gi, '')
+          // Remove meta tags
+          .replace(/<meta[^>]*>/gi, '')
+
+        // Parse the cleaned HTML and insert it
+        const viewFragment = editor.data.processor.toView(cleanedHtml)
+        const modelFragment = editor.data.toModel(viewFragment)
+
+        // Replace the content that would be inserted
+        data.content = modelFragment
+      }
+    },
+    { priority: 'high' }
+  )
+}
+
 const myCustomPreset: Preset = {
   ...defaultMarkdownPreset,
   description: 'Markdown editor without H1',
@@ -55,47 +87,38 @@ const myCustomPreset: Preset = {
         (option) => option.model !== 'heading1'
       )
     },
-    extraPlugins: [
-      function cleanGoogleDocsOnPaste(editor: CKEditor) {
-        const clipboardPlugin = editor.plugins.get('ClipboardPipeline')
+    extraPlugins: [cleanGoogleDocsOnPaste]
+  }
+}
 
-        clipboardPlugin.on(
-          'contentInsertion',
-          (evt: unknown, data: CKEditorInsertionData) => {
-            const htmlContent = data.dataTransfer.getData('text/html')
-
-            if (
-              htmlContent &&
-              (htmlContent.includes('docs-internal-guid') ||
-                htmlContent.includes('google-docs'))
-            ) {
-              const cleanedHtml = htmlContent
-                // Remove only the Google Docs wrapper <b> tag with font-weight:normal - is this too fragile?
-                .replace(/<b[^>]*font-weight:\s*normal[^>]*>/gi, '')
-                .replace(
-                  /<\/b>(?=<br class="Apple-interchange-newline">)/gi,
-                  ''
-                )
-                // Remove meta tags
-                .replace(/<meta[^>]*>/gi, '')
-
-              // Parse the cleaned HTML and insert it
-              const viewFragment = editor.data.processor.toView(cleanedHtml)
-              const modelFragment = editor.data.toModel(viewFragment)
-
-              // Replace the content that would be inserted
-              data.content = modelFragment
-            }
-          },
-          { priority: 'high' }
-        )
-      }
-    ]
+const ambassadorBioPreset: Preset = {
+  ...defaultMarkdownPreset,
+  name: 'ambassadorBio',
+  description: 'Simplified editor for ambassador biographies',
+  editorConfig: {
+    ...defaultMarkdownPreset.editorConfig,
+    toolbar: [
+      'bold',
+      'italic',
+      'strikethrough',
+      '|',
+      'link',
+      '|',
+      'bulletedList',
+      'numberedList',
+      '|',
+      'blockQuote',
+      '|',
+      'undo',
+      'redo'
+    ],
+    heading: undefined,
+    extraPlugins: [cleanGoogleDocsOnPaste]
   }
 }
 
 const myPluginConfig: PluginConfig = {
-  presets: [myCustomPreset]
+  presets: [myCustomPreset, ambassadorBioPreset]
 }
 
 export default {

--- a/cms/src/api/ambassador/content-types/ambassador/schema.json
+++ b/cms/src/api/ambassador/content-types/ambassador/schema.json
@@ -27,11 +27,15 @@
       "required": true
     },
     "description": {
-      "type": "richtext",
+      "type": "customField",
+      "customField": "plugin::ckeditor5.CKEditor",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
+      },
+      "options": {
+        "preset": "ambassadorBio"
       },
       "required": false
     },

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -458,6 +458,12 @@ export interface ApiAmbassadorAmbassador extends Struct.CollectionTypeSchema {
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private
     description: Schema.Attribute.RichText &
+      Schema.Attribute.CustomField<
+        'plugin::ckeditor5.CKEditor',
+        {
+          preset: 'ambassadorBio'
+        }
+      > &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true

--- a/src/components/ambassadors/Ambassador.astro
+++ b/src/components/ambassadors/Ambassador.astro
@@ -85,7 +85,16 @@ const hasLinks = linkedinUrl || grantReportUrl
     }
   </div>
   <div
-    class="ambassador__txt max-w-none [&_strong]:font-bold [&_strong]:text-black"
+    class:list={[
+      'ambassador__txt max-w-none',
+      '[&_strong]:font-bold [&_strong]:text-black',
+      '[&_a]:text-primary [&_a]:underline hover:[&_a]:no-underline',
+      '[&_ul]:list-disc [&_ul]:ps-space-m [&_ul]:mb-space-2xs',
+      '[&_ol]:list-decimal [&_ol]:ps-space-m [&_ol]:mb-space-2xs',
+      '[&_li]:mb-space-3xs [&_li]:leading-relaxed',
+      '[&_p]:mb-space-2xs [&_p:last-child]:mb-0',
+      '[&_blockquote]:border-l-4 [&_blockquote]:border-primary [&_blockquote]:ps-space-xs [&_blockquote]:italic [&_blockquote]:my-space-2xs'
+    ]}
     set:html={descriptionHtml}
   />
 </article>


### PR DESCRIPTION
## Summary

- Switch ambassador `description` field from Strapi's built-in richtext to CKEditor custom field (`plugin::ckeditor5.CKEditor`) with a restricted `ambassadorBio` preset
- Restricted toolbar: **bold, italic, strikethrough, link, bullet list, numbered list, blockquote, undo/redo** — removes headings, images, tables, code blocks, and other unsupported options
- Add rich text styling to `Ambassador.astro` so links, lists, paragraphs, and blockquotes render correctly on the frontend

<img width="1280" height="1080" alt="03-strapi-description-with-content" src="https://github.com/user-attachments/assets/63f8f1f9-acb4-4407-81b6-32930b69994a" />

<img width="1280" height="1080" alt="04-strapi-published" src="https://github.com/user-attachments/assets/60a8c44c-0870-4c4f-a910-e2fe058f5c8a" />

<img width="1280" height="633" alt="01-strapi-restricted-toolbar" src="https://github.com/user-attachments/assets/a3ea7f14-52f4-4d33-b88c-a81b9564f291" />
<img width="1280" height="1080" alt="02-strapi-description-restricted-toolbar" src="https://github.com/user-attachments/assets/eb8c9f54-5601-46b8-a17c-5f45dea1a0c4" />



## Related Issue

Fixes INTORG-567

## Manual Test

1. Start Strapi (`pnpm --dir cms develop`)
2. Go to Content Manager → Ambassador → create/edit an entry
3. Verify the Description toolbar only shows: B, I, S, link, lists, blockquote, undo, redo
4. Type formatted content (bold text, bullet list)
5. Verify formatted content renders correctly on the Astro frontend

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused (4 files)