### PR TITLE
feat(cms): format generated MDX files with Prettier on Strapi lifecycle writes INTORG-591

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -47,6 +47,7 @@
     "remark-mdx": "^3.1.1",
     "remark-parse": "11.0.0",
     "styled-components": "^6.1.19",
+    "prettier": "3.8.1",
     "turndown": "^7.2.2",
     "unified": "11.0.5",
     "zod": "^4.3.6"

--- a/cms/pnpm-lock.yaml
+++ b/cms/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       mdast-util-to-markdown:
         specifier: ^2.1.2
         version: 2.1.2
+      prettier:
+        specifier: 3.8.1
+        version: 3.8.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -5986,6 +5989,11 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
 
@@ -8002,6 +8010,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-editor-multi-root@47.4.0':
     dependencies:
@@ -8032,8 +8042,6 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-utils': 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-enter@47.4.0':
     dependencies:
@@ -8443,8 +8451,6 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-ui': 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-watchdog@47.4.0':
     dependencies:
@@ -10134,7 +10140,7 @@ snapshots:
       '@strapi/design-system': 2.2.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.17)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/permissions': 5.41.1
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/typescript-utils': 5.41.1
       '@strapi/utils': 5.41.1
       '@testing-library/dom': 10.4.1
@@ -10333,7 +10339,7 @@ snapshots:
       '@strapi/database': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)
       '@strapi/design-system': 2.2.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.2)(@codemirror/lint@6.9.5)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.17)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/utils': 5.41.1
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
@@ -10434,7 +10440,7 @@ snapshots:
       '@strapi/generators': 5.41.1(@types/node@25.4.0)
       '@strapi/logger': 5.41.1
       '@strapi/permissions': 5.41.1
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/typescript-utils': 5.41.1
       '@strapi/utils': 5.41.1
       '@vercel/stega': 0.1.2
@@ -10862,7 +10868,7 @@ snapshots:
       '@strapi/openapi': 5.41.1
       '@strapi/permissions': 5.41.1
       '@strapi/review-workflows': 5.41.1(6d9d4bf50717dda097ab439406d5332a)
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/typescript-utils': 5.41.1
       '@strapi/upload': 5.41.1(875d5a09f0e66a339eb16219cd5704cd)
       '@strapi/utils': 5.41.1
@@ -10963,6 +10969,36 @@ snapshots:
       - webpack-cli
       - webpack-dev-server
       - webpack-plugin-serve
+
+  '@strapi/types@5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)':
+    dependencies:
+      '@casl/ability': 6.7.5
+      '@koa/cors': 5.0.0
+      '@koa/router': 12.0.2
+      '@strapi/database': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)
+      '@strapi/logger': 5.41.1
+      '@strapi/permissions': 5.41.1
+      '@strapi/utils': 5.41.1
+      commander: 8.3.0
+      json-logic-js: 2.0.5
+      koa: 2.16.4
+      koa-body: 6.0.1
+      node-schedule: 2.1.1
+      typedoc: 0.25.10(typescript@5.4.4)
+      typedoc-github-wiki-theme: 1.1.0(typedoc-plugin-markdown@3.17.1(typedoc@0.25.10(typescript@5.9.3)))(typedoc@0.25.10(typescript@5.9.3))
+      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.10(typescript@5.9.3))
+      zod: 3.25.67
+    transitivePeerDependencies:
+      - '@types/node'
+      - better-sqlite3
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+      - typescript
 
   '@strapi/types@5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)':
     dependencies:
@@ -15075,6 +15111,8 @@ snapshots:
 
   prettier@3.3.3: {}
 
+  prettier@3.8.1: {}
+
   pretty-error@4.0.0:
     dependencies:
       lodash: 4.17.23
@@ -16225,6 +16263,14 @@ snapshots:
     dependencies:
       handlebars: 4.7.8
       typedoc: 0.25.10(typescript@5.9.3)
+
+  typedoc@0.25.10(typescript@5.4.4):
+    dependencies:
+      lunr: 2.3.9
+      marked: 4.3.0
+      minimatch: 9.0.9
+      shiki: 0.14.7
+      typescript: 5.4.4
 
   typedoc@0.25.10(typescript@5.9.3):
     dependencies:

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { shouldSkipMdxExport, getAdminAuthor } from './pageLifecycle'
 import { serializeContent } from '../serializers/blocks'
 import { scheduleGitSync, getTargetRepoRoot, type SyncContext } from './gitSync'
+import { formatMdx } from './mdx'
 import { BLOG_CONTENT_POPULATE } from './contentPopulate'
 import type { StrapiGlobal } from './strapiTypes'
 
