### PR TITLE
chore(cms): include scripts in tsconfig and resolve TS errors [WEB-150]

### DIFF
--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -32,7 +32,7 @@ export interface FrontmatterSchema {
   parse(data: unknown): unknown
   safeParse(data: unknown): {
     success: boolean
-    error?: { issues: Array<{ path: (string | number)[]; message: string }> }
+    error?: { issues: Array<{ path: PropertyKey[]; message: string }> }
   }
 }
 

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -95,7 +95,7 @@ async function uploadImageToStrapi(
       return null
     }
 
-    const data: Array<{ id: number }> = await res.json()
+    const data = (await res.json()) as Array<{ id: number }>
     return data[0]?.id || null
   } catch (err) {
     console.error(`Error uploading image "${filePath}: "`, err)

--- a/cms/scripts/sync-mdx/syncOperations.test.ts
+++ b/cms/scripts/sync-mdx/syncOperations.test.ts
@@ -36,6 +36,8 @@ function createMockStrapi() {
     getAllEntries: vi.fn().mockResolvedValue([]),
     findByPathSlug: vi.fn().mockResolvedValue(undefined),
     findUploadByUrl: vi.fn().mockResolvedValue(null),
+    findUploadByName: vi.fn().mockResolvedValue(null),
+    updateUploadAlt: vi.fn().mockResolvedValue(undefined),
     createEntry: vi
       .fn()
       .mockResolvedValue({ data: { documentId: 'new-1', pathSlug: 'test' } }),

--- a/cms/scripts/sync-mdx/validateFrontmatter.ts
+++ b/cms/scripts/sync-mdx/validateFrontmatter.ts
@@ -28,7 +28,8 @@ export function validateFrontmatter(
 
   if (!result.success && result.error) {
     const errors = result.error.issues.map((issue) => {
-      const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : ''
+      const path =
+        issue.path.length > 0 ? `${issue.path.map(String).join('.')}: ` : ''
       return `${path}${issue.message}`
     })
     return {

--- a/cms/tsconfig.json
+++ b/cms/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2022"],
     "outDir": "dist",
-    "rootDir": ".",
+    "noEmit": true,
     "strict": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -24,7 +24,8 @@
     "src/**/*.ts",
     "src/**/*.json",
     "config/**/*.ts",
-    "types/**/*.ts"
+    "types/**/*.ts",
+    "scripts/**/*.ts"
   ],
   "exclude": ["node_modules/**", "build/**", "dist/**", ".cache/**", ".tmp/**"]
 }


### PR DESCRIPTION
## Summary

`scripts/**/*.ts` was outside the cms TS project, so the language server could not resolve `@/utils` path aliases inside script files. This PR adds `scripts/**/*.ts` to `cms/tsconfig.json` `include` and resolves the type errors that surfaced once those files were type-checked.

- Drop `rootDir: "."` and add `noEmit: true`. Scripts import shared Zod schemas from `@site/schemas/content` (outside `cms/`), which violates `rootDir`. Nothing in the build/dev/test pipeline (Strapi uses swc/vite, scripts run via `tsx`, tests run via `vitest`) uses `tsc` to emit, so `noEmit` is safe and prevents stray emitted artifacts
- Bump `lib`/`target` to `ES2022` so `new Error(msg, { cause })` in `strapiClient.ts` and `sync-navigation.ts` type-checks. Project requires Node ≥18 (see `cms/package.json` engines), which supports it at runtime.
- Widen `FrontmatterSchema.path` from `(string | number)[]` to `PropertyKey[]` to match Zod 4's `$ZodIssue.path` type, and `String()`-map path elements in `validateFrontmatter` so symbol keys serialize safely.
- Cast `await res.json()` in `mdxTransformer` (current `@types/node` resolves it to `{}`).
- Add the missing `findUploadByName` and `updateUploadAlt` mocks to the `StrapiClient` mock in `syncOperations.test.ts`.

## Related Issue

Fixes WEB-150

## Manual Test

In your IDE, open any file under `cms/scripts/` that imports from `@/utils` (e.g. `cms/scripts/sync-mdx/config.ts`) and confirm the import resolves with no red squiggles. Then from `cms/`:

```sh
npx tsc --noEmit   # should be clean
pnpm test:sync-mdx # 246 tests pass
pnpm test:serializers # 33 tests pass
```

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused (5 files)
- [ ] Screenshots for UI changes (if applicable) 