### PR TITLE
Jm/intorg 625 dontimport optimizedimages

### DIFF
--- a/cms/scripts/sync-images.ts
+++ b/cms/scripts/sync-images.ts
@@ -26,6 +26,7 @@ const SCAN_DIRS: ReadonlyArray<{ dir: string; urlPrefix: string }> = [
   { dir: PATHS.UPLOADS, urlPrefix: `/${PATHS.UPLOADS.replace('public/', '')}` },
   { dir: 'public/img', urlPrefix: '/img' }
 ]
+const EXCLUDED_DIR_NAMES = new Set(['optimized'])
 
 const IMAGE_EXTENSIONS = new Set([
   '.jpg',
@@ -71,6 +72,7 @@ function collectImageFiles(dir: string): string[] {
       if (entry.name.startsWith('.')) continue
       const full = path.join(current, entry.name)
       if (entry.isDirectory()) {
+        if (EXCLUDED_DIR_NAMES.has(entry.name)) continue
         walk(full)
       } else if (IMAGE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
         results.push(full)

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -19,10 +19,7 @@ import { parseMdxToBlocks, type ParserContext } from './mdxBlockParser'
 import { MdxParserError } from './parserErrors'
 import { normalizeInlineImages } from './normalizeImages'
 import type { HeroCta } from '@/utils'
-import { getTargetRepoRoot } from '@/utils'
-import fs from 'fs/promises'
 import path from 'path'
-import mime from 'mime-types'
 
 export interface StrapiUploadContext {
   strapi: StrapiClient
@@ -54,59 +51,15 @@ function normalizeStrapiFilename(filename: string) {
     .replace(/[^\w_.]/g, '')
 }
 
-async function uploadImageToStrapi(
-  STRAPI_URL: string,
-  STRAPI_TOKEN: string,
-  {
-    filePath,
-    name,
-    alt
-  }: { filePath: string; name: string; alt: string | undefined }
-): Promise<number | null> {
-  if (!filePath) return null
-
-  try {
-    const rootDir = getTargetRepoRoot()
-    const fullPath = `${rootDir}/public${filePath}`
-
-    const fileBuffer = await fs.readFile(fullPath)
-    const mimeType = mime.lookup(fullPath) || 'application/octet-stream'
-    const formData = new FormData()
-    const blob = new Blob([fileBuffer], { type: mimeType })
-
-    formData.append('files', blob, path.basename(fullPath))
-    formData.append(
-      'fileInfo',
-      JSON.stringify({ name: name ?? undefined, alternativeText: alt ?? null })
-    )
-
-    const res = await fetch(`${STRAPI_URL}/api/upload`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${STRAPI_TOKEN}`
-      },
-      body: formData
-    })
-
-    if (!res.ok) {
-      console.error(
-        `Failed to upload image: ${filePath} (status ${res.status})`
-      )
-      return null
-    }
-
-    const data: Array<{ id: number }> = await res.json()
-    return data[0]?.id || null
-  } catch (err) {
-    console.error(`Error uploading image "${filePath}: "`, err)
-    return null
-  }
+function isLocalAssetPath(url: string): boolean {
+  return url.startsWith('/img/') || url.startsWith('/uploads/')
 }
 
-// Returns existing Strapi image ID or uploads a new image
+// Returns an existing Strapi upload ID for a referenced image.
+// Local assets must already exist in Strapi media records; this function never uploads.
 async function getImageFromStrapi(
-  { strapi, STRAPI_URL, STRAPI_TOKEN, dryRun }: StrapiUploadContext,
-  { image, alt }: { image: string | undefined; alt: string | undefined }
+  { strapi, dryRun }: StrapiUploadContext,
+  { image }: { image: string | undefined }
 ): Promise<number | null> {
   const photoUrl = nullOrValue(image)
   if (!photoUrl) return null
@@ -120,22 +73,19 @@ async function getImageFromStrapi(
     const byName = await strapi.findUploadByName(name)
     if (byName) return byName
 
-    if (dryRun) {
-      console.log(
-        `   🖼️  [DRY-RUN] Missing upload for "${photoUrl}"; skipping upload.`
-      )
-      return null
-    }
-
-    const uploaded = await uploadImageToStrapi(STRAPI_URL, STRAPI_TOKEN, {
-      filePath: photoUrl,
-      name,
-      alt
-    })
-    return uploaded
+    const localHint = isLocalAssetPath(photoUrl)
+      ? ' Start Strapi to run bootstrap seeding, or register this file in Media Library.'
+      : ''
+    const dryRunPrefix = dryRun ? '[DRY-RUN] ' : ''
+    throw new Error(
+      `${dryRunPrefix}Missing Strapi upload for image "${photoUrl}". Auto-upload is disabled to avoid duplicating local assets.${localHint}`
+    )
   } catch (err) {
-    console.error(`Error getting image from Strapi for "${image}":`, err)
-    return null
+    console.error(
+      `Error resolving image from Strapi for "${image}":`,
+      err instanceof Error ? err.message : err
+    )
+    throw err
   }
 }
 
@@ -405,12 +355,10 @@ export async function buildBlogPayload(
 
   const date = new Date(parsed.date || Date.now())
   const featureImage = await getImageFromStrapi(strapiUploadContext, {
-    image: parsed.featureImage,
-    alt: parsed.featureImageAlt
+    image: parsed.featureImage
   })
   const thumbnailImage = await getImageFromStrapi(strapiUploadContext, {
-    image: parsed.thumbnailImage,
-    alt: parsed.thumbnailImageAlt
+    image: parsed.thumbnailImage
   })
 
   const tags = (parsed.tags ?? []).map((tag) => ({ tagValue: tag }))
@@ -421,8 +369,7 @@ export async function buildBlogPayload(
       profileBio: bio.text || null,
       profileImage:
         (await getImageFromStrapi(strapiUploadContext, {
-          image: bio.image,
-          alt: bio.author
+          image: bio.image
         })) || null
     }))
   )

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -380,6 +380,7 @@ const SEED_DIRS: ReadonlyArray<{ dir: string; urlPrefix: string }> = [
   { dir: `uploads/${UPLOAD_SUBDIR}`, urlPrefix: `/uploads/${UPLOAD_SUBDIR}` },
   { dir: 'img', urlPrefix: '/img' }
 ]
+const EXCLUDED_SEED_SUBDIRS = new Set(['optimized'])
 
 async function seedUploadsFromDisk(strapi: StrapiInstance): Promise<void> {
   const query = strapi.db?.query('plugin::upload.file')
@@ -445,6 +446,7 @@ function collectImagePaths(dir: string): string[] {
       if (entry.name.startsWith('.')) continue
       const full = path.join(current, entry.name)
       if (entry.isDirectory()) {
+        if (EXCLUDED_SEED_SUBDIRS.has(entry.name)) continue
         walk(full)
       } else if (
         SEEDABLE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())


### PR DESCRIPTION
## Summary
- Updated MDX sync image resolution to stop auto-uploading missing local assets.
- `sync:mdx` now only links existing Strapi media records for image URLs.
- If an image is missing in Strapi, sync fails with a clear error instead of creating hashed duplicates in `public/uploads/img/original`.

## Related Issue
- Fixes INTORG-625

## Manual Test
1. Run `pnpm --dir cms run sync:all --force` with an MDX image not registered in Strapi.
2. Confirm sync fails with a “missing Strapi upload” error.
3. Confirm no new hashed file is created in `public/uploads/img/original`.
4. Register/seed the image in Strapi, rerun sync, and confirm success.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
