### PR TITLE
feat(blocks): add two-column text + media section [INTORG-661]

### DIFF
--- a/src/components/shared/TextMediaSection.astro
+++ b/src/components/shared/TextMediaSection.astro
@@ -51,8 +51,9 @@ const innerClasses = twMerge(
 )
 
 const textColumnClasses = twMerge(
-  'flex flex-col items-start gap-xl',
-  'desktop:flex-1 desktop:min-w-0',
+  'flex flex-col items-stretch gap-xl',
+  'tablet:items-center',
+  'desktop:flex-1 desktop:items-start desktop:min-w-0',
   '[&_h2]:font-poppins [&_h2]:text-h2 tablet:[&_h2]:text-h2-md desktop:[&_h2]:text-h2-lg',
   '[&_p]:font-poppins [&_p]:text-h5 tablet:[&_p]:text-h5-md desktop:[&_p]:text-h5-lg',
   theme === 'dark' && '[&_p]:text-neutral-25'

--- a/src/components/shared/TextMediaSection.astro
+++ b/src/components/shared/TextMediaSection.astro
@@ -58,6 +58,16 @@ const textColumnClasses = twMerge(
   '[&_p]:font-poppins [&_p]:text-h5 tablet:[&_p]:text-h5-md desktop:[&_p]:text-h5-lg',
   theme === 'dark' && '[&_p]:text-neutral-25'
 )
+
+// When the media column sits on the right, push the media element to the
+// container's right edge on desktop so it hugs the section gutter instead
+// of floating mid-column when the media is narrower than the 40% basis.
+// Not applied for mediaSide='left' since the column already hugs the left
+// edge via the row-reverse flip.
+const mediaColumnClasses = twMerge(
+  'desktop:basis-[40%] desktop:shrink-0',
+  mediaSide === 'right' && 'desktop:flex desktop:justify-end'
+)
 ---
 
 <section
@@ -71,7 +81,7 @@ const textColumnClasses = twMerge(
       <slot />
       <slot name="cta" />
     </div>
-    <div class="desktop:basis-[40%] desktop:shrink-0">
+    <div class={mediaColumnClasses}>
       <slot name="media" />
     </div>
   </div>

--- a/src/components/shared/TextMediaSection.astro
+++ b/src/components/shared/TextMediaSection.astro
@@ -52,8 +52,8 @@ const innerClasses = twMerge(
 
 const textColumnClasses = twMerge(
   'flex flex-col items-stretch gap-xl',
-  'tablet:items-center',
-  'desktop:flex-1 desktop:items-start desktop:min-w-0',
+  'tablet:items-start',
+  'desktop:flex-1 desktop:min-w-0',
   '[&_h2]:font-poppins [&_h2]:text-h2 tablet:[&_h2]:text-h2-md desktop:[&_h2]:text-h2-lg',
   '[&_p]:font-poppins [&_p]:text-h5 tablet:[&_p]:text-h5-md desktop:[&_p]:text-h5-lg',
   theme === 'dark' && '[&_p]:text-neutral-25'

--- a/src/components/shared/TextMediaSection.astro
+++ b/src/components/shared/TextMediaSection.astro
@@ -1,0 +1,77 @@
+---
+import { twMerge } from '@/utils'
+
+interface Props {
+  mediaSide?: 'left' | 'right'
+  theme?: 'light' | 'dark'
+  ariaLabel?: string
+  class?: string
+}
+
+const {
+  mediaSide = 'right',
+  theme = 'light',
+  ariaLabel,
+  class: className
+} = Astro.props
+
+// DOM order stays text → media regardless of `mediaSide`. The visual flip
+// happens via flex-*-reverse so keyboard / screen-reader order stays
+// text-first on every tier. Mobile order is per-section: `mediaSide="left"`
+// flips the column on mobile too (e.g. illustration above text), while
+// tablet always keeps text-first.
+//
+// Section paddings are a sensible default for the majority of two-column
+// home-page sections per Radu's layout rules; the outliers (e.g. tablet
+// "Designed to connect" wants `tablet:px-3xl-tight tablet:py-5xl`, mobile
+// "Making money…" wants `py-5xl`) override via the `class` prop and
+// tailwind-merge resolves the conflicts.
+//
+// Text is left-aligned at every tier. Sections that need centered text on
+// mobile/tablet (e.g. "Designed to connect") add `text-center
+// desktop:text-left` on the section via the `class` prop.
+//
+// Media column reserves ~40% of the row on desktop per Radu's layout
+// rules. Mobile/tablet items-stretch keeps it full-width; consumers can
+// constrain via classes on the media slot wrapper.
+const sectionClasses = twMerge(
+  'relative flex min-h-screen flex-col items-center justify-center',
+  'px-lg tablet:px-xl desktop:px-5xl',
+  'py-3xl-tight desktop:py-5xl',
+  theme === 'light' && 'bg-neutral-0 text-neutral-900',
+  theme === 'dark' && 'text-neutral-0',
+  className
+)
+
+const innerClasses = twMerge(
+  'mx-auto flex w-full flex-col items-stretch gap-3xl',
+  'desktop:max-w-content desktop:flex-row desktop:items-center desktop:gap-6xl',
+  mediaSide === 'left' &&
+    'flex-col-reverse tablet:flex-col desktop:flex-row-reverse'
+)
+
+const textColumnClasses = twMerge(
+  'flex flex-col items-start gap-xl',
+  'desktop:flex-1 desktop:min-w-0',
+  '[&_h2]:font-poppins [&_h2]:text-h2 tablet:[&_h2]:text-h2-md desktop:[&_h2]:text-h2-lg',
+  '[&_p]:font-poppins [&_p]:text-h5 tablet:[&_p]:text-h5-md desktop:[&_p]:text-h5-lg',
+  theme === 'dark' && '[&_p]:text-neutral-25'
+)
+---
+
+<section
+  aria-label={ariaLabel}
+  class={sectionClasses}
+  data-umami-component="text-media-section"
+>
+  <div class={innerClasses}>
+    <div class={textColumnClasses}>
+      <slot name="heading" />
+      <slot />
+      <slot name="cta" />
+    </div>
+    <div class="desktop:basis-[40%] desktop:shrink-0">
+      <slot name="media" />
+    </div>
+  </div>
+</section>

--- a/src/pages/preview/ui-components.astro
+++ b/src/pages/preview/ui-components.astro
@@ -4,6 +4,7 @@ import Button from '@/components/shared/Button.astro'
 import LinkButton from '@/components/shared/LinkButton.astro'
 import Icon from '@/components/shared/Icon.astro'
 import PillarCard from '@/components/shared/PillarCard.astro'
+import TextMediaSection from '@/components/shared/TextMediaSection.astro'
 ---
 
 <BaseLayout title="UI Components Preview">
@@ -11,406 +12,496 @@ import PillarCard from '@/components/shared/PillarCard.astro'
     <meta name="robots" content="noindex, nofollow" />
   </Fragment>
 
-  <main class="mx-auto max-w-(--max-content-width) px-lg py-2xl">
-    <h1 class="font-poppins mb-lg text-h2">UI Components Preview</h1>
-    <p class="mb-2xl text-body-lg-standard">
-      Internal reference for the new design-system components. SEO-excluded and
-      not linked from any nav. Future component PRs extend this page.
-    </p>
-
-    <nav aria-label="Sections" class="mb-2xl">
-      <ul class="flex flex-wrap gap-md list-none [&>a]:underline">
-        <li><a href="#buttons">Buttons</a></li>
-        <li><a href="#pillars-section">Pillars Section</a></li>
-      </ul>
-    </nav>
-
-    <section id="buttons" class="mb-3xl">
-      <h2 class="font-poppins mb-xl text-h3">Buttons</h2>
-
-      <h3 class="font-poppins mt-xl mb-md text-h4">Primary (lg)</h3>
-      <div class="flex flex-wrap items-center gap-md">
-        <Button>Default</Button>
-        <Button disabled>Disabled</Button>
-        <Button>
-          <Icon slot="icon-left" name="swap" />
-          With icon-left
-        </Button>
-        <Button>
-          With icon-right
-          <Icon slot="icon-right" name="swap" />
-        </Button>
-        <Button iconOnly aria-label="Next">
-          <Icon name="swap" />
-        </Button>
-      </div>
-
-      <h3 class="font-poppins mt-xl mb-md text-h4">Primary (sm)</h3>
-      <div class="flex flex-wrap items-center gap-md">
-        <Button size="sm">Default</Button>
-        <Button size="sm" disabled>Disabled</Button>
-        <Button size="sm">
-          <Icon slot="icon-left" name="swap" />
-          With icon-left
-        </Button>
-        <Button size="sm">
-          With icon-right
-          <Icon slot="icon-right" name="swap" />
-        </Button>
-        <Button size="sm" iconOnly aria-label="Next">
-          <Icon name="swap" />
-        </Button>
-      </div>
-
-      <h3 class="font-poppins mt-xl mb-md text-h4">
-        Symmetric vs asymmetric padding (text + icon)
-      </h3>
-      <p class="mb-md text-body-sm-standard">
-        Figma calls for asymmetric horizontal padding on text+icon buttons:
-        wider on the text side, tighter on the icon side. The current
-        implementation uses symmetric padding (the <code>px-xl</code> /
-        <code>px-md</code> compound variant) for code simplicity. Compare below and
-        pick one to ship.
+  <main class="py-2xl">
+    <div class="mx-auto max-w-(--max-content-width) px-lg">
+      <h1 class="font-poppins mb-lg text-h2">UI Components Preview</h1>
+      <p class="mb-2xl text-body-lg-standard">
+        Internal reference for the new design-system components. SEO-excluded
+        and not linked from any nav. Future component PRs extend this page.
       </p>
-      <p class="mb-md text-body-sm-standard text-neutral-75">
-        Asymmetric values used here step the icon-side padding down by one
-        t-shirt size (lg buttons: <code>xl</code> → <code>lg</code>; sm buttons:
-        <code>md</code> → <code>sm</code>). Tweak the values in this preview if
-        Figma specifies different exact tokens.
-      </p>
-      <dl
-        class="grid grid-cols-[max-content_1fr_1fr] gap-x-xl gap-y-md items-center"
-      >
-        <dt class="text-body-sm-standard"></dt>
-        <dt class="text-body-sm-standard text-neutral-75">
-          Symmetric (current)
-        </dt>
-        <dt class="text-body-sm-standard text-neutral-75">
-          Asymmetric (Figma)
-        </dt>
 
-        <dt class="text-body-sm-standard">lg, icon-left</dt>
-        <dd>
+      <nav aria-label="Sections" class="mb-2xl">
+        <ul class="flex flex-wrap gap-md">
+          <li><a class="underline" href="#buttons">Buttons</a></li>
+          <li>
+            <a class="underline" href="#text-media-section">
+              Text + media section
+            </a>
+          </li>
+          <li>
+            <a class="underline" href="#pillars-section">Pillars Section</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+
+    <div class="mx-auto max-w-(--max-content-width) px-lg">
+      <section id="buttons" class="mb-3xl">
+        <h2 class="font-poppins mb-xl text-h3">Buttons</h2>
+
+        <h3 class="font-poppins mt-xl mb-md text-h4">Primary (lg)</h3>
+        <div class="flex flex-wrap items-center gap-md">
+          <Button>Default</Button>
+          <Button disabled>Disabled</Button>
           <Button>
             <Icon slot="icon-left" name="swap" />
-            Continue
+            With icon-left
           </Button>
-        </dd>
-        <dd>
-          <Button class="ps-lg!">
-            <Icon slot="icon-left" name="swap" />
-            Continue
-          </Button>
-        </dd>
-
-        <dt class="text-body-sm-standard">lg, icon-right</dt>
-        <dd>
           <Button>
-            Continue
+            With icon-right
             <Icon slot="icon-right" name="swap" />
           </Button>
-        </dd>
-        <dd>
-          <Button class="pe-lg!">
-            Continue
-            <Icon slot="icon-right" name="swap" />
+          <Button iconOnly aria-label="Next">
+            <Icon name="swap" />
           </Button>
-        </dd>
+        </div>
 
-        <dt class="text-body-sm-standard">sm, icon-left</dt>
-        <dd>
+        <h3 class="font-poppins mt-xl mb-md text-h4">Primary (sm)</h3>
+        <div class="flex flex-wrap items-center gap-md">
+          <Button size="sm">Default</Button>
+          <Button size="sm" disabled>Disabled</Button>
           <Button size="sm">
             <Icon slot="icon-left" name="swap" />
-            Continue
+            With icon-left
           </Button>
-        </dd>
-        <dd>
-          <Button size="sm" class="ps-sm!">
-            <Icon slot="icon-left" name="swap" />
-            Continue
-          </Button>
-        </dd>
-
-        <dt class="text-body-sm-standard">sm, icon-right</dt>
-        <dd>
           <Button size="sm">
-            Continue
+            With icon-right
             <Icon slot="icon-right" name="swap" />
           </Button>
-        </dd>
-        <dd>
-          <Button size="sm" class="pe-sm!">
-            Continue
+          <Button size="sm" iconOnly aria-label="Next">
+            <Icon name="swap" />
+          </Button>
+        </div>
+
+        <h3 class="font-poppins mt-xl mb-md text-h4">
+          Symmetric vs asymmetric padding (text + icon)
+        </h3>
+        <p class="mb-md text-body-sm-standard">
+          Figma calls for asymmetric horizontal padding on text+icon buttons:
+          wider on the text side, tighter on the icon side. The current
+          implementation uses symmetric padding (the <code>px-xl</code> /
+          <code>px-md</code> compound variant) for code simplicity. Compare below
+          and pick one to ship.
+        </p>
+        <p class="mb-md text-body-sm-standard text-neutral-75">
+          Asymmetric values used here step the icon-side padding down by one
+          t-shirt size (lg buttons: <code>xl</code> → <code>lg</code>; sm
+          buttons:
+          <code>md</code> → <code>sm</code>). Tweak the values in this preview
+          if Figma specifies different exact tokens.
+        </p>
+        <dl
+          class="grid grid-cols-[max-content_1fr_1fr] gap-x-xl gap-y-md items-center"
+        >
+          <dt class="text-body-sm-standard"></dt>
+          <dt class="text-body-sm-standard text-neutral-75">
+            Symmetric (current)
+          </dt>
+          <dt class="text-body-sm-standard text-neutral-75">
+            Asymmetric (Figma)
+          </dt>
+
+          <dt class="text-body-sm-standard">lg, icon-left</dt>
+          <dd>
+            <Button>
+              <Icon slot="icon-left" name="swap" />
+              Continue
+            </Button>
+          </dd>
+          <dd>
+            <Button class="ps-lg!">
+              <Icon slot="icon-left" name="swap" />
+              Continue
+            </Button>
+          </dd>
+
+          <dt class="text-body-sm-standard">lg, icon-right</dt>
+          <dd>
+            <Button>
+              Continue
+              <Icon slot="icon-right" name="swap" />
+            </Button>
+          </dd>
+          <dd>
+            <Button class="pe-lg!">
+              Continue
+              <Icon slot="icon-right" name="swap" />
+            </Button>
+          </dd>
+
+          <dt class="text-body-sm-standard">sm, icon-left</dt>
+          <dd>
+            <Button size="sm">
+              <Icon slot="icon-left" name="swap" />
+              Continue
+            </Button>
+          </dd>
+          <dd>
+            <Button size="sm" class="ps-sm!">
+              <Icon slot="icon-left" name="swap" />
+              Continue
+            </Button>
+          </dd>
+
+          <dt class="text-body-sm-standard">sm, icon-right</dt>
+          <dd>
+            <Button size="sm">
+              Continue
+              <Icon slot="icon-right" name="swap" />
+            </Button>
+          </dd>
+          <dd>
+            <Button size="sm" class="pe-sm!">
+              Continue
+              <Icon slot="icon-right" name="swap" />
+            </Button>
+          </dd>
+        </dl>
+
+        <h3 class="font-poppins mt-xl mb-md text-h4">
+          Secondary (lg, light mode)
+        </h3>
+        <div class="flex flex-wrap items-center gap-md bg-neutral-0 p-lg">
+          <Button variant="secondary" mode="light">Default</Button>
+          <Button variant="secondary" mode="light" disabled>Disabled</Button>
+          <Button variant="secondary" mode="light">
+            <Icon slot="icon-left" name="swap" />
+            With icon-left
+          </Button>
+          <Button variant="secondary" mode="light">
+            With icon-right
             <Icon slot="icon-right" name="swap" />
           </Button>
-        </dd>
-      </dl>
-
-      <h3 class="font-poppins mt-xl mb-md text-h4">
-        Secondary (lg, light mode)
-      </h3>
-      <div class="flex flex-wrap items-center gap-md bg-neutral-0 p-lg">
-        <Button variant="secondary" mode="light">Default</Button>
-        <Button variant="secondary" mode="light" disabled>Disabled</Button>
-        <Button variant="secondary" mode="light">
-          <Icon slot="icon-left" name="swap" />
-          With icon-left
-        </Button>
-        <Button variant="secondary" mode="light">
-          With icon-right
-          <Icon slot="icon-right" name="swap" />
-        </Button>
-        <Button variant="secondary" mode="light" iconOnly aria-label="Next">
-          <Icon name="swap" />
-        </Button>
-      </div>
-
-      <h3 class="font-poppins mt-xl mb-md text-h4">
-        Secondary (sm, light mode)
-      </h3>
-      <div class="flex flex-wrap items-center gap-md bg-neutral-0 p-lg">
-        <Button variant="secondary" mode="light" size="sm">Default</Button>
-        <Button variant="secondary" mode="light" size="sm" disabled>
-          Disabled
-        </Button>
-        <Button variant="secondary" mode="light" size="sm">
-          <Icon slot="icon-left" name="swap" />
-          With icon-left
-        </Button>
-        <Button variant="secondary" mode="light" size="sm">
-          With icon-right
-          <Icon slot="icon-right" name="swap" />
-        </Button>
-        <Button
-          variant="secondary"
-          mode="light"
-          size="sm"
-          iconOnly
-          aria-label="Next"
-        >
-          <Icon name="swap" />
-        </Button>
-      </div>
-
-      <h3 class="font-poppins mt-xl mb-md text-h4">
-        Secondary (lg, dark mode)
-      </h3>
-      <div class="flex flex-wrap items-center gap-md bg-neutral-100 p-lg">
-        <Button variant="secondary" mode="dark">Default</Button>
-        <Button variant="secondary" mode="dark" disabled>Disabled</Button>
-        <Button variant="secondary" mode="dark">
-          <Icon slot="icon-left" name="swap" />
-          With icon-left
-        </Button>
-        <Button variant="secondary" mode="dark">
-          With icon-right
-          <Icon slot="icon-right" name="swap" />
-        </Button>
-        <Button variant="secondary" mode="dark" iconOnly aria-label="Next">
-          <Icon name="swap" />
-        </Button>
-      </div>
-
-      <h3 class="font-poppins mt-xl mb-md text-h4">
-        Secondary (sm, dark mode)
-      </h3>
-      <div class="flex flex-wrap items-center gap-md bg-neutral-100 p-lg">
-        <Button variant="secondary" mode="dark" size="sm">Default</Button>
-        <Button variant="secondary" mode="dark" size="sm" disabled>
-          Disabled
-        </Button>
-        <Button variant="secondary" mode="dark" size="sm">
-          <Icon slot="icon-left" name="swap" />
-          With icon-left
-        </Button>
-        <Button variant="secondary" mode="dark" size="sm">
-          With icon-right
-          <Icon slot="icon-right" name="swap" />
-        </Button>
-        <Button
-          variant="secondary"
-          mode="dark"
-          size="sm"
-          iconOnly
-          aria-label="Next"
-        >
-          <Icon name="swap" />
-        </Button>
-      </div>
-
-      <h3 class="font-poppins mt-xl mb-md text-h4">Ghost (footer)</h3>
-      <p class="mb-md text-body-sm-standard">
-        Mobile starts at h4/black; tablet+ scales down to body-sm-standard /
-        neutral-75. Hover deepens to black. The "Active" state is the
-        currently-selected footer nav link, signalled via
-        <code>aria-current="page"</code>, which flips text to orchid-100. Focus
-        draws a 1px orchid-100 border with rounded corners. Resize the viewport
-        to see the typography breakpoint flip.
-      </p>
-      <dl
-        class="grid grid-cols-[max-content_1fr] gap-x-xl gap-y-md items-center"
-      >
-        <dt class="text-body-sm-standard">Default</dt>
-        <dd>
-          <Button variant="ghost">Footer Ghost Button</Button>
-        </dd>
-        <dt class="text-body-sm-standard">Hover (mouse over to see)</dt>
-        <dd>
-          <Button variant="ghost">Footer Ghost Button</Button>
-        </dd>
-        <dt class="text-body-sm-standard">
-          Active (<code>aria-current="page"</code>)
-        </dt>
-        <dd>
-          <Button variant="ghost" aria-current="page">
-            Footer Ghost Button
+          <Button variant="secondary" mode="light" iconOnly aria-label="Next">
+            <Icon name="swap" />
           </Button>
-        </dd>
-        <dt class="text-body-sm-standard">Focus (Tab to it)</dt>
-        <dd>
-          <Button variant="ghost">Footer Ghost Button</Button>
-        </dd>
-        <dt class="text-body-sm-standard">As LinkButton (current page)</dt>
-        <dd>
-          <LinkButton variant="ghost" href="#buttons" aria-current="page">
-            Footer Ghost Button
+        </div>
+
+        <h3 class="font-poppins mt-xl mb-md text-h4">
+          Secondary (sm, light mode)
+        </h3>
+        <div class="flex flex-wrap items-center gap-md bg-neutral-0 p-lg">
+          <Button variant="secondary" mode="light" size="sm">Default</Button>
+          <Button variant="secondary" mode="light" size="sm" disabled>
+            Disabled
+          </Button>
+          <Button variant="secondary" mode="light" size="sm">
+            <Icon slot="icon-left" name="swap" />
+            With icon-left
+          </Button>
+          <Button variant="secondary" mode="light" size="sm">
+            With icon-right
+            <Icon slot="icon-right" name="swap" />
+          </Button>
+          <Button
+            variant="secondary"
+            mode="light"
+            size="sm"
+            iconOnly
+            aria-label="Next"
+          >
+            <Icon name="swap" />
+          </Button>
+        </div>
+
+        <h3 class="font-poppins mt-xl mb-md text-h4">
+          Secondary (lg, dark mode)
+        </h3>
+        <div class="flex flex-wrap items-center gap-md bg-neutral-100 p-lg">
+          <Button variant="secondary" mode="dark">Default</Button>
+          <Button variant="secondary" mode="dark" disabled>Disabled</Button>
+          <Button variant="secondary" mode="dark">
+            <Icon slot="icon-left" name="swap" />
+            With icon-left
+          </Button>
+          <Button variant="secondary" mode="dark">
+            With icon-right
+            <Icon slot="icon-right" name="swap" />
+          </Button>
+          <Button variant="secondary" mode="dark" iconOnly aria-label="Next">
+            <Icon name="swap" />
+          </Button>
+        </div>
+
+        <h3 class="font-poppins mt-xl mb-md text-h4">
+          Secondary (sm, dark mode)
+        </h3>
+        <div class="flex flex-wrap items-center gap-md bg-neutral-100 p-lg">
+          <Button variant="secondary" mode="dark" size="sm">Default</Button>
+          <Button variant="secondary" mode="dark" size="sm" disabled>
+            Disabled
+          </Button>
+          <Button variant="secondary" mode="dark" size="sm">
+            <Icon slot="icon-left" name="swap" />
+            With icon-left
+          </Button>
+          <Button variant="secondary" mode="dark" size="sm">
+            With icon-right
+            <Icon slot="icon-right" name="swap" />
+          </Button>
+          <Button
+            variant="secondary"
+            mode="dark"
+            size="sm"
+            iconOnly
+            aria-label="Next"
+          >
+            <Icon name="swap" />
+          </Button>
+        </div>
+
+        <h3 class="font-poppins mt-xl mb-md text-h4">Ghost (footer)</h3>
+        <p class="mb-md text-body-sm-standard">
+          Mobile starts at h4/black; tablet+ scales down to body-sm-standard /
+          neutral-75. Hover deepens to black. The "Active" state is the
+          currently-selected footer nav link, signalled via
+          <code>aria-current="page"</code>, which flips text to orchid-100.
+          Focus draws a 1px orchid-100 border with rounded corners. Resize the
+          viewport to see the typography breakpoint flip.
+        </p>
+        <dl
+          class="grid grid-cols-[max-content_1fr] gap-x-xl gap-y-md items-center"
+        >
+          <dt class="text-body-sm-standard">Default</dt>
+          <dd>
+            <Button variant="ghost">Footer Ghost Button</Button>
+          </dd>
+          <dt class="text-body-sm-standard">Hover (mouse over to see)</dt>
+          <dd>
+            <Button variant="ghost">Footer Ghost Button</Button>
+          </dd>
+          <dt class="text-body-sm-standard">
+            Active (<code>aria-current="page"</code>)
+          </dt>
+          <dd>
+            <Button variant="ghost" aria-current="page">
+              Footer Ghost Button
+            </Button>
+          </dd>
+          <dt class="text-body-sm-standard">Focus (Tab to it)</dt>
+          <dd>
+            <Button variant="ghost">Footer Ghost Button</Button>
+          </dd>
+          <dt class="text-body-sm-standard">As LinkButton (current page)</dt>
+          <dd>
+            <LinkButton variant="ghost" href="#buttons" aria-current="page">
+              Footer Ghost Button
+            </LinkButton>
+          </dd>
+        </dl>
+
+        <div class="flex flex-wrap gap-lg mt-xl">
+          <div class="p-lg">
+            <h3 class="font-poppins mb-md text-h4">FAB (light mode)</h3>
+            <div class="flex flex-wrap items-center gap-md">
+              <dl
+                class="grid grid-cols-[max-content_1fr] gap-x-xl gap-y-md items-center"
+              >
+                <dt class="text-body-sm-standard">Default</dt>
+                <dd>
+                  <LinkButton
+                    variant="fab"
+                    href="#buttons"
+                    iconOnly
+                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                  >
+                </dd>
+                <dt class="text-body-sm-standard">Hover (mouse over to see)</dt>
+                <dd>
+                  <LinkButton
+                    variant="fab"
+                    href="#buttons"
+                    iconOnly
+                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                  >
+                </dd>
+                <dt class="text-body-sm-standard">
+                  Focus (same as hover - Tab to it)
+                </dt>
+                <dd>
+                  <LinkButton
+                    variant="fab"
+                    href="#buttons"
+                    iconOnly
+                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                  >
+                </dd>
+                <dt class="text-body-sm-standard">Disabled</dt>
+                <dd>
+                  <LinkButton
+                    variant="fab"
+                    href="#buttons"
+                    iconOnly
+                    aria-label="Next"
+                    ariaDisabled
+                  >
+                    <Icon name="arrow-right" />
+                  </LinkButton>
+                </dd>
+              </dl>
+            </div>
+          </div>
+          <div class="bg-neutral-900 text-neutral-25 p-lg">
+            <h3 class="font-poppins mb-md text-h4">FAB (dark mode)</h3>
+            <div class="flex flex-wrap items-center gap-md">
+              <dl
+                class="grid grid-cols-[max-content_1fr] gap-x-xl gap-y-md items-center"
+              >
+                <dt class="text-body-sm-standard">Default</dt>
+                <dd>
+                  <LinkButton
+                    variant="fab"
+                    mode="dark"
+                    href="#buttons"
+                    iconOnly
+                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                  >
+                </dd>
+                <dt class="text-body-sm-standard">Hover (mouse over to see)</dt>
+                <dd>
+                  <LinkButton
+                    variant="fab"
+                    mode="dark"
+                    href="#buttons"
+                    iconOnly
+                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                  >
+                </dd>
+                <dt class="text-body-sm-standard">
+                  Focus (same as hover - Tab to it)
+                </dt>
+                <dd>
+                  <LinkButton
+                    variant="fab"
+                    mode="dark"
+                    href="#buttons"
+                    iconOnly
+                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                  >
+                </dd>
+                <dt class="text-body-sm-standard">Disabled</dt>
+                <dd>
+                  <LinkButton
+                    variant="fab"
+                    mode="dark"
+                    href="#buttons"
+                    iconOnly
+                    aria-label="Next"
+                    ariaDisabled
+                  >
+                    <Icon name="arrow-right" />
+                  </LinkButton>
+                </dd>
+              </dl>
+            </div>
+          </div>
+        </div>
+
+        <h3 class="font-poppins mt-xl mb-md text-h4">LinkButton</h3>
+        <div class="flex flex-wrap items-center gap-md">
+          <LinkButton href="#buttons">Internal link</LinkButton>
+          <LinkButton href="https://interledger.org" external>
+            External link
           </LinkButton>
-        </dd>
-      </dl>
+          <LinkButton href="#buttons" ariaDisabled
+            >aria-disabled link</LinkButton
+          >
+          <LinkButton href="#buttons" variant="secondary" mode="light">
+            Secondary link
+          </LinkButton>
+        </div>
 
-      <div class="flex flex-wrap gap-lg mt-xl">
-        <div class="p-lg">
-          <h3 class="font-poppins mb-md text-h4">FAB (light mode)</h3>
-          <div class="flex flex-wrap items-center gap-md">
-            <dl
-              class="grid grid-cols-[max-content_1fr] gap-x-xl gap-y-md items-center"
-            >
-              <dt class="text-body-sm-standard">Default</dt>
-              <dd>
-                <LinkButton
-                  variant="fab"
-                  href="#buttons"
-                  iconOnly
-                  aria-label="Next"><Icon name="arrow-right" /></LinkButton
-                >
-              </dd>
-              <dt class="text-body-sm-standard">Hover (mouse over to see)</dt>
-              <dd>
-                <LinkButton
-                  variant="fab"
-                  href="#buttons"
-                  iconOnly
-                  aria-label="Next"><Icon name="arrow-right" /></LinkButton
-                >
-              </dd>
-              <dt class="text-body-sm-standard">
-                Focus (same as hover - Tab to it)
-              </dt>
-              <dd>
-                <LinkButton
-                  variant="fab"
-                  href="#buttons"
-                  iconOnly
-                  aria-label="Next"><Icon name="arrow-right" /></LinkButton
-                >
-              </dd>
-              <dt class="text-body-sm-standard">Disabled</dt>
-              <dd>
-                <LinkButton
-                  variant="fab"
-                  href="#buttons"
-                  iconOnly
-                  aria-label="Next"
-                  ariaDisabled
-                >
-                  <Icon name="arrow-right" />
-                </LinkButton>
-              </dd>
-            </dl>
-          </div>
+        <h3 class="font-poppins mt-xl mb-md text-h4">Form integration</h3>
+        <form
+          class="flex flex-wrap items-center gap-md"
+          onsubmit="event.preventDefault()"
+        >
+          <Button type="submit">Submit</Button>
+          <Button type="reset" variant="secondary" mode="light">Reset</Button>
+        </form>
+
+        <h3 class="font-poppins mt-xl mb-md text-h4">RTL</h3>
+        <div dir="rtl" class="flex flex-wrap items-center gap-md">
+          <Button>RTL primary</Button>
+          <Button variant="secondary" mode="light">RTL secondary</Button>
         </div>
-        <div class="bg-neutral-900 text-neutral-25 p-lg">
-          <h3 class="font-poppins mb-md text-h4">FAB (dark mode)</h3>
-          <div class="flex flex-wrap items-center gap-md">
-            <dl
-              class="grid grid-cols-[max-content_1fr] gap-x-xl gap-y-md items-center"
-            >
-              <dt class="text-body-sm-standard">Default</dt>
-              <dd>
-                <LinkButton
-                  variant="fab"
-                  mode="dark"
-                  href="#buttons"
-                  iconOnly
-                  aria-label="Next"><Icon name="arrow-right" /></LinkButton
-                >
-              </dd>
-              <dt class="text-body-sm-standard">Hover (mouse over to see)</dt>
-              <dd>
-                <LinkButton
-                  variant="fab"
-                  mode="dark"
-                  href="#buttons"
-                  iconOnly
-                  aria-label="Next"><Icon name="arrow-right" /></LinkButton
-                >
-              </dd>
-              <dt class="text-body-sm-standard">
-                Focus (same as hover - Tab to it)
-              </dt>
-              <dd>
-                <LinkButton
-                  variant="fab"
-                  mode="dark"
-                  href="#buttons"
-                  iconOnly
-                  aria-label="Next"><Icon name="arrow-right" /></LinkButton
-                >
-              </dd>
-              <dt class="text-body-sm-standard">Disabled</dt>
-              <dd>
-                <LinkButton
-                  variant="fab"
-                  mode="dark"
-                  href="#buttons"
-                  iconOnly
-                  aria-label="Next"
-                  ariaDisabled
-                >
-                  <Icon name="arrow-right" />
-                </LinkButton>
-              </dd>
-            </dl>
-          </div>
-        </div>
+      </section>
+    </div>
+
+    <section id="text-media-section" aria-label="Text + media section examples">
+      <div class="mx-auto mb-xl max-w-(--max-content-width) px-lg">
+        <h2 class="font-poppins mb-md text-h3">Text + media section</h2>
+        <p class="text-body-lg-standard text-neutral-75">
+          Each example below is one full instance of <code
+            >TextMediaSection</code
+          >. Section dimensions are intentionally full-bleed: 100vh min-height,
+          1440px content cap, side margins 16 / 24 / 80 at mobile / tablet /
+          desktop. Resize through the 810 and 1200 thresholds to see the
+          breakpoint behaviour.
+        </p>
       </div>
 
-      <h3 class="font-poppins mt-xl mb-md text-h4">LinkButton</h3>
-      <div class="flex flex-wrap items-center gap-md">
-        <LinkButton href="#buttons">Internal link</LinkButton>
-        <LinkButton href="https://interledger.org" external>
-          External link
-        </LinkButton>
-        <LinkButton href="#buttons" ariaDisabled>aria-disabled link</LinkButton>
-        <LinkButton href="#buttons" variant="secondary" mode="light">
-          Secondary link
-        </LinkButton>
-      </div>
-
-      <h3 class="font-poppins mt-xl mb-md text-h4">Form integration</h3>
-      <form
-        class="flex flex-wrap items-center gap-md"
-        onsubmit="event.preventDefault()"
+      <TextMediaSection
+        mediaSide="right"
+        theme="light"
+        ariaLabel="Light theme, media right"
       >
-        <Button type="submit">Submit</Button>
-        <Button type="reset" variant="secondary" mode="light">Reset</Button>
-      </form>
+        <h2 slot="heading">Light theme, media right</h2>
+        <p>
+          Sample body copy. Resize through 810 / 1200 to see the stack-to-split
+          transition and the side-padding step (16 → 24 → 80).
+        </p>
+        <div
+          slot="media"
+          class="aspect-square mx-auto flex w-full max-w-[426px] items-center justify-center bg-neutral-25 text-neutral-75 desktop:mx-0 desktop:w-full"
+        >
+          media slot
+        </div>
+      </TextMediaSection>
 
-      <h3 class="font-poppins mt-xl mb-md text-h4">RTL</h3>
-      <div dir="rtl" class="flex flex-wrap items-center gap-md">
-        <Button>RTL primary</Button>
-        <Button variant="secondary" mode="light">RTL secondary</Button>
-      </div>
+      <TextMediaSection
+        mediaSide="left"
+        theme="light"
+        ariaLabel="Light theme, media left"
+      >
+        <h2 slot="heading">Light theme, media left</h2>
+        <p>
+          Same component with <code>mediaSide="left"</code>. Mobile order
+          reverses to put the media slot on top; tablet keeps text-first;
+          desktop puts media on the left of the row. DOM order stays text →
+          media on every tier.
+        </p>
+        <LinkButton slot="cta" href="#" variant="secondary" size="lg">
+          Optional CTA
+        </LinkButton>
+        <div
+          slot="media"
+          class="aspect-square mx-auto flex w-full max-w-[426px] items-center justify-center bg-neutral-25 text-neutral-75 desktop:mx-0 desktop:w-full"
+        >
+          media slot
+        </div>
+      </TextMediaSection>
+
+      <TextMediaSection
+        mediaSide="right"
+        theme="dark"
+        ariaLabel="Dark theme, media right"
+        class="bg-neutral-900"
+      >
+        <h2 slot="heading">Dark theme, media right</h2>
+        <p>
+          Dark variant: heading is <code>text-neutral-0</code>, body is
+          <code>text-neutral-25</code>. The component itself sets no background;
+          the caller wraps with the appropriate dark bg (here
+          <code>bg-neutral-900</code>).
+        </p>
+        <div
+          slot="media"
+          class="aspect-[426/286] mx-auto flex w-full max-w-[426px] items-center justify-center rounded-3xl bg-neutral-75 text-neutral-25 desktop:mx-0 desktop:w-full"
+        >
+          media slot
+        </div>
+      </TextMediaSection>
     </section>
 
     <section

--- a/src/pages/preview/ui-components.astro
+++ b/src/pages/preview/ui-components.astro
@@ -471,7 +471,13 @@ import TextMediaSection from '@/components/shared/TextMediaSection.astro'
           desktop puts media on the left of the row. DOM order stays text →
           media on every tier.
         </p>
-        <LinkButton slot="cta" href="#" variant="secondary" size="lg">
+        <LinkButton
+          slot="cta"
+          href="#"
+          variant="secondary"
+          size="lg"
+          class="px-lg"
+        >
           Optional CTA
         </LinkButton>
         <div

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -50,9 +50,9 @@ export default {
           'linear-gradient(to bottom, hsla(162, 86%, 12%, 1), hsla(176, 100%, 30%, 1))'
       },
 
-      // Breakpoints. md: and lg: align with the Figma design system's Tablet
-      // and Desktop tiers (768/1024, matching Tailwind v4 defaults). xs/sm/xl/2xl
-      // are auxiliary and don't correspond to Figma tiers.
+      // Breakpoints. md: and lg: are Tailwind v4 defaults kept for legacy
+      // code. tablet: (810) and desktop: (1200) are the redesign tiers from
+      // Radu's "Layout rules" — new design-system code uses these.
       screens: {
         xs: '480px',
         sm: '600px',


### PR DESCRIPTION
## Summary

- New `TextMediaSection` Astro block — foundation component for the redesigned home page (INTORG-660 family). Text on one side, image/video on the other, with a `mediaSide` prop (`'left' | 'right'`, default `'right'`) and a `theme` prop (`'light' | 'dark'`, default `'light'`). Hybrid API: props for layout meta, named slots (`heading` / default body / `cta` / `media`) for content.
- Additive `tablet: 810px` and `desktop: 1200px` screens tokens in [tailwind.config.mjs](tailwind.config.mjs), matching Radu's "Layout rules" frames in Figma. `md` / `lg` are unchanged so every existing `md:`/`lg:` consumer keeps its current behaviour.
- **`max-w-content` bumped from `1160px` → `1440px`** to match Radu's container spec. 
- Three visual-verification examples (`light/right`, `light/left`, `dark/right`) on the noindex preview page at [src/pages/preview/ui-components.astro](src/pages/preview/ui-components.astro). Page's `<main>` restructured so the new examples can span full width while the buttons section keeps its `max-w-content` cap.


## Related Issue

Fixes INTORG-661.

## Manual Test

**Visual verification of the new component**: `/preview/ui-components#text-media-section` (noindex, not linked).

1. `pnpm start` and open `http://localhost:1104/preview/ui-components#text-media-section`.
2. Resize through `390` (mobile), `900` (tablet), and `1440` (desktop). Confirm:
   - Below `1200px`: every example stacks vertically, text above media; outer side padding steps `16 → 24` at the `810` threshold.
   - At `1200px+`: two-column layout activates with `max-w-content` (1440), 120px gap, 80px side padding. The `light/left` example flips the visual order; DOM order stays text → media (verify by tabbing).
3. Toggle `prefers-reduced-motion: reduce` in DevTools (Rendering panel) — no animation regressions (the component intentionally doesn't bake in animation).

**Visual regression sweep for the `max-w-content` bump**: walk through the deploy preview at viewports `≥ 1440` (where the 280px widening is most visible) and check the affected files listed above. The "Notes for reviewers" section below has the full list.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run build`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused
- [x] Screenshots: visual verification on preview page 