### PR TITLE
feat(analytics): add Umami tracking for blog tags and developer author links INTORG-709 

### DIFF
--- a/src/components/blog/ArticleTags.astro
+++ b/src/components/blog/ArticleTags.astro
@@ -1,7 +1,11 @@
 ---
 import type { FoundationTag } from '@/schemas/content'
-import { getTagUrl, translateTag, useTranslations } from '@/utils'
-import { buildUmamiAttrs } from '@/utils/umami'
+import {
+  buildUmamiAttrs,
+  getTagUrl,
+  translateTag,
+  useTranslations
+} from '@/utils'
 interface Props {
   tags: FoundationTag[]
   path: string

--- a/src/components/blog/ArticleTags.astro
+++ b/src/components/blog/ArticleTags.astro
@@ -25,7 +25,10 @@ const tagAttrs = (tag: FoundationTag, label: string) =>
     {
       tags.map((tag) => (
         <li class="mb-space-xs">
-          <a href={getTagUrl(path, tag)} {...tagAttrs(tag, translateTag(tag, t))}>
+          <a
+            href={getTagUrl(path, tag)}
+            {...tagAttrs(tag, translateTag(tag, t))}
+          >
             #{translateTag(tag, t)}
           </a>
         </li>

--- a/src/components/blog/ArticleTags.astro
+++ b/src/components/blog/ArticleTags.astro
@@ -1,6 +1,7 @@
 ---
 import type { FoundationTag } from '@/schemas/content'
 import { getTagUrl, translateTag, useTranslations } from '@/utils'
+import { buildUmamiAttrs } from '@/utils/umami'
 interface Props {
   tags: FoundationTag[]
   path: string
@@ -8,6 +9,15 @@ interface Props {
 const { tags, path } = Astro.props
 const { routeLocale } = Astro.locals
 const t = useTranslations(routeLocale)
+
+const tagAttrs = (tag: FoundationTag, label: string) =>
+  buildUmamiAttrs({
+    pathname: Astro.url.pathname,
+    lang: routeLocale,
+    section: 'cta',
+    linkText: `#${label}`,
+    action: `tag_${tag}`
+  })
 ---
 
 <footer>
@@ -15,7 +25,9 @@ const t = useTranslations(routeLocale)
     {
       tags.map((tag) => (
         <li class="mb-space-xs">
-          <a href={getTagUrl(path, tag)}>#{translateTag(tag, t)}</a>
+          <a href={getTagUrl(path, tag)} {...tagAttrs(tag, translateTag(tag, t))}>
+            #{translateTag(tag, t)}
+          </a>
         </li>
       ))
     }

--- a/src/layouts/DevelopersBlogLayout.astro
+++ b/src/layouts/DevelopersBlogLayout.astro
@@ -23,6 +23,15 @@ const breadcrumbAttrs = (href: string, linkText: string) =>
     linkText
   })
 
+const authorLinkAttrs = (href: string, linkText: string) =>
+  buildUmamiAttrs({
+    pathname: Astro.url.pathname,
+    lang: routeLocale,
+    section: 'link',
+    href,
+    linkText
+  })
+
 const site = Astro.site!
 const ogImageUrl = frontmatter.ogImageUrl
   ? new URL(frontmatter.ogImageUrl, site).href
@@ -115,7 +124,12 @@ const rawHTMLString = `This article was originally published at <a href=${frontm
             Written by{' '}
             {frontmatter.authors.map((author: string, i: number) => {
               const authorElement = frontmatter.author_urls?.[i] ? (
-                <a href={frontmatter.author_urls[i]}>{author}</a>
+                <a
+                  href={frontmatter.author_urls[i]}
+                  {...authorLinkAttrs(frontmatter.author_urls[i], author)}
+                >
+                  {author}
+                </a>
               ) : (
                 <span>{author}</span>
               )


### PR DESCRIPTION
## Summary

- **`ArticleTags.astro`**: Instrument tag links with `buildUmamiAttrs`, matching **`TagFilter`**: `section: 'cta'`, `action: \`tag_${tag}\``, current pathname + locale, and link text including the visible `#` prefix so events aggregate with the blog filter chips (`blog_post:cta:tag_*`).
- **`DevelopersBlogLayout.astro`**: Instrument “Written by” author links with `section: 'link'` so events follow **`{page}:link:{destination}`** (same shape as inline MDX links), with author name as `data-umami-event-link-text`.

## Related Issue

Fixes INTORG-709 

## Manual Test

1. Open a **foundation** blog post that has tags; confirm tag links still work.
2. In devtools (or Umami), confirm clicks emit expected `data-umami-event` values (e.g. `blog_post:cta:tag_<tag>`).
3. Open a **developers** blog post with `author_urls`; click the author name; confirm events match `developer_post:link:<derived destination>` pattern and link text matches the byline.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)