### PR TITLE
fix(home): left-align Making Money Move CTA on desktop [INTORG-663]

### DIFF
--- a/src/components/pages/HomePage.astro
+++ b/src/components/pages/HomePage.astro
@@ -55,7 +55,7 @@ const t = useTranslations(pageLang)
         variant="secondary"
         mode="light"
         size="lg"
-        class="w-full tablet:w-auto tablet:mx-auto"
+        class="w-full tablet:w-auto tablet:mx-auto desktop:mx-0"
       >
         {t('home.making_money_move.cta_label')}
       </LinkButton>


### PR DESCRIPTION
## Summary

Regression fix for the Making Money Move CTA introduced by PR #290.

The merged class on the CTA is \`w-full tablet:w-auto tablet:mx-auto\`. \`tablet:mx-auto\` cascades to desktop in Tailwind's mobile-first model, so the auto margins keep centering the button at \`>=desktop\` breakpoint. Per the reviewer comment that was attached to PR #290:

> when you merge the last TextMediaSection can you please fix the cta on desktop to be left aligned instead of centered (it should only be centered on tablet)

Add \`desktop:mx-0\` to drop the auto margins at the desktop tier. The button is now:

- **Mobile**: full-width (\`w-full\`)
- **Tablet**: centered (\`w-auto\` + \`mx-auto\`)
- **Desktop**: left-aligned (\`w-auto\` + \`mx-0\`, picked up by \`TextMediaSection\`'s text column \`desktop:items-start\`)

## Related Issue

[INTORG-663](https://linear.app/interledger/issue/INTORG-663) — follow-up regression fix.

## Manual Test

1. Open the deploy preview, scroll to **Making money move like data**.
2. Resize across breakpoints:
   - Mobile (<810px): button stretches full width.
   - Tablet (810px–1199px): button is auto width, horizontally centered in the text column.
   - Desktop (≥1200px): button is auto width, left-aligned (hugging the left edge of the text column).


## Checks

- [x] \`pnpm run format\`
- [x] \`pnpm run lint\`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused (1 file, 1 line)
- [ ] Screenshots for UI changes (trivial visual change; verified via class cascade)