### PR TITLE
chore: added ADR for analytics

### DIFF
--- a/docs/decisions/002-spanish-fallback-disclaimer-behavior.md
+++ b/docs/decisions/002-spanish-fallback-disclaimer-behavior.md
@@ -1,6 +1,6 @@
 # ADR-002: Spanish fallback disclaimer behavior for Speaker list pages
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-09
 **Issue:** N/A
 

--- a/docs/decisions/004-locale-prefix-routing-for-translations.md
+++ b/docs/decisions/004-locale-prefix-routing-for-translations.md
@@ -1,6 +1,6 @@
 # ADR-004: Locale-prefix routing for translated pages
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-17
 **Issue:**
 

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -4,74 +4,175 @@
 **Date:** 2026-04-21
 **Issue:** N/A
 
+---
+
 ## Context
 
-Our Umami event tracking has grown inconsistent and increasingly hard to query. Problems fall into four categories:
+Our Umami event tracking has grown inconsistent and increasingly hard to query. Problems fall into four categories.
 
-**Manual naming drift.** Event names are typed by hand, producing case inconsistencies (`Content Hub` vs `Content hub`), mixed separators (hyphens, en-dashes, spaces), and duplicate multilingual variants. The same interaction appears under several slightly different names, making aggregation unreliable.
+**Manual naming drift.** Event names are entered manually, leading to inconsistencies. This causes the same interaction to be split across multiple slightly different names, making aggregation unreliable.
 
-**Over-specific event names.** Date-based events like `Blog - 2026-01-07` and content-specific one-offs create effectively unique events that cannot be grouped. Questions like "how do blog cards perform overall?" have no clean answer.
+**Over-specific event names.** Date-stamped events like `Blog - 2026-01-07` and content-specific one-offs create effectively unique events that cannot be grouped.
 
-**No ownership model.** There is no enforced separation between page context, component/UI, and content destination. Each event is constructed ad hoc, so naming decisions are inconsistent by construction.
+**No ownership model.** There is no enforced separation between page context, UI component, and link destination. Each event is constructed ad hoc, so naming decisions are inconsistent by construction.
 
-**Misalignment with the stack.** The site is built on reusable Astro components, and stable `pathSlug` identifiers. The analytics layer does not reflect this yet.
+**Misalignment with the stack.** The site is built on reusable Astro components, MDX page files with stable `pathSlug` identifiers, and a `locales` export for i18n. The analytics layer does not reflect this structure.
 
-Umami's UI is event-name-first, which creates a constraint: page context should appear in the event name, but encoding too much detail fragments events into long-tail noise. The schema must balance queryability with clean aggregation.
+Umami's UI is event-name-first: the event name is the primary filter, and event properties surface as secondary breakdown data. Page context therefore belongs in the event name — but encoding too much detail fragments events into long-tail noise. The schema must balance queryability with clean aggregation.
+
+---
 
 ## Decision
 
-All tracked link events follow a three-segment schema generated from code and content identifiers — never typed by hand:
+All tracked link events follow a three-segment schema, generated from code and content identifiers — never typed by hand:
 
 ```
 {page}:{component}:{label}
 ```
 
-**Page** and **Label** use the same `deriveLabel()` function — Page applied to `Astro.url.pathname`, Label applied to the link's `href`. Both take the last two path segments after stripping locale prefixes and join them with `_`. A profile page at `/grants/fellowship/sheena-allen` and a link pointing to it both produce `fellowship_sheena_allen` — unambiguous at both ends. Nothing is typed by hand.
+### Segments
 
-**Component** is a `const COMPONENT` declared inside each Astro component.
+**`page`** is the `pathSlug` defined in MDX frontmatter — a stable semantic identifier that does not change when page titles or URLs change.
 
-For **Label**, external URLs use the root domain with subdomain preserved where meaningful; GitHub gets special treatment to capture org and repo. The two-segment approach prevents collisions: `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` produce `fellowship_sheena_allen`, `judges_sheena_allen`, and `speakers_sheena_allen` — distinct regardless of where the link appears.
+**`component`** is a `const COMPONENT` declared inside each Astro component. The component declares its own identity; nothing is passed or inferred from outside.
 
-A `TrackedLink` Astro component is the single instrumentation point. It accepts `page`, `component`, and `href`, generates the event name, and sets two standard properties on every tracked link:
+**`label`** is derived at build time from the link's `href`.
 
-- `lang` — injected from `Astro.currentLocale`, never set manually
-- `link_text` — the visible link text as rendered
+Page and label segments must be derived by `deriveLabel()`. For internal links, the last two path segments are taken after stripping any locale prefix. For external links, the root and sub domains are used. GitHub gets special treatment to capture org and repo.
 
