### PR TITLE
fix(netlify): remove broad es 404 redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,11 +20,6 @@
 [context.deploy-preview]
   command = "pnpm install && pnpm run build"
 
-[[redirects]]
-  from = "/es/*"
-  to = "/es/404"
-  status = 404
-
 [[headers]]
   for = "/_astro/*"
   [headers.values]


### PR DESCRIPTION
fixes PR 222 - the netlify redirect was breaking all /es pages