### PR TITLE
fix(buttons): match Figma padding + icon sizing across variants

### DIFF
--- a/src/components/shared/Button.astro
+++ b/src/components/shared/Button.astro
@@ -13,24 +13,26 @@ const {
   mode,
   size,
   iconOnly,
-  iconSide,
   class: className,
   type = 'button',
   ...rest
 } = Astro.props
 
-const resolvedIconSide =
-  iconSide ??
-  (Astro.slots.has('icon-left')
-    ? 'left'
-    : Astro.slots.has('icon-right')
-      ? 'right'
-      : 'none')
-
 if (iconOnly && !rest['aria-label']) {
   // eslint-disable-next-line no-console
   console.warn('[Button] iconOnly={true} requires aria-label')
 }
+
+// Asymmetric padding is driven by which icon slot is filled. iconOnly
+// short-circuits to 'none' so a button with just an icon in the default
+// slot stays symmetrically padded.
+const iconPosition = iconOnly
+  ? 'none'
+  : Astro.slots.has('icon-left')
+    ? 'left'
+    : Astro.slots.has('icon-right')
+      ? 'right'
+      : 'none'
 ---
 
 <button
@@ -41,7 +43,7 @@ if (iconOnly && !rest['aria-label']) {
       mode,
       size,
       iconOnly,
-      iconSide: resolvedIconSide,
+      iconPosition,
       class: className
     })
   )}

--- a/src/components/shared/Icon.astro
+++ b/src/components/shared/Icon.astro
@@ -34,6 +34,7 @@ interface Props {
     | 'close'
     | 'menu'
   class?: string
+  size?: number
 }
 
 type IconDefinition = {
@@ -144,12 +145,14 @@ const ICONS: Record<Props['name'], IconDefinition> = {
   }
 }
 
-const { name, class: className } = Astro.props
+const { name, class: className, size = 20 } = Astro.props
 const { viewBox, body } = ICONS[name]
 ---
 
 <svg
-  class={twMerge('size-5', className)}
+  class={twMerge('shrink-0', className)}
+  width={size}
+  height={size}
   viewBox={viewBox}
   fill="currentColor"
   aria-hidden="true"

--- a/src/components/shared/LinkButton.astro
+++ b/src/components/shared/LinkButton.astro
@@ -8,7 +8,6 @@ type ButtonVariant = ButtonOpts['variant']
 type ButtonMode = ButtonOpts['mode']
 type ButtonSize = ButtonOpts['size']
 type ButtonIconOnly = ButtonOpts['iconOnly']
-type ButtonIconSide = ButtonOpts['iconSide']
 
 interface Props extends Omit<HTMLAttributes<'a'>, 'class' | 'href'> {
   href: string
@@ -16,7 +15,6 @@ interface Props extends Omit<HTMLAttributes<'a'>, 'class' | 'href'> {
   mode?: ButtonMode
   size?: ButtonSize
   iconOnly?: ButtonIconOnly
-  iconSide?: ButtonIconSide
   external?: boolean
   ariaDisabled?: boolean
   class?: string
@@ -30,7 +28,6 @@ const {
   mode,
   size,
   iconOnly,
-  iconSide,
   class: className,
   ...rest
 } = Astro.props
@@ -38,18 +35,21 @@ const {
 const { routeLocale } = Astro.locals
 const t = useTranslations(routeLocale)
 
-const resolvedIconSide: ButtonIconSide =
-  iconSide ??
-  (Astro.slots.has('icon-left')
-    ? 'left'
-    : Astro.slots.has('icon-right')
-      ? 'right'
-      : 'none')
-
 if (iconOnly && !rest['aria-label']) {
   // eslint-disable-next-line no-console
   console.warn('[LinkButton] iconOnly={true} requires aria-label')
 }
+
+// Asymmetric padding is driven by which icon slot is filled. iconOnly
+// short-circuits to 'none' so a button with just an icon in the default
+// slot stays symmetrically padded.
+const iconPosition = iconOnly
+  ? 'none'
+  : Astro.slots.has('icon-left')
+    ? 'left'
+    : Astro.slots.has('icon-right')
+      ? 'right'
+      : 'none'
 
 const targetAttrs = external
   ? { target: '_blank', rel: 'noopener noreferrer' }
@@ -71,7 +71,7 @@ const resolvedHref = ariaDisabled ? undefined : href
       mode,
       size,
       iconOnly,
-      iconSide: resolvedIconSide,
+      iconPosition,
       class: className
     })
   )}