-This makes `fellowship:hero:submittable` the same event in English and Spanish; the `lang` property distinguishes them. No duplicate events, no multilingual noise.
+Taking two segments rather than one prevents a class of collision where the final segment alone is ambiguous. `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all end in `sheena-allen` — with a single-segment rule they are indistinguishable. Two segments gives `fellowship_sheena_allen`, `judges_sheena_allen`, and `speakers_sheena_allen`.
 
-**Rich text is a deliberate exception.** Body content fields are editor-driven and can contain an unbounded variety of destinations. Encoding every destination into the event name would produce long-tail noise that clutters the event list. Rich text links instead use a two-segment name:
+Locale prefixes are stripped using the project's `locales` export as the source of truth. Event names should not differ based on locale. That can be filtered in Umami.
+
+### Implementation
+
+```typescript
+// src/lib/tracking.ts
+import { locales } from '../i18n/config';
+
+export function deriveLabel(href: string): string {
+  try {
+    const url = new URL(href, 'https://interledger.org');
+    const isInternal =
+      href.startsWith('/') ||
+      url.hostname === 'interledger.org' ||
+      url.hostname.endsWith('.interledger.org');
+
+    if (isInternal) {
+      const parts = stripLangPrefix(
+        url.pathname.replace(/\/$/, '').split('/').filter(Boolean)
+      );
+      return slugify(parts.slice(-2).join('_') || 'home');
+    }
+
+    if (url.hostname === 'github.com') {
+      return url.pathname.split('/').filter(Boolean).slice(0, 2).join('_') || 'github';
+    }
+
+    const hostParts = url.hostname.replace(/^www\./, '').split('.');
+    return slugify(hostParts.length > 2 ? `${hostParts[0]}_${hostParts[1]}` : hostParts[0]);
+  } catch {
+    return slugify(href);
+  }
+}
+
+const stripLangPrefix = (parts: string[]): string[] =>
+  (locales as string[]).includes(parts[0]) ? parts.slice(1) : parts;
+
+export const slugify = (text: string): string =>
+  text.toLowerCase().trim().replace(/\s+/g, '_').replace(/[^\w_]/g, '');
+```
+
+### TrackedLink component
+
+A single Astro component is the instrumentation point for all bounded link interactions across all three microsites.
+
+```astro
+---
+// src/components/TrackedLink.astro
+import { deriveLabel } from '../lib/tracking';
+
+interface Props {
+  pathSlug: string;
+  component: string;
+  href: string;
+  linkText?: string;
+}
+
+const { pathSlug, component, href, linkText } = Astro.props;
+const event = `${deriveLabel(pathSlug)}:${component}:${deriveLabel(href)}`;
+---
+
+<a
+  href={href}
+  data-umami-event={event}
+  data-umami-event-lang={Astro.currentLocale}
+  data-umami-event-link-text={linkText}  {/* linkText is optional — omit or pass undefined for icon-only/image links */}
+>
+  <slot />
+</a>
+```
+
+Two properties are set on every link: `lang` from `Astro.currentLocale`, and `link_text` capturing the visible label as rendered. This makes `fellowship:hero:submittable` the same event in English and Spanish — `lang` distinguishes them in breakdown data without duplicating events.
+
+### Rich text exception
+
+Body content fields are editor-driven and open-ended. Encoding every inline destination into the event name produces a large, unstructured family of low-volume events that clutters the Umami event list without adding queryable value.
+
+Rich text links use a two-segment name instead:
 
 ```
 {page}:richtext
 ```
 
-Label, destination URL, and link type are captured as event properties. Because this is an SSG build, attributes are injected at build time by processing the rendered HTML string — no client-side JavaScript required.
+Label, destination URL, and link type are captured as event properties. Because this is a static build, attributes are injected at build time by processing the rendered HTML string:
+
+```typescript
+// src/components/blocks/Paragraph.astro
+const processed = content.replace(/<a\s+href="([^"]+)"/g, (_, href) => {
+  const isInternal = href.startsWith('/') || href.includes('interledger.org');
+  const linkType = href.startsWith('#') ? 'anchor' : isInternal ? 'internal' : 'external';
+  return [
+    `<a href="${href}"`,
+    `data-umami-event="${page}:richtext"`,
+    `data-umami-event-label="${deriveLabel(href)}"`,
+    `data-umami-event-href="${href}"`,
+    `data-umami-event-link-type="${linkType}"`,
+  ].join(' ');
+});
+```
+
+The rule is: use three-segment naming for components where the destination set is bounded and intentional (nav, hero, card, cta, footer, faq, filter, breadcrumb). Use two-segment naming for components where destinations are open-ended and editor-driven (richtext).
+
+---
 
 ## Alternatives considered
 
-**Status quo (manual event strings).** Already producing 300+ events with inconsistent casing, mixed separators, and duplicate multilingual variants. Does not scale.
+**Status quo (manual event strings).** Producing 300+ events with inconsistent casing, mixed separators, and duplicate multilingual variants. Does not scale and cannot be queried reliably.
 
-**Single-segment derivation for page or label.** Collapses important context — `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all produce `sheena_allen` whether used as a page identifier or a link label. Ruled out for both.
+**Single-segment label derivation.** `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all collapse to `sheena_allen`. Ruled out — the final segment alone is frequently ambiguous.
 
 **Full path as label.** Produces near-unique event names for deep pages, defeating aggregation. Ruled out.
 
-**Pattern-based locale stripping.** A two-letter path segment that is not a locale code (`go`, `do`) would be incorrectly stripped. Using the project's `locales` export as the source of truth is more reliable. Adopted.
+**Selective tracking (only instrument what we know we care about).** An alternative approach is to track fewer events upfront and add more instrumentation as specific questions arise. The appeal is a cleaner event list with less noise. The problem is that analytics questions are often retrospective — you can't answer "which CTA drove fellowship applications last quarter?" if you only started tracking hero clicks this month. Selective tracking also requires ongoing human judgement about what is worth instrumenting, which reintroduces the manual decision-making this schema is designed to eliminate. The schema solves the noise problem structurally: bounded components produce a finite, predictable event set, and rich text is deliberately collapsed to `{page}:richtext` with detail in properties. The result is a clean event list without sacrificing any data.
 
-**Rich text using full three-segment schema.** The unbounded variety of editorial destinations would fragment the event list with low-volume, one-off events. Two-segment name with properties preserves drill-down capability while keeping the event list clean. Adopted.
+---
 
 ## Consequences
 
-**Positive:**
+**Positive**
 
 - Event names are generated, never typed. Casing drift, separator inconsistency, and copy-paste errors are structurally impossible.
-- Locale prefixes are stripped from labels; locale is a property. One event per interaction regardless of language.
-- `deriveLabel` runs at build time; rich text attributes are injected during the build. No runtime JavaScript dependency.
-- Adding a new page requires one `pathSlug` in frontmatter. Adding a new component requires one `const COMPONENT` declaration. No central registry to maintain.
-- Umami wildcard queries (`fellowship:*`, `*:hero:*`, `*:*:submittable`) give page-level, component-level, and destination-level views without any schema changes.
+- One event per interaction regardless of language. Locale is a property, not part of the event name.
+- `deriveLabel` and rich text processing run at build time.
+- Additive by default — new pages require one `pathSlug` in frontmatter, new components require one `const COMPONENT`. No central registry.
+- Umami wildcard queries (`fellowship:*`, `*:hero:*`, `*:*:submittable`) give clean page-level, component-level, and destination-level views. URL path filtering in Umami isolates microsites and locales without extra instrumentation.
+- Umami supports language filtering by selecting whether `/es/` is included or excluded in the path as a filter criteria.
+- Umami supports microsite filtering by selecting whether `/summit/` and `/hackathon/` segments are included or excluded in the path as a filter criteria.
 
-**Negative:**
 
-- `TrackedLink` must be adopted across all components to realise consistency benefits. A parallel period where old and new events coexist will require care when interpreting data.
-- The two-segment label is a heuristic. Unusual URL structures (very shallow paths, non-standard slugs) may produce less meaningful labels, though `slugify` ensures they are always safe.
-- Rich text link tracking depends on build-time HTML processing. Any server-side or client-side rendering path that bypasses this step will not be instrumented.
-- `deriveLabel` relies on the `locales` export staying accurate. A locale added to URLs but not to that export will cause the prefix to appear in both page and label segments.
+**Negative**
+
+- `TrackedLink` must be adopted across all components to realise consistency benefits.
+- Rich text instrumentation depends on build-time HTML processing.
+- Extra build steps and potential fragility.

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -32,11 +32,13 @@ All tracked link events follow a three-segment schema, generated from code and c
 
 ### Segments
 
-**`page`** is the `pathSlug` defined in MDX frontmatter — stable, and does not change when titles or URLs change.
+**`page`** is the `pathSlug` defined in MDX frontmatter — stable identifier.
 
 **`component`** is a `const COMPONENT` declared inside each Astro component. The component declares its own identity; nothing is passed or inferred from outside.
 
-**`label`** is derived at build time from the link's `href` via `deriveLabel()`. For internal links, the last two path segments are taken after stripping any locale prefix. For external links, root and sub domains are used. GitHub gets special treatment to capture org and repo.
+**`label`** is derived at build time from the link's `href`.
+
+The `page` and `label` segmnents are derived via `deriveLabel()`. For internal links, the last two path segments are taken after stripping any locale prefix. For external links, root and sub domains are used. GitHub gets special treatment to capture org and repo.
 
 Two segments instead of one prevents collisions where the final segment alone is ambiguous. `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all end in `sheena-allen`. Two segments gives `fellowship_sheena_allen`, `judges_sheena_allen`, and `speakers_sheena_allen`.
 

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -8,17 +8,17 @@
 
 ## Context
 
