### PR TITLE
feat(poc): react aria measurement page [INTORG-647]

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import starlight from '@astrojs/starlight'
 import starlightFullViewMode from 'starlight-fullview-mode'
 import netlify from '@astrojs/netlify'
 import mdx from '@astrojs/mdx'
+import react from '@astrojs/react'
 import { PUBLISHED_RFC_SIDEBAR_ITEMS } from './src/data/docs/rfcs.ts'
 import sitemap from '@astrojs/sitemap'
 import tailwindcss from '@tailwindcss/vite'
@@ -114,6 +115,7 @@ export default defineConfig({
       },
       disable404Route: true
     }),
+    react(),
     mdx(),
     sitemap({
       filter: (url) => !new URL(url).pathname.includes('/preview')

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@astro-community/astro-embed-youtube": "^0.5.10",
     "@astrojs/mdx": "^5.0.0",
     "@astrojs/netlify": "^7.0.1",
+    "@astrojs/react": "^5.0.4",
     "@astrojs/sitemap": "^3.7.1",
     "@astrojs/starlight": "^0.38.0",
     "@interledger/docs-design-system": "^0.11.2",
@@ -31,12 +32,16 @@
     "markdown-it": "^14.1.0",
     "marked": "^17.0.4",
     "node-html-parser": "^7.1.0",
+    "react": "^19.2.5",
+    "react-aria-components": "^1.17.0",
+    "react-dom": "^19.2.5",
     "sharp": "^0.34.5",
     "showdown": "^2.1.0",
     "starlight-fullview-mode": "^0.2.6",
     "starlight-links-validator": "^0.20.0",
     "tailwindcss": "^4.2.1",
     "turndown": "^7.2.2",
+    "web-vitals": "^5.2.0",
     "zod": "^4.3.6"
   },
   "pnpm": {
@@ -49,6 +54,8 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/markdown-it": "^14.1.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@typescript-eslint/parser": "^8.57.0",
     "astro-eslint-parser": "^1.3.0",
     "eslint": "^10.0.3",
@@ -57,6 +64,7 @@
     "globals": "^17.4.0",
     "prettier": "3.8.1",
     "prettier-plugin-astro": "0.14.1",
+    "tailwindcss-react-aria-components": "^2.1.0",
     "tsx": "^4.21.0",
     "typescript-eslint": "^8.57.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@astrojs/netlify':
         specifier: ^7.0.1
         version: 7.0.1(@types/node@25.4.0)(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      '@astrojs/react':
+        specifier: ^5.0.4
+        version: 5.0.4(@types/node@25.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       '@astrojs/sitemap':
         specifier: ^3.7.1
         version: 3.7.1
@@ -36,7 +39,7 @@ importers:
         version: 0.11.2
       '@tailwindcss/vite':
         specifier: ^4.2.1
-        version: 4.2.1(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.2.1(vite@7.3.2(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@types/showdown':
         specifier: ^2.0.6
         version: 2.0.6
@@ -61,6 +64,15 @@ importers:
       node-html-parser:
         specifier: ^7.1.0
         version: 7.1.0
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-aria-components:
+        specifier: ^1.17.0
+        version: 1.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -79,6 +91,9 @@ importers:
       turndown:
         specifier: ^7.2.2
         version: 7.2.2
+      web-vitals:
+        specifier: ^5.2.0
+        version: 5.2.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -89,6 +104,12 @@ importers:
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/parser':
         specifier: ^8.57.0
         version: 8.57.0(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
@@ -113,6 +134,9 @@ importers:
       prettier-plugin-astro:
         specifier: 0.14.1
         version: 0.14.1
+      tailwindcss-react-aria-components:
+        specifier: ^2.1.0
+        version: 2.1.0(tailwindcss@4.2.1)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -289,6 +313,9 @@ packages:
   '@astrojs/internal-helpers@0.8.0':
     resolution: {integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==}
 
+  '@astrojs/internal-helpers@0.9.0':
+    resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
+
   '@astrojs/markdown-remark@7.0.0':
     resolution: {integrity: sha512-jTAXHPy45L7o1ljH4jYV+ShtOHtyQUa1mGp3a5fJp1soX8lInuTJQ6ihmldHzVM4Q7QptU4SzIDIcKbBJO7sXQ==}
 
@@ -306,6 +333,15 @@ packages:
   '@astrojs/prism@4.0.0':
     resolution: {integrity: sha512-NndtNPpxaGinRpRytljGBvYHpTOwHycSZ/c+lQi5cHvkqqrHKWdkPEhImlODBNmbuB+vyQUNUDXyjzt66CihJg==}
     engines: {node: ^20.19.1 || >=22.12.0}
+
+  '@astrojs/react@5.0.4':
+    resolution: {integrity: sha512-yDNE4VnKOzCjH9dCBi7pT4F6kpI3M9TkS+uxnCB0sGIS6t5vKonOY+Hs/UUnSajJGT5jeBRfpI9IQp+r/n1fBA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
+      '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
 
   '@astrojs/sitemap@3.7.1':
     resolution: {integrity: sha512-IzQqdTeskaMX+QDZCzMuJIp8A8C1vgzMBp/NmHNnadepHYNHcxQdGLQZYfkbd2EbRXUfOS+UDIKx8sKg0oWVdw==}
@@ -459,6 +495,18 @@ packages:
 
   '@babel/plugin-transform-private-methods@7.28.6':
     resolution: {integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2041,11 +2089,20 @@ packages:
   '@interledger/docs-design-system@0.11.2':
     resolution: {integrity: sha512-btM1cWlL33gkH7F7ZfnVdb6ts2JH+BolVuAQ3RKHhrc7nune2Wu7Lu8ycabJmOBXIaVZooUfl8sPr1cKzzOCSQ==}
 
+  '@internationalized/date@3.12.1':
+    resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
+
   '@internationalized/date@3.5.4':
     resolution: {integrity: sha512-qoVJVro+O0rBaw+8HPjUB1iH8Ihf8oziEnqMnvhJUSuVIrHOuZ6eNLHNvzXJKUvAtaDiqMnRlg8Z2mgh09BlUw==}
 
   '@internationalized/number@3.5.3':
     resolution: {integrity: sha512-rd1wA3ebzlp0Mehj5YTuTI50AQEx80gWFyHcQu+u91/5NgdwBecO8BH6ipPfE+lmQ9d63vpB3H9SHoIUiupllw==}
+
+  '@internationalized/number@3.6.6':
+    resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
+
+  '@internationalized/string@3.2.8':
+    resolution: {integrity: sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3203,6 +3260,11 @@ packages:
   '@react-dnd/shallowequal@4.0.2':
     resolution: {integrity: sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==}
 
+  '@react-types/shared@3.34.0':
+    resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@reduxjs/toolkit@1.9.7':
     resolution: {integrity: sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==}
     peerDependencies:
@@ -3217,6 +3279,9 @@ packages:
   '@remix-run/router@1.23.2':
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
     engines: {node: '>=14.0.0'}
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -3855,6 +3920,18 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -4135,6 +4212,11 @@ packages:
     peerDependencies:
       '@types/react': ^18.0.0
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react-transition-group@4.4.12':
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
@@ -4349,6 +4431,12 @@ packages:
     resolution: {integrity: sha512-yrknSb3Dci6svCd/qhHqhFPDSw0QtjumcqdKMoNNzmOl5lMXTTiqzjWtG4Qask2HdvvzaNgSunbQGet8/GrKdA==}
     peerDependencies:
       vite: ^4 || ^5
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
@@ -5059,6 +5147,9 @@ packages:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
   clipboardy@4.0.0:
     resolution: {integrity: sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==}
     engines: {node: '>=18'}
@@ -5745,6 +5836,9 @@ packages:
 
   devalue@5.6.3:
     resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
+
+  devalue@5.7.1:
+    resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -8783,6 +8877,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   picoquery@2.5.0:
     resolution: {integrity: sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==}
 
@@ -9016,6 +9114,18 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-aria-components@1.17.0:
+    resolution: {integrity: sha512-0EyisMgvsFJ2aML3crDYv2tW5vT2Ryf8PGzY/g63JjDdCbLshlwazhS8JNtPF1vkTkungJJ6sVJbKyX+YKSoFA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-aria@3.48.0:
+    resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-dnd-html5-backend@16.0.1:
     resolution: {integrity: sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==}
 
@@ -9038,6 +9148,11 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
 
   react-dropzone@14.3.8:
     resolution: {integrity: sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==}
@@ -9126,6 +9241,10 @@ packages:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
 
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -9180,6 +9299,11 @@ packages:
     peerDependencies:
       react: ^16.3.0 || ^17.0.0 || ^18.0.0
 
+  react-stately@3.46.0:
+    resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -9205,6 +9329,10 @@ packages:
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   read-package-up@11.0.0:
@@ -9550,6 +9678,9 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
@@ -10018,6 +10149,11 @@ packages:
   system-architecture@0.1.0:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
+
+  tailwindcss-react-aria-components@2.1.0:
+    resolution: {integrity: sha512-wP1BHdqFoFVKTVscM/EIhd1WEBUcNqmPgucMl+nzVAnruq7dzmn2J4CYcJ9cpf1WiyklzO8SH6M+Z6ZoF9X4Jg==}
+    peerDependencies:
+      tailwindcss: ^4.0.0
 
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
@@ -10677,6 +10813,46 @@ packages:
       yaml:
         optional: true
 
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.1.2:
     resolution: {integrity: sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==}
     peerDependencies:
@@ -10761,6 +10937,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-vitals@5.2.0:
+    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -11120,6 +11299,10 @@ snapshots:
     dependencies:
       picomatch: 4.0.3
 
+  '@astrojs/internal-helpers@0.9.0':
+    dependencies:
+      picomatch: 4.0.4
+
   '@astrojs/markdown-remark@7.0.0':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
@@ -11216,6 +11399,31 @@ snapshots:
   '@astrojs/prism@4.0.0':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/react@5.0.4(@types/node@25.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)':
+    dependencies:
+      '@astrojs/internal-helpers': 0.9.0
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.2(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      devalue: 5.7.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      ultrahtml: 1.6.0
+      vite: 7.3.2(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   '@astrojs/sitemap@3.7.1':
     dependencies:
@@ -11452,6 +11660,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -11549,8 +11767,6 @@ snapshots:
       '@ckeditor/ckeditor5-core': 47.4.0
       '@ckeditor/ckeditor5-upload': 47.4.0
       ckeditor5: 47.4.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-alignment@47.4.0':
     dependencies:
@@ -11652,8 +11868,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       '@ckeditor/ckeditor5-widget': 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-cloud-services@47.4.0':
     dependencies:
@@ -11704,8 +11918,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-editor-classic@47.4.0':
     dependencies:
@@ -11715,8 +11927,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-editor-decoupled@47.4.0':
     dependencies:
@@ -11726,8 +11936,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-editor-inline@47.4.0':
     dependencies:
@@ -11769,16 +11977,12 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-utils': 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-enter@47.4.0':
     dependencies:
       '@ckeditor/ckeditor5-core': 47.4.0
       '@ckeditor/ckeditor5-engine': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-essentials@47.4.0':
     dependencies:
@@ -11801,8 +12005,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-font@47.4.0':
     dependencies:
@@ -11857,8 +12059,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       '@ckeditor/ckeditor5-widget': 47.4.0
       ckeditor5: 47.4.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-html-embed@47.4.0':
     dependencies:
@@ -11904,6 +12104,8 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-indent@47.4.0':
     dependencies:
@@ -11915,6 +12117,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-integrations-common@2.2.3(ckeditor5@47.4.0)':
     dependencies:
@@ -11926,6 +12130,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-link@47.4.0':
     dependencies:
@@ -11940,6 +12146,8 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-list@47.4.0':
     dependencies:
@@ -11953,6 +12161,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-markdown-gfm@47.4.0':
     dependencies:
@@ -11990,6 +12200,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       '@ckeditor/ckeditor5-widget': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-mention@47.4.0':
     dependencies:
@@ -11999,6 +12211,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-minimap@47.4.0':
     dependencies:
@@ -12007,6 +12221,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-page-break@47.4.0':
     dependencies:
@@ -12016,6 +12232,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       '@ckeditor/ckeditor5-widget': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-paragraph@47.4.0':
     dependencies:
@@ -12051,6 +12269,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-restricted-editing@47.4.0':
     dependencies:
@@ -12076,6 +12296,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-source-editing@47.4.0':
     dependencies:
@@ -12106,6 +12328,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-table@47.4.0':
     dependencies:
@@ -12118,6 +12342,8 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-theme-lark@47.4.0':
     dependencies:
@@ -12193,6 +12419,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/strapi-plugin-ckeditor@1.1.2(@strapi/strapi@5.41.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(@emotion/is-prop-valid@1.4.0)(@swc/helpers@0.5.18)(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.14))(@types/node@25.4.0)(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(codemirror@5.65.21)(esbuild@0.27.3)(koa@2.16.4)(lightningcss@1.31.1)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.0)(type-fest@4.41.0))(ckeditor5@47.4.0)(react@18.3.1)':
     dependencies:
@@ -13151,11 +13379,23 @@ snapshots:
     dependencies:
       mermaid: 11.12.3
 
+  '@internationalized/date@3.12.1':
+    dependencies:
+      '@swc/helpers': 0.5.18
+
   '@internationalized/date@3.5.4':
     dependencies:
       '@swc/helpers': 0.5.18
 
   '@internationalized/number@3.5.3':
+    dependencies:
+      '@swc/helpers': 0.5.18
+
+  '@internationalized/number@3.6.6':
+    dependencies:
+      '@swc/helpers': 0.5.18
+
+  '@internationalized/string@3.2.8':
     dependencies:
       '@swc/helpers': 0.5.18
 
@@ -14616,6 +14856,10 @@ snapshots:
 
   '@react-dnd/shallowequal@4.0.2': {}
 
+  '@react-types/shared@3.34.0(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
   '@reduxjs/toolkit@1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)':
     dependencies:
       immer: 9.0.21
@@ -14627,6 +14871,8 @@ snapshots:
       react-redux: 8.1.3(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)
 
   '@remix-run/router@1.23.2': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.57.1)':
     dependencies:
@@ -14852,7 +15098,7 @@ snapshots:
       '@strapi/design-system': 2.2.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/permissions': 5.41.1
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/typescript-utils': 5.41.1
       '@strapi/utils': 5.41.1
       '@testing-library/dom': 10.4.1
@@ -15051,7 +15297,7 @@ snapshots:
       '@strapi/database': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)
       '@strapi/design-system': 2.2.0(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(@strapi/icons@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@19.2.14))(@types/react@19.2.14)(codemirror@5.65.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.3.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/utils': 5.41.1
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
@@ -15152,7 +15398,7 @@ snapshots:
       '@strapi/generators': 5.41.1(@types/node@25.4.0)
       '@strapi/logger': 5.41.1
       '@strapi/permissions': 5.41.1
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/typescript-utils': 5.41.1
       '@strapi/utils': 5.41.1
       '@vercel/stega': 0.1.2
@@ -15580,7 +15826,7 @@ snapshots:
       '@strapi/openapi': 5.41.1
       '@strapi/permissions': 5.41.1
       '@strapi/review-workflows': 5.41.1(da0e1b948dfb179739de15f52a4f2951)
-      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)
+      '@strapi/types': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)
       '@strapi/typescript-utils': 5.41.1
       '@strapi/upload': 5.41.1(2e944d5aa0c984f4e827a207345beaec)
       '@strapi/utils': 5.41.1
@@ -15681,6 +15927,36 @@ snapshots:
       - webpack-cli
       - webpack-dev-server
       - webpack-plugin-serve
+
+  '@strapi/types@5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.4.4)':
+    dependencies:
+      '@casl/ability': 6.7.5
+      '@koa/cors': 5.0.0
+      '@koa/router': 12.0.2
+      '@strapi/database': 5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)
+      '@strapi/logger': 5.41.1
+      '@strapi/permissions': 5.41.1
+      '@strapi/utils': 5.41.1
+      commander: 8.3.0
+      json-logic-js: 2.0.5
+      koa: 2.16.4
+      koa-body: 6.0.1
+      node-schedule: 2.1.1
+      typedoc: 0.25.10(typescript@5.4.4)
+      typedoc-github-wiki-theme: 1.1.0(typedoc-plugin-markdown@3.17.1(typedoc@0.25.10(typescript@5.9.3)))(typedoc@0.25.10(typescript@5.9.3))
+      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.10(typescript@5.9.3))
+      zod: 3.25.67
+    transitivePeerDependencies:
+      - '@types/node'
+      - better-sqlite3
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+      - typescript
 
   '@strapi/types@5.41.1(@types/node@25.4.0)(better-sqlite3@12.8.0)(typescript@5.9.3)':
     dependencies:
@@ -15952,12 +16228,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.1(vite@7.3.2(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.2(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tanstack/react-virtual@3.13.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -16008,6 +16284,27 @@ snapshots:
   '@types/argparse@1.0.38': {}
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -16357,6 +16654,10 @@ snapshots:
       '@types/react': 19.2.14
     optional: true
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
   '@types/react-transition-group@4.4.12(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -16657,6 +16958,18 @@ snapshots:
       vite: 5.4.21(@types/node@25.4.0)(lightningcss@1.31.1)(terser@5.46.0)
     transitivePeerDependencies:
       - '@swc/helpers'
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.2(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -17577,6 +17890,8 @@ snapshots:
 
   cli-width@4.1.0: {}
 
+  client-only@0.0.1: {}
+
   clipboardy@4.0.0:
     dependencies:
       execa: 8.0.1
@@ -18256,6 +18571,8 @@ snapshots:
   dettle@1.0.5: {}
 
   devalue@5.6.3: {}
+
+  devalue@5.7.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -22066,6 +22383,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   picoquery@2.5.0: {}
 
   pify@4.0.1: {}
@@ -22320,6 +22639,31 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-aria-components@1.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@react-types/shared': 3.34.0(react@19.2.5)
+      '@swc/helpers': 0.5.18
+      client-only: 0.0.1
+      react: 19.2.5
+      react-aria: 3.48.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-dom: 19.2.5(react@19.2.5)
+      react-stately: 3.46.0(react@19.2.5)
+
+  react-aria@3.48.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@19.2.5)
+      '@swc/helpers': 0.5.18
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-stately: 3.46.0(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   react-dnd-html5-backend@16.0.1:
     dependencies:
       dnd-core: 16.0.1
@@ -22342,6 +22686,11 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
 
   react-dropzone@14.3.8(react@18.3.1):
     dependencies:
@@ -22458,6 +22807,8 @@ snapshots:
 
   react-refresh@0.14.0: {}
 
+  react-refresh@0.18.0: {}
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -22521,6 +22872,16 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  react-stately@3.46.0(react@19.2.5):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@19.2.5)
+      '@swc/helpers': 0.5.18
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@18.3.1):
     dependencies:
       get-nonce: 1.0.1
@@ -22548,6 +22909,8 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.2.5: {}
 
   read-package-up@11.0.0:
     dependencies:
@@ -23067,6 +23430,8 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  scheduler@0.27.0: {}
 
   schema-utils@3.3.0:
     dependencies:
@@ -23664,6 +24029,10 @@ snapshots:
 
   system-architecture@0.1.0: {}
 
+  tailwindcss-react-aria-components@2.1.0(tailwindcss@4.2.1):
+    dependencies:
+      tailwindcss: 4.2.1
+
   tailwindcss@4.2.1: {}
 
   tapable@2.3.0: {}
@@ -23915,6 +24284,14 @@ snapshots:
       handlebars: 4.7.8
       typedoc: 0.25.10(typescript@5.9.3)
 
+  typedoc@0.25.10(typescript@5.4.4):
+    dependencies:
+      lunr: 2.3.9
+      marked: 4.3.0
+      minimatch: 9.0.5
+      shiki: 0.14.7
+      typescript: 5.4.4
+
   typedoc@0.25.10(typescript@5.9.3):
     dependencies:
       lunr: 2.3.9
@@ -24138,6 +24515,10 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
   util-deprecate@1.0.2: {}
 
   utila@0.4.0: {}
@@ -24190,6 +24571,23 @@ snapshots:
       terser: 5.46.0
 
   vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.4.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.31.1
+      terser: 5.46.0
+      tsx: 4.21.0
+      yaml: 2.8.2
+
+  vite@7.3.2(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -24283,6 +24681,8 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@5.2.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/components/poc/AriaMobileDrawer.tsx
+++ b/src/components/poc/AriaMobileDrawer.tsx
@@ -1,0 +1,115 @@
+import {
+  Button,
+  Dialog,
+  DialogTrigger,
+  Heading,
+  Modal,
+  ModalOverlay
+} from 'react-aria-components'
+import type { MenuGroup } from '@/types/navigation'
+
+interface AriaMobileDrawerProps {
+  menuGroups: MenuGroup[]
+  triggerLabel?: string
+}
+
+const triggerButtonClass =
+  'inline-flex items-center justify-center w-10 h-10 bg-transparent border-0 cursor-pointer outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary hover:bg-gray-header'
+
+const overlayClass =
+  'fixed inset-0 z-50 bg-black/50 transition-opacity duration-200 entering:opacity-100 exiting:opacity-0 motion-reduce:transition-none'
+
+const drawerClass =
+  'fixed top-0 right-0 h-full w-[min(85vw,360px)] bg-white shadow-[-2px_0_12px_rgba(0,0,0,0.15)] outline-none flex flex-col transition-transform duration-200 entering:translate-x-0 exiting:translate-x-full motion-reduce:transition-none'
+
+const dialogClass =
+  'flex-1 flex flex-col p-space-m outline-none overflow-y-auto'
+
+const closeButtonClass =
+  'self-end bg-transparent border-0 cursor-pointer p-2 outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary hover:bg-gray-header'
+
+export default function AriaMobileDrawer({
+  menuGroups,
+  triggerLabel = 'Open menu'
+}: AriaMobileDrawerProps) {
+  return (
+    <DialogTrigger>
+      <Button className={triggerButtonClass} aria-label={triggerLabel}>
+        <span aria-hidden="true">☰</span>
+      </Button>
+      <ModalOverlay className={overlayClass} isDismissable>
+        <Modal className={drawerClass}>
+          <Dialog className={dialogClass} aria-label="Site navigation">
+            {({ close }) => (
+              <>
+                <Button
+                  slot="close"
+                  className={closeButtonClass}
+                  aria-label="Close menu"
+                >
+                  <span aria-hidden="true">✕</span>
+                </Button>
+                <Heading
+                  slot="title"
+                  className="text-step-1 mt-0 mb-space-s font-semibold"
+                >
+                  Menu
+                </Heading>
+                <nav>
+                  <ul className="list-none p-0 m-0 flex flex-col gap-1">
+                    {menuGroups.map((group) => (
+                      <li key={group.label}>
+                        {group.href && !group.items?.length ? (
+                          <a
+                            href={group.href}
+                            onClick={() => close()}
+                            className="block py-space-s px-space-2xs no-underline text-black hover:bg-gray-header"
+                          >
+                            {group.label}
+                          </a>
+                        ) : (
+                          <details className="group">
+                            <summary className="cursor-pointer py-space-s px-space-2xs list-none flex items-center justify-between hover:bg-gray-header">
+                              <span>{group.label}</span>
+                              <span
+                                aria-hidden="true"
+                                className="transition-transform group-open:rotate-180 motion-reduce:transition-none"
+                              >
+                                ▾
+                              </span>
+                            </summary>
+                            <ul className="list-none p-0 m-0 ps-space-s">
+                              {group.items?.map((item) => (
+                                <li key={item.label}>
+                                  <a
+                                    href={item.href ?? '#'}
+                                    target={
+                                      item.openInNewTab ? '_blank' : undefined
+                                    }
+                                    rel={
+                                      item.openInNewTab
+                                        ? 'noopener noreferrer'
+                                        : undefined
+                                    }
+                                    onClick={() => close()}
+                                    className="block py-space-s px-space-2xs no-underline text-black hover:bg-gray-header"
+                                  >
+                                    {item.label}
+                                  </a>
+                                </li>
+                              ))}
+                            </ul>
+                          </details>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
+              </>
+            )}
+          </Dialog>
+        </Modal>
+      </ModalOverlay>
+    </DialogTrigger>
+  )
+}

--- a/src/components/poc/AriaNavMenu.tsx
+++ b/src/components/poc/AriaNavMenu.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  Popover
+} from 'react-aria-components'
+import type { MenuGroup } from '@/types/navigation'
+
+interface AriaNavMenuProps {
+  menuGroups: MenuGroup[]
+}
+
+const triggerClass =
+  'inline-flex items-center whitespace-nowrap py-space-s px-space-2xs bg-transparent border-0 text-current cursor-pointer transition-colors duration-200 hover:bg-gray-header outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2'
+
+const arrowIconClass =
+  'inline-block w-[9px] ml-2 transition-transform duration-500 motion-reduce:transition-none'
+
+const popoverClass =
+  'bg-white border-l-2 border-gray-header shadow-[2px_3px_6px_-3px_hsla(0,0%,0%,0.06),-2px_3px_6px_-3px_hsla(0,0%,0%,0.06)] outline-none'
+
+const menuClass = 'list-none p-0 m-0 outline-none min-w-max'
+
+const menuItemClass =
+  'block py-space-2xs px-space-2xs no-underline text-black cursor-pointer outline-none focus:bg-gray-header focus:underline focus:underline-offset-[6px] hover:bg-gray-header'
+
+interface NavGroupProps {
+  group: MenuGroup
+}
+
+// After a close (Escape, click-out, hover-out, item click), suppress hover-open
+// for this many ms. Without this, the 1px overlap between trigger and popover
+// causes a phantom mouseenter on the trigger when the popover unmounts → reopen.
+const REOPEN_GUARD_MS = 300
+
+function NavGroup({ group }: NavGroupProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const liRef = useRef<HTMLLIElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const lastCloseAt = useRef(0)
+
+  const open = () => {
+    if (performance.now() - lastCloseAt.current < REOPEN_GUARD_MS) return
+    setIsOpen(true)
+  }
+
+  const close = () => {
+    lastCloseAt.current = performance.now()
+    setIsOpen(false)
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) setIsOpen(true)
+    else close()
+  }
+
+  // While open, track cursor at the document level using bounding-box geometry
+  // (NOT element.contains). RAC's Popover portals into an empty wrapper under
+  // <body>; when the cursor briefly hits that wrapper or the 1px overlap with
+  // the trigger, contains() returns false and we'd close → reopen → flicker.
+  // Geometry doesn't care about portal wrappers or z-order.
+  useEffect(() => {
+    if (!isOpen) return
+
+    const pointInRect = (r: DOMRect, x: number, y: number) =>
+      x >= r.left && x <= r.right && y >= r.top && y <= r.bottom
+
+    let raf: number | null = null
+    const handleMove = (e: MouseEvent) => {
+      if (raf !== null) cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => {
+        const li = liRef.current
+        const pop = popoverRef.current
+        if (!li) return
+        const inLi = pointInRect(
+          li.getBoundingClientRect(),
+          e.clientX,
+          e.clientY
+        )
+        const inPop = pop
+          ? pointInRect(pop.getBoundingClientRect(), e.clientX, e.clientY)
+          : false
+        if (!inLi && !inPop) close()
+      })
+    }
+
+    const handleFocusOut = () => {
+      requestAnimationFrame(() => {
+        const active = document.activeElement
+        if (
+          active !== document.body &&
+          !liRef.current?.contains(active) &&
+          !popoverRef.current?.contains(active)
+        ) {
+          close()
+        }
+      })
+    }
+
+    document.addEventListener('mousemove', handleMove)
+    document.addEventListener('focusin', handleFocusOut)
+    return () => {
+      document.removeEventListener('mousemove', handleMove)
+      document.removeEventListener('focusin', handleFocusOut)
+      if (raf !== null) cancelAnimationFrame(raf)
+    }
+  }, [isOpen])
+
+  return (
+    <li ref={liRef} onMouseEnter={open}>
+      <MenuTrigger isOpen={isOpen} onOpenChange={handleOpenChange}>
+        <Button className={triggerClass}>
+          <span>{group.label}</span>
+          <img
+            src="/img/arrow-menu.svg"
+            alt=""
+            aria-hidden="true"
+            className={`${arrowIconClass} ${isOpen ? 'translate-y-[30%] rotate-180' : ''}`}
+          />
+        </Button>
+        <Popover
+          ref={popoverRef}
+          className={popoverClass}
+          placement="bottom start"
+          offset={0}
+        >
+          <Menu className={menuClass}>
+            {group.items!.map((item) => (
+              <MenuItem
+                key={item.label}
+                href={item.href ?? '#'}
+                target={item.openInNewTab ? '_blank' : undefined}
+                rel={item.openInNewTab ? 'noopener noreferrer' : undefined}
+                className={menuItemClass}
+              >
+                {item.label}
+              </MenuItem>
+            ))}
+          </Menu>
+        </Popover>
+      </MenuTrigger>
+    </li>
+  )
+}
+
+export default function AriaNavMenu({ menuGroups }: AriaNavMenuProps) {
+  return (
+    <ul className="list-none p-0 m-0 flex items-center justify-center">
+      {menuGroups.map((group) => {
+        const hasChildren = !!group.items && group.items.length > 0
+        if (!hasChildren) {
+          return (
+            <li key={group.label}>
+              <a href={group.href ?? '#'} className={triggerClass}>
+                {group.label}
+              </a>
+            </li>
+          )
+        }
+        return <NavGroup key={group.label} group={group} />
+      })}
+    </ul>
+  )
+}

--- a/src/pages/poc/react-aria.astro
+++ b/src/pages/poc/react-aria.astro
@@ -81,7 +81,7 @@ const langLinkClass =
           <AriaMobileDrawer
             menuGroups={mainMenu}
             triggerLabel={t('nav.toggle_menu')}
-            client:idle
+            client:media="(max-width: 1059px)"
           />
         </div>
       </div>

--- a/src/pages/poc/react-aria.astro
+++ b/src/pages/poc/react-aria.astro
@@ -1,0 +1,112 @@
+---
+/**
+ * POC: React Aria nav components.
+ * INTORG-647 — measurement page; not linked from the live site.
+ *
+ * Replaces FoundationHeader with a RAC-based header so the page can be
+ * compared (Lighthouse / Web Vitals / bundle) against a baseline page that
+ * uses the vanilla FoundationHeader. The body content is intentionally
+ * lightweight so any score difference reflects the header swap, not page
+ * content.
+ *
+ * Hydration: `client:idle` mounts after first paint, before user likely
+ * interacts. `client:load` would block startup; `client:visible` is
+ * unreliable for above-the-fold content.
+ */
+import BaseLayout from '@/layouts/BaseLayout.astro'
+import FoundationFooter from '@/components/pages/FoundationFooter.astro'
+import FoundationLogo from '@/components/logos/FoundationLogo.astro'
+import LanguageSwitcher from '@/components/LanguageSwitcher.astro'
+import AriaNavMenu from '@/components/poc/AriaNavMenu.tsx'
+import AriaMobileDrawer from '@/components/poc/AriaMobileDrawer.tsx'
+import {
+  getNavigation,
+  useTranslations,
+  translatePath,
+  HOME_CONTENT_SLUG
+} from '@/utils'
+
+const { routeLocale } = Astro.locals
+const t = useTranslations(routeLocale)
+const { mainMenu, ctaButton } = getNavigation('foundation', routeLocale)
+
+const langItemClass =
+  "flex items-center after:mx-space-2xs after:opacity-80 after:text-primary-fallback after:content-['|'] last:after:content-none"
+const langLinkClass =
+  'block px-space-2xs py-space-s text-primary-fallback no-underline transition-colors duration-200 hover:text-primary data-[active=true]:underline data-[active=true]:decoration-2 data-[active=true]:underline-offset-[4px]'
+---
+
+<BaseLayout
+  title="React Aria POC"
+  description="POC page with React Aria nav components. Header swapped for measurement (INTORG-647)."
+  bodyClass="flex flex-col min-h-full min-w-[360px] font-titillium"
+>
+  <header
+    slot="header"
+    class="bg-white px-space-m sticky top-0 z-[2] border-t-2 border-gray-header shadow"
+    role="banner"
+  >
+    <nav
+      class="flex items-center justify-between min-[1060px]:grid min-[1060px]:grid-cols-[auto_1fr_auto] min-[1060px]:gap-space-s h-[var(--site-header-height)]"
+      aria-label={t('nav.main')}
+    >
+      <a
+        href={translatePath('foundation-pages', routeLocale, HOME_CONTENT_SLUG)}
+        class="w-[11em] flex-none"
+        aria-label={t('aria.logo.foundation')}
+      >
+        <FoundationLogo class="text-black" />
+      </a>
+
+      <div class="max-[1059px]:hidden min-[1060px]:block">
+        <AriaNavMenu menuGroups={mainMenu} client:idle />
+      </div>
+
+      <div class="flex items-center gap-space-s">
+        {
+          ctaButton && (
+            <a
+              class="self-center no-underline py-space-s hover:underline max-[1059px]:hidden"
+              href={ctaButton.href || '#'}
+              {...(ctaButton.openInNewTab
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+            >
+              {ctaButton.label}
+            </a>
+          )
+        }
+        <LanguageSwitcher itemClass={langItemClass} linkClass={langLinkClass} />
+        <div class="min-[1060px]:hidden">
+          <AriaMobileDrawer
+            menuGroups={mainMenu}
+            triggerLabel={t('nav.toggle_menu')}
+            client:idle
+          />
+        </div>
+      </div>
+    </nav>
+  </header>
+
+  <main
+    class="max-w-content mx-auto px-space-m py-space-xl flex flex-col gap-space-m"
+  >
+    <h1 class="text-step-3 font-semibold">React Aria POC</h1>
+    <p class="text-step-0 max-w-prose">
+      This page's header uses <code>react-aria-components</code> instead of the vanilla
+      <code>FoundationNavMenu</code> and hamburger-drawer JS. Compare against a baseline
+      page (e.g. <code>/</code> or <code>/about-us</code>) to isolate the cost
+      of the React + RAC runtime.
+    </p>
+    <p class="text-step--1 max-w-prose">
+      Append <code>?wv=1</code> to the URL to log Web Vitals to the console. Resize
+      below 1060px to exercise the mobile drawer.
+    </p>
+  </main>
+
+  <FoundationFooter slot="footer" />
+
+  <script>
+    import '@/scripts/web-vitals'
+  </script>
+</BaseLayout>

--- a/src/scripts/web-vitals.ts
+++ b/src/scripts/web-vitals.ts
@@ -1,0 +1,24 @@
+import { onCLS, onFCP, onINP, onLCP, onTTFB, type Metric } from 'web-vitals'
+
+const PREFIX = '[wv]'
+
+function shouldEnable(): boolean {
+  if (import.meta.env.DEV) return true
+  if (typeof window === 'undefined') return false
+  return new URLSearchParams(window.location.search).get('wv') === '1'
+}
+
+function logMetric(metric: Metric) {
+  console.info(
+    `${PREFIX} ${metric.name}: ${metric.value.toFixed(2)} (${metric.rating})`,
+    metric
+  )
+}
+
+if (shouldEnable()) {
+  onCLS(logMetric)
+  onFCP(logMetric)
+  onINP(logMetric)
+  onLCP(logMetric)
+  onTTFB(logMetric)
+}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -42,6 +42,11 @@
 @import 'tailwindcss';
 @config "../../tailwind.config.mjs";
 
+/* React Aria Components plugin — exposes RAC's data-attribute states
+   (focused, hovered, pressed, selected, entering, exiting, etc.) as
+   short Tailwind variants without the `data-` prefix. */
+@plugin "tailwindcss-react-aria-components";
+
 /* Theme layer - @theme tokens must be processed before @apply in base files */
 @import './theme.css';
 


### PR DESCRIPTION
## Summary

POC for INTORG-647 to measure the cost of adopting React Aria (`react-aria-components`) for the site's nav. Adds a parallel `/poc/react-aria` page with a hydrated React island that replaces the existing vanilla `FoundationNavMenu` and mobile-drawer JS. Existing pages and the live nav are untouched.

What's in this branch:

- `@astrojs/react`, `react`, `react-dom`, `react-aria-components`, `tailwindcss-react-aria-components`, `web-vitals` added.
- `src/components/poc/AriaNavMenu.tsx` and `src/components/poc/AriaMobileDrawer.tsx` — the React Aria versions of the menu and drawer.
- `src/pages/poc/react-aria.astro` — POC page, uses the same chrome as the live site but swaps the header for a RAC version.
- `src/scripts/web-vitals.ts` — logs CWV to the console (gated on `?wv=1` in prod, always on in dev).
- `poc-react-aria-report.md` at the repo root — full measurement report and a11y audit.

This PR isn't intended to merge as-is. It's the measurement vehicle for the recommendation in the report.

Headline numbers (CDN apples-to-apples, baseline = preview homepage with the same Netlify banner):

- Lighthouse Performance: 99 → 99 desktop, 78 → 78 mobile (median of 3). No regression.
- TBT: 0 ms → 0 ms on both form factors.
- LCP: +3 ms desktop, +39 ms mobile (within run-to-run noise).
- Site JS shipped: +106 KB gz.

The deploy preview's perf score is dragged down by Netlify's own ~313 KB preview banner, not a RAC issue. Predicted prod mobile LCP (local prod-build) is 1.36 s baseline → 2.10 s POC, both inside CWV "Good".

The report also flags three pre-existing WCAG 2.2 AA failures in the live nav: visible focus, `aria-haspopup`, mobile drawer focus trap. The recommendation is a split: patch the desktop nav in place for the first two, replace the mobile drawer with RAC `Dialog`/`Modal` for the third.

## Related Issue

[INTORG-647](https://linear.app/interledger/issue/INTORG-647/poc-with-react-aria) (parent: [INTORG-643](https://linear.app/interledger/issue/INTORG-643/set-up-design-system))

## Manual Test

Deploy preview: https://deploy-preview-259--interledger-org-v5.netlify.app/poc/react-aria

1. Hover a top-level nav item (e.g. Foundation). Submenu opens; mouse out closes it. No flicker, no re-open after Escape.
2. Tab into the nav. Each trigger shows a teal focus ring (white inset + primary outer).
3. Open a submenu with Enter or Space, then Arrow Up/Down between items, Escape to close.
4. Resize below 1060 px. Open the hamburger drawer; Tab is trapped inside, Escape closes and returns focus to the hamburger.
5. Append `?wv=1` and watch the console for LCP / INP / CLS / FCP / TTFB.


## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused (POC additions only; no edits to existing nav code)
- [x] Screenshots for UI changes
