### PR TITLE
chore: migrate fellows translations to v5

### DIFF
--- a/src/content/ambassadors/es/andria-barrett.mdx
+++ b/src/content/ambassadors/es/andria-barrett.mdx
@@ -1,0 +1,37 @@
+---
+name: 'Andria Barrett'
+pathSlug: 'andria-barrett'
+photo: '/uploads/img/original/andria_barrett_2026.png'
+photoAlt: 'Andria Barrett'
+category: 'Fellows 2026'
+tagline: 'Defensora de la inclusión financiera y promotora de comunidades'
+quote: '"Mi objetivo es proteger esta tradición de confianza y, al mismo tiempo, utilizar la tecnología para reducir los costos, ampliar el acceso y facilitar la participación de las personas".'
+locale: 'es'
+localizes: 'andria-barrett'
+---
+
+Andria Barrett es defensora de la inclusión financiera, con más de 15 años de experiencia ayudando a organizaciones a crear entornos donde las personas se sientan vistas, escuchadas y valoradas. Es fundadora de Diversity Agency, cofundadora de The Banker Ladies Council y directora de ROSCA Network, una organización canadiense que defiende, forma y apoya a los usuarios de ROSCA. Su trabajo se centra en ayudar a las mujeres a aumentar su confianza financiera y a generar ahorros a través de sistemas comunitarios.
+
+## Proyecto como embajadora
+
+El proyecto de Andria exploró si los miembros de las ROSCA (Asociaciones de Ahorro y Crédito Rotativo) estaban preparados para adoptar herramientas digitales y trasladar sus círculos de ahorro al entorno en línea.
+
+Conocidas con distintos nombres según la cultura (“pardna” en Jamaica, “susu” en Nigeria, “box-hand” en Guyana y “stokvel” en Sudáfrica), las ROSCA son sistemas de ahorro comunitarios de larga tradición. En su investigación, analizó cómo la tecnología digital podría respaldar estas prácticas financieras de confianza y, al mismo tiempo, preservar sus fundamentos culturales y sociales.
+
+## Qué inspiró su trabajo
+
+_"Crecí en una familia y en una comunidad donde las ROSCA/los círculos de ahorro eran algo normal"._
+
+Al crecer en una familia jamaicana en la que se utilizaba la **“pardna”** como una forma de ahorrar dinero, Andria observó de primera mano cómo estos círculos de ahorro ayudaban a las personas a mantener la disciplina en sus finanzas y a apoyarse mutuamente en momentos de necesidad.
+
+Su objetivo es proteger esta tradición de confianza y, al mismo tiempo, estudiar cómo la tecnología puede reducir los costos, ampliar el acceso y facilitar la participación de las personas a través de las fronteras.
+
+## Visión de futuro
+
+_"Creo que las herramientas digitales ayudarán a que las ROSCA/los círculos de ahorro continúen y crezcan, lo que facilitará que amigos, familiares y comunidades se apoyen económicamente entre sí, incluso cuando se encuentren en países diferentes"._
+
+Andria imagina un futuro en el que las herramientas digitales permitan a las comunidades seguir participando en círculos de ahorro independientemente de dónde vivan, lo que permitirá que amigos, familiares y comunidades se apoyen económicamente entre sí, incluso cuando se encuentren en países diferentes.
+
+## Lea sus contribuciones 
+
+[**https://community.interledger.org/andria**](https://community.interledger.org/andria)

--- a/src/content/ambassadors/es/ayden-ferdeline.mdx
+++ b/src/content/ambassadors/es/ayden-ferdeline.mdx
@@ -1,0 +1,33 @@
+---
+name: 'Ayden Férdeline'
+pathSlug: 'ayden-ferdeline'
+photo: '/uploads/img/original/ayden_2026.jpg'
+photoAlt: 'Ayden Férdeline'
+category: 'Fellows 2026'
+tagline: 'Líder en materia de políticas y defensor de Open Payments'
+quote: '"Los pagos no son solo transacciones; son gobernanza hecha realidad".'
+locale: 'es'
+localizes: 'ayden-ferdeline'
+---
+
+Ayden Férdeline es líder en políticas y tecnología, y trabaja en la intersección entre la infraestructura pública digital, la inclusión financiera y el impacto social. Su trabajo abarca la filantropía, la gobernanza global de Internet y los ecosistemas de Open Payments, y promueve los sistemas digitales interoperables y la colaboración de múltiples partes interesadas para ampliar el acceso equitativo a los servicios financieros en todo el mundo.
+
+## Proyecto como embajador
+
+Ayden puso en marcha y presidió la [Coalición Dinámica sobre Inclusión Financiera Digital del Foro de Gobernanza de Internet de las Naciones Unidas](https://intgovforum.org/en/content/dynamic-coalition-on-digital-financial-inclusion-dc-dfi). A través de este grupo de trabajo entre sesiones, reunió a responsables de políticas, tecnólogos, líderes de la sociedad civil y actores del sector privado para analizar cómo los sistemas de pago interoperables y la infraestructura pública digital pueden promover la inclusión financiera y, al mismo tiempo, proteger los derechos y la competencia.
+
+## Qué inspiró su trabajo
+
+_"Mi trayectoria hacia la inclusión financiera digital surgió a partir de mi trabajo previo en la gobernanza de Internet con múltiples partes interesadas, donde observé cómo los estándares técnicos determinan, de forma silenciosa, quién puede participar en el mundo digital"._
+
+Su trabajo se centra en cómo los sistemas abiertos e interoperables pueden contribuir a reequilibrar el poder en las economías digitales y a ampliar el acceso a la participación financiera.
+
+## Visión de futuro
+
+_"Imagino un futuro en el que la inclusión financiera se integre en el diseño de los sistemas financieros digitales desde el principio"._
+
+Considera que alinear los incentivos en torno a la interoperabilidad, la competencia justa y la infraestructura abierta puede crear sistemas más conectados, reducir costos y ampliar el acceso a los servicios financieros.
+
+## Lea sus contribuciones 
+
+[**https://community.interledger.org/ferdeline**](https://community.interledger.org/ferdeline)**&#xA0;**

--- a/src/content/ambassadors/es/erica-hargreave.mdx
+++ b/src/content/ambassadors/es/erica-hargreave.mdx
@@ -1,0 +1,37 @@
+---
+name: 'Erica Hargreave'
+pathSlug: 'erica-hargreave'
+photo: '/uploads/img/original/erica_2026.JPG'
+photoAlt: 'Erica Hargreave'
+category: 'Fellows 2026'
+tagline: 'Narradora y promotora de la comunidad de Open Payments '
+quote: '"Centrar la atención, la intención y el valor en asegurar que la accesibilidad se integre en el sistema desde el código".'
+locale: 'es'
+localizes: 'erica-hargreave'
+---
+
+Erica Hargreave es narradora y educadora galardonada a nivel internacional, apasionada por conectar a las comunidades con vías de financiamiento alternativas. A través de su labor como embajadora de la Fundación Interledger, impulsó colaboraciones, promovió la alfabetización en Web Monetization y creó oportunidades de divulgación para ayudar a creativos, educadores e iniciativas de impacto social a explorar vías de pago abiertas, inclusivas y sostenibles.
+
+## Proyecto como embajadora
+
+Como embajadora de la Fundación Interledger, Erica creó una comunidad entre distintos sectores a través de actividades de divulgación colaborativas y prácticas para promover Open Payments y Web Monetization. Convocó a profesionales de los medios de comunicación, creadores digitales, líderes de la educación abierta, comunidades indígenas y defensores de las personas con discapacidades para experimentar, conectarse y colaborar en la creación de vías para la adopción, las alianzas y el uso en el mundo real.
+
+Estas colaboraciones se centraron en generar un aprendizaje medible y en compartir conocimientos de forma abierta en todo el ecosistema global.
+
+## Qué inspiró su trabajo
+
+_"Al descubrir Open Payments, vimos la posibilidad de ayudar especialmente y crear oportunidades para las personas que viven en comunidades marginadas y que no pueden acceder a los empleos tradicionales de 9 a 5"._
+
+El trabajo de Erica se vio influido por su experiencia en los sistemas de financiamiento tradicionales de las industrias creativas y por los problemas de accesibilidad a los que se enfrentan muchos creadores y educadores. Su objetivo ha sido explorar modelos de financiamiento sostenibles que amplíen las oportunidades para las comunidades marginadas.
+
+## Visión de futuro
+
+_"Para mí, el futuro de la inclusión financiera consiste en crear vías financieras que ayuden a generar oportunidades para que las personas que viven en comunidades marginadas y que no pueden acceder a los empleos tradicionales de 9 a 5 obtengan ingresos de forma sostenible"._
+
+Destaca que la accesibilidad debe integrarse de forma deliberada en los sistemas financieros, desde la tecnología en que se basan hasta los programas comunitarios, los eventos y las oportunidades de financiamiento.
+
+## Lea sus contribuciones
+
+**&#xA0;**[https://community.interledger.org/ericahargreave/series/31](https://community.interledger.org/ericahargreave/series/31) - Informe provisional
+
+[https://community.interledger.org/ericahargreave/making-connections-helping-others-to-catalyze-potential-opportunities-explore-new-pathways-final-ambassadorship-report-3j4c](https://community.interledger.org/ericahargreave/making-connections-helping-others-to-catalyze-potential-opportunities-explore-new-pathways-final-ambassadorship-report-3j4c) - Informe final

--- a/src/content/ambassadors/es/gavin-chait.mdx
+++ b/src/content/ambassadors/es/gavin-chait.mdx
@@ -1,0 +1,35 @@
+---
+name: 'Gavin Chait'
+pathSlug: 'gavin-chait'
+photo: '/uploads/img/original/gavin_chait_2026.jpg'
+photoAlt: 'Gavin Chait'
+category: 'Fellows 2026'
+tagline: 'Científico de datos, investigador y defensor de los sistemas abiertos'
+quote: '"La exclusión financiera se produce porque las personas no tienen acceso a la economía formal".'
+locale: 'es'
+localizes: 'gavin-chait'
+---
+
+Gavin Chait es científico de datos, investigador, ingeniero y autor de ciencia ficción africana. Dirige el desarrollo de software y sistemas en la investigación de acceso abierto, centrándose en la ética y la curaduría. Su trabajo combina tecnología, geopolítica y narrativa, y escribe ficción especulativa inspirada en la mitología, la tecnología y el cambio global.
+
+## Proyecto como embajador
+
+Hop Sauna es una plataforma de software diseñada para reinventar la forma en que los creadores y sus seguidores intercambian dinero en línea. Está diseñada para desarrolladores que desean acelerar sus proyectos de desarrollo web mediante una plantilla de aplicación web progresiva completa.
+
+La plataforma simplifica aspectos del desarrollo que, aunque complejos, son rutinarios, como la autenticación, la integración de Open Payments y la configuración de la implementación, lo que permite a los desarrolladores centrarse en crear herramientas creativas y comerciales.
+
+## Qué inspiró su trabajo
+
+_“La exclusión financiera se produce porque las personas no tienen acceso a la economía formal”._
+
+Gavin ha dedicado gran parte de su vida profesional a trabajar en entornos con dificultades de desarrollo, desde asentamientos informales en los alrededores de Ciudad del Cabo hasta comunidades creativas y profesionales en todo el continente africano. Su trabajo se centra en ampliar el acceso a los sistemas financieros para que creadores y emprendedores puedan participar plenamente en la economía global.
+
+## Visión de futuro
+
+_"La diversidad surgirá de forma natural; en lugar de que una empresa centralizada decida algorítmicamente sobre una 'cultura' común, cada comunidad expresará su propia creatividad de forma independiente"._
+
+Imagina un ecosistema financiero federado en el que las comunidades mantengan su independencia y, al mismo tiempo, interactúen de forma fluida, lo que permitirá formas de comercio y participación más inclusivas y diversas.
+
+## **Lea sus contribuciones  &#xA0;**
+
+[https://community.interledger.org/turukawa](https://community.interledger.org/turukawa)

--- a/src/content/ambassadors/es/jeremiah-lee.mdx
+++ b/src/content/ambassadors/es/jeremiah-lee.mdx
@@ -1,0 +1,35 @@
+---
+name: 'Jeremiah Lee'
+pathSlug: 'jeremiah-lee'
+photo: '/uploads/img/original/jeremiah_2026.jpg'
+photoAlt: 'Jeremiah Lee'
+category: 'Fellows 2026'
+tagline: 'Desarrollador de software y defensor de los derechos humanos en el ámbito digital'
+quote: '"Unas pocas empresas no deberían controlar la esfera pública digital, ni el movimiento de dinero a nivel global".'
+locale: 'es'
+localizes: 'jeremiah-lee'
+---
+
+Jeremiah Lee es desarrollador de software humanitario y activista de derechos humanos en el ámbito digital. Anteriormente, trabajó en infraestructura de datos en Stripe, en integraciones de hardware en Spotify y en API web en Fitbit. Originario de California, actualmente vive en Estocolmo.
+
+## Proyecto como embajador
+
+El proyecto de Jeremiah analizó las oportunidades económicas derivadas de la transición de las plataformas de redes sociales centralizadas a la web social, también conocida como redes sociales federadas o fediverso (como Mastodon).
+
+Su trabajo se centró en llevar Web Monetization más allá de HTML, hacia el formato de datos central de la web social (Activity Streams 2) y su protocolo de entrega (ActivityPub), con el fin de ofrecer a los creadores de redes descentralizadas nuevas formas de obtener ingresos.
+
+## Qué inspiró su trabajo
+
+_"El surgimiento de la web social ofreció a los creadores, ignorados por las plataformas dominantes, la oportunidad de construir su propia audiencia"._
+
+Jeremiah vio la oportunidad de abordar la brecha en la monetización de los creadores llevando Open Payments de Interledger y Web Monetization a las redes sociales descentralizadas emergentes.
+
+## Visión de futuro
+
+_"Las redes sociales federadas necesitan redes de pago federadas. Un futuro más equitativo es posible y factible si luchamos por él ahora"._
+
+Considera que los sistemas de pago globales podrían evolucionar hasta convertirse en infraestructuras en red similares a Internet, lo que permitiría un acceso más equitativo a la participación financiera y reduciría la dependencia de las plataformas centralizadas.
+
+## Lea sus contribuciones 
+
+[https://community.interledger.org/jeremiahlee](https://community.interledger.org/jeremiahlee)

--- a/src/content/ambassadors/es/kokayi-walker.mdx
+++ b/src/content/ambassadors/es/kokayi-walker.mdx
@@ -1,0 +1,35 @@
+---
+name: 'Kokayi Walker'
+pathSlug: 'kokayi-walker'
+photo: '/uploads/img/original/kokayi_issa_2026.jpeg'
+photoAlt: 'Kokayi Walker'
+category: 'Fellows 2026'
+tagline: 'Artista, estratega e innovador cultural'
+quote: '"La inclusión financiera tiene que ver con la dignidad y la capacidad de decisión. La capacidad de participar plenamente en la vida económica".'
+locale: 'es'
+localizes: 'kokayi-walker'
+---
+
+Kokayi Walker es un músico nominado a los premios GRAMMY, becario Guggenheim y artista multidisciplinario radicado en Washington, D.C. Como vocalista de improvisación y productor, con participaciones en más de 80 grabaciones, su obra transforma las narrativas de la diáspora negra en experiencias participativas a través del sonido, el cine y los medios visuales.
+
+Como autor, estratega creativo y tecnólogo, Kokayi conecta el arte, la cultura y la tecnología para explorar nuevas formas en que los creadores y las comunidades pueden participar en las economías digitales.
+
+## Proyecto como embajador
+
+Durante su etapa en la comunidad de Interledger, Kokayi se centró en conectar a creativos, tecnólogos y líderes de pensamiento de todo el mundo. Para contribuir a ampliar el debate sobre la inclusión financiera, la cultura y las tecnologías emergentes, Kokayi ha apoyado y presentado el [pódcast FM](https://interledger.org/es/podcast), creado por la Fundación Interledger. 
+
+## Qué inspiró su trabajo
+
+“_Me inspiré para trabajar en la inclusión financiera digital después de ver a tantos creadores brillantes y pequeños emprendedores, especialmente en las comunidades negras y de la diáspora, operar dentro de sistemas que nunca se diseñaron para ellos”._
+
+Como artista y estratega, Kokayi ha experimentado de primera mano cómo el acceso puede determinar las oportunidades. Cree que las herramientas financieras digitales tienen el potencial de aumentar la transparencia, ampliar la participación y favorecer la creación de ecosistemas económicos más equitativos.
+
+## Visión de futuro
+
+_“Imagino un mundo sin barreras de acceso”._
+
+Para Kokayi, la inclusión financiera tiene que ver, en última instancia, con la dignidad, la propiedad y la garantía de que los creadores y las comunidades puedan participar plenamente en la construcción de futuros económicos sostenibles.
+
+## Obtenga más información sobre sus contribuciones
+
+Escuche el [pódcast FM](https://interledger.org/es/podcast)

--- a/src/content/ambassadors/es/lawil-karama.mdx
+++ b/src/content/ambassadors/es/lawil-karama.mdx
@@ -1,0 +1,37 @@
+---
+name: 'Lawil Karama'
+pathSlug: 'lawil-karama'
+photo: '/uploads/img/original/lawil_karama_2026.png'
+photoAlt: 'Lawil Karama'
+category: 'Fellows 2026'
+tagline: 'Artista conceptual y estratega de participación comunitaria'
+quote: '"Como artista que trabaja con comunidades de la diáspora y voces marginadas, vi cómo la exclusión financiera agravaba otras formas de exclusión".'
+locale: 'es'
+localizes: 'lawil-karama'
+---
+
+Lawil Karama es artista conceptual y ejecutiva de programas en la Fundación Interledger, donde dirige el programa de becas de Interledger y el programa de Convocatoria de ponencias. Su práctica artística abarca la instalación, la escultura y el arte de archivo computacional, y utiliza la reconstrucción conmemorativa y las narrativas de comunidades marginadas como formas de intervención política.
+
+## Proyecto como embajadora
+
+En 2022, antes de incorporarse a la Fundación Interledger, Lawil fue embajadora del programa Grant for the Web (ahora denominado programa de becas de Interledger) y trabajó para conectar el movimiento Web Monetization con comunidades marginales y espacios creativos especializados de toda Europa.
+
+Su trabajo se centró en ampliar el acceso para las voces subrepresentadas, apoyar a posibles beneficiarios en la redacción de solicitudes de subvenciones y fortalecer la participación de la comunidad para ampliar el alcance geográfico y cultural de los programas de subvenciones.
+
+## Qué inspiró su trabajo
+
+_"Mi camino hacia la inclusión financiera digital comenzó con una observación simple: los sistemas que rigen el acceso a los recursos nunca han sido neutrales"._
+
+A través de su trabajo con comunidades de la diáspora y voces marginadas, observó que, a menudo, la exclusión financiera agravaba otras formas de marginación social y cultural. Esto la llevó a analizar cómo una infraestructura financiera abierta podría contribuir a cambiar quiénes se benefician de la web.
+
+## Visión de futuro
+
+_"La inclusión financiera solo tendrá sentido si la infraestructura en la que se basa es abierta, interoperable y se crea con la participación de las comunidades a las que pretende servir"._
+
+Su trabajo se centra en garantizar que las comunidades más afectadas por la exclusión financiera participen en la configuración de las tecnologías y los sistemas destinados a apoyarlas.
+
+## Lea sus contribuciones 
+
+[https://community.interledger.org/lwlkarama/africa-in-colors-summit-3eh5](https://community.interledger.org/lwlkarama/africa-in-colors-summit-3eh5)
+
+[https://community.interledger.org/lwlkarama/the-art-of-reflection-2hoa](https://community.interledger.org/lwlkarama/the-art-of-reflection-2hoa)

--- a/src/content/ambassadors/es/santosh-viswanatham.mdx
+++ b/src/content/ambassadors/es/santosh-viswanatham.mdx
@@ -1,0 +1,33 @@
+---
+name: 'Santosh Viswanatham'
+pathSlug: 'santosh-viswanatham'
+photo: '/uploads/img/original/santosh_2026.jpg'
+photoAlt: 'Santosh Viswanatham'
+category: 'Fellows 2026'
+tagline: 'Defensor de la Web abierta y colaborador de código abierto'
+quote: '"Imagino un futuro en el que la inclusión financiera esté integrada de forma natural en la web".'
+locale: 'es'
+localizes: 'santosh-viswanatham'
+---
+
+Santosh Viswanatham es defensor de la Web abierta y antiguo embajador de la Fundación Interledger, apasionado por las tecnologías inclusivas y de código abierto. Entusiasta de JavaScript y conferencista en materia de tecnología, anteriormente ocupó el cargo de líder de participación en Mozilla, y sus contribuciones se reconocen en la sección _about:credits_ de Firefox.
+
+## Proyecto como embajador
+
+Santosh trabajó en el fortalecimiento del ecosistema de Web Monetization mediante la mejora de la documentación, la migración de bibliotecas a la especificación más reciente, el lanzamiento de guías para la comunidad y la creación de un programa de reconocimiento para los colaboradores. A través de charlas en todo el mundo, su participación en el Hacktoberfest y la colaboración con la comunidad, contribuyó a aumentar el conocimiento y la participación en una infraestructura financiera abierta e inclusiva.
+
+**A través de charlas internacionales en Asia y Europa, la participación de más de** 1300 colaboradores durante el Hacktoberfest **y el lanzamiento de iniciativas como&#xA0;**&#x6C;as guías _Get Involved_ y el programa _Open Badges_,**&#x20;Santosh contribuyó a mejorar tanto la experiencia de los desarrolladores como la participación de la comunidad internacional.**
+
+## Qué inspiró su trabajo
+
+Santosh, procedente de la India, fue testigo de primera mano de cómo los sistemas digitales y financieramente inclusivos pueden transformar vidas en apenas una década. La rápida adopción de los pagos digitales y de una infraestructura financiera inclusiva ha empoderado a millones de personas, al permitir que las pequeñas empresas operen en línea, posibilitar las transacciones instantáneas y ofrecer a las personas acceso a los sistemas financieros formales por primera vez.
+
+## Visión de futuro
+
+Santosh imagina un mundo en el que la inclusión financiera esté perfectamente integrada en la web.
+
+“_Imagino un futuro en el que la inclusión financiera esté integrada de forma natural en la web, lo que permitirá a cualquier persona, en cualquier lugar, enviar, recibir y ganar dinero en línea sin problemas y sin barreras innecesarias”._
+
+## Lea sus contribuciones 
+
+[https://community.interledger.org/devcer](https://community.interledger.org/devcer)

--- a/src/content/ambassadors/es/sheena-allen.mdx
+++ b/src/content/ambassadors/es/sheena-allen.mdx
@@ -1,0 +1,31 @@
+---
+name: 'Sheena Allen'
+pathSlug: 'sheena-allen'
+photo: '/uploads/img/original/sheena_allen_2026.JPG'
+photoAlt: 'Sheena Allen'
+category: 'Fellows 2026'
+tagline: 'Emprendedora, investigadora e innovadora en banca digital'
+quote: '"La inclusión financiera digital representa equidad, acceso y supervivencia económica para millones de personas".'
+locale: 'es'
+localizes: 'sheena-allen'
+---
+
+Sheena Allen es emprendedora, conferencista y antigua integrante de la lista Forbes 30 Under 30, y se convirtió en la mujer más joven de Estados Unidos en ser propietaria de un banco digital y dirigirlo. Creó su primera empresa tecnológica cuando estaba en la universidad, y su aplicación tuvo decenas de millones de descargas. Además, es copresentadora del pódcast _Rich Lessons_.
+
+## Proyecto como embajadora
+
+El proyecto de Sheena, _“Financial Exclusion in the Southern U.S.: The Real Whys, Challenges, and the Role of Digital Inclusion”_(Exclusión financiera en el sur de Estados Unidos: las verdaderas razones, desafíos y el papel de la inclusión digital), es un estudio de campo que analiza las barreras sistémicas y conductuales que contribuyen a la exclusión financiera en el sur de Estados Unidos.
+
+A través de entrevistas directas con personas no bancarizadas y subbancarizadas, su investigación se centra en experiencias de vida que los datos tradicionales a menudo pasan por alto, revelando los verdaderos obstáculos a los que se enfrentan las personas para acceder a los sistemas financieros y poniendo de relieve los ámbitos en los que las herramientas digitales podrían desempeñar un papel significativo para ampliar el acceso y las oportunidades.
+
+## Qué inspiró su trabajo
+
+Sheena creció en Terry, Misisipi, un estado con una de las mayores poblaciones de residentes no bancarizados y subbancarizados, y fue testigo de primera mano de cómo el sistema financiero tradicional fallaba a muchas personas de su comunidad. Esa experiencia la inspiró a crear una infraestructura financiera diseñada específicamente para las poblaciones marginadas.
+
+## Visión de futuro
+
+Sheena considera que, en el futuro, la inclusión financiera irá más allá de los servicios financieros “personalizados” y se orientará hacia sistemas financieros verdaderamente individualizados, en los que barreras como la ubicación geográfica, los ingresos y el historial crediticio dejen de impedir que las personas accedan a herramientas y oportunidades financieras.
+
+## Lea sus contribuciones
+
+[https://community.interledger.org/sheenaallen](https://community.interledger.org/sheenaallen)

--- a/src/content/ambassadors/es/smriti-parsheera.mdx
+++ b/src/content/ambassadors/es/smriti-parsheera.mdx
@@ -1,0 +1,35 @@
+---
+name: 'Smriti Parsheera'
+pathSlug: 'smriti-parsheera'
+photo: '/uploads/img/original/smriti_parsheera_2026.jpg'
+photoAlt: 'Smriti Parsheera'
+category: 'Fellows 2026'
+tagline: 'Abogada y especialista en derechos digitales'
+quote: '“Comprender cómo las distintas comunidades, en especial los grupos marginados, acceden a los servicios financieros digitales e interactúan con ellos es una pieza importante del rompecabezas”.'
+locale: 'es'
+localizes: 'smriti-parsheera'
+---
+
+Smriti Parsheera es abogada e investigadora en políticas digitales, estudia la gobernanza de las tecnologías digitales y su interacción con la sociedad. Su investigación se centra en el acceso digital, la privacidad, la gobernanza de los datos, la infraestructura pública digital y la inteligencia artificial. También es editora del libro _Private and Controversial_, que explora la intersección entre la salud pública y la privacidad.
+
+## Proyecto como embajadora
+
+El proyecto de investigación de Smriti, _Pinging Paradise_, estudió las experiencias vividas en materia de inclusión digital y financiera en el remoto distrito himalayo de Lahaul-Spiti, en el norte de la India.
+
+Además de esta investigación, colaboró con el equipo de Interledger para diseñar y llevar a cabo su iniciativa inaugural de Convocatoria de ponencias, lo que contribuyó a crear oportunidades para que más investigadores aportaran sus perspectivas sobre la inclusión financiera digital.
+
+## Qué inspiró su trabajo
+
+_“Comprender cómo las distintas comunidades, en especial los grupos marginados, acceden a los servicios financieros digitales e interactúan con ellos es una pieza importante del rompecabezas”._
+
+Su proyecto estuvo motivado por el deseo de profundizar el conocimiento sobre la inclusión digital entre las poblaciones tribales de la India, utilizando como caso práctico su región natal de Lahaul-Spiti, en Himachal Pradesh.
+
+## Visión de futuro
+
+_"El futuro de la inclusión financiera debe basarse en la conciencia de las diversas necesidades financieras y capacidades digitales de las personas que pertenecen a distintos grupos poblacionales"._
+
+Su investigación pone de relieve la importancia de que las iniciativas de inclusión financiera se basen en las realidades vividas y en las prácticas locales de las comunidades a las que pretenden atender.
+
+## Lea sus contribuciones
+
+[https://community.interledger.org/smrpar](https://community.interledger.org/smrpar)

--- a/src/content/ambassadors/es/stephanie-perrin.mdx
+++ b/src/content/ambassadors/es/stephanie-perrin.mdx
@@ -1,0 +1,33 @@
+---
+name: 'Stephanie Perrin'
+pathSlug: 'stephanie-perrin'
+photo: '/uploads/img/original/stephanie_perrin_2026.jpeg'
+photoAlt: 'Stephanie Perrin'
+category: 'Fellows 2026'
+tagline: 'Experta en privacidad y defensora de los derechos digitales'
+quote: '"Existe una gran necesidad de seguir trabajando para explicar adónde van los datos, dónde se almacenan y qué protecciones existen para ellos".'
+locale: 'es'
+localizes: 'stephanie-perrin'
+---
+
+Stephanie Perrin es consultora en privacidad y ética, y se jubiló tras 35 años de trabajo en política de comunicaciones para el Gobierno canadiense. Su trabajo se centra en la protección de la privacidad, los derechos digitales y la gobernanza ética en los sistemas financieros y tecnológicos emergentes.
+
+## Proyecto como embajadora
+
+El proyecto de Stephanie se centró en investigar marcos y herramientas adecuados en materia de privacidad y derechos humanos para quienes implementan el protocolo Interledger. En su trabajo, analizó cómo se pueden integrar las protecciones de la privacidad y las consideraciones éticas en las tecnologías financieras, mientras se respaldan sistemas de pago seguros y transparentes.
+
+## Qué inspiró su trabajo
+
+_"Los consumidores saben muy poco sobre cómo funcionaban los sistemas financieros antes de la aparición de las soluciones fintech. La demanda de verificación de la identidad implica la recopilación y monetización de los datos personales, pero parece que no existe un consenso sobre los controles de privacidad”._
+
+Su trabajo analiza cómo el rápido crecimiento de las tecnologías financieras ha generado confusión entre los usuarios que utilizan monedas digitales, plataformas de pago y sistemas de verificación de identidad, lo que plantea cuestiones importantes sobre cómo se recopilan, utilizan y protegen los datos personales.
+
+## Visión de futuro
+
+_"Queda mucho trabajo por hacer en este ámbito, con hincapié en una mayor transparencia y en la evaluación de riesgos, teniendo en cuenta los derechos humanos de las personas”._
+
+Stephanie subraya la importancia de la transparencia, de reforzar la protección de la privacidad y de aumentar la concienciación pública sobre la seguridad y los datos personales en los sistemas de tecnología financiera.
+
+## Lea sus contribuciones 
+
+[**https://community.interledger.org/how5**](https://community.interledger.org/how5)

--- a/src/content/ambassadors/es/victoria-coker.mdx
+++ b/src/content/ambassadors/es/victoria-coker.mdx
@@ -1,0 +1,35 @@
+---
+name: 'Victoria Coker'
+pathSlug: 'victoria-coker'
+photo: '/uploads/img/original/victoria_coker_2026.jpg'
+photoAlt: 'Victoria Coker'
+category: 'Fellows 2026'
+tagline: null
+quote: '"Para mí, el futuro de la inclusión financiera consiste en que todas las personas tengan acceso a los servicios financieros, independientemente de sus ingresos, su raza o su ubicación".'
+locale: 'es'
+localizes: 'victoria-coker'
+---
+
+Victoria Coker es una emprendedora con impacto social, especialista en marketing, artista multidisciplinaria e ingeniera de software certificada. Con más de una década de experiencia en diseño y marketing al servicio de diversas organizaciones, también fundó **Black Web Fest**, una iniciativa puesta en marcha en 2017 para rendir homenaje y apoyar a los creativos negros. Su trabajo se centra en crear oportunidades y generar un impacto duradero para su comunidad.
+
+## Proyecto como embajadora
+
+El proyecto de Victoria,_&#x20;“Unbanked in America:_ _Exploring the Financial Divide”_ (Personas no bancarizadas en Estados Unidos: explorando la brecha financiera), examina las barreras al acceso financiero a partir de datos de la FDIC de 2021, centrándose en Nueva York, Misisipi y Luisiana. A través de entrevistas con expertos, analiza las desigualdades estructurales a las que se enfrentan muchas comunidades no bancarizadas y subbancarizadas.
+
+Su investigación se presenta en una miniserie especial en el pódcast Future Money de la Fundación Interledger, donde el público puede interactuar con las ideas y las conversaciones derivadas del proyecto.
+
+## Qué inspiró su trabajo
+
+_"Mi experiencia personal me ha inspirado para trabajar en la inclusión financiera digital"._
+
+Al crecer en un hogar con bajos ingresos, Victoria vivió de primera mano las dificultades de no poder acceder a servicios bancarios. Estas experiencias forjaron su pasión por ayudar a las comunidades marginadas a generar riqueza y acceder a sistemas que históricamente las han excluido.
+
+## **Visión de futuro**
+
+_“Para mí, el futuro de la inclusión financiera consiste en que todas las personas tengan acceso a los servicios financieros, independientemente de sus ingresos, su raza o su ubicación”._
+
+Victoria espera que su trabajo impulse debates, fomente más investigaciones y atraiga una mayor inversión en la creación de sistemas, educación y apoyo comunitario para las poblaciones no bancarizadas y subbancarizadas de todo Estados Unidos.
+
+## Lea sus contribuciones
+
+[https://community.interledger.org/victoriac](https://community.interledger.org/victoriac)

--- a/src/content/ambassadors/es/xiaoji-song.mdx
+++ b/src/content/ambassadors/es/xiaoji-song.mdx
@@ -1,0 +1,35 @@
+---
+name: 'Xiaoji Song'
+pathSlug: 'xiaoji-song'
+photo: '/uploads/img/original/xiaoji_2026.jpg'
+photoAlt: 'Xiaoji Song'
+category: 'Fellows 2026'
+tagline: 'Artista y activista'
+quote: '"El futuro de la inclusión financiera es un futuro en el que se redistribuye el poder, no solo se mejoran las interfaces".'
+locale: 'es'
+localizes: 'xiaoji-song'
+---
+
+Xiaoji Song (ella/elle) es artista, activista e investigadora radicada en Berlín, y trabaja en la creación de infraestructuras alternativas e imaginarios relacionados con la migración, el trabajo y la tecnología.
+
+## Proyecto como embajadora
+
+_“Shifting Power in the Informal Economy”_ (Redistribuyendo el poder en la economía informal) es una iniciativa de investigación y defensa que analiza de forma crítica la naturaleza y la estructura de las economías informales en Europa. Sobre la base de información etnográfica y mapeos de partes interesadas de Berlín y Madrid, el proyecto cuestiona los supuestos convencionales y, al mismo tiempo, promueve la justicia financiera estructural mediante protocolos de Open Payments, herramientas de soberanía de datos y mecanismos de empoderamiento dirigidos por los trabajadores.
+
+## Qué inspiró su trabajo
+
+_"Resultó evidente que el problema no es el comportamiento individual, sino el diseño estructural"._
+
+Su trabajo surgió al observar cómo los trabajadores migrantes y de la economía informal hacían todo “correctamente” y, aun así, seguían quedando excluidos del acceso a cuentas bancarias, contratos y protecciones financieras, a pesar de que su trabajo sustenta las ciudades y las economías locales.
+
+## Visión de futuro
+
+_"Imagino un sistema financiero que reconozca la capacidad de acción de quienes históricamente han sido marginados"._
+
+Su proyecto explora cómo la informalidad, la migración y el trabajo en plataformas se entrecruzan en Europa, con el objetivo de influir en la forma en que los tecnólogos, los financiadores y los responsables de políticas entienden la inclusión financiera y la rendición de cuentas.
+
+## Lea sus contribuciones 
+
+[https://community.interledger.org/xiaoxiao_and_their_bahncard](https://community.interledger.org/xiaoxiao_and_their_bahncard)
+
+[Escuche el episodio del pódcast FM](https://podcast.interledger.org/@futuremoneypodcast/episodes/parallel-society)


### PR DESCRIPTION
## Summary
This PR migrates the translations for the fellows profile pages to v5

## Related Issue
Fixes INTORG-638

## Manual Test
- Verify Fellows list (spanish): navigate to `/es/grant/fellowship` and:
  - confirm that the Fellows list is displayed
  - ensure all text on the cards is in Spanish
- Verify Individual Fellow Pages - click on each Fellow card and: 
  - confirm navigation to the Spanish ID page for that Fellow
  - confirm that all visible text on the page is in Spanish
  - confirm the `translationDisclaimer` is not displayed

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
