### PR TITLE
fix: included full fallback functionality for misc astro pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,6 +14,9 @@ export default defineConfig({
   i18n: {
     locales: ['es', 'en'],
     defaultLocale: 'en',
+    fallback: {
+      es: 'en'
+    },
     routing: {
       prefixDefaultLocale: false,
       fallbackType: 'rewrite'

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -31,7 +31,9 @@ const hrefs = Object.fromEntries(
     const slug = entry?.[locale]
     const href = slug
       ? localizeRoute(buildRoutePath(currentBasePath, slug), locale)
-      : toDefaultSectionHref(locale, currentBasePath)
+      : currentSlug
+        ? localizeRoute(buildRoutePath(currentBasePath, currentSlug), locale)
+        : toDefaultSectionHref(locale, currentBasePath)
     return [locale, href]
   })
 ) as Record<Locale, string>

--- a/src/content/foundation-pages/es/grant/education.mdx
+++ b/src/content/foundation-pages/es/grant/education.mdx
@@ -7,10 +7,10 @@ localizes: 'grant/education'
 ---
 
 <CalloutText>
-Se encuentran disponibles subvenciones de hasta USD 50 000 para instituciones
-de educación superior que busquen inspirar a sus estudiantes a los fines de
-promover, favorecer e innovar en lo que respecta a soluciones para sistemas
-financieros digitales inclusivos.
+  Se encuentran disponibles subvenciones de hasta USD 50 000 para instituciones
+  de educación superior que busquen inspirar a sus estudiantes a los fines de
+  promover, favorecer e innovar en lo que respecta a soluciones para sistemas
+  financieros digitales inclusivos.
 </CalloutText>
 
 <Paragraph>

--- a/src/content/foundation-pages/grant/education.mdx
+++ b/src/content/foundation-pages/grant/education.mdx
@@ -6,9 +6,9 @@ locale: 'en'
 ---
 
 <CalloutText>
-Grants of up to $50,000 USD are available to higher education institutions
-that seek to inspire their students to advocate, champion and innovate
-solutions for inclusive digital financial systems.
+  Grants of up to $50,000 USD are available to higher education institutions
+  that seek to inspire their students to advocate, champion and innovate
+  solutions for inclusive digital financial systems.
 </CalloutText>
 
 <Paragraph>


### PR DESCRIPTION
## Summary
<!-- What changed and why -->
Miscellaneous astro pages would not use fallback EN content

## Related Issue
<!-- Fixes INTORG-123 -->
Fixes INTORG-527

## Manual Test
<!-- Reviewer steps (only if needed) -->

- https://deploy-preview-224--interledger-org-v5.netlify.app/es/contact
- https://deploy-preview-224--interledger-org-v5.netlify.app/es/hackathon-2023

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
