### PR TITLE
fix(styles): add bullet list styles to global prose CSS

### DIFF
--- a/src/styles/components/prose/default.css
+++ b/src/styles/components/prose/default.css
@@ -21,5 +21,23 @@
     & p {
       line-height: 1.39;
     }
+
+    /* Lists */
+    & ul {
+      margin-block-end: var(--spacing-space-s);
+      padding-inline-start: var(--spacing-space-m);
+      list-style-type: disc;
+    }
+
+    & ol {
+      margin-block-end: var(--spacing-space-s);
+      padding-inline-start: var(--spacing-space-m);
+      list-style-type: decimal;
+    }
+
+    & li {
+      margin-block-end: var(--spacing-space-xs);
+      line-height: 1.6;
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fixed bullet lists not rendering on summit pages (e.g., /summit/hackathon/). Added list styles to default.css so they're applied globally to all pages via the main element.

## Related Issue
INTORG-589

## Manual Test
- Visit /summit/hackathon/ and verify bullet lists render correctly

## Checks
- [x] `pnpm run format`
- [x] `pnpm run lint`