### PR TITLE
chore: added new ambassador redirects

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -111,7 +111,7 @@ The GitHub Actions workflow (`.github/workflows/lint.yml`) runs on every PR and 
 - **Branches**: `staging` is the preview environment, `main` is production.
 - **Strapi publishing**: Lifecycle hooks generate MDX and commit/push to `staging`.
 - **Netlify**: Auto-builds `staging` to preview and `main` to production.
-- **Self-hosted runner**: The `.github/workflows/staging-merge.yml` runs on push to `staging` via a self-hosted runner (`strapi-vm`). It automatically rebuilds Strapi CMS when `cms/` changes are detected, and syncs MDX to Strapi when `.md` or `.mdx` files change in `src/content/foundation-pages`, `src/content/summit-pages`, `src/content/foundation-blog-posts`, or `src/content/ambassadors`, including localized mirrors under `src/content/<locale>/...`.
+- **Self-hosted runner**: The `.github/workflows/staging-merge.yml` runs on push to `staging` via a self-hosted runner (`strapi-vm`). It automatically rebuilds Strapi CMS when `cms/` changes are detected, and syncs MDX to Strapi when `.md` or `.mdx` files change in any content collection (`src/content/foundation-pages`, `src/content/summit-pages`, `src/content/foundation-blog-posts`, etc.), including their localized mirrors under `src/content/<locale>/...`.
 - **Promotion**: Content moves from `staging` to `main` via PR approval.
 - **Preview drafts**: Drafts can be previewed via SSR without publishing.
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ For more information on Strapi lifecycles, synchronization scripts and preview f
   - Serves the live staging website (deployed via Netlify).
   - Serves the Strapi Admin interface (running on the GCP VM).
   - Any push to `staging` that modifies files in `/cms` triggers a rebuild of the Strapi Admin panel on the GCP VM.
-  - Any push to `staging` that modifies `.md` or `.mdx` files in `src/content/foundation-pages`, `src/content/summit-pages`, `src/content/foundation-blog-posts`, or `src/content/ambassadors` also triggers `sync:mdx`, including their localized mirrors under `src/content/<locale>/...`.
+  - Any push to `staging` that modifies `.md` or `.mdx` files in any content collection (`src/content/foundation-pages`, `src/content/summit-pages`, `src/content/foundation-blog-posts`, etc.) also triggers `sync:mdx`, including their localized mirrors under `src/content/<locale>/...`.
 
 ### Hosting Architecture
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'astro/config'
 import { fileURLToPath } from 'node:url'