--- a/src/components/shared/PillarCard.astro
+++ b/src/components/shared/PillarCard.astro
@@ -43,11 +43,12 @@ flex flex-col gap-lg desktop:text-center
 
   <LinkButton
     variant="fab"
+    iconOnly
     href={href}
     aria-label={title}
     external={external}
     {...umamiAttr}
   >
-    <Icon name="arrow-right" />
+    <Icon name="arrow-right" size={24} />
   </LinkButton>
 </article>

--- a/src/components/shared/buttonVariants.ts
+++ b/src/components/shared/buttonVariants.ts
@@ -72,17 +72,17 @@ export const buttonVariants = cva(
         dark: ''
       },
       size: {
-        lg: 'h-12 gap-sm py-lg min-w-11',
-        sm: 'h-11 gap-xs py-md min-w-11'
+        lg: 'h-12 gap-sm p-lg min-w-11',
+        sm: 'h-11 gap-xs p-md min-w-11'
       },
       iconOnly: {
-        true: 'aspect-square px-0',
+        true: 'aspect-square',
         false: ''
       },
-      iconSide: {
+      iconPosition: {
+        none: '',
         left: '',
-        right: '',
-        none: ''
+        right: ''
       }
     },
     compoundVariants: [
@@ -138,13 +138,13 @@ export const buttonVariants = cva(
           'aria-disabled:border-neutral-100 aria-disabled:text-neutral-75'
         ]
       },
-      { iconOnly: false, iconSide: 'left', size: 'lg', class: 'pl-lg pr-xl' },
-      { iconOnly: false, iconSide: 'right', size: 'lg', class: 'pl-xl pr-lg' },
-      { iconOnly: false, iconSide: 'none', size: 'lg', class: 'px-lg' },
-      { iconOnly: false, iconSide: 'left', size: 'sm', class: 'pl-md pr-lg' },
-      { iconOnly: false, iconSide: 'right', size: 'sm', class: 'pl-lg pr-md' },
-      { iconOnly: false, iconSide: 'none', size: 'sm', class: 'px-md' },
-      { variant: 'fab', class: 'py-md px-md' },
+      // Figma calls for asymmetric horizontal padding on text+icon buttons:
+      // the icon side keeps the base padding (lg:16 / sm:12), the text side
+      // bumps up one t-shirt size (lg:24 / sm:16) for optical balance.
+      { iconPosition: 'left', size: 'lg', class: 'pe-xl' },
+      { iconPosition: 'right', size: 'lg', class: 'ps-xl' },
+      { iconPosition: 'left', size: 'sm', class: 'pe-lg' },
+      { iconPosition: 'right', size: 'sm', class: 'ps-lg' },
       // Ghost overrides the boxed-button geometry: no fixed height, no
       // y-padding, no min-width, no rounded corners except on focus, and
       // a tight 4px x-padding regardless of the size variant.
@@ -159,7 +159,7 @@ export const buttonVariants = cva(
       mode: 'light',
       size: 'lg',
       iconOnly: false,
-      iconSide: 'none'
+      iconPosition: 'none'
     }
   }
 )

--- a/src/pages/preview/ui-components.astro
+++ b/src/pages/preview/ui-components.astro
@@ -214,7 +214,8 @@ const containerClass = `mx-auto max-w-(--max-content-width) px-lg`
                     variant="fab"
                     href="#buttons"
                     iconOnly
-                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                    aria-label="Next"
+                    ><Icon name="arrow-right" size={24} /></LinkButton
                   >
                 </dd>
                 <dt class="text-body-sm-standard">Hover (mouse over to see)</dt>
