### PR TITLE
Jm/intorg 644 spanish sync on staging Fixes INTORG-644

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,7 +1,7 @@
 name: Build and Sync
 # Runs on push to staging or playground only — not prod (prod has no Strapi instance, so no build or sync applies).
 # Conditionally rebuilds the Strapi CMS on the self-hosted runner if cms/ changed,
-# and/or syncs MDX content and navigation JSON to Strapi if those files changed.
+# and/or syncs to Strapi when any src/content/**/*.mdx (or navigation JSON) changes.
 # Does NOT trigger an Astro build — Astro is built and deployed separately via Netlify.
 
 on:
@@ -49,7 +49,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const contentPattern = /^src\/content\/(?:(?:foundation-pages|summit-pages|foundation-blog-posts|ambassadors)\/|[^/]+\/(?:foundation-pages|summit-pages|foundation-blog-posts|ambassadors)\/).+\.(md|mdx)$/
+            // Any MDX anywhere under Astro content collections (sync script only uploads configured roots).
+            const contentPattern = /^src\/content\/.+\.mdx$/
             const navigationPattern = /^src\/config\/(?:foundation-navigation|summit-navigation)\.json$/
             const zeroSha = '0000000000000000000000000000000000000000'
 
@@ -270,7 +271,11 @@ jobs:
 
   sync-to-strapi:
     needs: [detect-changes, rebuild-strapi]
+    # always() is required: if rebuild-strapi is skipped (no cms/ changes), GitHub would otherwise
+    # skip this job before evaluating `if`, even when content/navigation changed.
     if: |
+      always() &&
+      needs.detect-changes.result == 'success' &&
       (needs.rebuild-strapi.result == 'success' || needs.rebuild-strapi.result == 'skipped') &&
       (needs.detect-changes.outputs.content_changed == 'true' || needs.detect-changes.outputs.navigation_changed == 'true')
     runs-on: ubuntu-latest

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,7 +1,8 @@
 name: Build and Sync
 # Runs on push to staging or playground only — not prod (prod has no Strapi instance, so no build or sync applies).
 # Conditionally rebuilds the Strapi CMS on the self-hosted runner if cms/ changed,
-# and/or syncs to Strapi when any src/content/**/*.mdx (or navigation JSON) changes.
+# and/or syncs to Strapi when src/content changes (.md/.mdx), navigation JSON changes,
+# or static media under public/img/, public/uploads/, or public/documents/ changes.
 # Does NOT trigger an Astro build — Astro is built and deployed separately via Netlify.
 
 on:
@@ -49,8 +50,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Any MDX anywhere under Astro content collections (sync script only uploads configured roots).
-            const contentPattern = /^src\/content\/.+\.mdx$/
+            // Any Markdown/MDX under Astro content collections (sync script only uploads configured roots).
+            const contentPattern = /^src\/content\/.+\.(md|mdx)$/
+            const mediaPattern = /^public\/(?:img|uploads|documents)\//
             const navigationPattern = /^src\/config\/(?:foundation-navigation|summit-navigation)\.json$/
             const zeroSha = '0000000000000000000000000000000000000000'
 
@@ -168,8 +170,9 @@ jobs:
 
             const cmsChanged =
               changedFiles.some((file) => file.startsWith('cms/'))
-            const contentChanged =
-              changedFiles.some((file) => contentPattern.test(file))
+            const contentChanged = changedFiles.some(
+              (file) => contentPattern.test(file) || mediaPattern.test(file)
+            )
             const navigationChanged =
               changedFiles.some((file) => navigationPattern.test(file))
 
@@ -178,7 +181,7 @@ jobs:
             }
 
             if (contentChanged) {
-              core.info('Content changes detected')
+              core.info('Content or public media changes detected')
             }
 
             if (navigationChanged) {
@@ -300,7 +303,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Sync MDX and navigation to Strapi
+      - name: Sync content, media, and navigation to Strapi
         working-directory: cms
         run: |
           set -euo pipefail

--- a/src/content/foundation-blog-posts/2026-02-02-test-sync-placeholder.mdx
+++ b/src/content/foundation-blog-posts/2026-02-02-test-sync-placeholder.mdx
@@ -1,0 +1,24 @@
+---
+title: 'Test post for synchronization'
+description: 'This is a placeholder blog post used to test the synchronization flow on staging.'
+date: 2026-02-02
+pathSlug: test-sync-placeholder
+locale: en
+pillar: 'vision'
+featureImage: '/img/foundation-blog/social-web-announcement.jpg'
+featureImageAlt: 'Placeholder image'
+thumbnailImage: '/img/foundation-blog/social-web-announcement-thumbnail.jpg'
+thumbnailImageAlt: 'Placeholder thumbnail'
+tags:
+  - Announcements
+---
+
+<Paragraph>
+
+This is placeholder copy for testing content synchronization on staging. It does not contain real information and may be removed at any time.
+
+## Test section
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+</Paragraph>


### PR DESCRIPTION
## Summary

Content-only pushes skipped Strapi sync because `rebuild-strapi` was skipped and GitHub won’t run dependent jobs unless we gate with `always()`. Fixed that.

Also treating any `src/content/**/*.mdx` change as “content changed” so we don’t maintain a fragile folder allowlist (sync still only uploads what the scripts handle).

## Related Issue

Fixes INTORG-644

## Manual Test

Push only MDX under `src/content/` (no `cms/` changes) to `staging` or `playground` — **Build and Sync** should run `sync-to-strapi` while `rebuild-strapi` stays skipped.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)