-Our Umami event tracking has grown inconsistent and increasingly hard to query. Problems fall into four categories.
+Umami event tracking has grown inconsistent and hard to query. Four root causes:
 
-**Manual naming drift.** Event names are entered manually, leading to inconsistencies. This causes the same interaction to be split across multiple slightly different names, making aggregation unreliable.
+**Manual naming drift.** Events are named by hand, splitting the same interaction across inconsistent variants and breaking aggregation.
 
-**Over-specific event names.** Date-stamped events like `Blog - 2026-01-07` and content-specific one-offs create effectively unique events that cannot be grouped.
+**Over-specific event names.** Date-stamped events like `Blog - 2026-01-07` produce near-unique names that can't be grouped.
 
-**No ownership model.** There is no enforced separation between page context, UI component, and link destination. Each event is constructed ad hoc, so naming decisions are inconsistent by construction.
+**No ownership model.** No enforced separation between page context, component, and destination — each event is constructed ad hoc.
 
-**Misalignment with the stack.** The site is built on reusable Astro components, MDX page files with stable `pathSlug` identifiers, and a `locales` export for i18n. The analytics layer does not reflect this structure.
+**Misalignment with the stack.** The site uses reusable Astro components, stable `pathSlug` identifiers, and a `locales` export. The analytics layer doesn't reflect this.
 
-Umami's UI is event-name-first: the event name is the primary filter, and event properties surface as secondary breakdown data. Page context therefore belongs in the event name — but encoding too much detail fragments events into long-tail noise. The schema must balance queryability with clean aggregation.
+Umami's UI is event-name-first: the event name is the primary filter, with properties as secondary breakdown. Page context belongs in the name — but too much detail fragments events into long-tail noise. The schema must balance queryability with clean aggregation.
 
 ---
 
@@ -32,17 +32,15 @@ All tracked link events follow a three-segment schema, generated from code and c
 
 ### Segments
 
-**`page`** is the `pathSlug` defined in MDX frontmatter — a stable semantic identifier that does not change when page titles or URLs change.
+**`page`** is the `pathSlug` defined in MDX frontmatter — stable, and does not change when titles or URLs change.
 
 **`component`** is a `const COMPONENT` declared inside each Astro component. The component declares its own identity; nothing is passed or inferred from outside.
 
-**`label`** is derived at build time from the link's `href`.
+**`label`** is derived at build time from the link's `href` via `deriveLabel()`. For internal links, the last two path segments are taken after stripping any locale prefix. For external links, root and sub domains are used. GitHub gets special treatment to capture org and repo.
 
-Page and label segments must be derived by `deriveLabel()`. For internal links, the last two path segments are taken after stripping any locale prefix. For external links, the root and sub domains are used. GitHub gets special treatment to capture org and repo.
+Two segments instead of one prevents collisions where the final segment alone is ambiguous. `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all end in `sheena-allen`. Two segments gives `fellowship_sheena_allen`, `judges_sheena_allen`, and `speakers_sheena_allen`.
 
-Taking two segments rather than one prevents a class of collision where the final segment alone is ambiguous. `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all end in `sheena-allen` — with a single-segment rule they are indistinguishable. Two segments gives `fellowship_sheena_allen`, `judges_sheena_allen`, and `speakers_sheena_allen`.
-
-Locale prefixes are stripped using the project's `locales` export as the source of truth. Event names should not differ based on locale. That can be filtered in Umami.
+Locale prefixes are stripped using the project's `locales` export. Event names don't differ by locale — that's a filter in Umami.
 
 ### Implementation
 
@@ -94,7 +92,7 @@ export const slugify = (text: string): string =>
 
 ### TrackedLink component
 
-A single Astro component is the instrumentation point for all bounded link interactions across all three microsites.
+Single instrumentation point for all bounded link interactions across all three microsites.
 
 ```astro
 ---
@@ -117,17 +115,17 @@ const event = `${deriveLabel(pathSlug)}:${component}:${deriveLabel(href)}`
   data-umami-event={event}
   data-umami-event-lang={Astro.currentLocale}
   data-umami-event-link-text={linkText}
-  {/* linkText is optional — omit or pass undefined for icon-only/image links */}
+  {/* undefined for icon/image links */}
 >
   <slot />
 </a>
 ```
 
-Two properties are set on every link: `lang` from `Astro.currentLocale`, and `link_text` capturing the visible label as rendered. This makes `fellowship:hero:submittable` the same event in English and Spanish — `lang` distinguishes them in breakdown data without duplicating events.
+Every link gets `lang` from `Astro.currentLocale` and `link_text` from the visible label. `fellowship:hero:submittable` is the same event in English and Spanish — `lang` distinguishes them in breakdown data.
 
 ### Rich text exception
 
-Body content fields are editor-driven and open-ended. Encoding every inline destination into the event name produces a large, unstructured family of low-volume events that clutters the Umami event list without adding queryable value.
+Body content is editor-driven and open-ended. Encoding every inline destination into the event name produces a large, unstructured family of low-volume events that clutters the Umami event list.
 
 Rich text links use a two-segment name instead:
 
@@ -135,7 +133,7 @@ Rich text links use a two-segment name instead:
 {page}:richtext
 ```
 
-Label, destination URL, and link type are captured as event properties. Because this is a static build, attributes are injected at build time by processing the rendered HTML string:
+Label, destination URL, and link type are captured as properties, injected at build time:
 
 ```typescript
 // src/components/blocks/Paragraph.astro
@@ -156,19 +154,19 @@ const processed = content.replace(/<a\s+href="([^"]+)"/g, (_, href) => {
 })
 ```
 
-The rule is: use three-segment naming for components where the destination set is bounded and intentional (nav, hero, card, cta, footer, faq, filter, breadcrumb). Use two-segment naming for components where destinations are open-ended and editor-driven (richtext).
+The rule: three-segment names for components with bounded, intentional destinations (nav, hero, card, cta, footer, faq, filter, breadcrumb). Two-segment names for open-ended, editor-driven content (richtext).
 
 ---
 
 ## Alternatives considered
 
-**Status quo (manual event strings).** Producing 300+ events with inconsistent casing, mixed separators, and duplicate multilingual variants. Does not scale and cannot be queried reliably.
+**Status quo (manual event strings).** 300+ events with inconsistent casing, mixed separators, and duplicate multilingual variants. Doesn't scale.
 
-**Single-segment label derivation.** `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all collapse to `sheena_allen`. Ruled out — the final segment alone is frequently ambiguous.
+**Single-segment label derivation.** The final path segment is frequently ambiguous. Ruled out.
 
 **Full path as label.** Produces near-unique event names for deep pages, defeating aggregation. Ruled out.
 
