### PR TITLE
chore: added ADR: Reusable page templates and cross-section routing

### DIFF
--- a/docs/decisions/002-spanish-fallback-disclaimer-behavior.md
+++ b/docs/decisions/002-spanish-fallback-disclaimer-behavior.md
@@ -1,6 +1,6 @@
 # ADR-002: Spanish fallback disclaimer behavior for Speaker list pages
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-09
 **Issue:** N/A
 

--- a/docs/decisions/002-spanish-fallback-disclaimer-behavior.md
+++ b/docs/decisions/002-spanish-fallback-disclaimer-behavior.md
@@ -1,6 +1,6 @@
 # ADR-002: Spanish fallback disclaimer behavior for Speaker list pages
 
-**Status:** Accepted
+**Status:** Proposed
 **Date:** 2026-04-09
 **Issue:** N/A
 

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -6,15 +6,11 @@
 
 ## Context
 
-The redesign moves to a template-based approach to page authoring: grant pages, FAQs, and profiles (team members, summit speakers, hackathon judges, fellows, etc.) each follow a fixed structure. Home pages remain bespoke Astro-only pages; a custom page type continues to exist for freeform layouts. The redesign also breaks the hackathon out into a separate microsite, giving the site three sections: Foundation, Summit, and Hackathon.
+The redesign moves to a template-based approach: grant pages, FAQs, and profiles each follow a fixed structure. The site also splits into three sections — Foundation, Summit, and Hackathon — after the hackathon becomes a separate microsite.
 
-Template pages must work across all three sections. The previous architecture rooted everything in a section split, which would require duplicating template types in Strapi — a foundation profile, a summit profile, a hackathon profile — cluttering the editor interface and making the section boundary a concern it shouldn't own.
+Templates must work across all three sections without duplicating template types in Strapi. Two problems make this non-trivial:
 
