### PR TITLE
fix: fix header style on main website

### DIFF
--- a/src/components/docs/Header.astro
+++ b/src/components/docs/Header.astro
@@ -34,13 +34,6 @@ const foundationLabel = FOUNDATION_LABEL[routeLocale] ?? FOUNDATION_LABEL.en
 </div>
 
 <style>
-  :global(header) {
-    border-block-start: 2px solid var(--color-primary-fallback);
-    border-block-start: 2px solid var(--color-primary);
-    box-shadow: 0px 0px 12px -4px var(--color-primary-fallback);
-    box-shadow: 0px 0px 12px -4px var(--color-primary);
-  }
-
   .header {
     gap: var(--sl-nav-gap);
     align-items: center;

--- a/src/styles/interledger.css
+++ b/src/styles/interledger.css
@@ -57,6 +57,10 @@
 header.header {
   background-color: var(--sl-color-black);
   border-block-end: 0;
+  border-block-start: 2px solid var(--color-primary-fallback);
+  border-block-start: 2px solid var(--color-primary);
+  box-shadow: 0px 0px 12px -4px var(--color-primary-fallback);
+  box-shadow: 0px 0px 12px -4px var(--color-primary);
   font-family: 'Titillium Web';
 }
 


### PR DESCRIPTION
## Summary
Fix header styles on main website:
Moved the header border and box-shadow rules from the `:global(header)` block in `Header.astro` to `interledger.css`, which is already docs-scoped by being only imported in the docs layout, eliminating the need for :global() entirely.

## Related Issue
The docs `Header` component contains a `:global(header)` CSS rule that leaks its styles (border and box-shadow using --color-primary) to every header element site-wide, instead of scoping them to the docs section only.

## Manual Test
- Check the headers on the main website (e.g on `/blog`) no longer display the teal border and box-shadow (as in the imd below)

<img width="1274" height="345" alt="image" src="https://github.com/user-attachments/assets/b51f0f06-107e-40a0-850d-bbb61b029254" />
⬇️⬇️⬇️
<img width="1265" height="332" alt="image" src="https://github.com/user-attachments/assets/950ba3d6-d401-4122-a704-f17a659a7d30" />

- check the headers on the docs section of the website (e.g. `/developers/get-started/`) still display the correct styles

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)