-**Selective tracking (only instrument what we know we care about).** An alternative approach is to track fewer events upfront and add more instrumentation as specific questions arise. The appeal is a cleaner event list with less noise. The problem is that analytics questions are often retrospective — you can't answer "which CTA drove fellowship applications last quarter?" if you only started tracking hero clicks this month. Selective tracking also requires ongoing human judgement about what is worth instrumenting, which reintroduces the manual decision-making this schema is designed to eliminate. The schema solves the noise problem structurally: bounded components produce a finite, predictable event set, and rich text is deliberately collapsed to `{page}:richtext` with detail in properties. The result is a clean event list without sacrificing any data.
+**Selective tracking.** Track fewer events upfront and add more as questions arise. The problem is that analytics questions are often retrospective — you can't answer "which CTA drove fellowship applications last quarter?" if you only started tracking hero clicks this month. The schema solves the noise problem structurally: bounded components produce a finite, predictable event set; rich text collapses to `{page}:richtext` with detail in properties.
 
 ---
 
@@ -176,16 +174,13 @@ The rule is: use three-segment naming for components where the destination set i
 
 **Positive**
 
-- Event names are generated, never typed. Casing drift, separator inconsistency, and copy-paste errors are structurally impossible.
+- Event names are generated, never typed. Casing drift and copy-paste errors are structurally impossible.
 - One event per interaction regardless of language. Locale is a property, not part of the event name.
 - `deriveLabel` and rich text processing run at build time.
-- Additive by default — new pages require one `pathSlug` in frontmatter, new components require one `const COMPONENT`. No central registry.
-- Umami wildcard queries (`fellowship:*`, `*:hero:*`, `*:*:submittable`) give clean page-level, component-level, and destination-level views. URL path filtering in Umami isolates microsites and locales without extra instrumentation.
-- Umami supports language filtering by selecting whether `/es/` is included or excluded in the path as a filter criteria.
-- Umami supports microsite filtering by selecting whether `/summit/` and `/hackathon/` segments are included or excluded in the path as a filter criteria.
+- Additive by default — new pages need one `pathSlug` in frontmatter, new components need one `const COMPONENT`. No central registry.
+- Umami wildcard queries (`fellowship:*`, `*:hero:*`, `*:*:submittable`) give clean page-, component-, and destination-level views. Path filtering in Umami isolates microsites and locales.
 
 **Negative**
 
 - `TrackedLink` must be adopted across all components to realise consistency benefits.
-- Rich text instrumentation depends on build-time HTML processing.
-- Extra build steps and potential fragility.
+- Rich text instrumentation depends on build-time HTML processing, adding build steps and potential fragility.

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -48,39 +48,48 @@ Locale prefixes are stripped using the project's `locales` export as the source 
 
 ```typescript
 // src/lib/tracking.ts
-import { locales } from '../i18n/config';
+import { locales } from '../i18n/config'
 
 export function deriveLabel(href: string): string {
   try {
-    const url = new URL(href, 'https://interledger.org');
+    const url = new URL(href, 'https://interledger.org')
     const isInternal =
       href.startsWith('/') ||
       url.hostname === 'interledger.org' ||
-      url.hostname.endsWith('.interledger.org');
+      url.hostname.endsWith('.interledger.org')
 
     if (isInternal) {
       const parts = stripLangPrefix(
         url.pathname.replace(/\/$/, '').split('/').filter(Boolean)
-      );
-      return slugify(parts.slice(-2).join('_') || 'home');
+      )
+      return slugify(parts.slice(-2).join('_') || 'home')
     }
 
     if (url.hostname === 'github.com') {
-      return url.pathname.split('/').filter(Boolean).slice(0, 2).join('_') || 'github';
+      return (
+        url.pathname.split('/').filter(Boolean).slice(0, 2).join('_') ||
+        'github'
+      )
     }
 
-    const hostParts = url.hostname.replace(/^www\./, '').split('.');
-    return slugify(hostParts.length > 2 ? `${hostParts[0]}_${hostParts[1]}` : hostParts[0]);
+    const hostParts = url.hostname.replace(/^www\./, '').split('.')
+    return slugify(
+      hostParts.length > 2 ? `${hostParts[0]}_${hostParts[1]}` : hostParts[0]
+    )
   } catch {
-    return slugify(href);
+    return slugify(href)
   }
 }
 
 const stripLangPrefix = (parts: string[]): string[] =>
-  (locales as string[]).includes(parts[0]) ? parts.slice(1) : parts;
+  (locales as string[]).includes(parts[0]) ? parts.slice(1) : parts
 
 export const slugify = (text: string): string =>
-  text.toLowerCase().trim().replace(/\s+/g, '_').replace(/[^\w_]/g, '');
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^\w_]/g, '')
 ```
 
 ### TrackedLink component
@@ -90,24 +99,25 @@ A single Astro component is the instrumentation point for all bounded link inter
 ```astro
 ---
 // src/components/TrackedLink.astro
-import { deriveLabel } from '../lib/tracking';
+import { deriveLabel } from '../lib/tracking'
 
 interface Props {
-  pathSlug: string;
-  component: string;
-  href: string;
-  linkText?: string;
+  pathSlug: string
+  component: string
+  href: string
+  linkText?: string
 }
 
-const { pathSlug, component, href, linkText } = Astro.props;
-const event = `${deriveLabel(pathSlug)}:${component}:${deriveLabel(href)}`;
+const { pathSlug, component, href, linkText } = Astro.props
+const event = `${deriveLabel(pathSlug)}:${component}:${deriveLabel(href)}`
 ---
 
 <a
   href={href}
   data-umami-event={event}
   data-umami-event-lang={Astro.currentLocale}
-  data-umami-event-link-text={linkText}  {/* linkText is optional — omit or pass undefined for icon-only/image links */}
+  data-umami-event-link-text={linkText}
+  {/* linkText is optional — omit or pass undefined for icon-only/image links */}
 >
   <slot />
 </a>
@@ -130,16 +140,20 @@ Label, destination URL, and link type are captured as event properties. Because 
 ```typescript
 // src/components/blocks/Paragraph.astro
 const processed = content.replace(/<a\s+href="([^"]+)"/g, (_, href) => {