-The core problem has two parts:
-
-**Single-instance templates.** A template type (e.g. "FAQ") must generate correct routes and layouts regardless of which section it belongs to. Adding a new section should not require rethinking the architecture.
-
-**Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages and power summary and listing views (a team page, or the fellows section on the ambassadors page). These listing views need to query, filter, and group entries without duplicating content or route logic.
+**Single-instance templates** (e.g. FAQ) must generate correct routes and layouts regardless of section. **Collection-driven templates** (e.g. profiles) must also power listing and summary views — filtering by category and locale — without duplicating content or route logic.
 
 Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, i.e. how templates are defined) and page rendering (where a page lives and how it looks, i.e. where it's placed in the file system, what layoputs it uses, what components it uses). The bridge between them must be explicit but can be handled in various ways (how we nest the content collections, how we link them to the correct layout for rendering, how best to iterate through collection-driven templates to create views).
 
@@ -129,17 +125,11 @@ Everything else — URL slugs, page content — can be handled directly by edito
 
 ## Alternatives considered
 
-### Section-first routing (status quo)
+**Section-first routing (status quo)** — routes split by section, not template. Adding a new section is a structural change and may force template logic to be duplicated per section.
 
-The existing approach roots everything in a section split: summit pages and foundation pages live in separate route trees. This makes adding a new section (e.g. hackathon) a structural change rather than a configuration change, and forces template logic to be duplicated per section.
+**Separate collections per profile category** — a `fellows` collection, a `judges` collection, etc. Requires a developer change for every new category.
 
-### Separate collections per profile category
-
-Using a `fellows` collection, a `judges` collection, etc. mirrors the old section-first pattern at the collection level. It requires a developer change every time a new category is introduced, and makes cross-category queries (e.g. "all profiles for the hackathon") needlessly complex.
-
-### Strapi-enforced section/template compatibility
-
-Dynamic UI restrictions based on template or section are not reliably achievable with Strapi's conditional field support. Validation is enforced at build time instead.
+**Strapi-led template+section compatibility** — dynamic UI restrictions are not reliably achievable with Strapi's conditional field support. Validation will need to be enforced at build time instead.
 
 ## Consequences
 

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -16,7 +16,7 @@ The core problem has two parts:
 
 **Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages and power summary and listing views (a team page, or the fellows section on the ambassadors page). These listing views need to query, filter, and group entries without duplicating content or route logic.
 
-Two concerns must stay separate but coordinate correctly: content composition (what components make up a page) and page rendering (where a page lives and how it looks). The bridge between them must be explicit — template type in frontmatter is what Astro reads to determine layout, routing, and how collection entries are iterated into listing views.
+Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, i.e. how templates are defined) and page rendering (where a page lives and how it looks, i.e. where it's placed in the file system, what layoputs it uses, what components it uses). The bridge between them must be explicit but can be handled in various ways (how we nest the content collections, how we link them to the correct layout for rendering, how best to iterate through collection-driven templates to create views).
 
 ## Decision
 

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -22,16 +22,34 @@ Additionally, two concerns must stay separate but coordinate correctly: content 
 
 ## Decision
 
+### Editor experience in Strapi
+
+Editors create a new page by choosing a template type first: FAQ, grant, profile, or custom page. The template type determines what fields are available and what the page composition looks like — not which section it belongs to.
+
+Once a template is selected, the editor provides two required fields before filling in content:
+
+- **Locale** — the language of this entry (`en` or `es`).
+- **Path** — the full URL path for the page, including any section prefix. For example, `/summit/speakers/jane-doe` or `/hackathon/judges/ali-hassan`. Foundation pages have no prefix: `/fellows/jane-doe`.
+
+The path prefix is the mechanism by which an editor assigns a page to a section. There is no separate section dropdown — the path makes the section explicit and human-readable.
+
+Both Strapi and Astro validate that the path and section stay aligned:
+
+- **Strapi** validates on submission that the path prefix matches a known section (`/summit/`, `/hackathon/`, or no prefix for foundation). An invalid prefix is rejected before the content is saved.
+- **Astro** derives the `section` value from the path prefix at build time and verifies it has a corresponding entry in `LAYOUT_MAP`. A mismatch fails the build.
+
+This two-layer validation ensures a summit path always uses a summit layout, and a misconfigured path cannot silently produce a page in the wrong section.
+
 ### Template type as frontmatter bridge
 
-When an editor creates a page in Strapi, `templateType` and `section` fields are written into the exported MDX frontmatter. Astro reads this to select the correct components and layout.
+When an editor creates a page in Strapi, the `templateType`, `section` (derived from the path prefix), and `locale` fields are written into the exported MDX frontmatter. Astro reads these to select the correct collection, layout, and rendering behaviour.
 
 Collection entries carry four frontmatter fields that drive routing, layout selection, and filtering:
 
 ```
 templateType: profile   # selects components and layout
 category: fellow        # used by listing views to filter within a collection
-section: foundation     # determines URL prefix and layout component
+section: foundation     # derived from path prefix; determines layout component
 locale: en              # drives translation routing and listing view filtering
 ```
 
@@ -111,12 +129,13 @@ const fellows = await getCollection('profiles',
 
 ### Developer ownership surface
 
-Developers own exactly two things:
+Developers own exactly three things:
 
 - **New section** — add to `PREFIX_MAP`, `LAYOUT_MAP`, and create the layout component.
 - **New content collection** — add to `getStaticPaths`.
+- **Template composition** — define the rules for each template type, enforce them at build time, and expose the required fields in Strapi.
 
-Everything else — URL slugs, template composition, page content — is owned by editors in Strapi.
+Everything else — URL slugs, page content — can be handled directly by editors in Strapi.
 
 ## Alternatives considered
 
@@ -146,4 +165,4 @@ Ideally Strapi's UI would dynamically restrict available components based on the
 
 - All pages share a single route file; the routing surface is less immediately legible than file-based routes.
 - `PREFIX_MAP` and `LAYOUT_MAP` must be kept in sync manually — a section added to one but not the other will break the build.
-- Strapi cannot validate section/template compatibility at content-creation time; mismatches are only caught at build.
+- Strapi does not validate section/template compatibility by default; mismatches are only caught at build unless `beforeCreate` and `beforeUpdate` lifecycle hooks are added to enforce path prefix rules at save time.

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -6,20 +6,19 @@
 
 ## Context
 
-As background knoweldge
-1. As part of the redesign Jessica wants to move over to a temnplate absed approach for pages. The blogs have always been easiest for people to add because they have a set of predefine fields like title, descripotion, feature and thumbnail images, author info etc. So Jessic wants to extend this so that all grant pages folow the same format, we havea predefined FAQ page, we have one page type for all profiles (this could be team members, summit speakers, hackathon judges, fellows, etc), and so on.
-2. We will have the home pages as separate (Astro-only custom pages) and we will have a custom page type (like our summit and foudnation pages now that build up based off any selection of compoennts available through the dynamic zones).
-2. The redesign will be breaking the hackathon out into a separate microsite, so now we will have foundation pages, summit pages and hackathon pages. Let's refer to these as the three *sections* of the webiste
+The redesign introduces a template-based approach to page authoring. Blogs have always been the easiest content type to manage because they have a fixed set of fields — title, description, featured image, author info, etc. The goal is to extend this to other page types: grant pages follow a standard format, FAQs have a predefined structure, and all profiles (team members, summit speakers, hackathon judges, fellows, etc.) share a single type. Home pages remain bespoke Astro-only pages, and a custom page type continues to exist for freeform layouts built from dynamic zones.
 
-The template pages will need to work acros all sections of the webiste (foundation, summit and hackathon). The previous architecture rooted everything in a section split (summit vs. foundation), which would lead to duplicating template types on Strapi, do you want to add a foundation profile or a summit profile or a hackthon profile. This adds more options anbd clutter to the editor interface.
+The redesign also breaks the hackathon out into a separate microsite, giving the site three distinct sections: Foundation, Summit, and Hackathon.
+
+Template pages must work across all three sections. The previous architecture rooted everything in a section split, which would require duplicating template types in Strapi — a foundation profile, a summit profile, a hackathon profile — cluttering the editor interface and making the section boundary a concern it shouldn't own.
 
 The core problem has two parts:
 
-**Single-instance templates.** A single template type (e.g. "FAQ") must generate correct routes and layouts whether the content belongs to Foundation, Summit, or Hackathon. Adding a new section should not require rethinking the architecture.
+**Single-instance templates.** A template type (e.g. "FAQ") must generate correct routes and layouts regardless of which section it belongs to. Adding a new section should not require rethinking the architecture.
 
-**Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages (to view details on one person) _and_ power summary/listing views (a team page view collection, or the fellows view at the bottom of the ambassadors page). These listing views need to query, filter, and group entries — fellows vs. judges, foundation vs. hackathon — without duplicating content or route logic, as efficiently and cleanly as possible.
+**Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages and power summary and listing views (a team page, or the fellows section on the ambassadors page). These listing views need to query, filter, and group entries — fellows vs. judges, foundation vs. hackathon — without duplicating content or route logic.
 
-Additionaly, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, how templates are defined) and page rendering (where a page lives and how it looks, determined by the file system, layouts and components). The bridge between them must be explicit and machine-readable. I.e. a template approach can be solved through various content collection approaches on Astro, and is either made up of custom layouts, or it can simply use rules around wjhich components it can use in what order. 
+Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page) and page rendering (where a page lives and how it looks). The bridge between them must be explicit and machine-readable — a template type is declared in Strapi and Astro acts on it, without either side needing to know the other's internals.
 
 ## Decision
 

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -6,9 +6,7 @@
 
 ## Context
 