@@ -170,7 +171,7 @@ async function writeMDXFile({
   const mdxContent = generateBlogMDX(post)
 
   await fs.promises.mkdir(outputPath, { recursive: true })
-  await fs.promises.writeFile(filepath, mdxContent, 'utf-8')
+  await fs.promises.writeFile(filepath, await formatMdx(mdxContent), 'utf-8')
 
   console.log(`✅ Generated Blog Post MDX file: ${filepath}`)
   return filepath

--- a/cms/src/utils/flatContentLifecycle.ts
+++ b/cms/src/utils/flatContentLifecycle.ts
@@ -8,7 +8,7 @@
 import fs from 'fs'
 import path from 'path'
 import { shouldSkipMdxExport, getAdminAuthor } from './pageLifecycle'
-import { LOCALES } from './mdx'
+import { LOCALES, formatMdx } from './mdx'
 import {
   deleteLocaleMdxFiles,
   removeLocalizesFromLocaleFiles
@@ -103,7 +103,7 @@ export function createFlatLocaleMdxLifecycle<
     await fs.promises.mkdir(baseDir, { recursive: true })
     await fs.promises.writeFile(
       filepath,
-      generateContent(entry, englishSlug),
+      await formatMdx(generateContent(entry, englishSlug)),
       'utf-8'
     )
     console.log(`✅ Generated ${label} MDX: ${filepath}`)

--- a/cms/src/utils/mdx.ts
+++ b/cms/src/utils/mdx.ts
@@ -4,6 +4,7 @@
  */
 
 import fs from 'fs'
+import prettier from 'prettier'
 import yaml from 'js-yaml'
 import matter from 'gray-matter'
 import { marked } from 'marked'
@@ -181,6 +182,27 @@ export function heroFrontmatter(
     }))
   }
   return data
+}
+
+const PRETTIER_MDX_OPTIONS: prettier.Options = {
+  parser: 'mdx',
+  semi: false,
+  singleQuote: true,
+  trailingComma: 'none',
+  proseWrap: 'preserve'
+}
+
+/**
+ * Formats MDX content with Prettier using the project's code style.
+ * Returns the original content unchanged if formatting fails.
+ */
+export async function formatMdx(content: string): Promise<string> {
+  try {
+    return await prettier.format(content, PRETTIER_MDX_OPTIONS)
+  } catch (error) {
+    console.warn('prettier formatting failed, writing unformatted MDX:', error)
+    return content
+  }
 }
 
 export function seoFrontmatter(

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -19,6 +19,7 @@ import {
   seoFrontmatter,
   getPreservedFields,
   uidToLogLabel,
+  formatMdx,
   MATTER_STRINGIFY_OPTIONS
 } from './mdx'
 import {
@@ -199,11 +200,8 @@ async function writeMDXFile(
 
     // Preserve fields that exist in MDX but not in Strapi
     const preservedFields = getPreservedFields(filepath)
-    fs.writeFileSync(
-      filepath,
-      generateMDX(config, page, preservedFields, englishSlug),
-      'utf-8'
-    )
+    const mdxContent = generateMDX(config, page, preservedFields, englishSlug)
+    fs.writeFileSync(filepath, await formatMdx(mdxContent), 'utf-8')
     console.log(
       `✅ Generated ${uidToLogLabel(config.contentTypeUid)} MDX: ${filepath}`
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       mdast-util-to-markdown:
         specifier: ^2.1.2
         version: 2.1.2
+      prettier:
+        specifier: 3.8.1
+        version: 3.8.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -11865,6 +11868,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       '@ckeditor/ckeditor5-widget': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-html-support@47.4.0':
     dependencies:
@@ -11880,6 +11885,8 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-icons@47.4.0': {}
 
@@ -11908,8 +11915,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-integrations-common@2.2.3(ckeditor5@47.4.0)':
     dependencies:
@@ -11994,8 +11999,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-minimap@47.4.0':
     dependencies:
@@ -12910,18 +12913,6 @@ snapshots:
   '@formatjs/intl-localematcher@0.6.2':
     dependencies:
       tslib: 2.8.1
-
-  '@formatjs/intl@2.10.0(typescript@5.4.4)':
-    dependencies:
-      '@formatjs/ecma402-abstract': 1.18.2
-      '@formatjs/fast-memoize': 2.2.0
-      '@formatjs/icu-messageformat-parser': 2.7.6
-      '@formatjs/intl-displaynames': 6.6.6
-      '@formatjs/intl-listformat': 7.5.5
-      intl-messageformat: 10.5.11
-      tslib: 2.8.1
-    optionalDependencies:
-      typescript: 5.4.4
 
   '@formatjs/intl@2.10.0(typescript@5.9.3)':
     dependencies:
@@ -22375,7 +22366,7 @@ snapshots:
     dependencies:
       '@formatjs/ecma402-abstract': 1.18.2
       '@formatjs/icu-messageformat-parser': 2.7.6
-      '@formatjs/intl': 2.10.0(typescript@5.4.4)
+      '@formatjs/intl': 2.10.0(typescript@5.9.3)
       '@formatjs/intl-displaynames': 6.6.6
       '@formatjs/intl-listformat': 7.5.5
       '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.28)


### PR DESCRIPTION
## Summary

- Adds Prettier formatting to all three Strapi lifecycle MDX write paths (`pageLifecycle`, `blogLifecycle`, `flatContentLifecycle`). 
- A shared `formatMdx` utility in `cms/src/utils/mdx.ts` runs Prettier with the project's MDX code style
- `prettier` added to CMS runtime dependencies.

## Related Issue

[INTORG-591: Strapi must run linting as part of it's lifecycle](https://linear.app/interledger/issue/INTORG-591/strapi-must-run-linting-as-part-of-its-lifecycle)

## Manual Test

1. Publish or update a page/blog post via Strapi
2. Check the generated `.mdx` file in `src/content/` — it should be formatted consistently with `pnpm run format`

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)


Before
<img width="1252" height="348" alt="image" src="https://github.com/user-attachments/assets/fa03e4c4-1ae2-496b-ac82-2db6cd4453d7" />

After
<img width="1296" height="342" alt="image" src="https://github.com/user-attachments/assets/43399855-369c-4e7f-bd32-2beb9edb3565" />
