### PR TITLE
fix(cms): split scripts tsconfig so strapi develop emits configs correctly

### DIFF
--- a/cms/tsconfig.json
+++ b/cms/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "lib": ["ES2022"],
     "outDir": "dist",
-    "noEmit": true,
+    "rootDir": ".",
     "strict": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -24,8 +24,7 @@
     "src/**/*.ts",
     "src/**/*.json",
     "config/**/*.ts",
-    "types/**/*.ts",
-    "scripts/**/*.ts"
+    "types/**/*.ts"
   ],
   "exclude": ["node_modules/**", "build/**", "dist/**", ".cache/**", ".tmp/**"]
 }

--- a/cms/tsconfig.scripts.json
+++ b/cms/tsconfig.scripts.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".."
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["node_modules/**", "build/**", "dist/**", ".cache/**", ".tmp/**"]
+}


### PR DESCRIPTION
## Summary

`pnpm run develop` on `staging` fails with:

```
TypeError: Cannot destructure property 'client' of 'db.config.connection' as it is undefined.
```

Root cause: commit 2e4bfa63 (WEB-150) added `scripts/**/*.ts` to `cms/tsconfig.json` and dropped `rootDir: "."`. Two scripts (`mdxTransformer.ts`, `siteSchemas.ts`) import `@site/schemas/content` → `../src/*`, which lives outside `cms/`. TypeScript then infers `rootDir` as the repo root. Strapi's `develop` compiles against this tsconfig and uses `options.outDir` as `distDir`, so `cms/config/database.ts` was emitting to `dist/cms/config/database.js` instead of `dist/config/database.js`. Strapi reads configs from `distDir/config/*.js`, found none, and `db.config.connection` came back undefined.

Setting `rootDir: "./"` explicitly while keeping scripts in `include` is not an option, tsc errors because `../src/*` is outside rootDir.

### Fix

- **`cms/tsconfig.json`**: restore `rootDir: "."`, drop `scripts/**/*.ts` from `include`, remove `noEmit: true`. This is the tsconfig Strapi compiles against; keeping it scoped to files under `cms/` preserves the expected `dist/config/*.js` layout.
- **`cms/tsconfig.scripts.json`**: (new) extends the main tsconfig, sets `rootDir: ".."` to accommodate `@site/*` imports from scripts, `noEmit: true`, and includes `scripts/**/*.ts`. VSCode's TS language server automatically picks it up for files under `scripts/`, preserving the `@/utils` and `@site/*` alias resolution that WEB-150 was fixing.

Scripts are run via `tsx`/`vitest`, which don't depend on the tsconfig layout at runtime, only the language server does.

## Related Issue

Regression from #236 (WEB-150).

## Manual Test

1. `rm -rf cms/dist`
2. `cd cms && pnpm run develop`
3. Strapi should start and print `Strapi started successfully` with DB = sqlite.
4. Verify `cms/dist/config/database.js` exists (not `cms/dist/cms/config/database.js`).
5. Open `cms/scripts/sync-mdx/mdxTransformer.ts` in VSCode and confirm `@site/schemas/content` and `@/utils` aliases still resolve (no red squiggles, go-to-definition works).

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included (references #236)
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable) 