-The redesign introduces a template-based approach to page authoring. Blogs have always been the easiest content type to manage because they have a fixed set of fields — title, description, featured image, author info, etc. The goal is to extend this to other page types: grant pages follow a standard format, FAQs have a predefined structure, and all profiles (team members, summit speakers, hackathon judges, fellows, etc.) share a single type. Home pages remain bespoke Astro-only pages, and a custom page type continues to exist for freeform layouts built from dynamic zones.
-
-The redesign also breaks the hackathon out into a separate microsite, giving the site three distinct sections: Foundation, Summit, and Hackathon.
+The redesign moves to a template-based approach to page authoring: grant pages, FAQs, and profiles (team members, summit speakers, hackathon judges, fellows, etc.) each follow a fixed structure. Home pages remain bespoke Astro-only pages; a custom page type continues to exist for freeform layouts. The redesign also breaks the hackathon out into a separate microsite, giving the site three sections: Foundation, Summit, and Hackathon.
 
 Template pages must work across all three sections. The previous architecture rooted everything in a section split, which would require duplicating template types in Strapi — a foundation profile, a summit profile, a hackathon profile — cluttering the editor interface and making the section boundary a concern it shouldn't own.
 
@@ -30,12 +28,7 @@ Once a template is selected, the editor provides a required field before filling
 
 - **Path** — composed from three parts in the UI: a static `interledger.org` label, a section dropdown (`/`, `/summit`, `/hackathon`), and a free-text slug field for the remaining path. Together these produce the full URL, e.g. `interledger.org/summit/speakers/jane-doe`. The section dropdown is the canonical way an editor assigns a page to a section — no free-text prefix to mistype.
 
-Both Strapi and Astro validate that the path and section stay aligned:
-
-- **Strapi** stores the section selection and slug as separate fields, combining them into the exported path. The `beforeCreate` and `beforeUpdate` lifecycle hooks validate that the combination is well-formed before saving.
-- **Astro** derives the `section` value from the stored section field at build time and verifies it has a corresponding entry in `LAYOUT_MAP`. A mismatch fails the build.
-
-This two-layer validation ensures a summit page always uses a summit layout, and a misconfigured path cannot silently produce a page in the wrong section.
+Strapi stores section and slug as separate fields and validates their combination via `beforeCreate`/`beforeUpdate` hooks. Astro verifies the section has a matching `LAYOUT_MAP` entry at build time — a mismatch fails the build.
 
 ### Template type as frontmatter bridge
 
@@ -146,7 +139,7 @@ Using a `fellows` collection, a `judges` collection, etc. mirrors the old sectio
 
 ### Strapi-enforced section/template compatibility
 
