### PR TITLE
Sj/intorg 465

### DIFF
--- a/src/components/blog/BlogIndexFoundation.astro
+++ b/src/components/blog/BlogIndexFoundation.astro
@@ -7,20 +7,37 @@ import {
   buildUmamiAttrs,
   getBlogThumbnail
 } from '@/utils'
+import type { Locale } from '@/utils'
 import type { CollectionEntry } from 'astro:content'
 import TaxonomyFilter from './TaxonomyFilter.astro'
+import ContentLangFilter from './ContentLangFilter.astro'
+import ContentLangNotice from './ContentLangNotice.astro'
 import BlogIndexHeader from './BlogIndexHeader.astro'
 
 interface Props {
   posts: CollectionEntry<'foundation-blog'>[]
   allTerms?: string[]
+  enabledTerms?: string[]
   selectedTerm?: string
-  showTagFilter?: boolean
   blogIndexHref: string
+  contentLang: Locale
+  isTermFallback?: boolean
 }
-const { posts, allTerms = [], selectedTerm, blogIndexHref } = Astro.props
+const {
+  posts,
+  allTerms = [],
+  enabledTerms,
+  selectedTerm,
+  blogIndexHref,
+  contentLang,
+  isTermFallback
+} = Astro.props
 const { routeLocale } = Astro.locals
 const t = useTranslations(routeLocale)
