### PR TITLE
feat(cms): force leading slash on nav href fields [INTORG-605]

### DIFF
--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -5,6 +5,7 @@ import {
   scheduleGitSync,
   validateGitSyncRepoOnStartup,
   validateNoNestedJsx,
+  normalizeNavigationInput,
   LOCALES,
   shouldSkipMdxExport
 } from './utils'
@@ -1003,6 +1004,31 @@ export default {
             }
             return
           }
+        }
+        await next()
+      }
+    )
+
+    // Normalize nav href fields (force leading slash) before saving to DB
+    const NAV_PATTERN =
+      /\/content-manager\/single-types\/api::(foundation|summit)-navigation\./
+    strapi.server?.use?.(
+      async (
+        ctx: {
+          method?: string
+          url?: string
+          request?: { body?: Record<string, unknown> }
+        },
+        next: () => Promise<void>
+      ) => {
+        if (
+          (ctx.method === 'PUT' || ctx.method === 'POST') &&
+          NAV_PATTERN.test(ctx.url ?? '') &&
+          ctx.request?.body
+        ) {
+          normalizeNavigationInput(
+            ctx.request.body as Parameters<typeof normalizeNavigationInput>[0]
+          )
         }
         await next()
       }

--- a/cms/src/utils/index.ts
+++ b/cms/src/utils/index.ts
@@ -61,5 +61,6 @@ export {
 } from './flatContentLifecycle'
 export {
   type NavigationLifecycleConfig,
-  createNavigationLifecycle
+  createNavigationLifecycle,
+  normalizeNavigationInput
 } from './navigationLifecycle'

--- a/cms/src/utils/navigationLifecycle.ts
+++ b/cms/src/utils/navigationLifecycle.ts
@@ -218,29 +218,14 @@ async function exportAndCommitNavigation<T extends UID.ContentType>(
 
 export function normalizeNavigationInput(data: NavigationData): void {
   data.mainMenu?.forEach((group) => {
-    if (
-      group.href &&
-      !group.href.startsWith('/') &&
-      !group.href.startsWith('http')
-    ) {
-      group.href = `/${group.href}`
-    }
+    group.href = normalizeHref(group.href) ?? group.href
     group.items?.forEach((item) => {
-      if (
-        item.href &&
-        !item.href.startsWith('/') &&
-        !item.href.startsWith('http')
-      ) {
-        item.href = `/${item.href}`
-      }
+      item.href = normalizeHref(item.href) ?? item.href
     })
   })
-  if (
-    data.ctaButton?.href &&
-    !data.ctaButton.href.startsWith('/') &&
-    !data.ctaButton.href.startsWith('http')
-  ) {
-    data.ctaButton.href = `/${data.ctaButton.href}`
+  if (data.ctaButton) {
+    data.ctaButton.href =
+      normalizeHref(data.ctaButton.href) ?? data.ctaButton.href
   }
 }
 

--- a/cms/src/utils/navigationLifecycle.ts
+++ b/cms/src/utils/navigationLifecycle.ts
@@ -40,22 +40,30 @@ export interface NavigationLifecycleConfig<
   populate: Modules.Documents.Params.Populate.Any<T>
 }
 
+function normalizeHref(href: string | null | undefined): string | undefined {
+  if (!href) return undefined
+  if (href.startsWith('/') || href.startsWith('http')) return href
+  return `/${href}`
+}
+
 export function sanitizeMenuItem(
   item: MenuItem | null | undefined
 ): MenuItem | null {
   if (!item) return null
+  const href = normalizeHref(item.href)
   return {
     label: item.label,
-    ...(item.href ? { href: item.href } : {}),
+    ...(href ? { href } : {}),
     ...(item.openInNewTab ? { openInNewTab: true } : {})
   }
 }
 
 export function sanitizeMenuGroup(group: MenuGroup): MenuGroup {
   const items = group.items?.map(sanitizeMenuItem).filter(Boolean) ?? undefined
+  const href = normalizeHref(group.href)
   return {
     label: group.label,
-    ...(group.href ? { href: group.href } : {}),
+    ...(href ? { href } : {}),
     ...(items && items.length > 0 ? { items: items as MenuItem[] } : {})
   }
 }
@@ -208,10 +216,38 @@ async function exportAndCommitNavigation<T extends UID.ContentType>(
   }
 }
 
+export function normalizeNavigationInput(data: NavigationData): void {
+  data.mainMenu?.forEach((group) => {
+    if (group.href && !group.href.startsWith('/') && !group.href.startsWith('http')) {
+      group.href = `/${group.href}`
+    }
+    group.items?.forEach((item) => {
+      if (item.href && !item.href.startsWith('/') && !item.href.startsWith('http')) {
+        item.href = `/${item.href}`
+      }
+    })
+  })
+  if (data.ctaButton?.href && !data.ctaButton.href.startsWith('/') && !data.ctaButton.href.startsWith('http')) {
+    data.ctaButton.href = `/${data.ctaButton.href}`
+  }
+}
+
+interface BeforeEvent {
+  params: { data: NavigationData }
+}
+
 export function createNavigationLifecycle<T extends UID.ContentType>(
   config: NavigationLifecycleConfig<T>
 ) {
   return {
+    beforeCreate(event: BeforeEvent) {
+      normalizeNavigationInput(event.params.data)
+    },
+
+    beforeUpdate(event: BeforeEvent) {
+      normalizeNavigationInput(event.params.data)
+    },
+
     async afterCreate(_event: Event) {
       await exportAndCommitNavigation(config, 'Create')
     },

--- a/cms/src/utils/navigationLifecycle.ts
+++ b/cms/src/utils/navigationLifecycle.ts
@@ -218,16 +218,28 @@ async function exportAndCommitNavigation<T extends UID.ContentType>(
 
 export function normalizeNavigationInput(data: NavigationData): void {
   data.mainMenu?.forEach((group) => {
-    if (group.href && !group.href.startsWith('/') && !group.href.startsWith('http')) {
+    if (
+      group.href &&
+      !group.href.startsWith('/') &&
+      !group.href.startsWith('http')
+    ) {
       group.href = `/${group.href}`
     }
     group.items?.forEach((item) => {
-      if (item.href && !item.href.startsWith('/') && !item.href.startsWith('http')) {
+      if (
+        item.href &&
+        !item.href.startsWith('/') &&
+        !item.href.startsWith('http')
+      ) {
         item.href = `/${item.href}`
       }
     })
   })
-  if (data.ctaButton?.href && !data.ctaButton.href.startsWith('/') && !data.ctaButton.href.startsWith('http')) {
+  if (
+    data.ctaButton?.href &&
+    !data.ctaButton.href.startsWith('/') &&
+    !data.ctaButton.href.startsWith('http')
+  ) {
     data.ctaButton.href = `/${data.ctaButton.href}`
   }
 }


### PR DESCRIPTION
## Summary
Normalizes `href` values in navigation menu items and groups, forcing a leading `/` on any relative URL that's missing one (e.g. `grant/grant-web` → `/grant/grant-web`)

The fix is applied at two layers:
- **Koa middleware** (`src/index.ts`) — intercepts content-manager PUT/POST requests and normalizes the request body before Strapi saves to the DB, so the corrected value is reflected in the UI immediately
- **Lifecycle sanitization** (`navigationLifecycle.ts`) — `normalizeNavigationInput` is also called in `beforeCreate`/`beforeUpdate` hooks and during export sanitization, covering any programmatic saves that bypass the HTTP layer

## Related Issue
Fixes INTORG-605

## Manual Test
1. Open Foundation or Summit Navigation in the Strapi admin
2. Edit a menu item's Link URL — enter a value without a leading slash (e.g. `grant/grant-web`)
3. Save — confirm the stored value gains the leading slash and the UI reflects it on reload
4. Confirm external URLs (e.g. `https://example.com`) are not modified

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