-Ideally Strapi's UI would dynamically restrict available components based on the selected template or section. This is not reliably achievable with Strapi's current conditional field support. Validation is instead enforced at build time: if template composition is incompatible with the declared section, tests catch it before import.
+Dynamic UI restrictions based on template or section are not reliably achievable with Strapi's conditional field support. Validation is enforced at build time instead.
 
 ## Consequences
 

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -29,16 +29,14 @@ Editors create a new page by choosing a template type first: FAQ, grant, profile
 Once a template is selected, the editor provides two required fields before filling in content:
 
 - **Locale** — the language of this entry (`en` or `es`).
-- **Path** — the full URL path for the page, including any section prefix. For example, `/summit/speakers/jane-doe` or `/hackathon/judges/ali-hassan`. Foundation pages have no prefix: `/fellows/jane-doe`.
-
-The path prefix is the mechanism by which an editor assigns a page to a section. There is no separate section dropdown — the path makes the section explicit and human-readable.
+- **Path** — composed from three parts in the UI: a static `interledger.org` label, a section dropdown (`/`, `/summit`, `/hackathon`), and a free-text slug field for the remaining path. Together these produce the full URL, e.g. `interledger.org/summit/speakers/jane-doe`. The section dropdown is the canonical way an editor assigns a page to a section — no free-text prefix to mistype.
 
 Both Strapi and Astro validate that the path and section stay aligned:
 
-- **Strapi** validates on submission that the path prefix matches a known section (`/summit/`, `/hackathon/`, or no prefix for foundation). An invalid prefix is rejected before the content is saved.
-- **Astro** derives the `section` value from the path prefix at build time and verifies it has a corresponding entry in `LAYOUT_MAP`. A mismatch fails the build.
+- **Strapi** stores the section selection and slug as separate fields, combining them into the exported path. The `beforeCreate` and `beforeUpdate` lifecycle hooks validate that the combination is well-formed before saving.
+- **Astro** derives the `section` value from the stored section field at build time and verifies it has a corresponding entry in `LAYOUT_MAP`. A mismatch fails the build.
 
-This two-layer validation ensures a summit path always uses a summit layout, and a misconfigured path cannot silently produce a page in the wrong section.
+This two-layer validation ensures a summit page always uses a summit layout, and a misconfigured path cannot silently produce a page in the wrong section.
 
 ### Template type as frontmatter bridge
 
@@ -49,7 +47,7 @@ Collection entries carry four frontmatter fields that drive routing, layout sele
 ```
 templateType: profile   # selects components and layout
 category: fellow        # used by listing views to filter within a collection
-section: foundation     # derived from path prefix; determines layout component
+section: foundation     # set via section dropdown; determines layout component
 locale: en              # drives translation routing and listing view filtering
 ```
 

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -53,14 +53,14 @@ src/pages/[...slug].astro
 export async function getStaticPaths() {
   const allContent = [
     ...(await getCollection('profiles')),
-    ...(await getCollection('faqs')),
+    ...(await getCollection('faqs'))
     // add new collections here when new templates are added
-  ];
+  ]
 
-  return allContent.map(entry => ({
+  return allContent.map((entry) => ({
     params: { slug: buildPagePath(entry.data.section, entry.slug) },
-    props: { entry },
-  }));
+    props: { entry }
+  }))
 }
 ```
 
@@ -72,12 +72,12 @@ URL paths are assembled from a `PREFIX_MAP`:
 export const PREFIX_MAP: Record<Section, string> = {
   foundation: '',
   summit: 'summit',
-  hackathon: 'hackathon',
-};
+  hackathon: 'hackathon'
+}
 
 export function buildPagePath(section: Section, slug: string): string {
-  const prefix = PREFIX_MAP[section];
-  return [prefix, slug].filter(Boolean).join('/');
+  const prefix = PREFIX_MAP[section]
+  return [prefix, slug].filter(Boolean).join('/')
 }
 ```
 
@@ -87,15 +87,16 @@ The correct layout component is selected at render time from a `LAYOUT_MAP`:
 export const LAYOUT_MAP: Record<Section, AstroComponent> = {
   foundation: FoundationContentPage,
   summit: SummitContentPage,
-  hackathon: HackathonContentPage,
-};
+  hackathon: HackathonContentPage
+}
 ```
 
 ```astro
 ---
-const { entry } = Astro.props;
-const Layout = LAYOUT_MAP[entry.data.section];
+const { entry } = Astro.props
+const Layout = LAYOUT_MAP[entry.data.section]
 ---
+
 <Layout slug={entry.slug} contentLocale={entry.data.locale} />
 ```
 
@@ -108,9 +109,11 @@ Build-time validation also checks that the components used in an MDX file are co
 Because all profiles share a single collection, listing views filter by frontmatter — no separate collections or route logic required. Locale must always be included as a filter so listing views only surface content in the correct language:
 
 ```ts
