### PR TITLE
refactor(cms): convert page lifecycle and validators to errors-as-values [INTORG-716]

### DIFF
--- a/cms/scripts/sync-mdx/validateFrontmatter.test.ts
+++ b/cms/scripts/sync-mdx/validateFrontmatter.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
-import { validateFrontmatter, validateMdxFiles } from './validateFrontmatter'
+import {
+  validateFrontmatter,
+  validateMdxFiles,
+  ValidationError
+} from './validateFrontmatter'
 import type { ContentTypeConfig } from './config'
 import { createMdxFile } from './test-utils'
 
@@ -33,7 +37,7 @@ const summitConfig: ContentTypeConfig = {
 // Validates MDX frontmatter against Zod schemas before syncing to Strapi.
 // Invalid files are skipped during sync to avoid corrupting CMS data.
 describe('validateFrontmatter', () => {
-  it('returns null for valid foundation-pages frontmatter', () => {
+  it('returns the validated MDX file for valid foundation-pages frontmatter', () => {
     const mdx = createMdxFile({
       filepath: '/content/about.mdx',
       pathSlug: 'about-us',
@@ -42,10 +46,10 @@ describe('validateFrontmatter', () => {
 
     const result = validateFrontmatter(foundationConfig, mdx)
 
-    expect(result).toBeNull()
+    expect(result).toBe(mdx)
   })
 
-  it('returns null for valid summit-pages frontmatter', () => {
+  it('returns the validated MDX file for valid summit-pages frontmatter', () => {
     const mdx = createMdxFile({
       filepath: '/content/schedule.mdx',
       pathSlug: 'schedule',
@@ -54,10 +58,10 @@ describe('validateFrontmatter', () => {
 
     const result = validateFrontmatter(summitConfig, mdx)
 
-    expect(result).toBeNull()
+    expect(result).toBe(mdx)
   })
 
-  it('returns error with filepath when title is missing', () => {
+  it('returns ValidationError with filepath when title is missing', () => {
     const mdx = createMdxFile({
       filepath: '/content/invalid.mdx',
       pathSlug: 'invalid'
@@ -65,54 +69,55 @@ describe('validateFrontmatter', () => {
 
     const result = validateFrontmatter(foundationConfig, mdx)
 
-    expect(result).not.toBeNull()
-    expect(result!.filepath).toBe('/content/invalid.mdx')
+    expect(result).toBeInstanceOf(ValidationError)
+    expect((result as ValidationError).filepath).toBe('/content/invalid.mdx')
   })
 
-  it('returns error with slug from mdx file', () => {
+  it('returns ValidationError with slug from mdx file', () => {
     const mdx = createMdxFile({ pathSlug: 'test-slug' })
 
     const result = validateFrontmatter(foundationConfig, mdx)
 
-    expect(result).not.toBeNull()
-    expect(result!.pathSlug).toBe('test-slug')
+    expect(result).toBeInstanceOf(ValidationError)
+    expect((result as ValidationError).pathSlug).toBe('test-slug')
   })
 
-  it('returns error with locale from mdx file', () => {
+  it('returns ValidationError with locale from mdx file', () => {
     const mdx = createMdxFile({ locale: 'es' })
 
     const result = validateFrontmatter(foundationConfig, mdx)
 
-    expect(result).not.toBeNull()
-    expect(result!.locale).toBe('es')
+    expect(result).toBeInstanceOf(ValidationError)
+    expect((result as ValidationError).locale).toBe('es')
   })
 
-  it('returns error array with validation messages', () => {
+  it('returns ValidationError with validation messages', () => {
     const mdx = createMdxFile({})
 
     const result = validateFrontmatter(foundationConfig, mdx)
 
-    expect(result).not.toBeNull()
-    expect(result!.errors.length).toBeGreaterThan(0)
-    expect(result!.errors.some((e) => e.toLowerCase().includes('title'))).toBe(
-      true
-    )
+    expect(result).toBeInstanceOf(ValidationError)
+    const err = result as ValidationError
+    expect(err.errors.length).toBeGreaterThan(0)
+    expect(err.errors.some((e) => e.toLowerCase().includes('title'))).toBe(true)
   })
 
   // Empty string is not the same as missing — Zod's min(1) catches both
-  it('returns error when title is empty string', () => {
+  it('returns ValidationError when title is empty string', () => {
     const mdx = createMdxFile({ frontmatter: { title: '' } })
 
     const result = validateFrontmatter(foundationConfig, mdx)
 
-    expect(result).not.toBeNull()
-    expect(result!.errors.some((e) => e.toLowerCase().includes('title'))).toBe(
-      true
-    )
+    expect(result).toBeInstanceOf(ValidationError)
+    expect(
+      (result as ValidationError).errors.some((e) =>
+        e.toLowerCase().includes('title')
+      )
+    ).toBe(true)
   })
 
   // Slug comes from MDX file metadata, not frontmatter, but we still validate it
-  it('returns error when slug is empty in mdx file', () => {
+  it('returns ValidationError when slug is empty in mdx file', () => {
     const mdx = createMdxFile({
       pathSlug: '',
       frontmatter: { title: 'Valid Title' }
@@ -120,10 +125,12 @@ describe('validateFrontmatter', () => {
 
     const result = validateFrontmatter(foundationConfig, mdx)
 
-    expect(result).not.toBeNull()
-    expect(result!.errors.some((e) => e.toLowerCase().includes('slug'))).toBe(
-      true
-    )
+    expect(result).toBeInstanceOf(ValidationError)
+    expect(
+      (result as ValidationError).errors.some((e) =>
+        e.toLowerCase().includes('slug')
+      )
+    ).toBe(true)
   })
 })
 
@@ -183,6 +190,7 @@ describe('validateMdxFiles', () => {
 
     expect(valid).toHaveLength(0)
     expect(invalid).toHaveLength(1)
+    expect(invalid[0]).toBeInstanceOf(ValidationError)
     expect(invalid[0].pathSlug).toBe('missing-title')
     expect(invalid[0].errors.length).toBeGreaterThan(0)
   })

--- a/cms/scripts/sync-mdx/validateFrontmatter.ts
+++ b/cms/scripts/sync-mdx/validateFrontmatter.ts
@@ -7,19 +7,46 @@
 import type { ContentTypeConfig } from './config'
 import type { MDXFile } from './mdxTypes'
 
-export interface ValidationError {
+interface ValidationErrorContext {
   filepath: string
   pathSlug: string
   locale: string
   errors: string[]
 }
 
+/**
+ * Returned by `validateFrontmatter` when an MDX file fails its schema check.
+ * Subclasses Error so callers can narrow with `instanceof ValidationError`
+ * (or `instanceof Error`) and so the message field is human-readable in
+ * stack traces / logs.
+ */
+export class ValidationError extends Error {
+  public readonly filepath: string
+  public readonly pathSlug: string
+  public readonly locale: string
+  public readonly errors: string[]
+
+  constructor(ctx: ValidationErrorContext) {
+    super(`${ctx.filepath}: ${ctx.errors.join('; ')}`)
+    this.name = 'ValidationError'
+    this.filepath = ctx.filepath
+    this.pathSlug = ctx.pathSlug
+    this.locale = ctx.locale
+    this.errors = ctx.errors
+  }
+}
+
+/**
+ * Validate one MDX file against the schema for its content type.
+ * Returns the validated MDX file on success, or a `ValidationError`
+ * describing the problem on failure.
+ */
 export function validateFrontmatter(
   config: ContentTypeConfig,
   mdx: MDXFile
-): ValidationError | null {
+): MDXFile | ValidationError {
   const { schema } = config
-  if (!schema) return null
+  if (!schema) return mdx
 
   const result = schema.safeParse({
     ...mdx.frontmatter,
@@ -32,15 +59,15 @@ export function validateFrontmatter(
         issue.path.length > 0 ? `${issue.path.map(String).join('.')}: ` : ''
       return `${path}${issue.message}`
     })
-    return {
+    return new ValidationError({
       filepath: mdx.filepath,
       pathSlug: mdx.pathSlug,
       locale: mdx.locale,
       errors
-    }
+    })
   }
 
-  return null
+  return mdx
 }
 
 export function validateMdxFiles(
@@ -51,11 +78,11 @@ export function validateMdxFiles(
   const invalid: ValidationError[] = []
 
   for (const mdx of mdxFiles) {
-    const error = validateFrontmatter(config, mdx)
-    if (error) {
-      invalid.push(error)
+    const result = validateFrontmatter(config, mdx)
+    if (result instanceof ValidationError) {
+      invalid.push(result)
     } else {
-      valid.push(mdx)
+      valid.push(result)
     }
   }
 

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -989,16 +989,15 @@ export default {
           (ctx.method === 'PUT' || ctx.method === 'POST') &&
           CONTENT_MANAGER_PATTERN.test(ctx.url ?? '')
         ) {
-          try {
-            validateNoNestedJsx(ctx.request?.body?.content)
-          } catch (err: unknown) {
+          const validationErr = validateNoNestedJsx(ctx.request?.body?.content)
+          if (validationErr) {
             ctx.status = 400
             ctx.body = {
               data: null,
               error: {
                 status: 400,
                 name: 'ValidationError',
-                message: err instanceof Error ? err.message : String(err)
+                message: validationErr.message
               }
             }
             return

--- a/cms/src/utils/contentValidation.test.ts
+++ b/cms/src/utils/contentValidation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { validateNoNestedJsx } from '@/utils'
 
 describe('validateNoNestedJsx', () => {
-  it('throws when a paragraph block contains bare JSX', () => {
+  it('returns a ValidationError when a paragraph block contains bare JSX', () => {
     const content = [
       {
         __component: 'blocks.paragraph',
@@ -11,10 +11,12 @@ describe('validateNoNestedJsx', () => {
       }
     ]
 
-    expect(() => validateNoNestedJsx(content)).toThrow('<Blockquote>')
+    const err = validateNoNestedJsx(content)
+    expect(err).toBeInstanceOf(Error)
+    expect(err?.message).toContain('<Blockquote>')
   })
 
-  it('does not throw for plain markdown content', () => {
+  it('returns undefined for plain markdown content', () => {
     const content = [
       {
         __component: 'blocks.paragraph',
@@ -22,7 +24,7 @@ describe('validateNoNestedJsx', () => {
       }
     ]
 
-    expect(() => validateNoNestedJsx(content)).not.toThrow()
+    expect(validateNoNestedJsx(content)).toBeUndefined()
   })
 
   it('ignores JSX inside fenced code blocks', () => {
@@ -39,7 +41,7 @@ describe('validateNoNestedJsx', () => {
       }
     ]
 
-    expect(() => validateNoNestedJsx(content)).not.toThrow()
+    expect(validateNoNestedJsx(content)).toBeUndefined()
   })
 
   it('ignores non-paragraph blocks', () => {
@@ -50,12 +52,12 @@ describe('validateNoNestedJsx', () => {
       }
     ]
 
-    expect(() => validateNoNestedJsx(content)).not.toThrow()
+    expect(validateNoNestedJsx(content)).toBeUndefined()
   })
 
-  it('does nothing for non-array input', () => {
-    expect(() => validateNoNestedJsx(undefined)).not.toThrow()
-    expect(() => validateNoNestedJsx('raw string')).not.toThrow()
-    expect(() => validateNoNestedJsx(null)).not.toThrow()
+  it('returns undefined for non-array input', () => {
+    expect(validateNoNestedJsx(undefined)).toBeUndefined()
+    expect(validateNoNestedJsx('raw string')).toBeUndefined()
+    expect(validateNoNestedJsx(null)).toBeUndefined()
   })
 })

--- a/cms/src/utils/contentValidation.ts
+++ b/cms/src/utils/contentValidation.ts
@@ -17,12 +17,15 @@ function stripFencedCodeBlocks(text: string): string {
 /**
  * Validate that no Paragraph block contains bare JSX-like tags.
  *
- * Throws ValidationError if a `<CapitalLetter...` pattern is found outside
- * fenced code blocks in any blocks.paragraph content field. Strapi surfaces
- * ValidationError with the message visible in the admin UI.
+ * Returns a Strapi `ValidationError` when a `<CapitalLetter...` pattern is
+ * found outside fenced code blocks in any blocks.paragraph content field;
+ * returns `undefined` otherwise. The Strapi middleware that calls this
+ * narrows on the return and translates a returned error into a 400 response.
  */
-export function validateNoNestedJsx(content: unknown): void {
-  if (!Array.isArray(content)) return
+export function validateNoNestedJsx(
+  content: unknown
+): errors.ValidationError | undefined {
+  if (!Array.isArray(content)) return undefined
 
   for (const block of content) {
     if (
@@ -35,11 +38,13 @@ export function validateNoNestedJsx(content: unknown): void {
     const stripped = stripFencedCodeBlocks(block.content)
     const match = stripped.match(/<([A-Z][a-zA-Z]*)/)
     if (match) {
-      throw new errors.ValidationError(
+      return new errors.ValidationError(
         `Paragraph block contains JSX-like tag <${match[1]}>. ` +
           `Move it to its own top-level block, or wrap it in a code block (\`\`\`) ` +
           `if it's meant to be displayed as text.`
       )
     }
   }
+
+  return undefined
 }

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -68,6 +68,9 @@ interface Event {
  * strapi.requestContext uses AsyncLocalStorage — safe inside lifecycle hooks.
  */
 export function shouldSkipMdxExport(): boolean {
+  // Why: requestContext.get() throws when called outside an active request
+  // (e.g. boot-time, background jobs). That's a "no context" state, not an
+  // error — falling back to false is the right semantic.
   try {
     const ctx = strapi.requestContext.get()
     return ctx?.request?.headers?.['x-skip-mdx-export'] === 'true'
@@ -77,6 +80,9 @@ export function shouldSkipMdxExport(): boolean {
 }
 
 export function getAdminAuthor(): { name: string; email: string } | undefined {
+  // Why: same as shouldSkipMdxExport — requestContext.get() throws when there's
+  // no active request. Returning undefined means "no author info available,"
+  // which is a normal state rather than a failure.
   try {
     const ctx = strapi.requestContext.get()
     const user = ctx?.state?.user
@@ -195,7 +201,7 @@ async function writeMDXFile<T extends UID.ContentType>(
   config: PageLifecycleConfig<T>,
   page: PageData,
   englishSlug?: string
-): Promise<string> {
+): Promise<string | Error> {
   const locale = page.locale || defaultLang
   const outputDir = getOutputDir(config)
   const filepath = resolvePageFilepath(
@@ -220,19 +226,33 @@ async function writeMDXFile<T extends UID.ContentType>(
 
     return filepath
   } catch (error) {
-    console.error(
-      `Failed to write ${uidToLogLabel(config.contentTypeUid)} MDX file: ${filepath}`,
-      error
-    )
-    throw error
+    return error instanceof Error
+      ? new Error(
+          `Failed to write ${uidToLogLabel(config.contentTypeUid)} MDX file ${filepath}: ${error.message}`,
+          { cause: error }
+        )
+      : new Error(
+          `Failed to write ${uidToLogLabel(config.contentTypeUid)} MDX file ${filepath}: ${String(error)}`
+        )
   }
 }
 
+/**
+ * Fetch a published document for the given documentId and locale.
+ *
+ * Returns:
+ * - the page data on success
+ * - `null` when no published version exists for that locale (a normal state)
+ * - an `Error` when the Strapi document service throws (Strapi outage,
+ *   misconfigured populate clause, etc.)
+ *
+ * Callers narrow the three states to distinguish "skip" from "fail."
+ */
 async function fetchPublished<T extends UID.ContentType>(
   config: PageLifecycleConfig<T>,
   documentId: string,
   locale: string
-): Promise<PageData | null> {
+): Promise<PageData | null | Error> {
   try {
     const page = await strapi.documents(config.contentTypeUid).findOne({
       documentId,
@@ -242,11 +262,14 @@ async function fetchPublished<T extends UID.ContentType>(
     })
     return page as unknown as PageData | null
   } catch (error) {
-    console.error(
-      `Failed to fetch ${uidToLogLabel(config.contentTypeUid)} ${documentId} (${locale}):`,
-      error
-    )
-    return null
+    return error instanceof Error
+      ? new Error(
+          `Failed to fetch ${uidToLogLabel(config.contentTypeUid)} ${documentId} (${locale}): ${error.message}`,
+          { cause: error }
+        )
+      : new Error(
+          `Failed to fetch ${uidToLogLabel(config.contentTypeUid)} ${documentId} (${locale}): ${String(error)}`
+        )
   }
 }
 
@@ -255,29 +278,39 @@ async function exportAllLocales<T extends UID.ContentType>(
   documentId: string
 ): Promise<string[]> {
   const filepaths: string[] = []
-  const englishPage = await fetchPublished(config, documentId, defaultLang)
-  const englishSlug = englishPage?.pathSlug
+  // Fetch English first so we can pass its slug to localized exports for the
+  // `localizes` frontmatter link. If the fetch errors, we still attempt the
+  // other locales; they'll just write without an English link.
+  const englishResult = await fetchPublished(config, documentId, defaultLang)
+  if (englishResult instanceof Error) {
+    console.error(`⚠️  ${englishResult.message}`)
+  }
+  const englishPage = englishResult instanceof Error ? null : englishResult
+  const englishSlug = englishPage?.pathSlug ?? undefined
 
   for (const locale of LOCALES) {
-    try {
-      const page =
-        locale === defaultLang
-          ? englishPage
-          : await fetchPublished(config, documentId, locale)
-      if (!page) {
-        console.log(
-          `⏭️  No published ${locale} ${uidToLogLabel(config.contentTypeUid)} for ${documentId}`
-        )
-        continue
-      }
-      const filepath = await writeMDXFile(config, page, englishSlug)
-      filepaths.push(filepath)
-    } catch (error) {
-      console.error(
-        `⚠️  Failed to export ${locale} ${uidToLogLabel(config.contentTypeUid)} for ${documentId}:`,
-        error
-      )
+    const result =
+      locale === defaultLang
+        ? englishPage
+        : await fetchPublished(config, documentId, locale)
+
+    if (result instanceof Error) {
+      console.error(`⚠️  ${result.message}`)
+      continue
     }
+    if (!result) {
+      console.log(
+        `⏭️  No published ${locale} ${uidToLogLabel(config.contentTypeUid)} for ${documentId}`
+      )
+      continue
+    }
+
+    const filepath = await writeMDXFile(config, result, englishSlug)
+    if (filepath instanceof Error) {
+      console.error(`⚠️  ${filepath.message}`)
+      continue
+    }
+    filepaths.push(filepath)
   }
 
   return filepaths
@@ -359,6 +392,11 @@ function deleteMdxIfExists(
   label: string
 ): void {
   if (!fs.existsSync(filepath)) return
+  // Why: a failed unlink during cleanup is logged but not surfaced — the
+  // lifecycle hook continues to call scheduleGitSync. Returning Error here
+  // would force every caller to handle a state that's only ever a stale
+  // file we couldn't remove (filesystem permissions, in-flight reader),
+  // which we'd just log and continue anyway.
   try {
     fs.unlinkSync(filepath)
     console.log(`🗑️  Deleted ${locale} ${label} MDX: ${filepath}`)
@@ -413,6 +451,10 @@ export function createPageLifecycle<T extends UID.ContentType>(
       // a pathSlug change must remove the old file. Draft-only / never-published /
       // missing slug: no MDX path to reconcile, so skip.
       const existing = await fetchPublished(config, documentId, locale)
+      if (existing instanceof Error) {
+        console.error(`⚠️  ${existing.message}`)
+        return
+      }
       if (!existing?.pathSlug) return
 
       // Use Strapi’s published pathSlug only. Export always writes that value into


### PR DESCRIPTION
## Summary

Sub #4 of INTORG-614. Converts the remaining CMS surfaces outside the sync pipeline (page lifecycle hooks and the two validators) to errors-as-values.

What's in the diff:

- [pageLifecycle.ts](cms/src/utils/pageLifecycle.ts):
  - `fetchPublished` returns `PageData | null | Error`. Distinguishes "no published version for this locale" (normal absence) from "Strapi document service threw" (real error). Callers in `beforeUpdate` and `exportAllLocales` narrow the three states explicitly.
  - `writeMDXFile` returns `string | Error` instead of throwing. `exportAllLocales` narrows on the result and logs continue-on-error so a single locale failure doesn't abort the rest.
  - `shouldSkipMdxExport`, `getAdminAuthor`, `deleteMdxIfExists` keep their try/catch fallback semantics with explanatory `Why:` comments. Their "errors" are legitimate "no request context" or "stale file" states, not failures the lifecycle hook should react to.
- [validateFrontmatter.ts](cms/scripts/sync-mdx/validateFrontmatter.ts): `ValidationError` is now a real class extending `Error` instead of an interface. `validateFrontmatter` returns `MDXFile | ValidationError` (was `ValidationError | null`). `validateMdxFiles` narrows with `instanceof`.
- [contentValidation.ts](cms/src/utils/contentValidation.ts): `validateNoNestedJsx` returns `errors.ValidationError | undefined` instead of throwing. The Strapi middleware in [cms/src/index.ts](cms/src/index.ts) narrows on the return and translates to a 400 response. The try/catch around it is gone.
- Tests for `contentValidation` and `validateFrontmatter` updated to assert returned values. 

## Related Issue

INTORG-716 

## Manual Test

Run the CMS sync test suite:

\`\`\`
pnpm --dir cms test:sync-mdx
\`\`\`


## Checks

- [x] \`pnpm run format\`
- [x] \`pnpm run lint\`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. \`feat: ...\`, \`fix: ...\`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)