### PR TITLE
chore(ts): remove deprecated baseUrl from tsconfig INTORG-615

### DIFF
--- a/cms/tsconfig.json
+++ b/cms/tsconfig.json
@@ -12,11 +12,10 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "allowJs": true,
-    "baseUrl": ".",
     "paths": {
-      "@/utils": ["src/utils/index.ts"],
-      "@/utils/*": ["src/utils/*"],
-      "@/*": ["src/*"],
+      "@/utils": ["./src/utils/index.ts"],
+      "@/utils/*": ["./src/utils/*"],
+      "@/*": ["./src/*"],
       "@site/*": ["../src/*"]
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "jsx": "react-jsx",
     "jsxImportSource": "react"


### PR DESCRIPTION
## Summary

`baseUrl` is deprecated in TypeScript 6.0 and will stop functioning in TS 7.0. It was only present to anchor the `@/*` path alias — replacing `"src/*"` with `"./src/*"` makes the path relative and removes the need for `baseUrl` entirely.

## Related Issue

Fixes INTORG-615

## Manual Test

N/A — path aliases resolve identically, no behaviour change.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