-  const isInternal = href.startsWith('/') || href.includes('interledger.org');
-  const linkType = href.startsWith('#') ? 'anchor' : isInternal ? 'internal' : 'external';
+  const isInternal = href.startsWith('/') || href.includes('interledger.org')
+  const linkType = href.startsWith('#')
+    ? 'anchor'
+    : isInternal
+      ? 'internal'
+      : 'external'
   return [
     `<a href="${href}"`,
     `data-umami-event="${page}:richtext"`,
     `data-umami-event-label="${deriveLabel(href)}"`,
     `data-umami-event-href="${href}"`,
-    `data-umami-event-link-type="${linkType}"`,
-  ].join(' ');
-});
+    `data-umami-event-link-type="${linkType}"`
+  ].join(' ')
+})
 ```
 
 The rule is: use three-segment naming for components where the destination set is bounded and intentional (nav, hero, card, cta, footer, faq, filter, breadcrumb). Use two-segment naming for components where destinations are open-ended and editor-driven (richtext).
@@ -169,7 +183,6 @@ The rule is: use three-segment naming for components where the destination set i
 - Umami wildcard queries (`fellowship:*`, `*:hero:*`, `*:*:submittable`) give clean page-level, component-level, and destination-level views. URL path filtering in Umami isolates microsites and locales without extra instrumentation.
 - Umami supports language filtering by selecting whether `/es/` is included or excluded in the path as a filter criteria.
 - Umami supports microsite filtering by selecting whether `/summit/` and `/hackathon/` segments are included or excluded in the path as a filter criteria.
-
 
 **Negative**
 

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -38,72 +38,38 @@ All tracked link events follow a three-segment schema, generated from code and c
 
 **`label`** is derived at build time from the link's `href`.
 
-The `page` and `label` segments are derived via `deriveLabel()`. For internal links, the last two path segments are taken after stripping any locale prefix. For external links, root and sub domains are used. GitHub gets special treatment to capture org and repo.
+The `page` and `label` segments are both derived by `deriveLabel()` — the same rules apply in both contexts. For external links, subdomains are preserved — `learn.interledger.org` stays `learn_interledger`, not just `interledger`. `www` is stripped and the TLD is always dropped. For GitHub URLs, `github` is prepended to org and repo (e.g. `github.com/interledger/rafiki` → `github_interledger_rafiki`). All output is lowercase, spaces and hyphens become underscores, and non-word characters are stripped.
 
-Two segments instead of one prevents collisions where the final segment alone is ambiguous. `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all end in `sheena-allen`. Two segments gives `fellowship_sheena_allen`, `judges_sheena_allen`, and `speakers_sheena_allen`.
+### Label resolution rules
 
-Locale prefixes are stripped using the project's `locales` export. Microsite prefixes (`summit`, `hackathon`) are also stripped — both are better handled as URL path filters in Umami than encoded into every event name.
+For internal paths, resolution follows three steps in order:
 
-### Implementation
+1. **Strip locale prefix** — using the project's `locales` export as the source of truth. `/es/grants/fellowship` becomes `grants/fellowship`. Never pattern-matched — a two-letter segment that isn't a locale (e.g. `go`, `do`) is never stripped.
 
-```typescript
-// src/lib/tracking.ts
-import { locales } from '../i18n/config'
+2. **Resolve home names** — an empty path resolves to `foundation_home`. A path whose only remaining segment is a microsite name resolves to `{microsite}_home`. This gives root paths a meaningful, unambiguous identity.
 
-export function deriveLabel(href: string): string {
-  try {
-    const url = new URL(href, 'https://interledger.org')
-    const isInternal =
-      href.startsWith('/') ||
-      url.hostname === 'interledger.org' ||
-      url.hostname.endsWith('.interledger.org')
+3. **Strip microsite prefixes from longer paths, then take last two segments** — if `summit` or `hackathon` appear at the start of a multi-segment path, they are stripped before the two-segment slice. Microsite context is already captured by the URL path filter in Umami — it adds no value in the event name.
 
-    if (isInternal) {
-      const parts = stripMicrositePrefix(
-        stripLangPrefix(
-          url.pathname.replace(/\/$/, '').split('/').filter(Boolean)
-        )
-      )
-      return slugify(parts.slice(-2).join('_') || 'home')
-    }
+Two segments instead of one prevents collisions where the final segment alone is ambiguous. `/grants/fellowship/sheena-allen` and `/hackathon/judges/sheena-allen` both end in `sheena-allen` — two segments gives `fellowship_sheena_allen` and `judges_sheena_allen`.
 
-    if (url.hostname === 'github.com') {
-      return (
-        url.pathname.split('/').filter(Boolean).slice(0, 2).join('_') ||
-        'github'
-      )
-    }
-
-    const hostParts = url.hostname.replace(/^www\./, '').split('.')
-    return slugify(
-      hostParts.length > 2 ? `${hostParts[0]}_${hostParts[1]}` : hostParts[0]
-    )
-  } catch {
-    return slugify(href)
-  }
-}
-
-const MICROSITES = ['summit', 'hackathon'] as const
-
-const stripLangPrefix = (parts: string[]): string[] =>
-  (locales as string[]).includes(parts[0]) ? parts.slice(1) : parts
-
-const stripMicrositePrefix = (parts: string[]): string[] => {
-  while (
-    parts.length > 0 &&
-    (MICROSITES as readonly string[]).includes(parts[0])
-  )
-    parts = parts.slice(1)
-  return parts
-}
-
-export const slugify = (text: string): string =>
-  text
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, '_')
-    .replace(/[^\w_]/g, '')
-```
+| Path / URL                                | Resolved label              |
+| ----------------------------------------- | --------------------------- |
+| `/`                                       | `foundation_home`           |
+| `/es/`                                    | `foundation_home`           |
+| `/summit`                                 | `summit_home`               |
+| `/es/summit`                              | `summit_home`               |
+| `/hackathon`                              | `hackathon_home`            |
+| `/grants/fellowship`                      | `grants_fellowship`         |
+| `/es/grants/fellowship`                   | `grants_fellowship`         |
+| `/grants/fellowship/sheena-allen`         | `fellowship_sheena_allen`   |
+| `/summit/speakers/sheena-allen`           | `speakers_sheena_allen`     |
+| `/hackathon/judges/sheena-allen`          | `judges_sheena_allen`       |
+| `/summit/hackathon/resources`             | `resources`                 |
+| `https://github.com/interledger/rafiki`   | `github_interledger_rafiki` |
+| `https://github.com/interledger`          | `github_interledger`        |
+| `https://wallet.interledger-test.dev/...` | `wallet_interledger_test`   |
+| `https://learn.interledger.org/...`       | `learn_interledger`         |
+| `https://submittable.com/...`             | `submittable`               |
 
 ### TrackedLink component
 
@@ -145,17 +111,17 @@ Body content is editor-driven and open-ended. Encoding every inline destination 
 Rich text links use a two-segment name instead:
 
 ```
-{page}:richtext
+{page}:{component}
 ```
 
-A custom Markdown link renderer intercepts all links at build time and produces anchor elements with tracking attributes already in place:
+The component segment follows the same pattern as bounded components — each component declares its own `const COMPONENT` (e.g. `paragraph`, `blockquote`, `callout`). A custom Markdown link renderer intercepts all links at build time and produces anchor elements with tracking attributes already in place:
 
-- `data-umami-event` — `{page}:richtext`
+- `data-umami-event` — `{page}:{component}`
 - `data-umami-event-label` — derived label from `href`
 - `data-umami-event-lang` — current locale
 - `data-umami-event-link-text` — visible link text (null for icon/image links)
 
-The rule: three-segment names for components with bounded, intentional destinations (nav, hero, card, cta, footer, faq, filter, breadcrumb). Two-segment names for open-ended, editor-driven content (richtext).
+The rule: three-segment names for components with bounded, intentional destinations (nav, hero, card, cta, footer, faq, filter, breadcrumb). Two-segment names for open-ended, editor-driven content (paragraph, blockquote, callout).
 
 ---
 
@@ -167,7 +133,7 @@ The rule: three-segment names for components with bounded, intentional destinati
 
 **Full path as label.** Produces near-unique event names for deep pages, defeating aggregation. Ruled out.
 