+const contentLangOverride =
+  Astro.url.pathname.includes('/lang/') || contentLang !== routeLocale
+    ? contentLang
+    : undefined
 const developersHref = translatePath(
   'developers-blog',
   routeLocale,
@@ -50,12 +67,26 @@ const postAttrs = (
   imgAlt={t('blog.header.image_alt')}
 />
 
+<ContentLangFilter routeLocale={routeLocale} contentLang={contentLang} />
+
+<ContentLangNotice routeLocale={routeLocale} contentLang={contentLang} />
+
 <TaxonomyFilter
   collection="foundation-blog"
   terms={allTerms}
+  enabledTerms={enabledTerms}
   selectedTerm={selectedTerm}
   href={blogIndexHref}
+  contentLangOverride={contentLangOverride}
 />
+
+{
+  isTermFallback && (
+    <p class="mb-space-s text-step--1 text-gray-600 italic">
+      {t('blog.empty_tag_lang.message')}
+    </p>
+  )
+}
 
 <ol class="list-none p-0">
   {

--- a/src/components/blog/ContentLangFilter.astro
+++ b/src/components/blog/ContentLangFilter.astro
@@ -1,0 +1,70 @@
+---
+import { useTranslations, buildUmamiAttrs, stripPagination } from '@/utils'
+import type { Locale } from '@/utils'
+
+interface Props {
+  routeLocale: Locale
+  contentLang: Locale
+}
+
+const { routeLocale, contentLang } = Astro.props
+const t = useTranslations(routeLocale)
+
+// Derive lang-switch hrefs from the current pathname so that any active
+// category filter (including /category/all) is preserved when switching.
+// - On a /lang/ URL: swap the locale suffix, keeping the rest of the path.
+// - Otherwise: append /lang/<locale> to the current path.
+const pathname = stripPagination(Astro.url.pathname)
+const base = pathname.includes('/lang/')
+  ? pathname.replace(/\/lang\/[^/]+$/, '')
+  : pathname.includes('/category/')
+    ? pathname
+    : `${pathname}/category/all`
+const enHref = `${base}/lang/en`
+const esHref = `${base}/lang/es`
+
+const isEnActive = contentLang === 'en'
+const isEsActive = contentLang === 'es'
+
+const activeClass = ['bg-primary', 'text-white']
+const inactiveClass = ['bg-white']
+
+const btnAttrs = (lang: string) =>
+  buildUmamiAttrs({
+    pathname: Astro.url.pathname,
+    lang: routeLocale,
+    section: 'cta',
+    action: `lang_filter_${lang}`
+  })
+---
+
+<div class="mb-space-m">
+  <div class="font-semibold mb-3xs text-step--1">
+    {t('blog.lang_filter.label')}
+  </div>
+  <ul
+    class="flex flex-wrap gap-space-3xs list-none
+    [&_a]:px-space-2xs [&_a]:py-space-3xs [&_a]:text-step--1 [&_a]:rounded [&_a]:shadow [&_a]:underline [&_a]:decoration-transparent [&_a]:transition-all [&_a]:duration-300 [&_a]:hover:decoration-inherit"
+  >
+    <li>
+      <a
+        href={enHref}
+        class:list={isEnActive ? activeClass : inactiveClass}
+        aria-current={isEnActive ? 'page' : undefined}
+        {...btnAttrs('en')}
+      >
+        {t('blog.lang_filter.english')}
+      </a>
+    </li>
+    <li>
+      <a
+        href={esHref}
+        class:list={isEsActive ? activeClass : inactiveClass}
+        aria-current={isEsActive ? 'page' : undefined}
+        {...btnAttrs('es')}
+      >
+        {t('blog.lang_filter.spanish')}
+      </a>
+    </li>
+  </ul>
+</div>

--- a/src/components/blog/ContentLangNotice.astro
+++ b/src/components/blog/ContentLangNotice.astro
@@ -1,0 +1,45 @@
+---
+import { useTranslations, stripPagination } from '@/utils'
+import type { Locale } from '@/utils'
+
+interface Props {
+  routeLocale: Locale
+  contentLang: Locale
+}
+
+const { routeLocale, contentLang } = Astro.props
+const t = useTranslations(routeLocale)
+const base = stripPagination(Astro.url.pathname).replace(/\/lang\/[^/]+$/, '')
+const enHref = `${base}/lang/en`
+
+const isViewingEsOnEnPage = routeLocale === 'en' && contentLang === 'es'
+const isViewingEnOnEsPage = routeLocale === 'es' && contentLang === 'en'
+const showEsDisclaimer = contentLang === 'es'
+---
+
+{
+  isViewingEsOnEnPage && (
+    <aside role="note" class="text-step--1 text-gray-600 italic">
+      {t('blog.lang_filter.viewing_es_posts')}
+    </aside>
+  )
+}
+
+{
+  isViewingEnOnEsPage && (
+    <aside role="note" class="text-step--1 text-gray-600 italic">
+      {t('blog.lang_filter.viewing_en_posts')}
+    </aside>
+  )
+}
+
+{
+  showEsDisclaimer && (
+    <p class="text-step--1 text-gray-600">
+      {t('blog.lang_filter.more_en_available')}{' '}
+      <a href={enHref} class="underline hover:text-primary">
+        {t('blog.lang_filter.view_in_en')}
+      </a>
+    </p>
+  )
+}

--- a/src/components/blog/TaxonomyFilter.astro
+++ b/src/components/blog/TaxonomyFilter.astro
@@ -7,18 +7,35 @@ import {
   useTranslations,
   buildUmamiAttrs
 } from '@/utils'
+import type { Locale } from '@/utils'
 interface Props {
   collection: BlogCollectionType
   terms: string[]
+  enabledTerms?: string[]
   selectedTerm?: string
   href: string
+  contentLangOverride?: Locale
 }
-const { collection, terms, selectedTerm, href } = Astro.props
+const {
+  collection,
+  terms,
+  enabledTerms,
+  selectedTerm,
+  href,
+  contentLangOverride
+} = Astro.props
 const { routeLocale } = Astro.locals
 const t = useTranslations(routeLocale)
+
 const taxonomy = getBlogTaxonomy(collection)
+const enabledSet = enabledTerms ? new Set(enabledTerms) : null
+// Cross-lang routes always use "tag" as the URL segment (see tagFilter.ts).
+const allHref = contentLangOverride
+  ? `${href}/${taxonomy.segment}/all/lang/${contentLangOverride}`
+  : `${href}/${taxonomy.segment}/all`
 const activeClass = ['bg-primary', 'text-white']
 const inactiveClass = ['bg-white']
+const disabledClass = ['bg-white', 'opacity-50', 'cursor-not-allowed']
 
 const filterAttrs = (action: string, label: string) =>
   buildUmamiAttrs({
@@ -39,25 +56,46 @@ const filterAttrs = (action: string, label: string) =>
   [&_a]:px-space-2xs [&_a]:py-space-3xs [&_a]:text-step--1 [&_a]:rounded [&_a]:shadow [&_a]:underline [&_a]:decoration-transparent [&_a]:transition-all [&_a]:duration-300 [&_a]:hover:decoration-inherit"
   >
     <a
-      href={href}
+      href={allHref}
       class:list={!selectedTerm ? activeClass : inactiveClass}
       {...filterAttrs('filter_all', t('blog.filter.all'))}
     >
       {t('blog.filter.all')}
     </a>
     {
-      terms.map((term) => (
-        <a
-          href={getTermUrl(href, taxonomy.segment, term)}
-          class:list={selectedTerm === term ? activeClass : inactiveClass}
-          {...filterAttrs(
-            `filter_${taxonomy.segment}`,
-            translateTerm(taxonomy.i18nPrefix, term, t)
-          )}
-        >
-          {translateTerm(taxonomy.i18nPrefix, term, t)}
-        </a>
-      ))
+      terms.map((term) => {
+        const label = translateTerm(taxonomy.i18nPrefix, term, t)
+        const isEnabled = enabledSet === null || enabledSet.has(term)
+        const isActive = selectedTerm === term
+
+        if (!isEnabled) {
+          return (
+            <span
+              class:list={[
+                'px-space-2xs',
+                'py-space-3xs',
+                'text-step--1',
+                'rounded',
+                'shadow',
+                ...disabledClass
+              ]}
+              aria-disabled="true"
+            >
+              {label}
+            </span>
+          )
+        }
+        return (
+          <a
+            href={getTermUrl(href, taxonomy.segment, term, contentLangOverride)}
+            class:list={isActive ? activeClass : inactiveClass}
+            aria-current={isActive ? 'page' : undefined}
+            {...filterAttrs(`filter_${taxonomy.segment}`, label)}
+          >
+            {label}
+          </a>
+        )
+      })
     }
   </div>
 </div>

--- a/src/components/pages/FoundationBlogListingPage.astro
+++ b/src/components/pages/FoundationBlogListingPage.astro
@@ -13,14 +13,25 @@ import {
   getFeaturedPosts,
   useTranslations
 } from '@/utils'
+import type { Locale } from '@/utils'
 
 interface Props {
   page: Page
   allTerms: string[]
+  enabledTerms: string[]
   selectedTerm?: string
+  contentLang: Locale
+  isTermFallback?: boolean
 }
 
-const { page, allTerms, selectedTerm } = Astro.props
+const {
+  page,
+  allTerms,
+  enabledTerms,
+  selectedTerm,
+  contentLang,
+  isTermFallback
+} = Astro.props
 const { routeLocale } = Astro.locals
 const t = useTranslations(routeLocale)
 const basePath = stripPagination(Astro.url.pathname)
@@ -39,9 +50,14 @@ const description = translatedTerm
   ? t('blog.foundation.tag_description', { tag: translatedTerm })
   : t('blog.foundation.description')
 
-// Featured posts only show on the unfiltered first page. They are drawn from
-// the full collection, not the current page slice.
-const showFeatured = !selectedTerm && page.currentPage === 1
+// Featured posts only show on the bare blog index (first page, no filters).
+// Suppressed by any active category/tag filter (including /category/all) or explicit lang filter.
+const hasLangFilter = Astro.url.pathname.includes('/lang/')
+const hasTermFilter =
+  Astro.url.pathname.includes('/category/') ||
+  Astro.url.pathname.includes('/tag/')
+const showFeatured =
+  !selectedTerm && !hasTermFilter && !hasLangFilter && page.currentPage === 1
 const featuredPosts = showFeatured
   ? getFeaturedPosts(
       await getCollection(
@@ -68,8 +84,10 @@ const featuredPosts = showFeatured
         posts={page.data || []}
         allTerms={allTerms}
         selectedTerm={selectedTerm}
-        showTagFilter={true}
+        enabledTerms={enabledTerms}
         blogIndexHref={blogPath}
+        contentLang={contentLang}
+        isTermFallback={isTermFallback}
       />
       <Pagination
         baseUrl={basePath}

--- a/src/content/foundation-blog-posts/es/2024-03-15-es-anuncio-nuevo-programa-becas.mdx
+++ b/src/content/foundation-blog-posts/es/2024-03-15-es-anuncio-nuevo-programa-becas.mdx
@@ -1,0 +1,26 @@
+---
+title: 'Interledger Foundation anuncia nuevo programa de becas para América Latina'
+description: 'La Interledger Foundation lanza un nuevo ciclo de becas dirigido a organizaciones de América Latina que trabajan en inclusión financiera digital.'
+date: 2024-03-15
+pathSlug: es-anuncio-nuevo-programa-becas
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+La Interledger Foundation se complace en anunciar el lanzamiento de su nuevo programa de becas para organizaciones de América Latina. Este programa tiene como objetivo apoyar iniciativas que promuevan la inclusión financiera digital en la región.
+
+## Sobre el programa
+
+El programa ofrecerá financiamiento de hasta $50,000 USD para proyectos que demuestren un impacto medible en comunidades desatendidas. Las áreas prioritarias incluyen pagos transfronterizos, billeteras digitales y educación financiera.
+
+## Cómo aplicar
+
+Las organizaciones interesadas pueden enviar su solicitud a través de nuestro portal en línea antes del 30 de abril de 2024. Los criterios de selección incluyen alcance comunitario, viabilidad técnica y sostenibilidad del proyecto.
+
+Estamos emocionados de apoyar a emprendedores y organizaciones que están transformando el panorama financiero en América Latina.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2024-05-20-es-cumbre-pagos-digitales-africa.mdx
+++ b/src/content/foundation-blog-posts/es/2024-05-20-es-cumbre-pagos-digitales-africa.mdx
@@ -1,0 +1,27 @@
+---
+title: 'Resumen de la Cumbre de Pagos Digitales en África 2024'
+description: 'La Interledger Foundation participó en la Cumbre de Pagos Digitales en Nairobi, reuniendo a líderes de la industria para debatir el futuro de los pagos interoperables.'
+date: 2024-05-20
+pathSlug: es-cumbre-pagos-digitales-africa
+featured: false
+locale: es
+categories:
+  - Announcements
+  - Community & Events
+---
+
+<Paragraph>
+
+La semana pasada, el equipo de Interledger Foundation tuvo el honor de participar en la Cumbre de Pagos Digitales celebrada en Nairobi, Kenia. Este evento reunió a más de 500 profesionales de la industria financiera de todo el continente africano.
+
+## Principales conclusiones
+
+Durante los tres días de conferencia, los participantes debatieron sobre los desafíos y oportunidades en los pagos móviles transfronterizos. El protocolo Interledger fue reconocido como una solución clave para la interoperabilidad entre sistemas de pago locales.
+
+## Sesiones destacadas
+
+Nuestro director técnico presentó una demostración en vivo de transacciones en tiempo real utilizando la red Interledger. La audiencia mostró gran interés en las posibilidades que ofrece el protocolo para reducir los costos de remesas.
+
+Agradecemos a todos los asistentes y organizadores por hacer de este evento una experiencia tan enriquecedora.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2024-07-08-es-becarios-destacados-trimestre.mdx
+++ b/src/content/foundation-blog-posts/es/2024-07-08-es-becarios-destacados-trimestre.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Becarios destacados del segundo trimestre de 2024'
+description: 'Conoce a los organizaciones que recibieron financiamiento de la Interledger Foundation en el segundo trimestre del año y el impacto que están generando.'
+date: 2024-07-08
+pathSlug: es-becarios-destacados-trimestre
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+Nos complace presentar a los becarios más destacados del segundo trimestre de 2024. Estas organizaciones están liderando el camino hacia una mayor inclusión financiera en sus comunidades.
+
+## MobilePay Kenya
+
+MobilePay Kenya recibió una beca de $35,000 para expandir su plataforma de pagos móviles a zonas rurales con conectividad limitada. Durante el trimestre, lograron incorporar a más de 12,000 nuevos usuarios en tres condados.
+
+## Remesas Sin Fronteras
+
+Con una beca de $28,000, Remesas Sin Fronteras desarrolló una solución que reduce el costo promedio de envío de dinero entre México y Estados Unidos de un 7% a un 2.5%. Más de 5,000 familias se han beneficiado directamente.
+
+## FinTech Inclusiva
+
+Esta organización con sede en Colombia utilizó su beca de $42,000 para crear herramientas de educación financiera digital accesibles para comunidades indígenas, llegando a más de 8,000 personas.
+
+Estamos orgullosos del trabajo que estas organizaciones están realizando y esperamos seguir apoyando iniciativas de este calibre.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2024-08-14-es-protocolo-interledger-explicado.mdx
+++ b/src/content/foundation-blog-posts/es/2024-08-14-es-protocolo-interledger-explicado.mdx
@@ -1,0 +1,30 @@
+---
+title: 'El Protocolo Interledger explicado: cómo funciona la red de pagos abierta'
+description: 'Una guía accesible sobre cómo el Protocolo Interledger permite transferencias de valor entre distintas redes de pago de forma segura e instantánea.'
+date: 2024-08-14
+pathSlug: es-protocolo-interledger-explicado
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+El Protocolo Interledger (ILP) es la base tecnológica que hace posible el envío de dinero entre diferentes redes de pago, del mismo modo que el protocolo de internet permite enviar datos entre distintas redes informáticas.
+
+## ¿Cómo funciona?
+
+ILP funciona dividiendo los pagos en pequeños paquetes que viajan a través de una red de conectores. Cada conector actúa como un enrutador, encontrando el camino más eficiente para que el dinero llegue de un punto a otro, independientemente de la moneda o el sistema de pago utilizado.
+
+## Ventajas clave
+
+La principal ventaja del protocolo es su capacidad de conectar sistemas que antes eran incompatibles. Un usuario con una billetera en dólares puede enviar dinero a alguien con una billetera en pesos mexicanos, y la conversión ocurre automáticamente a lo largo del camino.
+
+## Casos de uso reales
+
+Hoy en día, el Protocolo Interledger alimenta aplicaciones de remesas, pagos de comercio electrónico y soluciones de monetización web. Su arquitectura abierta garantiza que ninguna empresa controle la red completa.
+
+Si deseas profundizar en la tecnología, te invitamos a explorar nuestra documentación técnica en el portal de desarrolladores.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2024-09-02-es-futuro-dinero-digital.mdx
+++ b/src/content/foundation-blog-posts/es/2024-09-02-es-futuro-dinero-digital.mdx
@@ -1,0 +1,28 @@
+---
+title: 'El futuro del dinero digital: reflexiones sobre la inclusión financiera global'
+description: 'Una reflexión sobre los avances y desafíos en la construcción de un sistema financiero más justo y accesible para todos, especialmente para los no bancarizados.'
+date: 2024-09-02
+pathSlug: es-futuro-dinero-digital
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+Vivimos en un momento histórico para las finanzas globales. Por primera vez, tenemos las herramientas tecnológicas para crear un sistema financiero verdaderamente inclusivo, pero la tecnología por sí sola no es suficiente.
+
+## La brecha de inclusión financiera
+
+Según cifras del Banco Mundial, más de 1,400 millones de adultos en el mundo siguen sin acceso a servicios financieros formales. Esta brecha no es solo un problema económico, sino una barrera que limita el potencial humano en comunidades enteras.
+
+## El papel de la tecnología
+
+Los pagos digitales y las tecnologías de código abierto como el Protocolo Interledger representan una oportunidad sin precedentes. Sin embargo, la implementación exitosa requiere más que infraestructura técnica; necesita diseño centrado en el usuario, regulación inteligente y alianzas locales sólidas.
+
+## Nuestra visión
+
+En la Interledger Foundation creemos que el dinero debería fluir como la información: libremente, instantáneamente y sin barreras artificiales. Trabajamos hacia un mundo donde cualquier persona, independientemente de dónde viva, pueda participar plenamente en la economía global.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2024-10-17-es-hackathon-interledger-2024.mdx
+++ b/src/content/foundation-blog-posts/es/2024-10-17-es-hackathon-interledger-2024.mdx
@@ -1,0 +1,29 @@
+---
+title: 'Hackathon Interledger 2024: innovadores de todo el mundo compiten por $100,000'
+description: 'El Hackathon Interledger 2024 convocó a más de 800 participantes de 45 países para desarrollar soluciones innovadoras de pagos abiertos en 48 horas.'
+date: 2024-10-17
+pathSlug: es-hackathon-interledger-2024
+featured: false
+locale: es
+categories:
+  - Community & Events
+  - Announcements
+---
+
+<Paragraph>
+
+Durante el pasado fin de semana, más de 800 desarrolladores, diseñadores y emprendedores de 45 países se reunieron virtualmente para participar en el Hackathon Interledger 2024. El evento fue un rotundo éxito, con proyectos que superaron todas las expectativas.
+
+## Los ganadores
+
+El primer lugar fue para el equipo PayFlow de Nigeria, que desarrolló una solución para micropagos en plataformas de streaming de contenido africano. Su proyecto demuestra cómo el Protocolo Interledger puede transformar la economía creativa en mercados emergentes.
+
+El segundo lugar lo obtuvo RemesaRápida de México, una aplicación que permite a trabajadores migrantes enviar dinero a sus familias con comisiones menores al 1%.
+
+## Proyectos honoríficos
+
+Otros diez proyectos recibieron menciones especiales, incluyendo soluciones para pagos agrícolas, plataformas educativas y herramientas de ahorro comunitario.
+
+El hackathon demostró una vez más que existe una comunidad global vibrante y comprometida con la visión de una internet financiera abierta.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2024-11-05-es-monetizacion-web-creadores.mdx
+++ b/src/content/foundation-blog-posts/es/2024-11-05-es-monetizacion-web-creadores.mdx
@@ -1,0 +1,28 @@
+---
+title: 'Monetización Web: una nueva era para los creadores de contenido hispanohablantes'
+description: 'Cómo la tecnología de Monetización Web está permitiendo a creadores de contenido en español generar ingresos directamente de su audiencia sin intermediarios.'
+date: 2024-11-05
+pathSlug: es-monetizacion-web-creadores
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+La Monetización Web representa un cambio fundamental en la relación entre creadores de contenido y sus audiencias. A diferencia de los modelos publicitarios tradicionales o las suscripciones mensuales, permite micropagos automáticos y continuos mientras los usuarios consumen contenido.
+
+## El problema actual
+
+Los creadores hispanohablantes se enfrentan a desafíos únicos: los ingresos publicitarios son significativamente menores que para el contenido en inglés, y las plataformas de suscripción tienen bajas tasas de adopción en muchos mercados latinoamericanos debido a la falta de acceso a tarjetas de crédito.
+
+## La solución de Monetización Web
+
+Con Monetización Web, un lector en Buenos Aires puede contribuir automáticamente unos centavos por minuto mientras lee un artículo, sin necesidad de registrarse ni introducir datos de pago. El proceso es invisible y sin fricción.
+
+## Casos de éxito
+
+Varios podcasters y periodistas independientes en México, Colombia y Argentina ya están utilizando esta tecnología para monetizar su trabajo. Los resultados iniciales muestran que pueden generar ingresos comparables a los modelos publicitarios tradicionales con una audiencia mucho más pequeña y comprometida.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2024-12-10-es-resultados-programa-becas-2024.mdx
+++ b/src/content/foundation-blog-posts/es/2024-12-10-es-resultados-programa-becas-2024.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Resultados del programa de becas 2024: un año de impacto global'
+description: 'Un repaso de los logros alcanzados por los becarios de la Interledger Foundation durante 2024, con métricas de impacto y testimonios de los equipos financiados.'
+date: 2024-12-10
+pathSlug: es-resultados-programa-becas-2024
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+Al cerrar el año 2024, hacemos un balance del impacto generado por los 47 proyectos que recibieron financiamiento de la Interledger Foundation a lo largo del año. Los resultados superan ampliamente nuestras expectativas iniciales.
+
+## Cifras clave del año
+
+- **$2.3 millones** distribuidos en becas a proyectos de 28 países
+- **340,000 personas** accedieron a servicios financieros por primera vez gracias a proyectos financiados
+- **67 soluciones tecnológicas** desarrolladas o mejoradas con apoyo de la Foundation
+- **89%** de los proyectos reportaron resultados positivos en sus métricas principales
+
+## Regiones con mayor impacto
+
+África Subsahariana continúa siendo la región donde nuestras becas generan el mayor impacto per cápita, seguida de cerca por el Sudeste Asiático y América Central. La creciente presencia de proyectos en idioma español refleja el compromiso de la Foundation con la comunidad hispanohablante.
+
+## Mirando hacia 2025
+
+Para el próximo año, ampliaremos el programa con un enfoque especial en proyectos que combinen inclusión financiera con educación digital. Las solicitudes para el primer ciclo de 2025 estarán abiertas a partir de enero.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2025-02-18-es-actualizacion-protocolo-ilp.mdx
+++ b/src/content/foundation-blog-posts/es/2025-02-18-es-actualizacion-protocolo-ilp.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Actualización del Protocolo Interledger: nuevas funcionalidades para 2025'
+description: 'La comunidad Interledger presenta las mejoras técnicas planeadas para el protocolo en 2025, incluyendo mayor velocidad de liquidación y soporte para nuevos tipos de activos.'
+date: 2025-02-18
+pathSlug: es-actualizacion-protocolo-ilp
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+El ecosistema Interledger continúa evolucionando. La comunidad de desarrolladores ha trabajado durante los últimos seis meses en una serie de mejoras sustanciales al protocolo que estarán disponibles durante 2025.
+
+## Mayor velocidad de liquidación
+
+Una de las mejoras más esperadas es la reducción del tiempo de liquidación final. Las pruebas actuales muestran que los nuevos algoritmos de enrutamiento pueden reducir el tiempo promedio de confirmación de transacciones en un 60%, pasando de varios segundos a menos de un segundo en la mayoría de los casos.
+
+## Soporte para nuevos tipos de activos
+
+El protocolo expandirá su soporte nativo para monedas digitales de banco central (CBDC), permitiendo que los sistemas nacionales de pago digital se integren directamente con la red Interledger sin necesidad de adaptadores intermediarios.
+
+## Mejoras en seguridad
+
+El nuevo sistema de pruebas de pago condicional ofrece garantías criptográficas más sólidas contra ataques de doble gasto, manteniendo la eficiencia del protocolo en redes de alta latencia.
+
+Invitamos a los desarrolladores interesados a revisar las propuestas de mejora (RFCs) en nuestro repositorio de GitHub y a participar en el proceso de revisión comunitaria.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2025-03-25-es-conferencia-inclusion-financiera-bogota.mdx
+++ b/src/content/foundation-blog-posts/es/2025-03-25-es-conferencia-inclusion-financiera-bogota.mdx
@@ -1,0 +1,31 @@
+---
+title: 'La Interledger Foundation en la Conferencia de Inclusión Financiera de Bogotá'
+description: 'Nuestra presencia en la mayor conferencia de inclusión financiera de América Latina, donde presentamos casos de uso del Protocolo Interledger para remesas y pagos rurales.'
+date: 2025-03-25
+pathSlug: es-conferencia-inclusion-financiera-bogota
+featured: false
+locale: es
+categories:
+  - Community & Events
+  - Announcements
+---
+
+<Paragraph>
+
+La semana pasada, la Interledger Foundation participó como ponente principal en la Conferencia de Inclusión Financiera de Bogotá, el evento de referencia para el sector fintech en América Latina con más de 2,000 asistentes de 20 países.
+
+## Nuestra presentación
+
+Nuestra representante regional, Ana García, presentó tres casos de uso concretos del Protocolo Interledger en contextos latinoamericanos: remesas México-Estados Unidos, pagos a agricultores en zonas rurales de Colombia, y micropagos para creadores de contenido en el cono sur.
+
+## Conversaciones clave
+
+Durante los talleres, tuvimos conversaciones muy productivas con representantes de bancos centrales de cinco países, todos interesados en explorar cómo sus CBDC podrían interoperar con redes de pago privadas a través de Interledger.
+
+## Próximos pasos
+
+Como resultado de la conferencia, estamos explorando tres nuevas alianzas estratégicas en la región. Compartiremos más detalles en las próximas semanas a medida que estas conversaciones avancen.
+
+Gracias a los organizadores y a todos los participantes por hacer de este evento una plataforma tan valiosa para el diálogo sobre el futuro financiero de la región.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2025-04-14-es-nueva-directora-regional.mdx
+++ b/src/content/foundation-blog-posts/es/2025-04-14-es-nueva-directora-regional.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Interledger Foundation nombra nueva directora regional para América Latina'
+description: 'La Interledger Foundation da la bienvenida a su nueva directora regional para América Latina, quien liderará la expansión de programas de inclusión financiera en la región.'
+date: 2025-04-14
+pathSlug: es-nueva-directora-regional
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+La Interledger Foundation se complace en anunciar la incorporación de María Elena Reyes como Directora Regional para América Latina. María Elena aporta más de 15 años de experiencia en el sector fintech y microfinanzas en la región.
+
+## Sobre María Elena Reyes
+
+Antes de unirse a la Foundation, María Elena fue directora de innovación en una institución de microfinanzas con presencia en ocho países latinoamericanos. También fue cofundadora de una fintech enfocada en pagos rurales que fue reconocida por el Banco Interamericano de Desarrollo como una de las cien mejores iniciativas de inclusión financiera del continente.
+
+## Su visión para la región
+
+"América Latina tiene una oportunidad única. Tenemos una población joven, alta penetración de smartphones y una necesidad urgente de soluciones financieras que funcionen para todos, no solo para quienes ya tienen acceso a la banca tradicional. El Protocolo Interledger puede ser la infraestructura sobre la que se construya esa visión," comentó María Elena.
+
+## Planes inmediatos
+
+En sus primeros tres meses, María Elena se enfocará en establecer alianzas con universidades locales, fortalecer la comunidad de desarrolladores hispanohablantes y lanzar un nuevo ciclo de becas con enfoque regional.
+
+Le damos la más cálida bienvenida a nuestro equipo.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2025-05-30-es-open-payments-remesas.mdx
+++ b/src/content/foundation-blog-posts/es/2025-05-30-es-open-payments-remesas.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Open Payments: transformando el mercado de remesas en América Latina'
+description: 'Cómo el estándar Open Payments está reduciendo las comisiones de remesas y mejorando la experiencia de millones de migrantes latinoamericanos que envían dinero a sus familias.'
+date: 2025-05-30
+pathSlug: es-open-payments-remesas
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+Las remesas representan una fuente vital de ingresos para millones de familias en América Latina. En países como El Salvador, Honduras y Guatemala, las remesas equivalen a entre el 20% y el 25% del PIB nacional. Sin embargo, los costos de envío siguen siendo excesivamente altos, con comisiones que promedian entre el 5% y el 8%.
+
+## El estándar Open Payments
+
+Open Payments es un estándar abierto que define cómo las aplicaciones pueden solicitar y autorizar pagos de forma segura sin compartir datos financieros sensibles. Al ser un estándar, cualquier proveedor puede implementarlo, lo que fomenta la competencia y reduce los costos.
+
+## Impacto en las remesas
+
+Las pruebas piloto realizadas en corredores de remesas entre Estados Unidos y México han demostrado reducciones en costos del 60% al 75%. Esto se traduce en miles de dólares adicionales que llegan a las familias en lugar de quedarse en intermediarios.
+
+## Adopción creciente
+
+Actualmente, más de 30 instituciones financieras en América Latina están en proceso de implementar el estándar Open Payments. La Interledger Foundation proporciona recursos técnicos y apoyo durante el proceso de integración.
+
+Si tu institución está interesada en adoptar Open Payments, te invitamos a contactarnos para recibir orientación técnica gratuita.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2025-07-22-es-becas-educacion-financiera-digital.mdx
+++ b/src/content/foundation-blog-posts/es/2025-07-22-es-becas-educacion-financiera-digital.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Nuevas becas para proyectos de educación financiera digital en comunidades rurales'
+description: 'La Interledger Foundation abre convocatoria para becas destinadas a organizaciones que desarrollen programas de educación financiera digital en comunidades rurales de habla hispana.'
+date: 2025-07-22
+pathSlug: es-becas-educacion-financiera-digital
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+La Interledger Foundation abre su convocatoria para el nuevo programa de becas enfocado en educación financiera digital para comunidades rurales. Este ciclo dispone de $800,000 USD para distribuir entre proyectos seleccionados.
+
+## Requisitos de elegibilidad
+
+Para ser elegible, las organizaciones deben demostrar presencia activa en comunidades rurales, capacidad de implementar programas de al menos seis meses de duración, y un plan de medición de impacto claro. Se dará preferencia a proyectos que integren el aprendizaje práctico con el uso de herramientas de pago digital.
+
+## Categorías de financiamiento
+
+**Becas semilla** ($10,000 - $25,000): para organizaciones en etapa inicial que buscan probar un concepto innovador.
+
+**Becas de crecimiento** ($25,000 - $75,000): para organizaciones con experiencia previa que buscan escalar un programa existente.
+
+**Becas de impacto sistémico** ($75,000 - $150,000): para organizaciones consolidadas con planes de alcance nacional o regional.
+
+## Proceso de solicitud
+
+Las solicitudes deben enviarse antes del 15 de septiembre de 2025. El proceso incluye una revisión inicial, entrevistas con los finalistas y una decisión final en octubre.
+
+Visita nuestra página de becas para descargar las bases completas y el formulario de solicitud.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2025-09-15-es-interoperabilidad-clave-inclusion.mdx
+++ b/src/content/foundation-blog-posts/es/2025-09-15-es-interoperabilidad-clave-inclusion.mdx
@@ -1,0 +1,32 @@
+---
+title: 'La interoperabilidad como clave para la inclusión financiera: lecciones de cinco años'
+description: 'Reflexiones sobre lo que hemos aprendido en cinco años trabajando para hacer los sistemas de pago más interoperables, y por qué la apertura de estándares es fundamental.'
+date: 2025-09-15
+pathSlug: es-interoperabilidad-clave-inclusion
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+Cinco años de trabajo en la intersección de tecnología y finanzas inclusivas nos han enseñado una lección fundamental: la interoperabilidad no es solo una característica técnica deseable, es un requisito indispensable para la inclusión financiera real.
+
+## El problema de los silos
+
+Históricamente, los sistemas de pago digital se desarrollaron en silos. Cada operador de billetera digital, cada banco, cada red de pago operaba de forma aislada. Esto creó un paisaje fragmentado donde el dinero podía circular libremente dentro de un sistema pero quedaba atrapado en sus fronteras.
+
+## Por qué importa para los excluidos
+
+Esta fragmentación afecta desproporcionadamente a las personas con menos recursos. Quienes tienen acceso a los servicios financieros tradicionales pueden navegar estas barreras con relativa facilidad; quienes dependen de servicios alternativos como el dinero móvil se encuentran confinados a ecosistemas limitados.
+
+## El modelo de la internet como referencia
+
+La internet es el mejor ejemplo de cómo la interoperabilidad abierta puede transformar un sector. Nadie es dueño del protocolo TCP/IP, pero todos se benefician de él. El Protocolo Interledger aspira a ser el TCP/IP del dinero digital.
+
+## Los obstáculos persisten
+
+A pesar del progreso, siguen existiendo barreras significativas: intereses comerciales de actores dominantes, marcos regulatorios nacionales fragmentados y la percepción de que la apertura amenaza la ventaja competitiva. Superar estos obstáculos requiere tanto liderazgo técnico como político.
+
+</Paragraph>

--- a/src/content/foundation-blog-posts/es/2025-11-03-es-alianza-universidades-latam.mdx
+++ b/src/content/foundation-blog-posts/es/2025-11-03-es-alianza-universidades-latam.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Interledger Foundation lanza alianza con diez universidades latinoamericanas'
+description: 'Una nueva alianza académica conecta a la Interledger Foundation con diez universidades de América Latina para fomentar la investigación y el desarrollo de talento en pagos digitales abiertos.'
+date: 2025-11-03
+pathSlug: es-alianza-universidades-latam
+featured: false
+locale: es
+categories:
+  - Announcements
+---
+
+<Paragraph>
+
+La Interledger Foundation se complace en anunciar la firma de acuerdos de colaboración con diez universidades líderes de América Latina. Esta alianza académica es la mayor que la Foundation ha establecido hasta la fecha y marca un hito en nuestro compromiso con el desarrollo de talento regional.
+
+## Las instituciones participantes
+
+Las universidades que forman parte de esta alianza inicial incluyen instituciones de México, Colombia, Brasil, Argentina, Chile y Perú. Cada institución aportará su fortaleza particular, desde investigación en criptografía hasta programas de emprendimiento social.
+
+## Beneficios de la alianza
+
+Los estudiantes de las universidades aliadas tendrán acceso a:
+
+- Recursos técnicos de la Foundation para proyectos finales de carrera
+- Pasantías remuneradas en organizaciones del ecosistema Interledger
+- Participación prioritaria en hackathons y competencias de innovación
+- Mentorías con expertos internacionales en pagos digitales
+
+## Investigación conjunta
+
+Adicionalmente, la Foundation financiará tres proyectos de investigación conjunta sobre temas críticos: regulación de pagos digitales en contextos de alta informalidad, diseño de interfaces para usuarios con baja literacidad digital, y modelos de gobernanza para redes de pago descentralizadas.
+
+Los primeros resultados de investigación se presentarán en la Conferencia Interledger de 2026.
+
+</Paragraph>

--- a/src/data/ui.ts
+++ b/src/data/ui.ts
@@ -59,6 +59,20 @@ export const ui = {
     'blog.featured.title': 'Featured',
     'blog.published': 'Published',
     'blog.updated': 'Last updated',
+    'blog.lang_filter.label': 'Filter by language:',
+    'blog.lang_filter.english': 'English',
+    'blog.lang_filter.spanish': 'Spanish',
+    // Only rendered on the English site when the Spanish filter is active.
+    // TRANSLATION NOTE: No translation needed
+    'blog.lang_filter.viewing_es_posts': 'Showing Spanish posts',
+    // Only rendered on the Spanish site when the English filter is active.
+    'blog.lang_filter.viewing_en_posts': 'Showing English posts',
+    // Shown whenever the Spanish content filter is active (on either EN or ES site)
+    'blog.lang_filter.more_en_available': 'More posts available in English',
+    'blog.lang_filter.view_in_en': 'View in English',
+    'blog.empty_tag_lang.message':
+      'No posts found for this tag in the selected language.',
+    'blog.empty_tag_lang.cta': 'View all posts',
     'blog.read_more': 'Read more',
     'blog.community.foundation.start':
       'If you want to stay updated with all open opportunities and news from the Interledger Foundation, you can subscribe to our',
@@ -266,6 +280,18 @@ export const ui = {
     'blog.featured.title': '',
     'blog.published': '',
     'blog.updated': '',
+    'blog.lang_filter.label': 'Filtrar por idioma:',
+    'blog.lang_filter.english': 'Inglés',
+    'blog.lang_filter.spanish': 'Español',
+    // Shown on ES pages when the English filter is active
+    'blog.lang_filter.viewing_en_posts': 'Mostrando publicaciones en inglés',
+    // Shown whenever the Spanish content filter is active (on either EN or ES site)
+    'blog.lang_filter.more_en_available':
+      'Nota: hay más publicaciones disponibles en inglés',
+    'blog.lang_filter.view_in_en': 'Ver en inglés',
+    'blog.empty_tag_lang.message':
+      'No se encontraron publicaciones para esta etiqueta en el idioma seleccionado.',
+    'blog.empty_tag_lang.cta': 'Ver todas las publicaciones',
     'blog.read_more': '',
     'blog.community.foundation.start': '',
     'blog.community.foundation.middle': '',

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,23 +1,23 @@
 ---
+import type { Page, GetStaticPaths } from 'astro'
 import { paginateAllPosts } from '@/utils'
-import type { GetStaticPaths, Page } from 'astro'
+import type { Locale } from '@/utils'
 import FoundationBlogListingPage from '@/components/pages/FoundationBlogListingPage.astro'
 
 type Props = {
   page: Page
   allTerms: string[]
+  enabledTerms: string[]
+  contentLang: Locale
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-  const paths = await paginateAllPosts({
+  return paginateAllPosts({
     paginate,
     collection: 'foundation-blog',
     lang: 'en'
   })
-  return paths
 }
-
-const { page, allTerms } = Astro.props
 ---
 
-<FoundationBlogListingPage page={page} allTerms={allTerms} />
+<FoundationBlogListingPage {...Astro.props} />

--- a/src/pages/blog/category/[category]/[...page].astro
+++ b/src/pages/blog/category/[category]/[...page].astro
@@ -1,28 +1,25 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
 import { paginatePostsByTerm } from '@/utils'
+import type { Locale } from '@/utils'
 import FoundationBlogListingPage from '@/components/pages/FoundationBlogListingPage.astro'
 
 type Props = {
   page: Page
   allTerms: string[]
-  selectedTerm: string
+  enabledTerms: string[]
+  contentLang: Locale
+  selectedTerm?: string
+  isTermFallback?: boolean
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-  const paths = await paginatePostsByTerm({
+  return paginatePostsByTerm({
     paginate,
     collection: 'foundation-blog',
     lang: 'en'
   })
-  return paths
 }
-
-const { page, allTerms, selectedTerm } = Astro.props
 ---
 
-<FoundationBlogListingPage
-  page={page}
-  allTerms={allTerms}
-  selectedTerm={selectedTerm}
-/>
+<FoundationBlogListingPage {...Astro.props} />

--- a/src/pages/blog/category/[category]/lang/[contentLang]/[...page].astro
+++ b/src/pages/blog/category/[category]/lang/[contentLang]/[...page].astro
@@ -1,6 +1,6 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import { paginateAllPosts } from '@/utils'
+import { paginatePostsByTerm } from '@/utils'
 import type { Locale } from '@/utils'
 import FoundationBlogListingPage from '@/components/pages/FoundationBlogListingPage.astro'
 
@@ -9,14 +9,24 @@ type Props = {
   allTerms: string[]
   enabledTerms: string[]
   contentLang: Locale
+  selectedTerm?: string
+  isTermFallback?: boolean
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-  return paginateAllPosts({
+  const enPaths = await paginatePostsByTerm({
     paginate,
     collection: 'foundation-blog',
-    lang: 'es'
+    lang: 'en',
+    contentLang: 'en'
   })
+  const esPaths = await paginatePostsByTerm({
+    paginate,
+    collection: 'foundation-blog',
+    lang: 'en',
+    contentLang: 'es'
+  })
+  return [...enPaths, ...esPaths]
 }
 ---
 

--- a/src/pages/es/blog/category/[category]/[...page].astro
+++ b/src/pages/es/blog/category/[category]/[...page].astro
@@ -1,28 +1,25 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
 import { paginatePostsByTerm } from '@/utils'
+import type { Locale } from '@/utils'
 import FoundationBlogListingPage from '@/components/pages/FoundationBlogListingPage.astro'
 
 type Props = {
   page: Page
   allTerms: string[]
-  selectedTerm: string
+  enabledTerms: string[]
+  contentLang: Locale
+  selectedTerm?: string
+  isTermFallback?: boolean
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-  const paths = await paginatePostsByTerm({
+  return paginatePostsByTerm({
     paginate,
     collection: 'foundation-blog',
     lang: 'es'
   })
-  return paths
 }
-
-const { page, allTerms, selectedTerm } = Astro.props
 ---
 
-<FoundationBlogListingPage
-  page={page}
-  allTerms={allTerms}
-  selectedTerm={selectedTerm}
-/>
+<FoundationBlogListingPage {...Astro.props} />

--- a/src/pages/es/blog/category/[category]/lang/[contentLang]/[...page].astro
+++ b/src/pages/es/blog/category/[category]/lang/[contentLang]/[...page].astro
@@ -1,6 +1,6 @@
 ---
 import type { Page, GetStaticPaths } from 'astro'
-import { paginateAllPosts } from '@/utils'
+import { paginatePostsByTerm } from '@/utils'
 import type { Locale } from '@/utils'
 import FoundationBlogListingPage from '@/components/pages/FoundationBlogListingPage.astro'
 
@@ -9,14 +9,24 @@ type Props = {
   allTerms: string[]
   enabledTerms: string[]
   contentLang: Locale
+  selectedTerm?: string
+  isTermFallback?: boolean
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
-  return paginateAllPosts({
+  const enPaths = await paginatePostsByTerm({
     paginate,
     collection: 'foundation-blog',
-    lang: 'es'
+    lang: 'es',
+    contentLang: 'en'
   })
+  const esPaths = await paginatePostsByTerm({
+    paginate,
+    collection: 'foundation-blog',
+    lang: 'es',
+    contentLang: 'es'
+  })
+  return [...enPaths, ...esPaths]
 }
 ---
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -62,6 +62,7 @@ export {
   getTermSlug,
   getTermUrl,
   translateTerm,
+  buildContentLangHrefs,
   paginateAllPosts,
   paginatePostsByTerm
 } from './main/tagFilter'

--- a/src/utils/main/languageSwitcherHrefs.ts
+++ b/src/utils/main/languageSwitcherHrefs.ts
@@ -7,6 +7,46 @@ function toDefaultSectionHref(locale: Locale, basePath: string): string {
   return localizeRoute(normalizeBasePath(basePath), locale)
 }
 
+function isBlogPath(basePath: string): boolean {
+  return basePath.endsWith('/blog')
+}
+
+function parseBlogSlug(slug: string): {
+  term?: string
+  contentLang?: Locale
+  segment?: 'tag' | 'category'
+} {
+  const parts = slug.split('/').filter(Boolean)
+  const last = parts.at(-1)
+  const relevant = last && /^\d+$/.test(last) ? parts.slice(0, -1) : parts
+
+  const tagIdx = relevant.indexOf('tag')
+  const categoryIdx = relevant.indexOf('category')
+  const termIdx = tagIdx >= 0 ? tagIdx : categoryIdx
+  const langIdx = relevant.indexOf('lang')
+  return {
+    term: termIdx >= 0 ? relevant[termIdx + 1] : undefined,
+    contentLang: langIdx >= 0 ? (relevant[langIdx + 1] as Locale) : undefined,
+    segment: tagIdx >= 0 ? 'tag' : categoryIdx >= 0 ? 'category' : undefined
+  }
+}
+
+function buildBlogSwitchHref(
+  basePath: string,
+  slug: string,
+  targetLocale: Locale
+): string {
+  const { term, contentLang, segment } = parseBlogSlug(slug)
+  const targetContentLang = contentLang ?? targetLocale
+  const hasExplicitLang = contentLang !== undefined
+  let href = localizeRoute(normalizeBasePath(basePath), targetLocale)
+  if (term) {
+    href += `/${segment ?? 'category'}/${term}`
+  }
+  if (hasExplicitLang) href += `/lang/${targetContentLang}`
+  return href
+}
+
 export function getLanguageSwitcherHrefs(
   currentSlug: string,
   currentBasePath: string
@@ -15,6 +55,16 @@ export function getLanguageSwitcherHrefs(
 
   return Object.fromEntries(
     switcherLocales.map((locale) => {
+      if (isBlogPath(currentBasePath)) {
+        const { term, contentLang } = parseBlogSlug(currentSlug)
+        if (term || contentLang) {
+          return [
+            locale,
+            buildBlogSwitchHref(currentBasePath, currentSlug, locale)
+          ]
+        }
+      }
+
       const slug = entry?.[locale]
       const href = slug
         ? localizeRoute(buildRoutePath(currentBasePath, slug), locale)

--- a/src/utils/main/tagFilter.ts
+++ b/src/utils/main/tagFilter.ts
@@ -53,13 +53,40 @@ export function getTermSlug(term: string) {
   return term.toLowerCase().replace(/\s+/g, '-')
 }
 
-/** Builds the URL of a taxonomy filter page, e.g. `/blog/category/announcements`. */
+/** Builds the URL of a taxonomy filter page, e.g. `/blog/category/announcements`.
+ *  Cross-lang combo routes always use "tag" as the generic URL segment, so we
+ *  switch to it whenever a contentLangOverride is present.
+ */
 export function getTermUrl(
   basePath: string,
   segment: BlogTaxonomy['segment'],
-  term: string
+  term: string,
+  contentLangOverride?: Locale
 ) {
-  return `${basePath}/${segment}/${getTermSlug(term)}`
+  const slug = getTermSlug(term)
+  if (contentLangOverride) {
+    return `${basePath}/${segment}/${slug}/lang/${contentLangOverride}`
+  }
+  return `${basePath}/${segment}/${slug}`
+}
+
+/**
+ * Builds the EN and ES hrefs for the content-language toggle buttons/links.
+ * Both links always use the /lang/<locale> URL form so the selection is
+ * reflected in the URL and stays sticky through subsequent navigation
+ * (taxonomy filter, All button, language switcher).
+ */
+export function buildContentLangHrefs(
+  blogIndexHref: string,
+  selectedTerm?: string
+): { enHref: string; esHref: string } {
+  const crossLangBase = selectedTerm
+    ? `${blogIndexHref}/category/${getTermSlug(selectedTerm)}`
+    : blogIndexHref
+  return {
+    enHref: `${crossLangBase}/lang/en`,
+    esHref: `${crossLangBase}/lang/es`
+  }
 }
 
 export function translateTerm(
@@ -76,55 +103,117 @@ async function fetchPostsAndTerms(
   lang: Locale
 ) {
   const { field } = getBlogTaxonomy(collection)
-  const blogEntries = (
-    await getCollection(collection, ({ data }) => data.locale === lang)
-  ).sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  const allEntries = (await getCollection(collection)).sort(
+    (a, b) => b.data.date.getTime() - a.data.date.getTime()
+  )
+  const blogEntries = allEntries.filter((entry) => entry.data.locale === lang)
   // Collect all unique terms across posts
   const allTerms = [
-    ...new Set(blogEntries.flatMap((entry) => getEntryTerms(entry, field)))
+    ...new Set(allEntries.flatMap((entry) => getEntryTerms(entry, field)))
   ].sort()
 
-  return { blogEntries, allTerms }
+  const enabledTerms = new Set(
+    blogEntries.flatMap((entry) => getEntryTerms(entry, field))
+  )
+
+  return { blogEntries, allTerms, enabledTerms }
 }
 
 export async function paginateAllPosts({
   paginate,
   collection,
-  lang
+  lang,
+  contentLang
 }: {
   paginate: PaginateFunction
   collection: BlogCollectionType
   lang: Locale
+  contentLang?: Locale
 }) {
-  const { blogEntries, allTerms } = await fetchPostsAndTerms(collection, lang)
+  const effectiveLang = contentLang ?? lang
+  const { blogEntries, allTerms, enabledTerms } = await fetchPostsAndTerms(
+    collection,
+    effectiveLang
+  )
+  const langParam = contentLang ? { contentLang } : undefined
   return paginate(blogEntries, {
+    params: langParam,
     pageSize: 10,
-    props: { allTerms }
+    props: {
+      allTerms,
+      enabledTerms: [...enabledTerms],
+      contentLang: effectiveLang
+    }
   })
 }
 
 export async function paginatePostsByTerm({
   paginate,
   collection,
-  lang
+  lang,
+  contentLang
 }: {
   paginate: PaginateFunction
   collection: BlogCollectionType
   lang: Locale
+  contentLang?: Locale
 }) {
   const { field, segment } = getBlogTaxonomy(collection)
-  const { blogEntries, allTerms } = await fetchPostsAndTerms(collection, lang)
-  // Create a paginated set of pages for each term
-  return allTerms.flatMap((term) => {
-    const termSlug = getTermSlug(term)
+  const effectiveLang = contentLang ?? lang
+  const { blogEntries, allTerms, enabledTerms } = await fetchPostsAndTerms(
+    collection,
+    effectiveLang
+  )
+
+  // For combined term+lang routes the URL segment is always "tag" (generic);
+  // for term-only routes it matches the collection's taxonomy segment.
+  const termParamKey = segment
+
+  const termPaths = allTerms.flatMap((tag) => {
+    const termSlug = getTermSlug(tag)
     const filteredEntries = blogEntries.filter((entry) =>
-      getEntryTerms(entry, field).some((t) => t === term)
+      getEntryTerms(entry, field).some((t) => t === tag)
     )
 
-    return paginate(filteredEntries, {
-      params: { [segment]: termSlug },
+    const langParam = contentLang ? { contentLang } : undefined
+
+    // When no posts match the tag+lang combo, paginate all lang posts as a fallback
+    // so the page renders with content rather than 404 or an empty list. The tag
+    // stays in the URL so switching back to the other lang preserves the filter.
+    const pageEntries =
+      filteredEntries.length > 0 ? filteredEntries : blogEntries
+    const isTermFallback = filteredEntries.length === 0
+
+    return paginate(pageEntries, {
+      params: { [termParamKey]: termSlug, ...langParam },
       pageSize: 10,
-      props: { allTerms, selectedTerm: term }
+      props: {
+        allTerms,
+        enabledTerms: [...enabledTerms],
+        selectedTerm: tag,
+        contentLang: effectiveLang,
+        isTermFallback
+      }
     })
   })
+
+  // Generate /<segment>/all (or /tag/all/lang/<locale>) so the "All" filter button
+  // has a canonical URL on both simple and cross-lang routes.
+  const allParams = contentLang
+    ? { [termParamKey]: 'all', contentLang }
+    : { [termParamKey]: 'all' }
+
+  const allPath = paginate(blogEntries, {
+    params: allParams,
+    pageSize: 10,
+    props: {
+      allTerms,
+      enabledTerms: [...enabledTerms],
+      selectedTerm: undefined,
+      contentLang: effectiveLang,
+      isTermFallback: false
+    }
+  })
+
+  return [...termPaths, ...allPath]
 }


### PR DESCRIPTION
## Summary
<!-- What changed and why -->

Blogs can be filtered by language and tags and should be able to switch between `ES` and `EN` states while keeping consistent states and pagination.

### On `EN` page `/blog`

- When you land on `/blog` the `EN` language content filter should be set and the `All` tag should be set and no disclaimers are shown
- Can select lang content filter and paginate (i.e. pagniation carries awareness of language filters consistently for `next`, `previous`, `first` and `last` buttons)
    - if you use the `ES` language content filter two disclaimers should be shown (`blog.lang_filter.viewing_es_posts` and `blog.lang_filter.more_en_available`)
    - if you use the `EN` filter then no disclaimers should be shown
- Can select content tag filter and pagniate (i.e. pagniation carries awareness of tag filters consistently for `next`, `previous`, `first` and `last` buttons)
- Can select language and tag content filters and paginate (i.e. pagniation carries awareness of language and tag filters consistently for `next`, `previous`, `first` and `last` buttons)
- Can move between language filters, once you've entered `/blog` and clicked a filter the URL will never clear back to `/blog` again. it will always have `/blog/lang/en` or `/blog/tag/announcements/lang/es/`. On all pages with tags and / or language filters we remove the featured blogs section from showing.
- Can switch tag filters (only one tag can be applied at a time). After the first filter is applied it never goes back to `/blog` it will go back to `/blog/tag/all`. On all pages with tags and / or language filters we remove the featured blogs section from showing.
- Can remove tag filters (ie. return to `All`)
- Changing any filter (language or tag) while on a paginated results page resets pagination to page 1.

### On `ES` page `/es/blog`

- When you land on `/es/blog` the `ES` language content filter should be set and the `All` tag should be set and a disclaimer should show (`blog.lang_filter.more_en_available`)
- Can select lang content filter and paginate (i.e. pagniation carries awareness of language filters consistently for `next`, `previous`, `first` and `last` buttons)
    - if you select the `EN` filter then one disclaimer should show (`blog.lang_filter.viewing_en_posts`)
    - if you filter on `ES` then one disclaimer should show (`blog.lang_filter.more_en_available`).
- Can select content tag filter and pagniate (i.e. pagniation carries awareness of tag filters consistently for `next`, `previous`, `first` and `last` buttons)
- Can select language and tag content filters and paginate (i.e. pagniation carries awareness of language and tag filters consistently for `next`, `previous`, `first` and `last` buttons)
- Can move between language filters, once you've entered `/es/blog` and clicked a filter the URL will never clear back to `/es/blog` again. it will always have `/es/blog/lang/en` or `/es/blog/tag/announcements/lang/es/`. On all pages with tags and / or language filters we remove the featured blogs section from showing.
- Can switch tag filters (only one tag can be applied at a time). After the first filter is applied it never goes back to `/es/blog` it will go back to `/es/blog/tag/all`. On all pages with tags and / or language filters we remove the featured blogs section from showing.
- Can remove tag filters (ie. return to `All`)
- Changing any filter (language or tag) while on a paginated results page resets pagination to page 1.

### Navigating from `EN` to `ES` using the global language switcher

- If you land on `/blog` and switch to `/es/blog` then the `ES` language content filter should be set and the `All` tag should be set and a disclaimer should show (`blog.lang_filter.more_en_available`)
- If you are on `/blog` and you select the `ES` language filter and then use the global language switcher to navigate to `/es/blog` the `ES` language filter should stay on and a disclaimer should show (`blog.lang_filter.more_en_available`)
- If you are on `/blog` and you select a tag filter and then use the global language switcher to navigate to `/es/blog` the `ES` language filter should be applied and the tag should be applied and a disclaimer should be present (`blog.lang_filter.more_en_available`)
- If you are on `/blog` and you select the `EN` language filter and a tag filter and then use the global language switcher to navigate to `/es/blog` the `EN` language filter should be applied (it was saved to the url so it was intentional and should be respected) and the tag should be applied and a disclaimer should be present (`blog.lang_filter.viewing_en_posts`)
- If you are on a pagination page e.g. `/blog/tag/announcements/lang/es/2`, `/blog/5`, etc. For any language or tag filter combination and you switch to the `ES` site using the global langauge switcher then pagination should always return to the first page.

### Navigating from ES to EN using the global language switcher

- If you land on `/es/blog` and switch to `/blog` then the `EN` language content filter should be set and the `All` tag should be set and no disclaimers should show
- If you are on `/es/blog` and you select the `EN` language filter and then use the global language switcher to navigate to `/blog` the `EN` language filter should stay on and no disclaimers should be shown
- If you are on `/es/blog` and you select a tag filter and then use the global language switcher to navigate to `/blog` the `EN` language filter should be set on and the tag should be applied and no disclaimers should be applied
- If you are on `/es/blog` and you select the `ES` language filter and a tag filter and then use the global language switcher to navigate to `/blog` the `ES` language filter should be applied (it was saved to the url so it was intentional and should be respected) and the tag should be applied and a disclaimer should be present (`blog.lang_filter.viewing_es_posts`)
- If you are on a pagination page e.g. `/es/blog/tag/announcements/lang/en/3`, `/es/blog/2`, etc. For any language or tag filter combination and you switch to the `EN` site using the global langauge switcher then pagination should always return to the first page.

#### Tag Availability & Empty State

All tags are available when the `EN` language filter is active. Only a subset of tags are available when the `ES` language filter is active. Unavailable tags are greyed out but still visible.

Edge case — tag becomes unavailable after switching to `ES`: if a user has an `EN`-only tag selected and then switches to the `ES` language filter (via the content filter or the global switcher), no posts will match. In this state:

Show `blog.empty_tag_lang.message` and `blog.lang_filter.more_en_available`
Below those disclaimers, display all `ES` posts (ignoring the now-invalid tag filter) rather than showing an empty list. But keep the tag as part of the URL path since if the person switches to the `EN` site then their tag settings will still be respected. 

### Routing

The` src/pages/blog/lang/[contentLang]/[...page].astro` route is not used, it falls back on the `src/pages/blog/category/[category]/lang/[contentLang]/[...page].astro` route since the "all" category can be applied safely as a default, using a single unified route pattern eliminates unnecessary page duplication while still supporting all language and tag filter combinations. This means a URL without an explicit tag filter will always resolve with category/all rather than having a separate, tag-less route variant.`. Since the "all" category can be applied safely as a default, using a single unified route pattern eliminates unnecessary page duplication while still supporting all language and tag filter combinations. This means a URL without an explicit tag filter will always resolve with category/all rather than having a separate, tag-less route variant.

## Related Issue
<!-- Fixes INTORG-123 -->

Fixes INTORG-465

## Manual Test
<!-- Reviewer steps (only if needed) -->

See all required behaviour in the description

## Checks

- [ ] `pnpm run format`
- [ ] `pnpm run lint`

## PR Checklist

- [ ] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
