### PR TITLE
chore: removed legacy ES blog handling

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -36,6 +36,11 @@ export const redirects = {
   '/news/reflections-2025-payments-canada-summit-innovate-collaborate-and-transform-future-payments':
     '/news/reflections-2025-payments-canada-summit',
 
+  // Spanish developer blog content
+  '/developers/blog/es': '/es/developers/blog',
+  '/developers/blog/2025-06-04-ES-El-Universo-Interledger':
+    '/es/developers/blog/el-universo-interledger',
+
   // Summit pages
   '/summit/key-information': '/summit/media-kit',
   '/summit/2025-summit-schedule': '/summit/schedule',

--- a/src/components/blog/BlogIndexDevelopers.astro
+++ b/src/components/blog/BlogIndexDevelopers.astro
@@ -45,35 +45,15 @@ const {
             >
               {blogPostEntry.data.date.toDateString()}
             </time>
-            {blogPostEntry.data.locale === 'es' ? (
-              <div class="flex items-start gap-space-2xs">
-                <h2 class="text-step-1">
-                  <a
-                    href={postPath}
-                    class="text-black font-semibold underline decoration-transparent transition-all duration-300 hover:text-primary hover:decoration-inherit"
-                    data-umami-event={`Blog - ${blogPostEntry.data.date.toISOString().slice(0, 10)} (title)`}
-                  >
-                    {blogPostEntry.data.title}
-                  </a>
-                </h2>
-                <a
-                  class="mt-space-3xs rounded border-[1.5px] bg-white px-1 text-step--1 no-underline"
-                  href={path}
-                >
-                  ES
-                </a>
-              </div>
-            ) : (
-              <h2 class="text-step-1">
-                <a
-                  href={postPath}
-                  class="text-black font-semibold underline decoration-transparent transition-all duration-300 hover:text-primary hover:decoration-inherit"
-                  data-umami-event={`Blog - ${blogPostEntry.data.date.toISOString().slice(0, 10)} (title)`}
-                >
-                  {blogPostEntry.data.title}
-                </a>
-              </h2>
-            )}
+            <h2 class="text-step-1">
+              <a
+                href={postPath}
+                class="text-black font-semibold underline decoration-transparent transition-all duration-300 hover:text-primary hover:decoration-inherit"
+                data-umami-event={`Blog - ${blogPostEntry.data.date.toISOString().slice(0, 10)} (title)`}
+              >
+                {blogPostEntry.data.title}
+              </a>
+            </h2>
 
             <p class="mb-space-2xs grow">
               {blogPostEntry.data.description


### PR DESCRIPTION
## Summary
<!-- What changed and why -->
Removed legacy workaround Spanish blog handling
You can see these two PRs that added it in origionally to check if it's removed

- https://github.com/interledger/interledger.org-developers/pull/144/changes#diff-c3f0ff783e91eb7167bc4e0c2bfec7726f9f1a6842ac62138661ff9ffef37532
- https://github.com/interledger/interledger.org-developers/pull/143/changes#diff-b194de210ce12bb7a3480e44c04b4859a4f2b6a1e2358beba7798cfed82d252c

## Related Issue
<!-- Fixes INTORG-123 -->
Fixes INTORG-492

## Manual Test
<!-- Reviewer steps (only if needed) -->
ES tag removed:
[Before](https://interledger.org/developers/blog/es/):
<img width="1319" height="618" alt="image" src="https://github.com/user-attachments/assets/81aeeeaa-636c-4b15-b0a2-97da3512f8f6" />

[After](https://deploy-preview-219--interledger-org-v5.netlify.app/es/developers/blog/)
<img width="1319" height="618" alt="image" src="https://github.com/user-attachments/assets/7d333a3e-b77b-4d2d-b3c6-770f28022986" />


## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)
