### PR TITLE
fix(cms-sync): fail fast when strapi is offline

### DIFF
--- a/cms/scripts/ensureStrapiRunning.ts
+++ b/cms/scripts/ensureStrapiRunning.ts
@@ -13,22 +13,20 @@ export async function assertStrapiRunning(
   timeoutMs = 4000
 ): Promise<void> {
   const normalized = baseUrl.replace(/\/+$/, '')
-  const probeUrls = [`${normalized}/_health`, `${normalized}/admin`]
+  const probeUrl = `${normalized}/_health`
 
   let lastError: unknown = null
 
-  for (const url of probeUrls) {
-    try {
-      const response = await withTimeout(
-        (signal) => fetch(url, { method: 'GET', signal }),
-        timeoutMs
-      )
+  try {
+    const response = await withTimeout(
+      (signal) => fetch(probeUrl, { method: 'GET', signal }),
+      timeoutMs
+    )
 
-      // Any HTTP response means the server is reachable (even 401/403/404).
-      if (response.status >= 100) return
-    } catch (error) {
-      lastError = error
-    }
+    // Any HTTP response means the server is reachable (even 401/403/404).
+    if (response.status >= 100) return
+  } catch (error) {
+    lastError = error
   }
 
   const reason =

--- a/cms/scripts/ensureStrapiRunning.ts
+++ b/cms/scripts/ensureStrapiRunning.ts
@@ -39,4 +39,3 @@ export async function assertStrapiRunning(
       `Start Strapi first: cd cms && pnpm run develop`
   )
 }
-

--- a/cms/scripts/ensureStrapiRunning.ts
+++ b/cms/scripts/ensureStrapiRunning.ts
@@ -1,0 +1,42 @@
+function withTimeout<T>(
+  promiseFactory: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+  return promiseFactory(controller.signal).finally(() => clearTimeout(timeout))
+}
+
+export async function assertStrapiRunning(
+  baseUrl: string,
+  timeoutMs = 4000
+): Promise<void> {
+  const normalized = baseUrl.replace(/\/+$/, '')
+  const probeUrls = [`${normalized}/_health`, `${normalized}/admin`]
+
+  let lastError: unknown = null
+
+  for (const url of probeUrls) {
+    try {
+      const response = await withTimeout(
+        (signal) => fetch(url, { method: 'GET', signal }),
+        timeoutMs
+      )
+
+      // Any HTTP response means the server is reachable (even 401/403/404).
+      if (response.status >= 100) return
+    } catch (error) {
+      lastError = error
+    }
+  }
+
+  const reason =
+    lastError instanceof Error ? ` (${lastError.message})` : ' (no response)'
+
+  throw new Error(
+    `Strapi does not appear to be running at ${baseUrl}${reason}\n` +
+      `Start Strapi first: cd cms && pnpm run develop`
+  )
+}
+

--- a/cms/scripts/sync-all.ts
+++ b/cms/scripts/sync-all.ts
@@ -6,7 +6,7 @@
  *   pnpm run sync:all --force    # bypass branch check for mdx
  */
 
-import { execSync } from 'child_process'
+import { spawnSync } from 'child_process'
 
 const FORCE = process.argv.includes('--force')
 
@@ -18,5 +18,13 @@ const scripts = [
 
 for (const cmd of scripts) {
   console.log(`\n▶ ${cmd}\n`)
-  execSync(cmd, { stdio: 'inherit' })
+  const result = spawnSync(cmd, {
+    stdio: 'inherit',
+    shell: true
+  })
+
+  if (result.status !== 0) {
+    console.error(`\n❌ sync:all stopped because "${cmd}" failed.`)
+    process.exit(result.status ?? 1)
+  }
 }

--- a/cms/scripts/sync-delete-all.ts
+++ b/cms/scripts/sync-delete-all.ts
@@ -19,6 +19,7 @@ import fs from 'fs'
 import path from 'path'
 import dotenv from 'dotenv'
 import { getProjectRoot, LOCALES } from '@/utils'
+import { assertStrapiRunning } from './ensureStrapiRunning'
 import {
   createStrapiClient,
   type StrapiClient,
@@ -170,6 +171,7 @@ Default collections: ${DEFAULT_COLLECTIONS.join(', ')}
     process.exit(1)
   }
 
+  await assertStrapiRunning(baseUrl)
   const strapi = createStrapiClient({ baseUrl, token })
 
   if (dryRun) {

--- a/cms/scripts/sync-images.ts
+++ b/cms/scripts/sync-images.ts
@@ -16,8 +16,9 @@ import fs from 'fs'
 import path from 'path'
 import { config } from 'dotenv'
 import { getProjectRoot, PATHS } from '@/utils'
+import { assertStrapiRunning } from './ensureStrapiRunning'
 
-config({ path: path.resolve(process.cwd(), '../.env') })
+config({ path: path.resolve(process.cwd(), '../.env'), quiet: true })
 
 const STRAPI_URL = process.env.STRAPI_URL ?? 'http://localhost:1337'
 const STRAPI_TOKEN = process.env.STRAPI_API_TOKEN ?? ''
@@ -87,6 +88,7 @@ async function main() {
     console.error('❌ STRAPI_API_TOKEN is required. Set it in .env')
     process.exit(1)
   }
+  await assertStrapiRunning(STRAPI_URL)
 
   const projectRoot = getProjectRoot()
   let totalRegistered = 0
@@ -141,6 +143,9 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error('Fatal error:', err)
+  console.error(
+    '❌ Fatal error:',
+    err instanceof Error ? err.message : String(err)
+  )
   process.exit(1)
 })

--- a/cms/scripts/sync-mdx/index.ts
+++ b/cms/scripts/sync-mdx/index.ts
@@ -14,6 +14,7 @@ import path from 'path'
 import { spawnSync } from 'child_process'
 import dotenv from 'dotenv'
 import { getProjectRoot } from '@/utils'
+import { assertStrapiRunning } from '../ensureStrapiRunning'
 import { buildContentTypes } from './config'
 import { createStrapiClient } from './strapiClient'
 import { syncAll } from './syncCoordinator'
@@ -62,6 +63,7 @@ async function main() {
   }
 
   console.log(`🔗 Connecting to: ${STRAPI_URL}`)
+  await assertStrapiRunning(STRAPI_URL)
 
   if (DRY_RUN) {
     console.log('🔍 DRY-RUN MODE - No changes will be made\n')

--- a/cms/scripts/sync-navigation.ts
+++ b/cms/scripts/sync-navigation.ts
@@ -12,6 +12,7 @@ import fs from 'fs'
 import path from 'path'
 import dotenv from 'dotenv'
 import { assertRunFromCms, getConfigPath, getProjectRoot } from '@/utils'
+import { assertStrapiRunning } from './ensureStrapiRunning'
 const DRY_RUN = process.argv.includes('--dry-run')
 
 interface MenuItem {
@@ -192,6 +193,7 @@ async function main() {
     process.exit(1)
   }
 
+  await assertStrapiRunning(STRAPI_URL)
   await syncAllNavigations(projectRoot, STRAPI_URL, STRAPI_TOKEN)
 
   if (DRY_RUN) {


### PR DESCRIPTION
## Summary
- Added a shared Strapi health check for sync scripts.
- `sync:mdx`, `sync:navigation`, `sync:images`, and `sync:delete-all` now fail fast with a clear “start Strapi” message.
- `sync:all` now exits cleanly on child script failure without noisy stack traces.

## Related Issue
- Fixes INTORG-624

## Manual Test
1. Stop Strapi and run `pnpm --dir cms run sync:all --force` (expect clear error).
2. Start Strapi and rerun (expect normal execution).

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)
![Screenshot 2026-04-14 at 20 29 16](https://github.com/user-attachments/assets/1c94369f-5364-4b96-a191-8bc96559e22e)