-const fellows = await getCollection('profiles',
-  entry => entry.data.category === 'fellow' && entry.data.locale === currentLocale
-);
+const fellows = await getCollection(
+  'profiles',
+  (entry) =>
+    entry.data.category === 'fellow' && entry.data.locale === currentLocale
+)
 ```
 
 ### Developer ownership surface

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -14,11 +14,11 @@ Template pages must work across all three sections. The previous architecture ro
 
 The core problem has two parts:
 
-**Single-instance templates.** A template type (e.g. "FAQ" which is just a single page instance) must generate correct routes and layouts regardless of which section it belongs to. Adding a new section should not require rethinking the architecture.
+**Single-instance templates.** A template type (e.g. "FAQ") must generate correct routes and layouts regardless of which section it belongs to. Adding a new section should not require rethinking the architecture.
 
-**Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages and power summary and listing views (a team page, or the fellows section on the ambassadors page). These listing views need to query, filter, and group entries efficiently (probably using a category field) without duplicating content or route logic.
+**Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages and power summary and listing views (a team page, or the fellows section on the ambassadors page). These listing views need to query, filter, and group entries without duplicating content or route logic.
 
-Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, i.e. how templates are defined) and page rendering (where a page lives and how it looks, i.e. where it's placed in the file system, what layoputs it uses, what components it uses). The bridge between them must be explicit but can be handled in various ways (how we nest the content collections, how we link them to the correct layout for rendering, how best to iterate through collection-driven templates to create views).
+Two concerns must stay separate but coordinate correctly: content composition (what components make up a page) and page rendering (where a page lives and how it looks). The bridge between them must be explicit — template type in frontmatter is what Astro reads to determine layout, routing, and how collection entries are iterated into listing views.
 
 ## Decision
 
@@ -40,7 +40,7 @@ This two-layer validation ensures a summit page always uses a summit layout, and
 
 ### Template type as frontmatter bridge
 
-When an editor creates a page in Strapi, the `templateType`, `section` (derived from the path prefix), and `locale` fields are written into the exported MDX frontmatter. Astro reads these to select the correct collection, layout, and rendering behaviour.
+When an editor creates a page in Strapi, `templateType`, `section`, and `locale` are written into the exported MDX frontmatter. Astro reads these to select the correct collection, layout, and rendering behaviour.
 
 Collection entries carry four frontmatter fields that drive routing, layout selection, and filtering:
 
@@ -113,7 +113,7 @@ const Layout = LAYOUT_MAP[entry.data.section];
 
 If a `section` value appears in content with no matching entry in `LAYOUT_MAP`, the build fails.
 
-We should also ensure that when a page is added as a file on Astro, that we fail if it breaks the template requirements for that `templateType`
+Build-time validation also checks that the components used in an MDX file are compatible with its declared `templateType`, failing loudly on any mismatch.
 
 ### Listing views via frontmatter filters
 

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -1,0 +1,147 @@
+# ADR-003: Reusable page templates and cross-section routing
+
+**Status:** Proposed
+**Date:** 2026-04-17
+**Issue:** [INTORG-560](https://linear.app/interledger/issue/INTORG-560/fellows-creata-id-pages)
+
+## Context
+
+As background knoweldge
+1. As part of the redesign Jessica wants to move over to a temnplate absed approach for pages. The blogs have always been easiest for people to add because they have a set of predefine fields like title, descripotion, feature and thumbnail images, author info etc. So Jessic wants to extend this so that all grant pages folow the same format, we havea predefined FAQ page, we have one page type for all profiles (this could be team members, summit speakers, hackathon judges, fellows, etc), and so on.
+2. We will have the home pages as separate (Astro-only custom pages) and we will have a custom page type (like our summit and foudnation pages now that build up based off any selection of compoennts available through the dynamic zones).
+2. The redesign will be breaking the hackathon out into a separate microsite, so now we will have foundation pages, summit pages and hackathon pages. Let's refer to these as the three *sections* of the webiste
+
+The template pages will need to work acros all sections of the webiste (foundation, summit and hackathon). The previous architecture rooted everything in a section split (summit vs. foundation), which would lead to duplicating template types on Strapi, do you want to add a foundation profile or a summit profile or a hackthon profile. This adds more options anbd clutter to the editor interface.
+
+The core problem has two parts:
+
+**Single-instance templates.** A single template type (e.g. "FAQ") must generate correct routes and layouts whether the content belongs to Foundation, Summit, or Hackathon. Adding a new section should not require rethinking the architecture.
+
+**Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages (to view details on one person) _and_ power summary/listing views (a team page view collection, or the fellows view at the bottom of the ambassadors page). These listing views need to query, filter, and group entries — fellows vs. judges, foundation vs. hackathon — without duplicating content or route logic, as efficiently and cleanly as possible.
+
+Additionaly, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, how templates are defined) and page rendering (where a page lives and how it looks, determined by the file system, layouts and components). The bridge between them must be explicit and machine-readable. I.e. a template approach can be solved through various content collection approaches on Astro, and is either made up of custom layouts, or it can simply use rules around wjhich components it can use in what order. 
+
+## Decision
+
+### Template type as frontmatter bridge
+
+When an editor creates a page in Strapi, a `templateType` field is written into the exported MDX frontmatter. Astro reads this to select the correct components and layout. Strapi has no knowledge of Astro's rendering — it only records intent.
+
+Collection entries carry three frontmatter fields that drive routing, layout selection, and filtering:
+
+```
+templateType: profile   # selects components and layout
+category: fellow        # used by listing views to filter within a collection
+section: foundation     # determines URL prefix and layout component
+```
+
+### Single catch-all route
+
+All content is served through a single catch-all route:
+
+```
+src/pages/[...slug].astro
+```
+
+`getStaticPaths` collects all content collections and builds paths from frontmatter:
+
+```ts
+export async function getStaticPaths() {
+  const allContent = [
+    ...(await getCollection('profiles')),
+    ...(await getCollection('faqs')),
+    // add new collections here when created
+  ];
+
+  return allContent.map(entry => ({
+    params: { slug: buildPagePath(entry.data.section, entry.slug) },
+    props: { entry },
+  }));
+}
+```
+
+### Section prefix and layout maps
+
+URL paths are assembled from a `PREFIX_MAP`:
+
+```ts
+export const PREFIX_MAP: Record<Section, string> = {
+  foundation: '',
+  summit: 'summit',
+  hackathon: 'summit/hackathon',
+};
+
+export function buildPagePath(section: Section, slug: string): string {
+  const prefix = PREFIX_MAP[section];
+  return [prefix, slug].filter(Boolean).join('/');
+}
+```
+
+The correct layout component is selected at render time from a `LAYOUT_MAP`:
+
+```ts
+export const LAYOUT_MAP: Record<Section, AstroComponent> = {
+  foundation: FoundationContentPage,
+  summit: SummitContentPage,
+  hackathon: HackathonContentPage,
+};
+```
+
+```astro
+---
+const { entry } = Astro.props;
+const Layout = LAYOUT_MAP[entry.data.section];
+---
+<Layout slug={entry.slug} contentLocale={entry.data.locale} />
+```
+
+If a `section` value appears in content with no matching entry in `LAYOUT_MAP`, the build fails loudly.
+
+### Listing views via frontmatter filters
+
+Because all profiles share a single collection, listing views filter by frontmatter — no separate collections or route logic required:
+
+```ts
+const fellows = await getCollection('profiles',
+  entry => entry.data.category === 'fellow'
+);
+```
+
+### Developer ownership surface
+
+Developers own exactly two things:
+
+- **New section** — add to `PREFIX_MAP`, `LAYOUT_MAP`, and create the layout component.
+- **New content collection** — add to `getStaticPaths`.
+
+Everything else — URL slugs, template composition, page content — is owned by editors in Strapi.
+
+## Alternatives considered
+
+### Section-first routing (status quo)
+
+The existing approach roots everything in a section split: summit pages and foundation pages live in separate route trees. This makes adding a new section (e.g. hackathon) a structural change rather than a configuration change, and forces template logic to be duplicated per section.
+
+### Separate collections per profile category
+
+Using a `fellows` collection, a `judges` collection, etc. mirrors the old section-first pattern at the collection level. It requires a developer change every time a new category is introduced, and makes cross-category queries (e.g. "all profiles for the hackathon") needlessly complex.
+
+### Strapi-enforced section/template compatibility
+
+Ideally Strapi's UI would dynamically restrict available components based on the selected template or section. This is not reliably achievable with Strapi's current conditional field support. Validation is instead enforced at build time: if template composition is incompatible with the declared section, tests catch it before import.
+
+## Consequences
+
+**Positive:**
+
+- Adding a new section is a two-line config change; no route restructuring needed.
+- Editors control URL slugs, template selection, and content entirely from Strapi.
+- Listing views are simple frontmatter filters — no duplication, no separate route logic.
+- A missing `LAYOUT_MAP` entry is a hard build failure, not a silent runtime error.
+- Translations work naturally: shared collections with locale frontmatter, path generation via `buildPagePath`.
+
+**Negative:**
+
+- All pages share a single route file; the routing surface is less immediately legible than file-based routes.
+- `PREFIX_MAP` and `LAYOUT_MAP` must be kept in sync manually — a section added to one but not the other will break the build.
+- Strapi cannot validate section/template compatibility at content-creation time; mismatches are only caught at build.

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -16,7 +16,7 @@ The core problem has two parts:
 
 **Single-instance templates.** A template type (e.g. "FAQ" which is just a single page instance) must generate correct routes and layouts regardless of which section it belongs to. Adding a new section should not require rethinking the architecture.
 
-**Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages and power summary and listing views (a team page, or the fellows section on the ambassadors page). These listing views need to query, filter, and group entries efficiently (probably usinga  category field) without duplicating content or route logic.
+**Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages and power summary and listing views (a team page, or the fellows section on the ambassadors page). These listing views need to query, filter, and group entries efficiently (probably using a category field) without duplicating content or route logic.
 
 Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, i.e. how templates are defined) and page rendering (where a page lives and how it looks, i.e. where it's placed in the file system, what layoputs it uses, what components it uses). The bridge between them must be explicit but can be handled in various ways (how we nest the content collections, how we link them to the correct layout for rendering, how best to iterate through collection-driven templates to create views).
 
@@ -26,12 +26,13 @@ Additionally, two concerns must stay separate but coordinate correctly: content 
 
 When an editor creates a page in Strapi, `templateType` and `section` fields are written into the exported MDX frontmatter. Astro reads this to select the correct components and layout.
 
-Collection entries carry three frontmatter fields that drive routing, layout selection, and filtering:
+Collection entries carry four frontmatter fields that drive routing, layout selection, and filtering:
 
 ```
 templateType: profile   # selects components and layout
 category: fellow        # used by listing views to filter within a collection
 section: foundation     # determines URL prefix and layout component
