### PR TITLE
chore: remove stale unused environment variable references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,6 @@ HOST=0.0.0.0
 PORT=1337
 
 # Database
-DATABASE_CLIENT=better-sqlite3
 DATABASE_FILENAME=.tmp/data.db
 
 # Strapi API (used by Astro to fetch content)
@@ -19,9 +18,6 @@ STRAPI_API_TOKEN=your-api-token
 
 # Astro frontend URL (used by Strapi for preview iframe)
 ASTRO_PREVIEW_URL=http://localhost:1103
-
-# CORS — space-separated list of allowed frontend origins
-# FRONTEND_ORIGINS=http://localhost:1103
 
 # Media uploads
 # Only needed if uploads are hosted externally (CDN, S3, etc.).

--- a/cms/README.md
+++ b/cms/README.md
@@ -41,25 +41,19 @@ Set `ASTRO_PREVIEW_URL` to match your Astro dev server port (default `http://loc
 
 #### Environment variables
 
-| Variable                    | Description                                                                                                                                                                                                             |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                      | CMS runs on port 1337 (default)                                                                                                                                                                                         |
-| `DATABASE_CLIENT`           | Using better-sqlite3                                                                                                                                                                                                    |
-| `ASTRO_PREVIEW_URL`         | Must match the Astro dev server URL (e.g. `http://localhost:1103`)                                                                                                                                                      |
-| `MDX_OUTPUT_PATH`           | Base output path for page MDX files. Default behavior resolves to `STRAPI_GIT_SYNC_REPO_PATH/src/content/foundation-pages` for English pages, with localizations written under `src/content/foundation-pages/{locale}/` |
-| `STRAPI_GIT_SYNC_REPO_PATH` | Target git clone used for lifecycle hook commits (default: `~/interledger.org-v5-staging`)                                                                                                                              |
-| `STRAPI_UPLOADS_BASE_URL`   | Base URL prepended to upload paths in generated content files (e.g. `https://cdn.example.com`). Only needed if uploads are hosted externally. When unset, upload paths stay relative (`/uploads/...`).                  |
-| `STRAPI_DISABLE_GIT_SYNC`   | Set to `true` to skip the automatic git commit and push after content changes. Useful in local development.                                                                                                             |
-| `FRONTEND_ORIGINS`          | Origins allowed for CORS (e.g., local dev, staging, production Astro sites)                                                                                                                                             |
+| Variable                    | Description                                                                                                                                                                                            |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PORT`                      | CMS runs on port 1337 (default)                                                                                                                                                                        |
+| `ASTRO_PREVIEW_URL`         | Must match the Astro dev server URL (e.g. `http://localhost:1103`)                                                                                                                                     |
+| `STRAPI_GIT_SYNC_REPO_PATH` | Target git clone used for lifecycle hook commits (default: `~/interledger.org-v5-staging`)                                                                                                             |
+| `STRAPI_UPLOADS_BASE_URL`   | Base URL prepended to upload paths in generated content files (e.g. `https://cdn.example.com`). Only needed if uploads are hosted externally. When unset, upload paths stay relative (`/uploads/...`). |
+| `STRAPI_DISABLE_GIT_SYNC`   | Set to `true` to skip the automatic git commit and push after content changes. Useful in local development.                                                                                            |
 
 ### Git Sync Repository Target
 
 Lifecycle hooks that commit MDX updates now write to a dedicated staging clone configured by `STRAPI_GIT_SYNC_REPO_PATH`.
 
-For page MDX output, the resolution order is:
-
-1. `MDX_OUTPUT_PATH`
-2. `src/content/foundation-pages` (resolved inside `STRAPI_GIT_SYNC_REPO_PATH`)
+Page MDX output is written under `src/content/foundation-pages` inside `STRAPI_GIT_SYNC_REPO_PATH`, with localized pages under `src/content/foundation-pages/{locale}/`.
 
 This was introduced to:
 
@@ -393,7 +387,7 @@ cms/
 ### MDX files not generating
 
 1. Check that the content item is **published** (not just saved as draft)
-2. Verify the `MDX_OUTPUT_PATH` in `.env` points to the correct directory
+2. Verify the staging clone configured by `STRAPI_GIT_SYNC_REPO_PATH` points to the correct repository
 3. Check file permissions on the content directory (e.g. `src/content/foundation-pages`)
 4. Look for errors in the Strapi console output
 
@@ -427,7 +421,7 @@ pnpm add dotenv
 
 - The `.env` file contains secrets - never commit it to version control
 - Change the default secrets in `.env` before deploying to production
-- Update `FRONTEND_ORIGINS` in `.env` and `config/middlewares.ts` for production
+- Review the allowed CORS origins in `config/middlewares.ts` for production
 
 ## Support
 

--- a/cms/README.md
+++ b/cms/README.md
@@ -47,7 +47,6 @@ Set `ASTRO_PREVIEW_URL` to match your Astro dev server port (default `http://loc
 | `DATABASE_CLIENT`           | Using better-sqlite3                                                                                                                                                                                                    |
 | `ASTRO_PREVIEW_URL`         | Must match the Astro dev server URL (e.g. `http://localhost:1103`)                                                                                                                                                      |
 | `MDX_OUTPUT_PATH`           | Base output path for page MDX files. Default behavior resolves to `STRAPI_GIT_SYNC_REPO_PATH/src/content/foundation-pages` for English pages, with localizations written under `src/content/foundation-pages/{locale}/` |
-| `PAGES_MDX_OUTPUT_PATH`     | Legacy page output override (used if `MDX_OUTPUT_PATH` is not set)                                                                                                                                                      |
 | `STRAPI_GIT_SYNC_REPO_PATH` | Target git clone used for lifecycle hook commits (default: `~/interledger.org-v5-staging`)                                                                                                                              |
 | `STRAPI_UPLOADS_BASE_URL`   | Base URL prepended to upload paths in generated content files (e.g. `https://cdn.example.com`). Only needed if uploads are hosted externally. When unset, upload paths stay relative (`/uploads/...`).                  |
 | `STRAPI_DISABLE_GIT_SYNC`   | Set to `true` to skip the automatic git commit and push after content changes. Useful in local development.                                                                                                             |
@@ -60,8 +59,7 @@ Lifecycle hooks that commit MDX updates now write to a dedicated staging clone c
 For page MDX output, the resolution order is:
 
 1. `MDX_OUTPUT_PATH`
-2. `PAGES_MDX_OUTPUT_PATH`
-3. `src/content/foundation-pages` (resolved inside `STRAPI_GIT_SYNC_REPO_PATH`)
+2. `src/content/foundation-pages` (resolved inside `STRAPI_GIT_SYNC_REPO_PATH`)
 
 This was introduced to:
 


### PR DESCRIPTION
## Summary
<!-- What changed and why -->
This PR removes stale environment variable references that are no longer used by the codebase and updates the CMS docs to match the current runtime behavior.

What was removed

PAGES_MDX_OUTPUT_PATH
Removed the last remaining references from cms/README.md. This legacy fallback is not read anywhere in the codebase.

MDX_OUTPUT_PATH
Removed from cms/README.md. Page MDX output is not configured via env anymore; it is resolved from the lifecycle config and STRAPI_GIT_SYNC_REPO_PATH.

FRONTEND_ORIGINS
Removed from .env.example and cms/README.md. CORS origins are currently hardcoded in cms/config/middlewares.ts, so this env var was misleading.

DATABASE_CLIENT
Removed from .env.example and cms/README.md. The database config is hardcoded to SQLite in cms/config/database.ts.

## Related Issue
<!-- Fixes INTORG-123 -->
Fixes INTORG-491

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [ ] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