-**Selective tracking.** Track fewer events upfront. The problem is that analytics questions are often retrospective and the cost of not capturing a link is permanent. You can always filter noise out at query time, but you can never go back and reconstruct clicks that were never tracked. With a schema this clean, every link fires a well-structured event that costs you nothing to ignore and potentially a lot to have missed. Selectivity made sense when events were messy and every new one required a manual decision. When generation is automatic and the schema is consistent, we can capture everything with less noise and enhanced filtering. The schema solves the noise problem structurally: bounded components produce a finite, predictable event set; rich text collapses to `{page}:richtext` with detail in properties.
+**Selective tracking.** Track fewer events upfront. The problem is that analytics questions are often retrospective and the cost of not capturing a link is permanent. You can always filter noise out at query time, but you can never go back and reconstruct clicks that were never tracked. With a schema this clean, every link fires a well-structured event that costs you nothing to ignore and potentially a lot to have missed. Selectivity made sense when events were messy and every new one required a manual decision. When generation is automatic and the schema is consistent, we can capture everything with less noise and enhanced filtering. The schema solves the noise problem structurally: bounded components produce a finite, predictable event set; rich text collapses to `{page}:{component}` with detail in properties.
 
 ---
 

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -56,7 +56,7 @@ Two segments instead of one prevents collisions where the final segment alone is
 | `/es/`                                    | `foundation_home`           |
 | `/summit`                                 | `summit_home`               |
 | `/es/summit`                              | `summit_home`               |
-| `/summit/hackathon`                        | `hackathon_home`            |
+| `/summit/hackathon`                       | `hackathon_home`            |
 | `/grants/fellowship`                      | `grants_fellowship`         |
 | `/es/grants/fellowship`                   | `grants_fellowship`         |
 | `/grants/fellowship/sheena-allen`         | `fellowship_sheena_allen`   |

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -1,6 +1,6 @@
 # ADR-005: Analytics event tracking schema
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-21
 **Issue:** N/A
 

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -135,25 +135,41 @@ Rich text links use a two-segment name instead:
 {page}:richtext
 ```
 
-Label, destination URL, and link type are captured as properties, injected at build time:
+Label, destination URL, and link type are captured as properties via a rehype plugin registered once in `astro.config.ts`. It reads `pathSlug` from MDX frontmatter at build time and operates on the HTML AST — no regex over rendered strings:
 
 ```typescript
-// src/components/blocks/Paragraph.astro
-const processed = content.replace(/<a\s+href="([^"]+)"/g, (_, href) => {
-  const isInternal = href.startsWith('/') || href.includes('interledger.org')
-  const linkType = href.startsWith('#')
-    ? 'anchor'
-    : isInternal
-      ? 'internal'
-      : 'external'
-  return [
-    `<a href="${href}"`,
-    `data-umami-event="${page}:richtext"`,
-    `data-umami-event-label="${deriveLabel(href)}"`,
-    `data-umami-event-href="${href}"`,
-    `data-umami-event-link-type="${linkType}"`
-  ].join(' ')
-})
+// src/lib/rehypeUmamiTracking.ts
+import { visit } from 'unist-util-visit'
+import { deriveLabel } from './tracking'
+import type { Root } from 'hast'
+
+export function rehypeUmamiTracking() {
+  return (tree: Root, file: any) => {
+    const page = file.data.astro?.frontmatter?.pathSlug ?? 'unknown'
+
+    visit(tree, 'element', (node) => {
+      if (node.tagName !== 'a') return
+      const href = node.properties?.href as string
+      if (!href) return
+
+      const isInternal =
+        href.startsWith('/') || href.includes('interledger.org')
+      const linkType = href.startsWith('#')
+        ? 'anchor'
+        : isInternal
+          ? 'internal'
+          : 'external'
+
+      node.properties = {
+        ...node.properties,
+        'data-umami-event': `${page}:richtext`,
+        'data-umami-event-label': deriveLabel(href),
+        'data-umami-event-href': href,
+        'data-umami-event-link-type': linkType
+      }
+    })
+  }
+}
 ```
 
 The rule: three-segment names for components with bounded, intentional destinations (nav, hero, card, cta, footer, faq, filter, breadcrumb). Two-segment names for open-ended, editor-driven content (richtext).
@@ -168,7 +184,7 @@ The rule: three-segment names for components with bounded, intentional destinati
 
 **Full path as label.** Produces near-unique event names for deep pages, defeating aggregation. Ruled out.
 
-**Selective tracking.** Track fewer events upfront and add more as questions arise. The problem is that analytics questions are often retrospective — you can't answer "which CTA drove fellowship applications last quarter?" if you only started tracking hero clicks this month. The schema solves the noise problem structurally: bounded components produce a finite, predictable event set; rich text collapses to `{page}:richtext` with detail in properties.
+**Selective tracking.** Track fewer events upfront. The problem is that analytics questions are often retrospective and the cost of not capturing a link is permanent. You can always filter noise out at query time, but you can never go back and reconstruct clicks that were never tracked. With a schema this clean, every link fires a well-structured event that costs you nothing to ignore and potentially a lot to have missed. Selectivity made sense when events were messy and every new one required a manual decision. When generation is automatic and the schema is consistent, we can capture everything with less noise and enhanced filtering. The schema solves the noise problem structurally: bounded components produce a finite, predictable event set; rich text collapses to `{page}:richtext` with detail in properties.
 
 ---
 
@@ -185,4 +201,4 @@ The rule: three-segment names for components with bounded, intentional destinati
 **Negative**
 
 - `TrackedLink` must be adopted across all components to realise consistency benefits.
-- Rich text instrumentation depends on build-time HTML processing, adding build steps and potential fragility.
+- Rich text instrumentation requires the rehype plugin to run correctly and `pathSlug` to be present in frontmatter.

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -1,0 +1,77 @@
+# ADR-005: Analytics event tracking schema
+
+**Status:** Proposed
+**Date:** 2026-04-21
+**Issue:** N/A
+
+## Context
+
+Our Umami event tracking has grown inconsistent and increasingly hard to query. Problems fall into four categories:
+
+**Manual naming drift.** Event names are typed by hand, producing case inconsistencies (`Content Hub` vs `Content hub`), mixed separators (hyphens, en-dashes, spaces), and duplicate multilingual variants. The same interaction appears under several slightly different names, making aggregation unreliable.
+
+**Over-specific event names.** Date-based events like `Blog - 2026-01-07` and content-specific one-offs create effectively unique events that cannot be grouped. Questions like "how do blog cards perform overall?" have no clean answer.
+
+**No ownership model.** There is no enforced separation between page context, component/UI, and content destination. Each event is constructed ad hoc, so naming decisions are inconsistent by construction.
+
+**Misalignment with the stack.** The site is built on reusable Astro components, and stable `pathSlug` identifiers. The analytics layer does not reflect this yet.
+
+Umami's UI is event-name-first, which creates a constraint: page context should appear in the event name, but encoding too much detail fragments events into long-tail noise. The schema must balance queryability with clean aggregation.
+
+## Decision
+
+All tracked link events follow a three-segment schema generated from code and content identifiers — never typed by hand:
+
+```
+{page}:{component}:{label}
+```
+
+**Page** and **Label** use the same `deriveLabel()` function — Page applied to `Astro.url.pathname`, Label applied to the link's `href`. Both take the last two path segments after stripping locale prefixes and join them with `_`. A profile page at `/grants/fellowship/sheena-allen` and a link pointing to it both produce `fellowship_sheena_allen` — unambiguous at both ends. Nothing is typed by hand.
+
+**Component** is a `const COMPONENT` declared inside each Astro component.
+
+For **Label**, external URLs use the root domain with subdomain preserved where meaningful; GitHub gets special treatment to capture org and repo. The two-segment approach prevents collisions: `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` produce `fellowship_sheena_allen`, `judges_sheena_allen`, and `speakers_sheena_allen` — distinct regardless of where the link appears.
+
+A `TrackedLink` Astro component is the single instrumentation point. It accepts `page`, `component`, and `href`, generates the event name, and sets two standard properties on every tracked link:
+
+- `lang` — injected from `Astro.currentLocale`, never set manually
+- `link_text` — the visible link text as rendered
+
+This makes `fellowship:hero:submittable` the same event in English and Spanish; the `lang` property distinguishes them. No duplicate events, no multilingual noise.
+
+**Rich text is a deliberate exception.** Body content fields are editor-driven and can contain an unbounded variety of destinations. Encoding every destination into the event name would produce long-tail noise that clutters the event list. Rich text links instead use a two-segment name:
+
+```
+{page}:richtext
+```
+
+Label, destination URL, and link type are captured as event properties. Because this is an SSG build, attributes are injected at build time by processing the rendered HTML string — no client-side JavaScript required.
+
+## Alternatives considered
+
+**Status quo (manual event strings).** Already producing 300+ events with inconsistent casing, mixed separators, and duplicate multilingual variants. Does not scale.
+
+**Single-segment derivation for page or label.** Collapses important context — `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all produce `sheena_allen` whether used as a page identifier or a link label. Ruled out for both.
+
+**Full path as label.** Produces near-unique event names for deep pages, defeating aggregation. Ruled out.
+
+**Pattern-based locale stripping.** A two-letter path segment that is not a locale code (`go`, `do`) would be incorrectly stripped. Using the project's `locales` export as the source of truth is more reliable. Adopted.
+
+**Rich text using full three-segment schema.** The unbounded variety of editorial destinations would fragment the event list with low-volume, one-off events. Two-segment name with properties preserves drill-down capability while keeping the event list clean. Adopted.
+
+## Consequences
+
+**Positive:**
+
+- Event names are generated, never typed. Casing drift, separator inconsistency, and copy-paste errors are structurally impossible.
+- Locale prefixes are stripped from labels; locale is a property. One event per interaction regardless of language.
+- `deriveLabel` runs at build time; rich text attributes are injected during the build. No runtime JavaScript dependency.
+- Adding a new page requires one `pathSlug` in frontmatter. Adding a new component requires one `const COMPONENT` declaration. No central registry to maintain.
+- Umami wildcard queries (`fellowship:*`, `*:hero:*`, `*:*:submittable`) give page-level, component-level, and destination-level views without any schema changes.
+
+**Negative:**
+
+- `TrackedLink` must be adopted across all components to realise consistency benefits. A parallel period where old and new events coexist will require care when interpreting data.
+- The two-segment label is a heuristic. Unusual URL structures (very shallow paths, non-standard slugs) may produce less meaningful labels, though `slugify` ensures they are always safe.
+- Rich text link tracking depends on build-time HTML processing. Any server-side or client-side rendering path that bypasses this step will not be instrumented.
+- `deriveLabel` relies on the `locales` export staying accurate. A locale added to URLs but not to that export will cause the prefix to appear in both page and label segments.

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -56,7 +56,7 @@ Two segments instead of one prevents collisions where the final segment alone is
 | `/es/`                                    | `foundation_home`           |
 | `/summit`                                 | `summit_home`               |
 | `/es/summit`                              | `summit_home`               |