@@ -223,7 +224,8 @@ const containerClass = `mx-auto max-w-(--max-content-width) px-lg`
                     variant="fab"
                     href="#buttons"
                     iconOnly
-                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                    aria-label="Next"
+                    ><Icon name="arrow-right" size={24} /></LinkButton
                   >
                 </dd>
                 <dt class="text-body-sm-standard">
@@ -234,7 +236,8 @@ const containerClass = `mx-auto max-w-(--max-content-width) px-lg`
                     variant="fab"
                     href="#buttons"
                     iconOnly
-                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                    aria-label="Next"
+                    ><Icon name="arrow-right" size={24} /></LinkButton
                   >
                 </dd>
                 <dt class="text-body-sm-standard">Disabled</dt>
@@ -246,7 +249,7 @@ const containerClass = `mx-auto max-w-(--max-content-width) px-lg`
                     aria-label="Next"
                     ariaDisabled
                   >
-                    <Icon name="arrow-right" />
+                    <Icon name="arrow-right" size={24} />
                   </LinkButton>
                 </dd>
               </dl>
@@ -265,7 +268,8 @@ const containerClass = `mx-auto max-w-(--max-content-width) px-lg`
                     mode="dark"
                     href="#buttons"
                     iconOnly
-                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                    aria-label="Next"
+                    ><Icon name="arrow-right" size={24} /></LinkButton
                   >
                 </dd>
                 <dt class="text-body-sm-standard">Hover (mouse over to see)</dt>
@@ -275,7 +279,8 @@ const containerClass = `mx-auto max-w-(--max-content-width) px-lg`
                     mode="dark"
                     href="#buttons"
                     iconOnly
-                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                    aria-label="Next"
+                    ><Icon name="arrow-right" size={24} /></LinkButton
                   >
                 </dd>
                 <dt class="text-body-sm-standard">
@@ -287,7 +292,8 @@ const containerClass = `mx-auto max-w-(--max-content-width) px-lg`
                     mode="dark"
                     href="#buttons"
                     iconOnly
-                    aria-label="Next"><Icon name="arrow-right" /></LinkButton
+                    aria-label="Next"
+                    ><Icon name="arrow-right" size={24} /></LinkButton
                   >
                 </dd>
                 <dt class="text-body-sm-standard">Disabled</dt>
@@ -300,7 +306,7 @@ const containerClass = `mx-auto max-w-(--max-content-width) px-lg`
                     aria-label="Next"
                     ariaDisabled
                   >
-                    <Icon name="arrow-right" />
+                    <Icon name="arrow-right" size={24} />
                   </LinkButton>
                 </dd>
               </dl>


### PR DESCRIPTION
Aligns the shared button component with Figma after a design audit.

- **`buttonVariants.ts`**: symmetric `p-lg` / `p-md` instead of `py-*` overrides; `iconOnly` no longer forces `px-0`; replaced `iconSide` with `iconPosition` using logical `ps-*` / `pe-*` (text side bumps one size for optical balance); FAB inherits base padding.
- **`Button.astro` / `LinkButton.astro`**: `iconPosition` auto-derived from `Astro.slots.has('icon-left' | 'icon-right')`; old `iconSide` prop removed.
- **`Icon.astro`**: numeric `size` prop (default 20) maps to SVG `width` / `height`; `shrink-0` to prevent flex-induced squashing on FABs.
- **`PillarCard.astro`**: FAB passes `iconOnly` and `size={24}`.

Figma: [primary](https://www.figma.com/design/Tjtpc6NlHguR9DUcemSVb5/ILF-New-Design?node-id=53-573) · [secondary](https://www.figma.com/design/Tjtpc6NlHguR9DUcemSVb5/ILF-New-Design?node-id=466-58447) · [FAB](https://www.figma.com/design/Tjtpc6NlHguR9DUcemSVb5/ILF-New-Design?node-id=466-58457).

## Manual test

Open `/preview/ui-components`, spot-check that buttons have `p-lg` / `p-md` symmetric padding by default and `pe-xl` / `ps-xl` (lg) or `pe-lg` / `ps-lg` (sm) on text+icon variants. FAB renders as a 48×48 circle.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`