-import { redirects } from './redirects.js'
+import { redirects } from './redirects.ts'
 import starlight from '@astrojs/starlight'
 import starlightFullViewMode from 'starlight-fullview-mode'
 import netlify from '@astrojs/netlify'

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -113,8 +113,8 @@ function normalizePathSlug(pathSlug: unknown): string {
  * Resolves the MDX filepath for a page from `pathSlug` (full URL path, no leading slash).
  * Segments before the last `/` are directories; the last segment is the filename stem.
  *
- * English: grant/ambassadors → {outputDir}/grant/ambassadors.mdx
- * Spanish: grant/ambassadors → {outputDir}/es/grant/ambassadors.mdx
+ * English: grant/fellowship → {outputDir}/grant/fellowship.mdx
+ * Spanish: grant/fellowship → {outputDir}/es/grant/fellowship.mdx
  * English: about-us         → {outputDir}/about-us.mdx
  */
 export function resolvePageFilepath(

--- a/redirects.ts
+++ b/redirects.ts
@@ -14,6 +14,8 @@ export const redirects = {
   '/grant-web': '/grant/grant-web',
   '/hacktoberfest-0': '/hacktoberfest',
   '/hacktoberfest-2023': '/hacktoberfest',
+  '/grant/ambassadors': '/grant/fellowship',
+  '/grant/ambassadors/faq': '/grant/fellowship/faq',
 
   // Foundation + site pages (Spanish)
   '/es/open-payments-es': '/es/open-payments',
@@ -23,6 +25,8 @@ export const redirects = {
   '/es/grant-web': '/es/grant/grant-web',
   '/es/grant/educacion': '/es/grant/education',
   '/es/grant/embajadores': '/es/grant/ambassadors',
+  '/es/grant/ambassadors': '/es/grant/fellowship',
+  '/es/grant/ambassadors/faq': '/es/grant/fellowship/faq',
 
   // News + blog content
   '/blog/2021/04/14/introducing-the-interledger-foundation':
@@ -124,5 +128,5 @@ export const redirects = {
   '/network-fees-interledger-ecosystem':
     '/policy-and-advocacy/network-fees-interledger-ecosystem',
   '/role-stablecoins-facilitating-low-value-low-cost-transactions':
-    '/policy-and-advocacy/role-stablecoins-facilitating-low-value-low-cost-transactions'
+    '/policy-and-advocacy/role-stablecoins-facilitating-low-value-low-cost-transactions',
 }

--- a/redirects.ts
+++ b/redirects.ts
@@ -128,5 +128,5 @@ export const redirects = {
   '/network-fees-interledger-ecosystem':
     '/policy-and-advocacy/network-fees-interledger-ecosystem',
   '/role-stablecoins-facilitating-low-value-low-cost-transactions':
-    '/policy-and-advocacy/role-stablecoins-facilitating-low-value-low-cost-transactions',
+    '/policy-and-advocacy/role-stablecoins-facilitating-low-value-low-cost-transactions'
 }

--- a/src/config/foundation-navigation.es.json
+++ b/src/config/foundation-navigation.es.json
@@ -64,7 +64,7 @@
         },
         {
           "label": "Fellowship Program",
-          "href": "/grant/ambassadors"
+          "href": "/grant/fellowship"
         },
         {
           "label": "Grant for Web",

--- a/src/config/foundation-navigation.json
+++ b/src/config/foundation-navigation.json
@@ -63,7 +63,7 @@
         },
         {
           "label": "Fellowship Program",
-          "href": "/grant/ambassadors"
+          "href": "/grant/fellowship"
         },
         {
           "label": "Grant for Web",

--- a/src/content/foundation-blog-posts/2025-08-01-open-payments-help-roscas-modernise-global-impact.mdx
+++ b/src/content/foundation-blog-posts/2025-08-01-open-payments-help-roscas-modernise-global-impact.mdx
@@ -59,6 +59,6 @@ Looking to the future, Barrett says she is determined to preserve the spirit of 
 
 “_Collaborative efforts are the best way to make ROSCAs more accessible, secure, and impactful. We know that women and immigrants are often excluded from mainstream financial services, but digital ROSCAs will go a long way to help them gain access to new opportunities for financial empowerment and independence – which is exactly what ROSCAs have always represented_,” she says.
 
-Read more in her [report](https://community.interledger.org/andria/project-name-ilf-ambassador-progress-report-1c86) and learn more about our[ Ambassador program](https://interledger.org/ambassadors).
+Read more in her [report](https://community.interledger.org/andria/project-name-ilf-ambassador-progress-report-1c86) and learn more about our[ Ambassador program](https://interledger.org/grant/fellowship).
 
 </Paragraph>

--- a/src/content/foundation-blog-posts/2025-10-06-reimagining-e-commerce-and-social-media.mdx
+++ b/src/content/foundation-blog-posts/2025-10-06-reimagining-e-commerce-and-social-media.mdx
@@ -15,7 +15,7 @@ tags:
 
 <Paragraph>
 
-[ILF Ambassador Gavin Chait](https://interledger.org/ambassadors) is a passionate advocate for financial inclusion. With [Hop Sauna](https://community.interledger.org/hopsauna/hop-sauna-ilf-ambassador-progress-report-35oa), he is developing a core technical platform that enables developers to create federated, community-managed web shops that offer customised digital objects of their design.
+[ILF Ambassador Gavin Chait](https://interledger.org/grant/fellowship) is a passionate advocate for financial inclusion. With [Hop Sauna](https://community.interledger.org/hopsauna/hop-sauna-ilf-ambassador-progress-report-35oa), he is developing a core technical platform that enables developers to create federated, community-managed web shops that offer customised digital objects of their design.
 
 At the core of Hop Sauna is the idea of community-moderated commerce. This is a bold step towards establishing a more inclusive and diverse e-commerce landscape.
 

--- a/src/content/foundation-pages/about-us.mdx
+++ b/src/content/foundation-pages/about-us.mdx
@@ -11,7 +11,7 @@ The Interledger Foundation (ILF) is a mission-driven nonprofit ensuring that no 
 
 ## Our role?
 
-We collaborate with entrepreneurs, organizations, and governments to [advocate](/policy-and-advocacy) for equitable access to financial systems and steward the interoperable technologies that power the Internet of Opportunity (IoO). To advance this work we fund [financial services](/financial-services) projects, [education](/education) initiatives, and [ambassador](/ambassadors) programs.
+We collaborate with entrepreneurs, organizations, and governments to [advocate](/policy-and-advocacy) for equitable access to financial systems and steward the interoperable technologies that power the Internet of Opportunity (IoO). To advance this work we fund [financial services](/financial-services) projects, [education](/education) initiatives, and [ambassador](/grant/fellowship) programs.
 
 ## The Problem We’re Solving
 

--- a/src/content/foundation-pages/es/about-us.mdx
+++ b/src/content/foundation-pages/es/about-us.mdx
@@ -12,7 +12,7 @@ La Interledger Foundation (ILF) es una organización sin fines de lucro impulsad
 
 ## Nuestro papel
 
-Colaboramos con emprendedores, organizaciones y gobiernos para [impulsar](/policy-and-advocacy) el acceso equitativo a los sistemas financieros y custodiar las tecnologías interoperables que impulsan el Internet de Oportunidades (IoO). Para avanzar este trabajo financiamos proyectos de [servicios financieros](/financial-services), iniciativas de [educación](/education) y programas de [embajadores](/ambassadors).
+Colaboramos con emprendedores, organizaciones y gobiernos para [impulsar](/policy-and-advocacy) el acceso equitativo a los sistemas financieros y custodiar las tecnologías interoperables que impulsan el Internet de Oportunidades (IoO). Para avanzar este trabajo financiamos proyectos de [servicios financieros](/financial-services), iniciativas de [educación](/education) y programas de [embajadores](/grant/fellowship).
 
 ## El problema que estamos resolviendo
 

--- a/src/content/foundation-pages/grant/fellowship.mdx
+++ b/src/content/foundation-pages/grant/fellowship.mdx
@@ -1,5 +1,5 @@
 ---
-pathSlug: 'grant/ambassadors'
+pathSlug: 'grant/fellowship'
 title: 'Fellowship Program'
 pillar: 'mission'
 heroTitle: 'Engage new voices'


### PR DESCRIPTION
## Summary
<!-- What changed and why -->
We updated ambassador pages to have a new url, `fellowship` instead of `ambassador` v5 needs to support all the redirects that v4 supports so I am migrating them over. 

## Related Issue
<!-- Fixes INTORG-123 -->
Fixes INTORG-622

## Manual Test
<!-- Reviewer steps (only if needed) -->
- https://deploy-preview-247--interledger-org-v5.netlify.app/grant/ambassadors redirects to https://deploy-preview-247--interledger-org-v5.netlify.app/grant/fellwoship
- https://deploy-preview-247--interledger-org-v5.netlify.app/es/grant/ambassadors redirects to https://deploy-preview-247--interledger-org-v5.netlify.app/es/grant/fellwoship
- https://deploy-preview-247--interledger-org-v5.netlify.app/grant/ambassadors/faq redirects to https://deploy-preview-247--interledger-org-v5.netlify.app/grant/fellwoship/faq
- https://deploy-preview-247--interledger-org-v5.netlify.app/es/grant/ambassadors/faq redirects to https://deploy-preview-247--interledger-org-v5.netlify.app/es/grant/fellwoship/faq

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