-| `summit/hackathon`                        | `hackathon_home`            |
+| `/summit/hackathon`                        | `hackathon_home`            |
 | `/grants/fellowship`                      | `grants_fellowship`         |
 | `/es/grants/fellowship`                   | `grants_fellowship`         |
 | `/grants/fellowship/sheena-allen`         | `fellowship_sheena_allen`   |

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -42,7 +42,7 @@ The `page` and `label` segments are derived via `deriveLabel()`. For internal li
 
 Two segments instead of one prevents collisions where the final segment alone is ambiguous. `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all end in `sheena-allen`. Two segments gives `fellowship_sheena_allen`, `judges_sheena_allen`, and `speakers_sheena_allen`.
 
-Locale prefixes are stripped using the project's `locales` export. Event names don't differ by locale — that's a filter in Umami.
+Locale prefixes are stripped using the project's `locales` export. Microsite prefixes (`summit`, `hackathon`) are also stripped — both are better handled as URL path filters in Umami than encoded into every event name.
 
 ### Implementation
 
@@ -59,8 +59,10 @@ export function deriveLabel(href: string): string {
       url.hostname.endsWith('.interledger.org')
 
     if (isInternal) {
-      const parts = stripLangPrefix(
-        url.pathname.replace(/\/$/, '').split('/').filter(Boolean)
+      const parts = stripMicrositePrefix(
+        stripLangPrefix(
+          url.pathname.replace(/\/$/, '').split('/').filter(Boolean)
+        )
       )
       return slugify(parts.slice(-2).join('_') || 'home')
     }
@@ -81,8 +83,19 @@ export function deriveLabel(href: string): string {
   }
 }
 
+const MICROSITES = ['summit', 'hackathon'] as const
+
 const stripLangPrefix = (parts: string[]): string[] =>
   (locales as string[]).includes(parts[0]) ? parts.slice(1) : parts
+
+const stripMicrositePrefix = (parts: string[]): string[] => {
+  while (
+    parts.length > 0 &&
+    (MICROSITES as readonly string[]).includes(parts[0])
+  )
+    parts = parts.slice(1)
+  return parts
+}
 
 export const slugify = (text: string): string =>
   text

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -32,13 +32,13 @@ All tracked link events follow a three-segment schema, generated from code and c
 
 ### Segments
 
-**`page`** is the `pathSlug` defined in MDX frontmatter — stable identifier.
+**`page`** is derived from the page’s `pathSlug` defined in MDX frontmatter, which is the stable identifier.
 
-**`component`** is a `const COMPONENT` declared inside each Astro component. The component declares its own identity; nothing is passed or inferred from outside.
+**`component`** is defined by the Astro component rendering the link (via a local `const COMPONENT`).
 
 **`label`** is derived at build time from the link's `href`.
 
-The `page` and `label` segmnents are derived via `deriveLabel()`. For internal links, the last two path segments are taken after stripping any locale prefix. For external links, root and sub domains are used. GitHub gets special treatment to capture org and repo.
+The `page` and `label` segments are derived via `deriveLabel()`. For internal links, the last two path segments are taken after stripping any locale prefix. For external links, root and sub domains are used. GitHub gets special treatment to capture org and repo.
 
 Two segments instead of one prevents collisions where the final segment alone is ambiguous. `/grants/fellowship/sheena-allen`, `/hackathon/judges/sheena-allen`, and `/summit/speakers/sheena-allen` all end in `sheena-allen`. Two segments gives `fellowship_sheena_allen`, `judges_sheena_allen`, and `speakers_sheena_allen`.
 

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -135,42 +135,12 @@ Rich text links use a two-segment name instead:
 {page}:richtext
 ```
 