+locale: en              # drives translation routing and listing view filtering
 ```
 
 ### Single catch-all route
@@ -100,11 +101,11 @@ We should also ensure that when a page is added as a file on Astro, that we fail
 
 ### Listing views via frontmatter filters
 
-Because all profiles share a single collection, listing views filter by frontmatter — no separate collections or route logic required:
+Because all profiles share a single collection, listing views filter by frontmatter — no separate collections or route logic required. Locale must always be included as a filter so listing views only surface content in the correct language:
 
 ```ts
 const fellows = await getCollection('profiles',
-  entry => entry.data.category === 'fellow'
+  entry => entry.data.category === 'fellow' && entry.data.locale === currentLocale
 );
 ```
 

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -14,17 +14,17 @@ Template pages must work across all three sections. The previous architecture ro
 
 The core problem has two parts:
 
-**Single-instance templates.** A template type (e.g. "FAQ") must generate correct routes and layouts regardless of which section it belongs to. Adding a new section should not require rethinking the architecture.
+**Single-instance templates.** A template type (e.g. "FAQ" which is just a single page instance) must generate correct routes and layouts regardless of which section it belongs to. Adding a new section should not require rethinking the architecture.
 
-**Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages and power summary and listing views (a team page, or the fellows section on the ambassadors page). These listing views need to query, filter, and group entries — fellows vs. judges, foundation vs. hackathon — without duplicating content or route logic.
+**Collection-driven templates.** Some templates (e.g. profiles) must do two things: generate individual routed pages and power summary and listing views (a team page, or the fellows section on the ambassadors page). These listing views need to query, filter, and group entries efficiently (probably usinga  category field) without duplicating content or route logic.
 
-Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page) and page rendering (where a page lives and how it looks). The bridge between them must be explicit and machine-readable — a template type is declared in Strapi and Astro acts on it, without either side needing to know the other's internals.
+Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, i.e. how templates are defined) and page rendering (where a page lives and how it looks, i.e. where it's placed in the file system, what layoputs it uses, what components it uses). The bridge between them must be explicit but can be handled in various ways (how we nest the content collections, how we link them to the correct layout for rendering, how best to iterate through collection-driven templates to create views).
 
 ## Decision
 
 ### Template type as frontmatter bridge
 
-When an editor creates a page in Strapi, a `templateType` field is written into the exported MDX frontmatter. Astro reads this to select the correct components and layout. Strapi has no knowledge of Astro's rendering — it only records intent.
+When an editor creates a page in Strapi, `templateType` and `section` fields are written into the exported MDX frontmatter. Astro reads this to select the correct components and layout.
 
 Collection entries carry three frontmatter fields that drive routing, layout selection, and filtering:
 
@@ -49,7 +49,7 @@ export async function getStaticPaths() {
   const allContent = [
     ...(await getCollection('profiles')),
     ...(await getCollection('faqs')),
-    // add new collections here when created
+    // add new collections here when new templates are added
   ];
 
   return allContent.map(entry => ({
@@ -67,7 +67,7 @@ URL paths are assembled from a `PREFIX_MAP`:
 export const PREFIX_MAP: Record<Section, string> = {
   foundation: '',
   summit: 'summit',
-  hackathon: 'summit/hackathon',
+  hackathon: 'hackathon',
 };
 
 export function buildPagePath(section: Section, slug: string): string {
@@ -94,7 +94,9 @@ const Layout = LAYOUT_MAP[entry.data.section];
 <Layout slug={entry.slug} contentLocale={entry.data.locale} />
 ```
 
