### PR TITLE
fix(cms): delete old MDX files when pathSlug changes [INTORG-626]

### DIFF
--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -4,6 +4,7 @@ import { shouldSkipMdxExport, getAdminAuthor } from './pageLifecycle'
 import { serializeContent } from '../serializers/blocks'
 import { scheduleGitSync, getTargetRepoRoot, type SyncContext } from './gitSync'
 import {
+  LOCALES,
   defaultLang,
   formatMdx,
   yamlSingleQuoteScalar,
@@ -56,6 +57,7 @@ interface BlogResult {
 interface BlogEvent {
   model: { singularName: string }
   result: BlogResult
+  state: { oldPathSlug?: string; oldDate?: string }
 }
 
 /**
@@ -223,6 +225,59 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
       ? path.join(projectRoot, outputDir, locale)
       : path.join(projectRoot, outputDir)
 
+  function deleteMdxIfExists(filepath: string, locale: string): void {
+    if (!fs.existsSync(filepath)) return
+    try {
+      fs.unlinkSync(filepath)
+      console.log(`🗑️  Deleted old ${locale} blog MDX: ${filepath}`)
+    } catch (error) {
+      console.error(`Failed to delete blog MDX: ${filepath}`, error)
+    }
+  }
+
+  /**
+   * Delete old blog MDX files for all locales when EN slug changes.
+   * Blog filenames include the date: `{date}-{slug}.mdx` where slug is the
+   * english slug for all locales (via resolveFilenameSlug).
+   */
+  function deleteOldBlogFiles(oldEnSlug: string, oldDate: string): void {
+    for (const locale of LOCALES) {
+      const filename = generateFilename({ date: oldDate, pathSlug: oldEnSlug })
+      const filepath = path.join(getOutputPath(locale), filename)
+      deleteMdxIfExists(filepath, locale)
+    }
+  }
+
+  /** Export all locale variants for a blog post (mirrors pageLifecycle pattern). */
+  async function exportAllBlogLocales(documentId: string): Promise<string[]> {
+    const filepaths: string[] = []
+    const enPost = await fetchBlogPost(documentId, defaultLang)
+
+    for (const locale of LOCALES) {
+      try {
+        const post =
+          locale === defaultLang
+            ? enPost
+            : await fetchBlogPost(documentId, locale)
+        if (!post) {
+          console.log(`⏭️  No published ${locale} blog post for ${documentId}`)
+          continue
+        }
+        const filepath = await writeMDXFile({
+          outputPath: getOutputPath(post.locale),
+          post
+        })
+        filepaths.push(filepath)
+      } catch (error) {
+        console.error(
+          `⚠️  Failed to export ${locale} blog post for ${documentId}:`,
+          error
+        )
+      }
+    }
+    return filepaths
+  }
+
   return {
     async afterCreate(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
@@ -240,17 +295,58 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
       }
       scheduleGitSync(label, ctx)
     },
+    async beforeUpdate(event: {
+      params?: {
+        locale?: string
+        documentId?: string
+        data?: { documentId?: string; locale?: string }
+      }
+      state: { oldPathSlug?: string; oldDate?: string }
+    }) {
+      if (shouldSkipMdxExport()) return
+      const documentId =
+        event.params?.documentId ?? event.params?.data?.documentId
+      if (!documentId) return
+
+      // Always stash the EN slug/date — all locale filenames depend on it
+      const enPost = await fetchBlogPost(documentId, defaultLang)
+      if (!enPost?.pathSlug) return
+
+      event.state.oldPathSlug = enPost.pathSlug
+      event.state.oldDate = enPost.date
+    },
     async afterUpdate(event: BlogEvent) {
       if (shouldSkipMdxExport()) return
       const { result } = event
       if (!result || !result.publishedAt) return
       const label = event.model.singularName
-      const post = await fetchBlogPost(result.documentId, result.locale)
-      if (!post) return
-      console.log(`📝 Updating ${label} MDX for: ${post.pathSlug}`)
-      await writeMDXFile({ outputPath: getOutputPath(post.locale), post })
+      const { oldPathSlug, oldDate } = event.state
+
+      const enPost = await fetchBlogPost(result.documentId, defaultLang)
+      const currentEnSlug = enPost?.pathSlug
+
+      // If the EN slug changed, delete old files for all locales and re-export
+      if (
+        oldPathSlug &&
+        oldDate &&
+        currentEnSlug &&
+        oldPathSlug !== currentEnSlug
+      ) {
+        console.log(
+          `🗑️  Blog pathSlug changed from "${oldPathSlug}" to "${currentEnSlug}", deleting old MDX files`
+        )
+        deleteOldBlogFiles(oldPathSlug, oldDate)
+        console.log(`📝 Re-exporting all ${label} locales: ${currentEnSlug}`)
+        await exportAllBlogLocales(result.documentId)
+      } else {
+        const post = await fetchBlogPost(result.documentId, result.locale)
+        if (!post) return
+        console.log(`📝 Updating ${label} MDX for: ${post.pathSlug}`)
+        await writeMDXFile({ outputPath: getOutputPath(post.locale), post })
+      }
+
       const ctx: SyncContext = {
-        slug: post.pathSlug,
+        slug: result.pathSlug,
         action: 'update',
         author: getAdminAuthor()
       }

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -326,12 +326,7 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
       const currentEnSlug = enPost?.pathSlug
 
       // If the EN slug changed, delete old files for all locales and re-export
-      if (
-        oldPathSlug &&
-        oldDate &&
-        currentEnSlug &&
-       currentEnSlug
-      ) {
+      if (oldPathSlug && oldDate && currentEnSlug && currentEnSlug) {
         console.log(
           `🗑️  Blog pathSlug changed from "${oldPathSlug}" to "${currentEnSlug}", deleting old MDX files`
         )

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -330,7 +330,7 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
         oldPathSlug &&
         oldDate &&
         currentEnSlug &&
-        oldPathSlug !== currentEnSlug
+       currentEnSlug
       ) {
         console.log(
           `🗑️  Blog pathSlug changed from "${oldPathSlug}" to "${currentEnSlug}", deleting old MDX files`

--- a/cms/src/utils/flatContentLifecycle.ts
+++ b/cms/src/utils/flatContentLifecycle.ts
@@ -143,6 +143,27 @@ export function createFlatLocaleMdxLifecycle<
     return path.join(getBaseDir(locale), `${pathSlug}.mdx`)
   }
 
+  function deleteMdxIfExists(filepath: string, locale: string): void {
+    if (!fs.existsSync(filepath)) return
+    try {
+      fs.unlinkSync(filepath)
+      console.log(`🗑️  Deleted old ${locale} ${label} MDX: ${filepath}`)
+    } catch (error) {
+      console.error(`Failed to delete ${label} MDX: ${filepath}`, error)
+    }
+  }
+
+  /**
+   * Delete old MDX files for all locales when EN slug changes.
+   * All locale filenames use the EN slug (via resolveFilenameSlug).
+   */
+  function deleteOldFiles(oldEnSlug: string): void {
+    for (const locale of LOCALES) {
+      const filepath = getFilePath(locale, oldEnSlug)
+      deleteMdxIfExists(filepath, locale)
+    }
+  }
+
   return {
     async afterCreate(event: { result?: T }) {
       const { result } = event
@@ -160,10 +181,44 @@ export function createFlatLocaleMdxLifecycle<
       }
       scheduleGitSync(label, ctx)
     },
-    async afterUpdate(event: { result?: T }) {
+    async beforeUpdate(event: {
+      params?: {
+        locale?: string
+        documentId?: string
+        data?: { documentId?: string; locale?: string }
+        where?: Record<string, unknown>
+      }
+      state: { oldPathSlug?: string }
+    }) {
+      if (shouldSkipMdxExport()) return
+      const documentId =
+        event.params?.documentId ?? event.params?.data?.documentId
+      if (!documentId) return
+
+      // Stash the EN slug — all locale filenames depend on it
+      const enEntry = await fetchPublished(documentId, defaultLang)
+      if (!enEntry?.pathSlug) return
+
+      event.state.oldPathSlug = enEntry.pathSlug
+    },
+    async afterUpdate(event: { result?: T; state: { oldPathSlug?: string } }) {
       const { result } = event
       if (shouldSkipMdxExport()) return
       if (!result?.documentId || !result.publishedAt) return
+
+      const { oldPathSlug } = event.state
+
+      // Re-fetch EN to get the current slug
+      const enEntry = await fetchPublished(result.documentId, defaultLang)
+      const currentEnSlug = enEntry?.pathSlug
+
+      if (oldPathSlug && currentEnSlug && oldPathSlug !== currentEnSlug) {
+        console.log(
+          `🗑️  ${label} pathSlug changed from "${oldPathSlug}" to "${currentEnSlug}", deleting old MDX files`
+        )
+        deleteOldFiles(oldPathSlug)
+      }
+
       console.log(
         `📝 Updating ${label} MDX for all locales: ${result.pathSlug}`
       )


### PR DESCRIPTION
## Summary

- Blog and flat content (ambassador) lifecycles were missing `beforeUpdate`/`afterUpdate` slug-change handling that `pageLifecycle` already had
- When an editor changed a `pathSlug` in Strapi, the old MDX file stayed on disk, causing `sync-mdx` to create a duplicate entry on next run
- Added `beforeUpdate` hooks to stash the old EN slug (and date for blogs), and `afterUpdate` logic to delete old MDX files for all locales and re-export when a slug change is detected

## Related Issue

Fixes INTORG-626

## Manual Test

1. Start Strapi locally (`pnpm --dir cms develop`)
2. Pick a published ambassador or blog post, note its current `pathSlug`
3. Change the slug in Strapi admin, save & publish
4. Verify the old MDX file is deleted and only the new one exists on disk
5. Run `pnpm --dir cms run sync:mdx:dry-run` — should not attempt to create the old slug as a new entry
6. If the entry has an ES localization, verify `es/` files are also cleaned up and `localizes` references updated

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)