-Label, destination URL, and link type are captured as properties via a rehype plugin registered once in `astro.config.ts`. It reads `pathSlug` from MDX frontmatter at build time and operates on the HTML AST — no regex over rendered strings:
+A custom Markdown link renderer intercepts all links at build time and produces anchor elements with tracking attributes already in place:
 
-```typescript
-// src/lib/rehypeUmamiTracking.ts
-import { visit } from 'unist-util-visit'
-import { deriveLabel } from './tracking'
-import type { Root } from 'hast'
-
-export function rehypeUmamiTracking() {
-  return (tree: Root, file: any) => {
-    const page = file.data.astro?.frontmatter?.pathSlug ?? 'unknown'
-
-    visit(tree, 'element', (node) => {
-      if (node.tagName !== 'a') return
-      const href = node.properties?.href as string
-      if (!href) return
-
-      const isInternal =
-        href.startsWith('/') || href.includes('interledger.org')
-      const linkType = href.startsWith('#')
-        ? 'anchor'
-        : isInternal
-          ? 'internal'
-          : 'external'
-
-      node.properties = {
-        ...node.properties,
-        'data-umami-event': `${page}:richtext`,
-        'data-umami-event-label': deriveLabel(href),
-        'data-umami-event-href': href,
-        'data-umami-event-link-type': linkType
-      }
-    })
-  }
-}
-```
+- `data-umami-event` — `{page}:richtext`
+- `data-umami-event-label` — derived label from `href`
+- `data-umami-event-lang` — current locale
+- `data-umami-event-link-text` — visible link text (null for icon/image links)
 
 The rule: three-segment names for components with bounded, intentional destinations (nav, hero, card, cta, footer, faq, filter, breadcrumb). Two-segment names for open-ended, editor-driven content (richtext).
 

--- a/docs/decisions/005-analytics-event-tracking-schema.md
+++ b/docs/decisions/005-analytics-event-tracking-schema.md
@@ -42,13 +42,11 @@ The `page` and `label` segments are both derived by `deriveLabel()` — the same
 
 ### Label resolution rules
 
-For internal paths, resolution follows three steps in order:
+For internal paths, resolution follows two steps in order:
 
 1. **Strip locale prefix** — using the project's `locales` export as the source of truth. `/es/grants/fellowship` becomes `grants/fellowship`. Never pattern-matched — a two-letter segment that isn't a locale (e.g. `go`, `do`) is never stripped.
 
-2. **Resolve home names** — an empty path resolves to `foundation_home`. A path whose only remaining segment is a microsite name resolves to `{microsite}_home`. This gives root paths a meaningful, unambiguous identity.
-
-3. **Strip microsite prefixes from longer paths, then take last two segments** — if `summit` or `hackathon` appear at the start of a multi-segment path, they are stripped before the two-segment slice. Microsite context is already captured by the URL path filter in Umami — it adds no value in the event name.
+2. **Resolve the label** — if the remaining path is empty, return `foundation_home`. If every remaining segment is a microsite name (`summit`, `hackathon`), return `{last_segment}_home` — so `/summit/hackathon/` resolves to `hackathon_home`. Otherwise, take the last two segments as normal. Microsites are not stripped from longer paths — `/summit/2022` resolves to `summit_2022`, and `/summit/speakers/sheena-allen` resolves to `speakers_sheena_allen`.
 
 Two segments instead of one prevents collisions where the final segment alone is ambiguous. `/grants/fellowship/sheena-allen` and `/hackathon/judges/sheena-allen` both end in `sheena-allen` — two segments gives `fellowship_sheena_allen` and `judges_sheena_allen`.
 
@@ -58,13 +56,15 @@ Two segments instead of one prevents collisions where the final segment alone is
 | `/es/`                                    | `foundation_home`           |
 | `/summit`                                 | `summit_home`               |
 | `/es/summit`                              | `summit_home`               |
-| `/hackathon`                              | `hackathon_home`            |
+| `summit/hackathon`                        | `hackathon_home`            |
 | `/grants/fellowship`                      | `grants_fellowship`         |
 | `/es/grants/fellowship`                   | `grants_fellowship`         |
 | `/grants/fellowship/sheena-allen`         | `fellowship_sheena_allen`   |
 | `/summit/speakers/sheena-allen`           | `speakers_sheena_allen`     |
 | `/hackathon/judges/sheena-allen`          | `judges_sheena_allen`       |
-| `/summit/hackathon/resources`             | `resources`                 |
+| `/summit/hackathon`                       | `hackathon_home`            |
+| `/summit/2022`                            | `summit_2022`               |
+| `/summit/hackathon/resources`             | `hackathon_resources`       |
 | `https://github.com/interledger/rafiki`   | `github_interledger_rafiki` |
 | `https://github.com/interledger`          | `github_interledger`        |
 | `https://wallet.interledger-test.dev/...` | `wallet_interledger_test`   |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -12,6 +12,7 @@ An ADR captures a single technical decision: the context that forced it, what wa
 | 002 | Spanish fallback disclaimer behavior              | Proposed | 2026-04-09 |
 | 003 | Reusable page templates and cross-section routing | Proposed | 2026-04-17 |
 | 004 | Locale-prefix routing for translations            | Proposed | 2026-04-17 |
+| 005 | Analytics event tracking schema                   | Proposed | 2026-04-21 |
 
 ## Writing a new ADR
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -9,10 +9,10 @@ An ADR captures a single technical decision: the context that forced it, what wa
 | #   | Title                                             | Status   | Date       |
 | --- | ------------------------------------------------- | -------- | ---------- |
 | 001 | Path handling for Astro content collections       | Accepted | 2026-03-27 |
-| 002 | Spanish fallback disclaimer behavior              | Proposed | 2026-04-09 |
+| 002 | Spanish fallback disclaimer behavior              | Accepted | 2026-04-09 |
 | 003 | Reusable page templates and cross-section routing | Proposed | 2026-04-17 |
-| 004 | Locale-prefix routing for translations            | Proposed | 2026-04-17 |
-| 005 | Analytics event tracking schema                   | Proposed | 2026-04-21 |
+| 004 | Locale-prefix routing for translations            | Accepted | 2026-04-17 |
+| 005 | Analytics event tracking schema                   | Accepted | 2026-04-21 |
 
 ## Writing a new ADR
 


### PR DESCRIPTION
## Summary
<!-- What changed and why -->
Our current tracking is difficult to query and unreliable due to:

Manual naming drift (case, separators, duplicates)
Overly specific, non-aggregatable events (e.g. date-based blog events)
No clear separation between page, component, and destination
Misalignment with our component-based architecture

This PR introduces a standardized event tracking schema for Umami and documents it in ADR-005.

## Related Issue
<!-- Fixes INTORG-123 -->
Fixes INTORG-646

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