-If a `section` value appears in content with no matching entry in `LAYOUT_MAP`, the build fails loudly.
+If a `section` value appears in content with no matching entry in `LAYOUT_MAP`, the build fails.
+
+We should also ensure that when a page is added as a file on Astro, that we fail if it breaks the template requirements for that `templateType`
 
 ### Listing views via frontmatter filters
 

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -26,9 +26,8 @@ Two concerns must stay separate but coordinate correctly: content composition (w
 
 Editors create a new page by choosing a template type first: FAQ, grant, profile, or custom page. The template type determines what fields are available and what the page composition looks like — not which section it belongs to.
 
-Once a template is selected, the editor provides two required fields before filling in content:
+Once a template is selected, the editor provides a required field before filling in content:
 
-- **Locale** — the language of this entry (`en` or `es`).
 - **Path** — composed from three parts in the UI: a static `interledger.org` label, a section dropdown (`/`, `/summit`, `/hackathon`), and a free-text slug field for the remaining path. Together these produce the full URL, e.g. `interledger.org/summit/speakers/jane-doe`. The section dropdown is the canonical way an editor assigns a page to a section — no free-text prefix to mistype.
 
 Both Strapi and Astro validate that the path and section stay aligned:

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -9,7 +9,7 @@ An ADR captures a single technical decision: the context that forced it, what wa
 | #   | Title                                             | Status   | Date       |
 | --- | ------------------------------------------------- | -------- | ---------- |
 | 001 | Path handling for Astro content collections       | Accepted | 2026-03-27 |
-| 002 | Spanish fallback disclaimer behavior              | Accepted | 2026-04-09 |
+| 002 | Spanish fallback disclaimer behavior              | Proposed | 2026-04-09 |
 | 003 | Reusable page templates and cross-section routing | Proposed | 2026-04-17 |
 
 ## Writing a new ADR

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -6,11 +6,11 @@ An ADR captures a single technical decision: the context that forced it, what wa
 
 ## Decisions
 
-| #   | Title                                       | Status   | Date       |
-| --- | ------------------------------------------- | -------- | ---------- |
-| 001 | Path handling for Astro content collections          | Accepted | 2026-03-27 |
-| 002 | Spanish fallback disclaimer behavior                 | Accepted | 2026-04-09 |
-| 003 | Reusable page templates and cross-section routing    | Proposed | 2026-04-17 |
+| #   | Title                                             | Status   | Date       |
+| --- | ------------------------------------------------- | -------- | ---------- |
+| 001 | Path handling for Astro content collections       | Accepted | 2026-03-27 |
+| 002 | Spanish fallback disclaimer behavior              | Accepted | 2026-04-09 |
+| 003 | Reusable page templates and cross-section routing | Proposed | 2026-04-17 |
 
 ## Writing a new ADR
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,8 +8,9 @@ An ADR captures a single technical decision: the context that forced it, what wa
 
 | #   | Title                                       | Status   | Date       |
 | --- | ------------------------------------------- | -------- | ---------- |
-| 001 | Path handling for Astro content collections | Accepted | 2026-03-27 |
-| 002 | Spanish fallback disclaimer behavior        | Proposed | 2026-04-09 |
+| 001 | Path handling for Astro content collections          | Accepted | 2026-03-27 |
+| 002 | Spanish fallback disclaimer behavior                 | Accepted | 2026-04-09 |
+| 003 | Reusable page templates and cross-section routing    | Proposed | 2026-04-17 |
 
 ## Writing a new ADR
 


### PR DESCRIPTION
## Summary
<!-- What changed and why -->

The redesign introduces a template-based approach to page authoring. Blogs have always been the easiest content type to manage because they have a fixed set of fields — title, description, featured image, author info, etc. The goal is to extend this to other page types: grant pages follow a standard format, FAQs have a predefined structure, and all profiles (team members, summit speakers, hackathon judges, fellows, etc.) share a single type. Home pages remain bespoke Astro-only pages, and a custom page type continues to exist for freeform layouts built from dynamic zones.

The redesign also breaks the hackathon out into a separate microsite, giving the site three distinct sections: Foundation, Summit, and Hackathon.

Template pages must work across all three sections.

ADR discusses a proposed solution

## Related Issue
<!-- Fixes INTORG-123 -->
Related to https://linear.app/interledger/issue/INTORG-560/fellows-creata-id-pages

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
