### PR TITLE
refactor(cms-mdx): convert parser and block handlers to errors-as-values [INTORG-714]

### DIFF
--- a/cms/scripts/migrate-blog-to-components.ts
+++ b/cms/scripts/migrate-blog-to-components.ts
@@ -86,6 +86,8 @@ async function main() {
     try {
       const blocks = await parseMdxToBlocks(body, { ...ctx, sourceText: body })
 
+      if (blocks instanceof Error) throw blocks
+
       if (blocks.length === 0) {
         console.log(`   ⏭️  ${file} — no blocks produced, skipping`)
         skipped++

--- a/cms/scripts/sync-mdx/ambassadorHandler.test.ts
+++ b/cms/scripts/sync-mdx/ambassadorHandler.test.ts
@@ -155,10 +155,10 @@ describe('Ambassador handler', () => {
     ])
   })
 
-  it('throws MISSING_REQUIRED_PROP when pathSlug is missing', async () => {
-    await expect(
-      parseMdxToBlocks('<Ambassador />', ctxWith({}))
-    ).rejects.toMatchObject({
+  it('returns MISSING_REQUIRED_PROP when pathSlug is missing', async () => {
+    const result = await parseMdxToBlocks('<Ambassador />', ctxWith({}))
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
       code: ParserErrorCode.MISSING_REQUIRED_PROP
     })
   })
@@ -208,10 +208,13 @@ describe('AmbassadorGrid handler', () => {
     expect(blocks[0]).not.toHaveProperty('heading')
   })
 
-  it('throws MISSING_REQUIRED_PROP when both pathSlugs and category are missing', async () => {
-    await expect(
-      parseMdxToBlocks('<AmbassadorGrid heading="Team" />', ctxWith({}))
-    ).rejects.toMatchObject({
+  it('returns MISSING_REQUIRED_PROP when both pathSlugs and category are missing', async () => {
+    const result = await parseMdxToBlocks(
+      '<AmbassadorGrid heading="Team" />',
+      ctxWith({})
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
       code: ParserErrorCode.MISSING_REQUIRED_PROP
     })
   })
@@ -244,13 +247,13 @@ describe('AmbassadorGrid handler', () => {
     expect(blocks[0]).not.toHaveProperty('heading')
   })
 
-  it('throws UNRESOLVED_RELATION when any pathSlug is unresolved', async () => {
-    await expect(
-      parseMdxToBlocks(
-        '<AmbassadorGrid pathSlugs={["alice","ghost"]} />',
-        ctxWith({ alice: 'doc-alice' })
-      )
-    ).rejects.toMatchObject({
+  it('returns UNRESOLVED_RELATION when any pathSlug is unresolved', async () => {
+    const result = await parseMdxToBlocks(
+      '<AmbassadorGrid pathSlugs={["alice","ghost"]} />',
+      ctxWith({ alice: 'doc-alice' })
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
       code: ParserErrorCode.UNRESOLVED_RELATION
     })
   })

--- a/cms/scripts/sync-mdx/ambassadorHandler.ts
+++ b/cms/scripts/sync-mdx/ambassadorHandler.ts
@@ -16,7 +16,11 @@ import type {
   AmbassadorBlock,
   AmbassadorsGridBlock
 } from './types.blocks'
-import { MdxParserError, ParserErrorCode } from './parserErrors'
+import {
+  MdxParserError,
+  ParserErrorCode,
+  tryCatchParserError
+} from './parserErrors'
 import { getStringAttr, getStringArrayAttr } from './jsxExtract'
 import { registerComponentHandler, type ParserContext } from './mdxBlockParser'
 
@@ -33,7 +37,8 @@ import { registerComponentHandler, type ParserContext } from './mdxBlockParser'
  * 3. Throw UNRESOLVED_RELATION if neither found
  *
  * The returned function matches the `resolveRelation` signature on
- * ParserContext so it can be plugged in directly.
+ * ParserContext so it can be plugged in directly. Throws are caught at
+ * the handler boundary by `tryCatchParserError` and returned as values.
  */
 export function createRelationResolver(
   strapi: StrapiClient,
@@ -62,17 +67,19 @@ export function createRelationResolver(
 async function handleAmbassador(
   node: JsxBlockNode,
   ctx: ParserContext
-): Promise<ParsedBlock[]> {
-  const pathSlug = getStringAttr(node, 'pathSlug', { required: true })
+): Promise<ParsedBlock[] | MdxParserError> {
+  return tryCatchParserError(async () => {
+    const pathSlug = getStringAttr(node, 'pathSlug', { required: true })
 
-  const { documentId } = await ctx.resolveRelation!('ambassadors', pathSlug)
+    const { documentId } = await ctx.resolveRelation!('ambassadors', pathSlug)
 
-  const block: AmbassadorBlock = {
-    __component: 'blocks.ambassador',
-    ambassador: { connect: [{ documentId }] }
-  }
+    const block: AmbassadorBlock = {
+      __component: 'blocks.ambassador',
+      ambassador: { connect: [{ documentId }] }
+    }
 
-  return [block]
+    return [block]
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -82,36 +89,40 @@ async function handleAmbassador(
 async function handleAmbassadorGrid(
   node: JsxBlockNode,
   ctx: ParserContext
-): Promise<ParsedBlock[]> {
-  const heading = getStringAttr(node, 'heading')
-  const pathSlugs = getStringArrayAttr(node, 'pathSlugs')
-  const category = getStringAttr(node, 'category')
+): Promise<ParsedBlock[] | MdxParserError> {
+  return tryCatchParserError(async () => {
+    const heading = getStringAttr(node, 'heading')
+    const pathSlugs = getStringArrayAttr(node, 'pathSlugs')
+    const category = getStringAttr(node, 'category')
 
-  if (!pathSlugs && !category) {
-    throw new MdxParserError({
-      code: ParserErrorCode.MISSING_REQUIRED_PROP,
-      message: 'AmbassadorGrid requires either "pathSlugs" or "category".'
-    })
-  }
+    if (!pathSlugs && !category) {
+      throw new MdxParserError({
+        code: ParserErrorCode.MISSING_REQUIRED_PROP,
+        message: 'AmbassadorGrid requires either "pathSlugs" or "category".'
+      })
+    }
 
-  const block: AmbassadorsGridBlock = {
-    __component: 'blocks.ambassadors-grid'
-  }
+    const block: AmbassadorsGridBlock = {
+      __component: 'blocks.ambassadors-grid'
+    }
 
-  if (heading !== undefined) {
-    block.heading = heading
-  }
-  if (category !== undefined) {
-    block.category = category
-  }
-  if (pathSlugs && pathSlugs.length > 0) {
-    const resolved = await Promise.all(
-      pathSlugs.map((pathSlug) => ctx.resolveRelation!('ambassadors', pathSlug))
-    )
-    block.ambassadors = { connect: resolved }
-  }
+    if (heading !== undefined) {
+      block.heading = heading
+    }
+    if (category !== undefined) {
+      block.category = category
+    }
+    if (pathSlugs && pathSlugs.length > 0) {
+      const resolved = await Promise.all(
+        pathSlugs.map((pathSlug) =>
+          ctx.resolveRelation!('ambassadors', pathSlug)
+        )
+      )
+      block.ambassadors = { connect: resolved }
+    }
 
-  return [block]
+    return [block]
+  })
 }
 
 // ---------------------------------------------------------------------------

--- a/cms/scripts/sync-mdx/blockquoteHandler.test.ts
+++ b/cms/scripts/sync-mdx/blockquoteHandler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { parseMdxToBlocks, type ParserContext } from './mdxBlockParser'
-import { ParserErrorCode } from './parserErrors'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
 
 // Side-effect import: registers Blockquote handler
 import './blockquoteHandler'
@@ -109,20 +109,16 @@ describe('Blockquote handler', () => {
     expect(quote).toContain('<strong>strong</strong>')
   })
 
-  it('throws when children are empty (self-closing)', async () => {
-    await expect(
-      parseMdxToBlocks('<Blockquote source="Author" />', ctx)
-    ).rejects.toMatchObject({
-      code: ParserErrorCode.INVALID_PROP_VALUE
-    })
+  it('returns INVALID_PROP_VALUE when children are empty (self-closing)', async () => {
+    const result = await parseMdxToBlocks('<Blockquote source="Author" />', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
   })
 
-  it('throws when children are empty (open/close with no content)', async () => {
-    await expect(
-      parseMdxToBlocks('<Blockquote></Blockquote>', ctx)
-    ).rejects.toMatchObject({
-      code: ParserErrorCode.INVALID_PROP_VALUE
-    })
+  it('returns INVALID_PROP_VALUE when children are empty (open/close with no content)', async () => {
+    const result = await parseMdxToBlocks('<Blockquote></Blockquote>', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
   })
 })
 

--- a/cms/scripts/sync-mdx/blockquoteHandler.ts
+++ b/cms/scripts/sync-mdx/blockquoteHandler.ts
@@ -16,39 +16,45 @@ import {
   type JsxBlockNode,
   type ParserContext
 } from './mdxBlockParser'
-import { MdxParserError, ParserErrorCode } from './parserErrors'
+import {
+  MdxParserError,
+  ParserErrorCode,
+  tryCatchParserError
+} from './parserErrors'
 
 async function handleBlockquote(
   node: JsxBlockNode,
   _ctx: ParserContext
-): Promise<ParsedBlock[]> {
-  const source = getStringAttr(node, 'source')
+): Promise<ParsedBlock[] | MdxParserError> {
+  return tryCatchParserError(() => {
+    const source = getStringAttr(node, 'source')
 
-  const quote =
-    node.children.length > 0 ? childrenToMarkdown(node.children) : ''
+    const quote =
+      node.children.length > 0 ? childrenToMarkdown(node.children) : ''
 
-  if (!quote) {
-    throw new MdxParserError({
-      code: ParserErrorCode.INVALID_PROP_VALUE,
-      message:
-        'Blockquote requires non-empty children content for the quote field.',
-      component: 'Blockquote',
-      prop: 'children',
-      line: node.position?.start.line,
-      column: node.position?.start.column
-    })
-  }
+    if (!quote) {
+      throw new MdxParserError({
+        code: ParserErrorCode.INVALID_PROP_VALUE,
+        message:
+          'Blockquote requires non-empty children content for the quote field.',
+        component: 'Blockquote',
+        prop: 'children',
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
 
-  const block: BlockquoteBlock = {
-    __component: 'blocks.blockquote',
-    quote
-  }
+    const block: BlockquoteBlock = {
+      __component: 'blocks.blockquote',
+      quote
+    }
 
-  if (source !== undefined) {
-    block.source = source
-  }
+    if (source !== undefined) {
+      block.source = source
+    }
 
-  return [block]
+    return [block]
+  })
 }
 
 registerComponentHandler('Blockquote', handleBlockquote)

--- a/cms/scripts/sync-mdx/calloutTextHandler.test.ts
+++ b/cms/scripts/sync-mdx/calloutTextHandler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { parseMdxToBlocks, type ParserContext } from './mdxBlockParser'
-import { ParserErrorCode } from './parserErrors'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
 
 // Side-effect import: registers CalloutText handler
 import './calloutTextHandler'
@@ -83,20 +83,16 @@ describe('CalloutText handler', () => {
     expect(content).toContain('<strong>strong</strong>')
   })
 
-  it('throws when children are empty (self-closing)', async () => {
-    await expect(
-      parseMdxToBlocks('<CalloutText />', ctx)
-    ).rejects.toMatchObject({
-      code: ParserErrorCode.INVALID_PROP_VALUE
-    })
+  it('returns INVALID_PROP_VALUE when children are empty (self-closing)', async () => {
+    const result = await parseMdxToBlocks('<CalloutText />', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
   })
 
-  it('throws when children are empty (open/close with no content)', async () => {
-    await expect(
-      parseMdxToBlocks('<CalloutText></CalloutText>', ctx)
-    ).rejects.toMatchObject({
-      code: ParserErrorCode.INVALID_PROP_VALUE
-    })
+  it('returns INVALID_PROP_VALUE when children are empty (open/close with no content)', async () => {
+    const result = await parseMdxToBlocks('<CalloutText></CalloutText>', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
   })
 })
 

--- a/cms/scripts/sync-mdx/calloutTextHandler.ts
+++ b/cms/scripts/sync-mdx/calloutTextHandler.ts
@@ -14,32 +14,38 @@ import {
   type JsxBlockNode,
   type ParserContext
 } from './mdxBlockParser'
-import { MdxParserError, ParserErrorCode } from './parserErrors'
+import {
+  MdxParserError,
+  ParserErrorCode,
+  tryCatchParserError
+} from './parserErrors'
 
 async function handleCalloutText(
   node: JsxBlockNode,
   _ctx: ParserContext
-): Promise<ParsedBlock[]> {
-  const content =
-    node.children.length > 0 ? childrenToMarkdown(node.children) : ''
+): Promise<ParsedBlock[] | MdxParserError> {
+  return tryCatchParserError(() => {
+    const content =
+      node.children.length > 0 ? childrenToMarkdown(node.children) : ''
 
-  if (!content) {
-    throw new MdxParserError({
-      code: ParserErrorCode.INVALID_PROP_VALUE,
-      message: 'CalloutText requires non-empty children content.',
-      component: 'CalloutText',
-      prop: 'children',
-      line: node.position?.start.line,
-      column: node.position?.start.column
-    })
-  }
+    if (!content) {
+      throw new MdxParserError({
+        code: ParserErrorCode.INVALID_PROP_VALUE,
+        message: 'CalloutText requires non-empty children content.',
+        component: 'CalloutText',
+        prop: 'children',
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
 
-  const block: CalloutTextBlock = {
-    __component: 'blocks.callout-text',
-    content
-  }
+    const block: CalloutTextBlock = {
+      __component: 'blocks.callout-text',
+      content
+    }
 
-  return [block]
+    return [block]
+  })
 }
 
 registerComponentHandler('CalloutText', handleCalloutText)

--- a/cms/scripts/sync-mdx/mdxBlockParser.test.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.test.ts
@@ -18,79 +18,51 @@ describe('parseMdxToBlocks', () => {
     expect(await parseMdxToBlocks('   \n\n  ', ctx)).toEqual([])
   })
 
-  it('throws MdxParserError for malformed MDX', async () => {
+  it('returns MdxParserError for malformed MDX', async () => {
     // Unclosed JSX tag that remark-mdx cannot parse
-    await expect(parseMdxToBlocks('<Broken attr={>', ctx)).rejects.toThrow(
-      MdxParserError
-    )
-
-    await expect(
-      parseMdxToBlocks('<Broken attr={>', ctx)
-    ).rejects.toMatchObject({ code: ParserErrorCode.MDX_PARSE_ERROR })
+    const result = await parseMdxToBlocks('<Broken attr={>', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.MDX_PARSE_ERROR })
   })
 
-  it('throws UNSUPPORTED_COMPONENT for unregistered JSX', async () => {
-    await expect(
-      parseMdxToBlocks('<UnknownWidget foo="bar" />', ctx)
-    ).rejects.toThrow(MdxParserError)
-
-    await expect(
-      parseMdxToBlocks('<UnknownWidget foo="bar" />', ctx)
-    ).rejects.toMatchObject({
+  it('returns UNSUPPORTED_COMPONENT for unregistered JSX', async () => {
+    const result = await parseMdxToBlocks('<UnknownWidget foo="bar" />', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
       code: ParserErrorCode.UNSUPPORTED_COMPONENT,
       component: 'UnknownWidget'
     })
   })
 
-  it('throws DYNAMIC_EXPRESSION for bare top-level expressions', async () => {
+  it('returns DYNAMIC_EXPRESSION for bare top-level expressions', async () => {
     // {someVariable} becomes mdxFlowExpression in the AST
-    await expect(parseMdxToBlocks('{someVariable}', ctx)).rejects.toThrow(
-      MdxParserError
-    )
-
-    await expect(parseMdxToBlocks('{someVariable}', ctx)).rejects.toMatchObject(
-      {
-        code: ParserErrorCode.DYNAMIC_EXPRESSION
-      }
-    )
+    const result = await parseMdxToBlocks('{someVariable}', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
   })
 
-  it('throws DYNAMIC_EXPRESSION for arrow function expressions', async () => {
-    await expect(
-      parseMdxToBlocks('{() => doSomething()}', ctx)
-    ).rejects.toMatchObject({
-      code: ParserErrorCode.DYNAMIC_EXPRESSION
-    })
+  it('returns DYNAMIC_EXPRESSION for arrow function expressions', async () => {
+    const result = await parseMdxToBlocks('{() => doSomething()}', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
   })
 
-  it('throws DYNAMIC_EXPRESSION for import statements', async () => {
-    await expect(
-      parseMdxToBlocks('import { foo } from "bar"', ctx)
-    ).rejects.toThrow(MdxParserError)
-
-    await expect(
-      parseMdxToBlocks('import { foo } from "bar"', ctx)
-    ).rejects.toMatchObject({
-      code: ParserErrorCode.DYNAMIC_EXPRESSION
-    })
+  it('returns DYNAMIC_EXPRESSION for import statements', async () => {
+    const result = await parseMdxToBlocks('import { foo } from "bar"', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
   })
 
-  it('throws DYNAMIC_EXPRESSION for export statements', async () => {
-    await expect(
-      parseMdxToBlocks('export const x = 1', ctx)
-    ).rejects.toMatchObject({
-      code: ParserErrorCode.DYNAMIC_EXPRESSION
-    })
+  it('returns DYNAMIC_EXPRESSION for export statements', async () => {
+    const result = await parseMdxToBlocks('export const x = 1', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
   })
 
-  it('throws UNSUPPORTED_COMPONENT for JSX fragments', async () => {
-    await expect(parseMdxToBlocks('<>\n  content\n</>', ctx)).rejects.toThrow(
-      MdxParserError
-    )
-
-    await expect(
-      parseMdxToBlocks('<>\n  content\n</>', ctx)
-    ).rejects.toMatchObject({
+  it('returns UNSUPPORTED_COMPONENT for JSX fragments', async () => {
+    const result = await parseMdxToBlocks('<>\n  content\n</>', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
       code: ParserErrorCode.UNSUPPORTED_COMPONENT
     })
   })

--- a/cms/scripts/sync-mdx/mdxBlockParser.ts
+++ b/cms/scripts/sync-mdx/mdxBlockParser.ts
@@ -9,7 +9,8 @@
  * Design:
  * - AST-first: parse once, walk once, map each node to a block handler.
  * - Strict: unsupported JSX, dynamic expressions, and missing required
- *   props produce hard errors via `MdxParserError`.
+ *   props produce hard errors via `MdxParserError`, surfaced as a returned
+ *   value (errors-as-values, see CLAUDE.md "Errors as Values").
  * - Extensible: component handlers are registered in `COMPONENT_HANDLERS`
  *   and new components only need a handler function + type entry.
  */
@@ -40,7 +41,9 @@ export type JsxBlockNode = MdxJsxFlowElement | MdxJsxTextElement
  * Handler for a single JSX component.
  *
  * Receives the AST node and an opaque context (for relation resolution
- * etc.) and returns one or more block payloads.
+ * etc.) and returns one or more block payloads, or an `MdxParserError`
+ * if the input fails validation. Handlers do not throw `MdxParserError`
+ * to their caller; they catch their own internal throws and return them.
  *
  * Handlers are async to support relation lookups (e.g. ambassador pathSlug
  * resolution).
@@ -48,7 +51,7 @@ export type JsxBlockNode = MdxJsxFlowElement | MdxJsxTextElement
 export type ComponentHandler = (
   node: JsxBlockNode,
   ctx: ParserContext
-) => Promise<ParsedBlock[]>
+) => Promise<ParsedBlock[] | MdxParserError>
 
 /**
  * Context passed to component handlers during parsing.
@@ -136,31 +139,28 @@ function unwrapTextElement(
  * Parse an MDX body string into an ordered array of Strapi dynamic-zone
  * block payloads.
  *
+ * Returns `MdxParserError` instead of throwing on irrecoverable issues
+ * (unsupported JSX, bad props, parse errors). Callers narrow with
+ * `instanceof MdxParserError` before consuming the result.
+ *
  * @example
  * ```ts
- * // Given MDX body:
- * //   <Ambassador pathSlug="caroline-sinders" />
- * //   <AmbassadorGrid heading="Our Team" pathSlugs={["alice","bob"]} />
- * //
- * // Returns (once handlers are registered):
- * // [
- * //   { __component: 'blocks.ambassador', ambassador: { documentId: '...' }},
- * //   { __component: 'blocks.ambassadors-grid', heading: 'Our Team', ambassadors: [...] }
- * // ]
- *
- * const blocks = await parseMdxToBlocks(mdxBody, { locale: 'en' })
+ * const result = await parseMdxToBlocks(mdxBody, { locale: 'en' })
+ * if (result instanceof MdxParserError) {
+ *   // handle parse failure
+ *   return
+ * }
+ * // result is ParsedBlock[]
  * ```
  *
  * @param mdxBody - Raw MDX body content (no frontmatter)
  * @param ctx - Parser context (locale, services, etc.)
- * @returns Ordered array of block payloads ready for Strapi import
- *
- * @throws {MdxParserError} on unsupported JSX, bad props, parse errors
+ * @returns Ordered array of block payloads, or `MdxParserError` on failure
  */
 export async function parseMdxToBlocks(
   mdxBody: string,
   ctx: ParserContext
-): Promise<ParsedBlock[]> {
+): Promise<ParsedBlock[] | MdxParserError> {
   if (!mdxBody.trim()) return []
 
   // Parse MDX into AST.
@@ -172,7 +172,7 @@ export async function parseMdxToBlocks(
   try {
     tree = unified().use(remarkParse).use(remarkMdx).parse(mdxBody)
   } catch (err) {
-    throw new MdxParserError({
+    return new MdxParserError({
       code: ParserErrorCode.MDX_PARSE_ERROR,
       message: `Failed to parse MDX: ${err instanceof Error ? err.message : String(err)}`
     })
@@ -209,7 +209,7 @@ export async function parseMdxToBlocks(
       const componentName = jsxNode.name
 
       if (!componentName) {
-        throw new MdxParserError({
+        return new MdxParserError({
           code: ParserErrorCode.UNSUPPORTED_COMPONENT,
           message:
             'Encountered a JSX fragment (<>...</>). Fragments are not supported.',
@@ -220,7 +220,7 @@ export async function parseMdxToBlocks(
 
       const handler = COMPONENT_HANDLERS[componentName]
       if (!handler) {
-        throw new MdxParserError({
+        return new MdxParserError({
           code: ParserErrorCode.UNSUPPORTED_COMPONENT,
           message: `Unsupported JSX component "${componentName}".`,
           component: componentName,
@@ -230,6 +230,7 @@ export async function parseMdxToBlocks(
       }
 
       const result = await handler(jsxNode, ctx)
+      if (result instanceof MdxParserError) return result
       blocks.push(...result)
       // Skip to next node — don't let handled JSX fall through to
       // the markdown fallback which would double-emit the source text.
@@ -241,7 +242,7 @@ export async function parseMdxToBlocks(
       node.type === 'mdxTextExpression'
     ) {
       const expr = node as { value?: string; position?: Root['position'] }
-      throw new MdxParserError({
+      return new MdxParserError({
         code: ParserErrorCode.DYNAMIC_EXPRESSION,
         message: `Top-level expression "{${expr.value ?? '...'}}" is not supported.`,
         line: node.position?.start.line,
@@ -253,7 +254,7 @@ export async function parseMdxToBlocks(
     // pipeline is converted to Strapi blocks, not executed as JS modules.
     if (node.type === 'mdxjsEsm') {
       const esm = node as { value?: string; position?: Root['position'] }
-      throw new MdxParserError({
+      return new MdxParserError({
         code: ParserErrorCode.DYNAMIC_EXPRESSION,
         message: `Import/export statements are not supported: "${esm.value ?? '...'}"`,
         line: node.position?.start.line,

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -241,26 +241,24 @@ export async function buildPagePayload(
   if (mdxBody.length > 0) {
     if (parserCtx) {
       // Parse MDX body into structured dynamic-zone blocks.
-      // Parser errors (unsupported JSX, missing props, unresolved relations)
-      // are intentional hard failures — re-thrown with file context.
-      try {
-        data.content = await parseMdxToBlocks(mdxBody, {
-          ...parserCtx,
-          sourceText: mdxBody
+      // Parser errors are returned as `MdxParserError` values; we re-throw
+      // them here with file context so the existing pipeline-level handlers
+      // (sub #3 will refactor those to errors-as-values too) catch them.
+      const parsed = await parseMdxToBlocks(mdxBody, {
+        ...parserCtx,
+        sourceText: mdxBody
+      })
+      if (parsed instanceof MdxParserError) {
+        throw new MdxParserError({
+          code: parsed.code,
+          message: `[${mdx.pathSlug}] ${parsed.message}`,
+          component: parsed.component,
+          prop: parsed.prop,
+          line: parsed.line,
+          column: parsed.column
         })
-      } catch (err) {
-        if (err instanceof MdxParserError) {
-          throw new MdxParserError({
-            code: err.code,
-            message: `[${mdx.pathSlug}] ${err.message}`,
-            component: err.component,
-            prop: err.prop,
-            line: err.line,
-            column: err.column
-          })
-        }
-        throw err
       }
+      data.content = parsed
     } else {
       // Fallback: store entire body as a single paragraph block
       data.content = [
@@ -477,24 +475,21 @@ export async function buildBlogPayload(
   const mdxBody = (mdx.content || '').trim()
   let content: unknown
   if (parserCtx && mdxBody.length > 0) {
-    try {
-      content = await parseMdxToBlocks(mdxBody, {
-        ...parserCtx,
-        sourceText: mdxBody
+    const parsed = await parseMdxToBlocks(mdxBody, {
+      ...parserCtx,
+      sourceText: mdxBody
+    })
+    if (parsed instanceof MdxParserError) {
+      throw new MdxParserError({
+        code: parsed.code,
+        message: `[${mdx.pathSlug}] ${parsed.message}`,
+        component: parsed.component,
+        prop: parsed.prop,
+        line: parsed.line,
+        column: parsed.column
       })
-    } catch (err) {
-      if (err instanceof MdxParserError) {
-        throw new MdxParserError({
-          code: err.code,
-          message: `[${mdx.pathSlug}] ${err.message}`,
-          component: err.component,
-          prop: err.prop,
-          line: err.line,
-          column: err.column
-        })
-      }
-      throw err
     }
+    content = parsed
   } else {
     content = normalizeInlineImages(mdxBody)
   }

--- a/cms/scripts/sync-mdx/paragraphHandler.test.ts
+++ b/cms/scripts/sync-mdx/paragraphHandler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { parseMdxToBlocks, type ParserContext } from './mdxBlockParser'
-import { ParserErrorCode } from './parserErrors'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
 
 // Side-effect imports: register handlers
 import './paragraphHandler'
@@ -75,22 +75,22 @@ describe('Paragraph handler', () => {
     expect(blocks[0]).not.toHaveProperty('alignment')
   })
 
-  it('throws when children are empty (self-closing)', async () => {
-    await expect(parseMdxToBlocks('<Paragraph />', ctx)).rejects.toMatchObject({
-      code: ParserErrorCode.INVALID_PROP_VALUE
-    })
+  it('returns INVALID_PROP_VALUE when children are empty (self-closing)', async () => {
+    const result = await parseMdxToBlocks('<Paragraph />', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
   })
 
-  it('throws when children are empty (open/close with no content)', async () => {
-    await expect(
-      parseMdxToBlocks('<Paragraph></Paragraph>', ctx)
-    ).rejects.toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
+  it('returns INVALID_PROP_VALUE when children are empty (open/close with no content)', async () => {
+    const result = await parseMdxToBlocks('<Paragraph></Paragraph>', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
   })
 
-  it('throws when content prop is an empty string', async () => {
-    await expect(
-      parseMdxToBlocks('<Paragraph content="" />', ctx)
-    ).rejects.toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
+  it('returns INVALID_PROP_VALUE when content prop is an empty string', async () => {
+    const result = await parseMdxToBlocks('<Paragraph content="" />', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
   })
 })
 
@@ -213,7 +213,7 @@ describe('Paragraph handler — rich markdown content', () => {
 // ---------------------------------------------------------------------------
 
 describe('Paragraph handler — nested JSX guard', () => {
-  it('throws on nested flow JSX element', async () => {
+  it('returns NESTED_JSX on nested flow JSX element', async () => {
     const mdx = [
       '<Paragraph>',
       'Some text.',
@@ -223,20 +223,24 @@ describe('Paragraph handler — nested JSX guard', () => {
       '</Paragraph>'
     ].join('\n')
 
-    await expect(parseMdxToBlocks(mdx, ctx)).rejects.toMatchObject({
+    const result = await parseMdxToBlocks(mdx, ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
       code: ParserErrorCode.NESTED_JSX,
       message: expect.stringContaining('<Blockquote>')
     })
   })
 
-  it('throws on nested text JSX element', async () => {
+  it('returns NESTED_JSX on nested text JSX element', async () => {
     const mdx = [
       '<Paragraph>',
       'Text before <CalloutText content="notice" /> text after.',
       '</Paragraph>'
     ].join('\n')
 
-    await expect(parseMdxToBlocks(mdx, ctx)).rejects.toMatchObject({
+    const result = await parseMdxToBlocks(mdx, ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
       code: ParserErrorCode.NESTED_JSX,
       message: expect.stringContaining('<CalloutText>')
     })

--- a/cms/scripts/sync-mdx/paragraphHandler.ts
+++ b/cms/scripts/sync-mdx/paragraphHandler.ts
@@ -17,7 +17,11 @@ import {
   type JsxBlockNode,
   type ParserContext
 } from './mdxBlockParser'
-import { MdxParserError, ParserErrorCode } from './parserErrors'
+import {
+  MdxParserError,
+  ParserErrorCode,
+  tryCatchParserError
+} from './parserErrors'
 
 /**
  * Walk AST children looking for nested JSX elements (flow or text).
@@ -86,49 +90,51 @@ function extractChildrenContent(
 async function handleParagraph(
   node: JsxBlockNode,
   ctx: ParserContext
-): Promise<ParsedBlock[]> {
-  // Prefer content prop if present: <Paragraph content="..." />
-  const contentAttr = getStringAttr(node, 'content')
+): Promise<ParsedBlock[] | MdxParserError> {
+  return tryCatchParserError(() => {
+    // Prefer content prop if present: <Paragraph content="..." />
+    const contentAttr = getStringAttr(node, 'content')
 
-  let content: string
-  if (contentAttr !== undefined) {
-    content = contentAttr
-  } else {
-    // Extract from children: <Paragraph>...children...</Paragraph>
-    const children = node.children
+    let content: string
+    if (contentAttr !== undefined) {
+      content = contentAttr
+    } else {
+      // Extract from children: <Paragraph>...children...</Paragraph>
+      const children = node.children
 
-    // Guard: detect nested JSX before extracting content
-    if (children && children.length > 0) {
-      const nestedJsx = findNestedJsx(children)
-      if (nestedJsx) {
-        throw new MdxParserError({
-          code: ParserErrorCode.NESTED_JSX,
-          message: `Paragraph contains nested JSX component \`<${nestedJsx.name}>\` at line ${nestedJsx.line ?? '?'}. Move it to a top-level sibling, or wrap it in a code block if it's meant to be literal text.`,
-          component: 'Paragraph',
-          line: nestedJsx.line,
-          column: nestedJsx.column
-        })
+      // Guard: detect nested JSX before extracting content
+      if (children && children.length > 0) {
+        const nestedJsx = findNestedJsx(children)
+        if (nestedJsx) {
+          throw new MdxParserError({
+            code: ParserErrorCode.NESTED_JSX,
+            message: `Paragraph contains nested JSX component \`<${nestedJsx.name}>\` at line ${nestedJsx.line ?? '?'}. Move it to a top-level sibling, or wrap it in a code block if it's meant to be literal text.`,
+            component: 'Paragraph',
+            line: nestedJsx.line,
+            column: nestedJsx.column
+          })
+        }
       }
+
+      // Prefer raw source slicing when available to avoid lossy AST
+      // re-serialization (HTML entity decoding, bracket escaping).
+      content = extractChildrenContent(children, ctx) ?? ''
     }
 
-    // Prefer raw source slicing when available to avoid lossy AST
-    // re-serialization (HTML entity decoding, bracket escaping).
-    content = extractChildrenContent(children, ctx) ?? ''
-  }
+    if (!content) {
+      throw new MdxParserError({
+        code: ParserErrorCode.INVALID_PROP_VALUE,
+        message:
+          'Paragraph requires non-empty content. Strapi blocks.paragraph has content as required.',
+        component: 'Paragraph',
+        prop: 'content',
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
 
-  if (!content) {
-    throw new MdxParserError({
-      code: ParserErrorCode.INVALID_PROP_VALUE,
-      message:
-        'Paragraph requires non-empty content. Strapi blocks.paragraph has content as required.',
-      component: 'Paragraph',
-      prop: 'content',
-      line: node.position?.start.line,
-      column: node.position?.start.column
-    })
-  }
-
-  return [buildParagraphBlock(node, content)]
+    return [buildParagraphBlock(node, content)]
+  })
 }
 
 function buildParagraphBlock(

--- a/cms/scripts/sync-mdx/parserErrors.test.ts
+++ b/cms/scripts/sync-mdx/parserErrors.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { MdxParserError, ParserErrorCode } from './parserErrors'
+import {
+  MdxParserError,
+  ParserErrorCode,
+  tryCatchParserError
+} from './parserErrors'
 
 describe('MdxParserError', () => {
   it('sets code, message, and component', () => {
@@ -53,5 +57,36 @@ describe('MdxParserError', () => {
     expect(ParserErrorCode.MDX_PARSE_ERROR).toBe('MDX_PARSE_ERROR')
     expect(ParserErrorCode.UNRESOLVED_RELATION).toBe('UNRESOLVED_RELATION')
     expect(ParserErrorCode.CONFLICTING_PROPS).toBe('CONFLICTING_PROPS')
+  })
+})
+
+describe('tryCatchParserError', () => {
+  it('returns the resolved value when the function succeeds', async () => {
+    const result = await tryCatchParserError(async () => 'ok')
+    expect(result).toBe('ok')
+  })
+
+  it('returns the thrown MdxParserError instead of rejecting', async () => {
+    const boom = new MdxParserError({
+      code: ParserErrorCode.UNSUPPORTED_COMPONENT,
+      message: 'boom'
+    })
+    const result = await tryCatchParserError(async () => {
+      throw boom
+    })
+    expect(result).toBe(boom)
+  })
+
+  it('lets non-MdxParserError throws propagate', async () => {
+    await expect(
+      tryCatchParserError(async () => {
+        throw new Error('network down')
+      })
+    ).rejects.toThrow('network down')
+  })
+
+  it('handles synchronous functions', async () => {
+    const result = await tryCatchParserError(() => 42)
+    expect(result).toBe(42)
   })
 })

--- a/cms/scripts/sync-mdx/parserErrors.ts
+++ b/cms/scripts/sync-mdx/parserErrors.ts
@@ -59,9 +59,8 @@ export interface ParserErrorContext {
 }
 
 /**
- * Thrown by the MDX block parser on any irrecoverable issue.
- *
- * Callers should catch this at the pipeline boundary and surface
+ * Returned by the MDX block parser and block handlers on any irrecoverable
+ * parsing issue. Callers narrow with `instanceof MdxParserError` and surface
  * the structured context for debugging.
  */
 export class MdxParserError extends Error {
@@ -83,5 +82,29 @@ export class MdxParserError extends Error {
     this.prop = ctx.prop
     this.line = ctx.line
     this.column = ctx.column
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Run an async fn and convert thrown `MdxParserError` into a returned value.
+ * Other thrown values (network, programmer bugs) propagate so the caller
+ * can decide how to surface them.
+ *
+ * Companion to `tryCatchAsync` in `cms/src/utils/tryCatch.ts`, narrowed to
+ * `MdxParserError` so handler/parser return types stay precisely typed
+ * as `T | MdxParserError` rather than the broader `T | Error`.
+ */
+export async function tryCatchParserError<T>(
+  fn: () => T | Promise<T>
+): Promise<T | MdxParserError> {
+  try {
+    return await fn()
+  } catch (err) {
+    if (err instanceof MdxParserError) return err
+    throw err
   }
 }

--- a/cms/scripts/sync-mdx/pdfEmbedHandler.test.ts
+++ b/cms/scripts/sync-mdx/pdfEmbedHandler.test.ts
@@ -36,9 +36,13 @@ describe('PdfEmbed handler — not yet registered', () => {
     // Since this test file imports './pdfEmbedHandler' below, we verify the
     // pre-registration state by checking that the handler IS registered after import.
     // The "before" scenario is covered by the UNSUPPORTED_COMPONENT path in mdxBlockParser.
-    await expect(
-      parseMdxToBlocks('<UnknownComponent />', { locale: 'en' })
-    ).rejects.toMatchObject({ code: ParserErrorCode.UNSUPPORTED_COMPONENT })
+    const result = await parseMdxToBlocks('<UnknownComponent />', {
+      locale: 'en'
+    })
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
+      code: ParserErrorCode.UNSUPPORTED_COMPONENT
+    })
   })
 })
 
@@ -139,33 +143,39 @@ describe('PdfEmbed handler — all props present', () => {
 // ---------------------------------------------------------------------------
 
 describe('PdfEmbed handler — errors', () => {
-  it('throws MISSING_REQUIRED_PROP when url is missing', async () => {
-    await expect(
-      parseMdxToBlocks('<PdfEmbed />', ctxWith())
-    ).rejects.toMatchObject({ code: ParserErrorCode.MISSING_REQUIRED_PROP })
+  it('returns MISSING_REQUIRED_PROP when url is missing', async () => {
+    const result = await parseMdxToBlocks('<PdfEmbed />', ctxWith())
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
+      code: ParserErrorCode.MISSING_REQUIRED_PROP
+    })
   })
 
-  it('throws DYNAMIC_EXPRESSION when url is a dynamic expression', async () => {
-    await expect(
-      parseMdxToBlocks('<PdfEmbed url={someVar} />', ctxWith())
-    ).rejects.toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
+  it('returns DYNAMIC_EXPRESSION when url is a dynamic expression', async () => {
+    const result = await parseMdxToBlocks(
+      '<PdfEmbed url={someVar} />',
+      ctxWith()
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
   })
 
-  it('throws UNRESOLVED_RELATION when internal URL is not found in Strapi', async () => {
-    await expect(
-      parseMdxToBlocks(
-        '<PdfEmbed url="/uploads/missing.pdf" />',
-        ctxWith({}) // no entries
-      )
-    ).rejects.toMatchObject({ code: ParserErrorCode.UNRESOLVED_RELATION })
+  it('returns UNRESOLVED_RELATION when internal URL is not found in Strapi', async () => {
+    const result = await parseMdxToBlocks(
+      '<PdfEmbed url="/uploads/missing.pdf" />',
+      ctxWith({}) // no entries
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.UNRESOLVED_RELATION })
   })
 
-  it('throws UNRESOLVED_RELATION when resolveMediaUpload is not in context', async () => {
-    await expect(
-      parseMdxToBlocks('<PdfEmbed url="/uploads/file.pdf" />', {
-        locale: 'en'
-      })
-    ).rejects.toMatchObject({ code: ParserErrorCode.UNRESOLVED_RELATION })
+  it('returns UNRESOLVED_RELATION when resolveMediaUpload is not in context', async () => {
+    const result = await parseMdxToBlocks(
+      '<PdfEmbed url="/uploads/file.pdf" />',
+      { locale: 'en' }
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.UNRESOLVED_RELATION })
   })
 })
 

--- a/cms/scripts/sync-mdx/pdfEmbedHandler.ts
+++ b/cms/scripts/sync-mdx/pdfEmbedHandler.ts
@@ -11,42 +11,48 @@
 
 import type { JsxBlockNode } from './mdxBlockParser'
 import type { ParsedBlock, PdfEmbedBlock } from './types.blocks'
-import { MdxParserError, ParserErrorCode } from './parserErrors'
+import {
+  MdxParserError,
+  ParserErrorCode,
+  tryCatchParserError
+} from './parserErrors'
 import { getStringAttr } from './jsxExtract'
 import { registerComponentHandler, type ParserContext } from './mdxBlockParser'
 
 async function handlePdfEmbed(
   node: JsxBlockNode,
   ctx: ParserContext
-): Promise<ParsedBlock[]> {
-  const url = getStringAttr(node, 'url', { required: true })
-  const label = getStringAttr(node, 'label')
+): Promise<ParsedBlock[] | MdxParserError> {
+  return tryCatchParserError(async () => {
+    const url = getStringAttr(node, 'url', { required: true })
+    const label = getStringAttr(node, 'label')
 
-  const block: PdfEmbedBlock = {
-    __component: 'blocks.pdf-embed',
-    source: url.startsWith('/') ? 'media_library' : 'external_url'
-  }
-
-  if (label !== undefined) {
-    block.label = label
-  }
-
-  if (block.source === 'media_library') {
-    // Internal Strapi media upload — resolve to integer file ID
-    if (!ctx.resolveMediaUpload) {
-      throw new MdxParserError({
-        code: ParserErrorCode.UNRESOLVED_RELATION,
-        message:
-          'resolveMediaUpload is required for internal PdfEmbed URLs but was not provided.',
-        component: 'PdfEmbed'
-      })
+    const block: PdfEmbedBlock = {
+      __component: 'blocks.pdf-embed',
+      source: url.startsWith('/') ? 'media_library' : 'external_url'
     }
-    block.file = await ctx.resolveMediaUpload(url)
-  } else {
-    block.externalUrl = url
-  }
 
-  return [block]
+    if (label !== undefined) {
+      block.label = label
+    }
+
+    if (block.source === 'media_library') {
+      // Internal Strapi media upload — resolve to integer file ID
+      if (!ctx.resolveMediaUpload) {
+        throw new MdxParserError({
+          code: ParserErrorCode.UNRESOLVED_RELATION,
+          message:
+            'resolveMediaUpload is required for internal PdfEmbed URLs but was not provided.',
+          component: 'PdfEmbed'
+        })
+      }
+      block.file = await ctx.resolveMediaUpload(url)
+    } else {
+      block.externalUrl = url
+    }
+
+    return [block]
+  })
 }
 
 // Registration (runs on import)

--- a/cms/scripts/sync-mdx/videoEmbedHandler.test.ts
+++ b/cms/scripts/sync-mdx/videoEmbedHandler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { parseMdxToBlocks } from './mdxBlockParser'
-import { ParserErrorCode } from './parserErrors'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
 
 // Side-effect import: registers VideoEmbed handler
 import './videoEmbedHandler'
@@ -60,34 +60,41 @@ describe('VideoEmbed handler', () => {
 // ---------------------------------------------------------------------------
 
 describe('VideoEmbed handler — errors', () => {
-  it('throws MISSING_REQUIRED_PROP when url is missing', async () => {
-    await expect(
-      parseMdxToBlocks('<VideoEmbed title="No URL" />', ctx)
-    ).rejects.toMatchObject({ code: ParserErrorCode.MISSING_REQUIRED_PROP })
+  it('returns MISSING_REQUIRED_PROP when url is missing', async () => {
+    const result = await parseMdxToBlocks('<VideoEmbed title="No URL" />', ctx)
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
+      code: ParserErrorCode.MISSING_REQUIRED_PROP
+    })
   })
 
-  it('throws MISSING_REQUIRED_PROP when title is missing', async () => {
-    await expect(
-      parseMdxToBlocks(
-        '<VideoEmbed url="https://www.youtube.com/watch?v=abc" />',
-        ctx
-      )
-    ).rejects.toMatchObject({ code: ParserErrorCode.MISSING_REQUIRED_PROP })
+  it('returns MISSING_REQUIRED_PROP when title is missing', async () => {
+    const result = await parseMdxToBlocks(
+      '<VideoEmbed url="https://www.youtube.com/watch?v=abc" />',
+      ctx
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
+      code: ParserErrorCode.MISSING_REQUIRED_PROP
+    })
   })
 
-  it('throws DYNAMIC_EXPRESSION when url is a dynamic expression', async () => {
-    await expect(
-      parseMdxToBlocks('<VideoEmbed url={someVar} title="Test" />', ctx)
-    ).rejects.toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
+  it('returns DYNAMIC_EXPRESSION when url is a dynamic expression', async () => {
+    const result = await parseMdxToBlocks(
+      '<VideoEmbed url={someVar} title="Test" />',
+      ctx
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
   })
 
-  it('throws DYNAMIC_EXPRESSION when title is a dynamic expression', async () => {
-    await expect(
-      parseMdxToBlocks(
-        '<VideoEmbed url="https://youtube.com/watch?v=abc" title={someVar} />',
-        ctx
-      )
-    ).rejects.toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
+  it('returns DYNAMIC_EXPRESSION when title is a dynamic expression', async () => {
+    const result = await parseMdxToBlocks(
+      '<VideoEmbed url="https://youtube.com/watch?v=abc" title={someVar} />',
+      ctx
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
   })
 })
 

--- a/cms/scripts/sync-mdx/videoEmbedHandler.ts
+++ b/cms/scripts/sync-mdx/videoEmbedHandler.ts
@@ -2,21 +2,24 @@ import type { ParsedBlock, VideoEmbedBlock } from './types.blocks'
 import { getStringAttr } from './jsxExtract'
 import { registerComponentHandler, type ParserContext } from './mdxBlockParser'
 import type { JsxBlockNode } from './mdxBlockParser'
+import { MdxParserError, tryCatchParserError } from './parserErrors'
 
 async function handleVideoEmbed(
   node: JsxBlockNode,
   _ctx: ParserContext
-): Promise<ParsedBlock[]> {
-  const url = getStringAttr(node, 'url', { required: true })
-  const title = getStringAttr(node, 'title', { required: true })
+): Promise<ParsedBlock[] | MdxParserError> {
+  return tryCatchParserError(() => {
+    const url = getStringAttr(node, 'url', { required: true })
+    const title = getStringAttr(node, 'title', { required: true })
 
-  const block: VideoEmbedBlock = {
-    __component: 'blocks.video-embed',
-    url,
-    title
-  }
+    const block: VideoEmbedBlock = {
+      __component: 'blocks.video-embed',
+      url,
+      title
+    }
 
-  return [block]
+    return [block]
+  })
 }
 
 registerComponentHandler('VideoEmbed', handleVideoEmbed)


### PR DESCRIPTION
## Summary

Sub #2 of INTORG-614. Converts the MDX parser and the six block handlers to errors-as-values: `parseMdxToBlocks` and each handler now return `T | MdxParserError` instead of throwing. Callers narrow with `instanceof MdxParserError`.

The boundary lives at the handler entry. Internal throws (jsxExtract validators, handler-internal `MdxParserError` construction, downstream `strapiClient` throws) stay as-is and get caught by a small `tryCatchParserError` helper in `parserErrors.ts`. That keeps jsxExtract's 62 inline throws and strapiClient's HTTP throws out of this PR.

What's in the diff:

- New `tryCatchParserError<T>(fn)` helper in [parserErrors.ts](cms/scripts/sync-mdx/parserErrors.ts). Catches `MdxParserError`; lets other throws propagate. Four vitest cases.
- [mdxBlockParser.ts](cms/scripts/sync-mdx/mdxBlockParser.ts): `parseMdxToBlocks` returns `ParsedBlock[] | MdxParserError`. Internal throws on `UNSUPPORTED_COMPONENT`, `MDX_PARSE_ERROR`, `DYNAMIC_EXPRESSION`, fragment all become returns. Handler dispatch narrows on the returned union before pushing blocks.
- Six handlers ([blockquote](cms/scripts/sync-mdx/blockquoteHandler.ts), [callout-text](cms/scripts/sync-mdx/calloutTextHandler.ts), [paragraph](cms/scripts/sync-mdx/paragraphHandler.ts), [video-embed](cms/scripts/sync-mdx/videoEmbedHandler.ts), [pdf-embed](cms/scripts/sync-mdx/pdfEmbedHandler.ts), [ambassador + ambassador-grid](cms/scripts/sync-mdx/ambassadorHandler.ts)): each handler body wrapped in `tryCatchParserError`. Outer signature returns the union; internal throws unchanged.
- [mdxTransformer.ts](cms/scripts/sync-mdx/mdxTransformer.ts) (2 call sites) and [migrate-blog-to-components.ts](cms/scripts/migrate-blog-to-components.ts) (1 call site): narrow on the parser's returned union. The try/catch around parser calls in mdxTransformer is gone.
- Seven test files: `rejects.toMatchObject` becomes `toBeInstanceOf(MdxParserError)` + `toMatchObject`. `createRelationResolver` tests stay as `rejects.toThrow` because the resolver itself still throws (caught at the handler boundary).


## Related Issue

INTORG-714 

## Manual Test

Run the CMS sync test suite:

\`\`\`
pnpm --dir cms test:sync-mdx
\`\`\`


## Checks

- [x] \`pnpm run format\`
- [x] \`pnpm run lint\`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. \`feat: ...\`, \`fix: ...\`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)