### PR TITLE
feat(cms): disable H1 in CKEditor and migrate richtext fields to custom field

### DIFF
--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -47,11 +47,36 @@ const DOC_ID_TITLE_PATTERN = /^[a-z0-9]{20,26}\s*\|/
 
 const headingOptionsWithoutH1 = [
   { model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
-  { model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
-  { model: 'heading3', view: 'h3', title: 'Heading 3', class: 'ck-heading_heading3' },
-  { model: 'heading4', view: 'h4', title: 'Heading 4', class: 'ck-heading_heading4' },
-  { model: 'heading5', view: 'h5', title: 'Heading 5', class: 'ck-heading_heading5' },
-  { model: 'heading6', view: 'h6', title: 'Heading 6', class: 'ck-heading_heading6' }
+  {
+    model: 'heading2',
+    view: 'h2',
+    title: 'Heading 2',
+    class: 'ck-heading_heading2'
+  },
+  {
+    model: 'heading3',
+    view: 'h3',
+    title: 'Heading 3',
+    class: 'ck-heading_heading3'
+  },
+  {
+    model: 'heading4',
+    view: 'h4',
+    title: 'Heading 4',
+    class: 'ck-heading_heading4'
+  },
+  {
+    model: 'heading5',
+    view: 'h5',
+    title: 'Heading 5',
+    class: 'ck-heading_heading5'
+  },
+  {
+    model: 'heading6',
+    view: 'h6',
+    title: 'Heading 6',
+    class: 'ck-heading_heading6'
+  }
 ]
 
 const markdownPresetNoH1: Preset = {

--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -45,16 +45,21 @@ interface CKEditor {
 const DOC_ID_PATTERN = /^[a-z0-9]{20,26}$/
 const DOC_ID_TITLE_PATTERN = /^[a-z0-9]{20,26}\s*\|/
 
-const myCustomPreset: Preset = {
+const headingOptionsWithoutH1 = [
+  { model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
+  { model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
+  { model: 'heading3', view: 'h3', title: 'Heading 3', class: 'ck-heading_heading3' },
+  { model: 'heading4', view: 'h4', title: 'Heading 4', class: 'ck-heading_heading4' },
+  { model: 'heading5', view: 'h5', title: 'Heading 5', class: 'ck-heading_heading5' },
+  { model: 'heading6', view: 'h6', title: 'Heading 6', class: 'ck-heading_heading6' }
+]
+
+const markdownPresetNoH1: Preset = {
   ...defaultMarkdownPreset,
-  description: 'Markdown editor without H1',
+  description: 'Default Markdown editor without H1',
   editorConfig: {
     ...defaultMarkdownPreset.editorConfig,
-    heading: {
-      options: defaultMarkdownPreset.editorConfig.heading?.options?.filter(
-        (option) => option.model !== 'heading1'
-      )
-    },
+    heading: { options: headingOptionsWithoutH1 },
     extraPlugins: [
       function cleanGoogleDocsOnPaste(editor: CKEditor) {
         const clipboardPlugin = editor.plugins.get('ClipboardPipeline')
@@ -95,7 +100,7 @@ const myCustomPreset: Preset = {
 }
 
 const myPluginConfig: PluginConfig = {
-  presets: [myCustomPreset]
+  presets: [markdownPresetNoH1]
 }
 
 export default {

--- a/cms/src/api/ambassador/content-types/ambassador/schema.json
+++ b/cms/src/api/ambassador/content-types/ambassador/schema.json
@@ -27,7 +27,11 @@
       "required": true
     },
     "description": {
-      "type": "richtext",
+      "type": "customField",
+      "customField": "plugin::ckeditor5.CKEditor",
+      "options": {
+        "preset": "defaultMarkdown"
+      },
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/cms/src/components/blocks/blockquote.json
+++ b/cms/src/components/blocks/blockquote.json
@@ -12,7 +12,11 @@
       "required": true
     },
     "source": {
-      "type": "richtext"
+      "type": "customField",
+      "customField": "plugin::ckeditor5.CKEditor",
+      "options": {
+        "preset": "defaultMarkdown"
+      }
     }
   }
 }

--- a/cms/src/components/blocks/callout-text.json
+++ b/cms/src/components/blocks/callout-text.json
@@ -8,7 +8,11 @@
   "options": {},
   "attributes": {
     "content": {
-      "type": "richtext",
+      "type": "customField",
+      "customField": "plugin::ckeditor5.CKEditor",
+      "options": {
+        "preset": "defaultMarkdown"
+      },
       "required": true
     }
   }

--- a/cms/src/components/blocks/image-row.json
+++ b/cms/src/components/blocks/image-row.json
@@ -17,7 +17,11 @@
       }
     },
     "content": {
-      "type": "richtext",
+      "type": "customField",
+      "customField": "plugin::ckeditor5.CKEditor",
+      "options": {
+        "preset": "defaultMarkdown"
+      },
       "required": true,
       "pluginOptions": {
         "i18n": {

--- a/cms/src/components/blocks/paragraph.json
+++ b/cms/src/components/blocks/paragraph.json
@@ -8,7 +8,11 @@
   "options": {},
   "attributes": {
     "content": {
-      "type": "richtext",
+      "type": "customField",
+      "customField": "plugin::ckeditor5.CKEditor",
+      "options": {
+        "preset": "defaultMarkdown"
+      },
       "required": true,
       "pluginOptions": {
         "i18n": {

--- a/cms/types/generated/components.d.ts
+++ b/cms/types/generated/components.d.ts
@@ -42,7 +42,13 @@ export interface BlocksBlockquote extends Struct.ComponentSchema {
   }
   attributes: {
     quote: Schema.Attribute.Text & Schema.Attribute.Required
-    source: Schema.Attribute.RichText
+    source: Schema.Attribute.RichText &
+      Schema.Attribute.CustomField<
+        'plugin::ckeditor5.CKEditor',
+        {
+          preset: 'defaultMarkdown'
+        }
+      >
   }
 }
 
@@ -54,7 +60,14 @@ export interface BlocksCalloutText extends Struct.ComponentSchema {
     icon: 'megaphone'
   }
   attributes: {
-    content: Schema.Attribute.RichText & Schema.Attribute.Required
+    content: Schema.Attribute.RichText &
+      Schema.Attribute.Required &
+      Schema.Attribute.CustomField<
+        'plugin::ckeditor5.CKEditor',
+        {
+          preset: 'defaultMarkdown'
+        }
+      >
   }
 }
 
@@ -369,6 +382,12 @@ export interface BlocksImageRow extends Struct.ComponentSchema {
       }>
     content: Schema.Attribute.RichText &
       Schema.Attribute.Required &
+      Schema.Attribute.CustomField<
+        'plugin::ckeditor5.CKEditor',
+        {
+          preset: 'defaultMarkdown'
+        }
+      > &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true
@@ -415,6 +434,12 @@ export interface BlocksParagraph extends Struct.ComponentSchema {
       Schema.Attribute.DefaultTo<'left'>
     content: Schema.Attribute.RichText &
       Schema.Attribute.Required &
+      Schema.Attribute.CustomField<
+        'plugin::ckeditor5.CKEditor',
+        {
+          preset: 'defaultMarkdown'
+        }
+      > &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -458,6 +458,12 @@ export interface ApiAmbassadorAmbassador extends Struct.CollectionTypeSchema {
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private
     description: Schema.Attribute.RichText &
+      Schema.Attribute.CustomField<
+        'plugin::ckeditor5.CKEditor',
+        {
+          preset: 'defaultMarkdown'
+        }
+      > &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true


### PR DESCRIPTION
## Summary

- Removes H1 from the CKEditor heading dropdown by hardcoding heading options (H2–H6 + Paragraph) in both the HTML and Markdown presets in `app.tsx`
- Migrates `richtext` fields in `paragraph`, `blockquote`, `image-row`, `callout-text`, and `ambassador` schemas to ck5

## Related Issue

Fixes INTORG-571

## Manual Test

1. Open any content type in the Strapi admin that has a rich text block (e.g. Paragraph, Blockquote)
2. Click into the content field and open the Headings dropdown
3. Confirm H1 / Heading 1 is no longer listed

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)

<img width="1230" height="738" alt="image" src="https://github.com/user-attachments/assets/e9bde216-0ad0-40a6-b864-bc956b54ba8b" />

