### PR TITLE
feat(home): add Lenis smooth scroll to homepage [INTORG-734]

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dotenv": "^17.2.4",
     "gray-matter": "^4.0.3",
     "html-to-text": "^9.0.5",
+    "lenis": "^1.3.23",
     "markdown-it": "^14.1.0",
     "marked": "^17.0.4",
     "node-html-parser": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       html-to-text:
         specifier: ^9.0.5
         version: 9.0.5
+      lenis:
+        specifier: ^1.3.23
+        version: 1.3.23(react@18.3.1)
       markdown-it:
         specifier: ^14.1.0
         version: 14.1.1
@@ -7618,6 +7621,20 @@ packages:
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
+  lenis@1.3.23:
+    resolution: {integrity: sha512-YxYq3TJqj9sJNv0V9SkyQHejt14xwyIwgDaaMK89Uf9SxQfIszu+gTQSSphh6BWlLTNVKvvXAGkg+Zf+oFIevg==}
+    peerDependencies:
+      '@nuxt/kit': '>=3.0.0'
+      react: '>=17.0.0'
+      vue: '>=3.0.0'
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      react:
+        optional: true
+      vue:
+        optional: true
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -11692,6 +11709,8 @@ snapshots:
       '@ckeditor/ckeditor5-core': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-code-block@47.4.0':
     dependencies:
@@ -11761,8 +11780,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-editor-multi-root@47.4.0':
     dependencies:
@@ -11793,8 +11810,6 @@ snapshots:
     dependencies:
       '@ckeditor/ckeditor5-utils': 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-enter@47.4.0':
     dependencies:
@@ -12087,8 +12102,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-restricted-editing@47.4.0':
     dependencies:
@@ -12216,8 +12229,6 @@ snapshots:
       '@ckeditor/ckeditor5-engine': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-widget@47.4.0':
     dependencies:
@@ -20666,6 +20677,10 @@ snapshots:
       readable-stream: 2.3.8
 
   leac@0.6.0: {}
+
+  lenis@1.3.23(react@18.3.1):
+    optionalDependencies:
+      react: 18.3.1
 
   leven@3.1.0: {}
 

--- a/src/components/pages/HomePage.astro
+++ b/src/components/pages/HomePage.astro
@@ -7,6 +7,7 @@ import StatsSection, {
 import TextMediaSection from '@/components/shared/TextMediaSection.astro'
 import VideoEmbed from '@/components/shared/VideoEmbed.astro'
 import LinkButton from '@/components/shared/LinkButton.astro'
+import SmoothScroll from '@/components/shared/SmoothScroll.astro'
 import { useTranslations, type Locale } from '@/utils'
 import PillarsSection from '@/components/shared/PillarsSection.astro'
 
@@ -49,6 +50,7 @@ const stats: StatItem[] = [
   title={t('site.title')}
   description={t('site.description')}
 >
+  <SmoothScroll />
   <main>
     <HomepageHero pageLang={pageLang} pathname={Astro.url.pathname} />
     <TextMediaSection

--- a/src/components/shared/SmoothScroll.astro
+++ b/src/components/shared/SmoothScroll.astro
@@ -1,0 +1,10 @@
+---
+/**
+ * Drop-in client-side smooth scroll. Loads Lenis on mount and disables
+ * itself when the user prefers reduced motion. See src/scripts/smooth-scroll.ts.
+ */
+---
+
+<script>
+  import '@/scripts/smooth-scroll'
+</script>

--- a/src/scripts/smooth-scroll.ts
+++ b/src/scripts/smooth-scroll.ts
@@ -1,0 +1,107 @@
+import Lenis from 'lenis'
+
+// duration in seconds. Mirrors the Framer prototype's Smooth Scroll
+// component (intensity: 9 → duration: 9/10).
+const DURATION_SECONDS = 0.9
+
+const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
+
+let lenis: Lenis | null = null
+let rafId: number | null = null
+
+function tagOverflowElements(): void {
+  for (const el of document.querySelectorAll('*')) {
+    if (!(el instanceof HTMLElement)) continue
+    if (getComputedStyle(el).overflow === 'auto') {
+      el.setAttribute('data-lenis-prevent', '')
+    }
+  }
+}
+
+function getHeaderOffset(): number {
+  const header = document.querySelector('.foundation-header')
+  return header instanceof HTMLElement ? header.offsetHeight : 0
+}
+
+function findAnchorTarget(hash: string): HTMLElement | null {
+  try {
+    const el = document.querySelector(decodeURIComponent(hash))
+    return el instanceof HTMLElement ? el : null
+  } catch {
+    return null
+  }
+}
+
+function onAnchorClick(event: MouseEvent): void {
+  if (!lenis) return
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey
+  ) {
+    return
+  }
+
+  const target = event.target
+  if (!(target instanceof Element)) return
+
+  const anchor = target.closest('a[href]')
+  if (!(anchor instanceof HTMLAnchorElement)) return
+
+  if (anchor.origin !== window.location.origin) return
+  if (anchor.pathname !== window.location.pathname) return
+
+  const hash = anchor.hash
+  if (!hash || hash === '#') return
+
+  const destination = findAnchorTarget(hash)
+  if (!destination) return
+
+  event.preventDefault()
+  const scrollMarginTop =
+    parseFloat(getComputedStyle(destination).scrollMarginTop) || 0
+  const offset = scrollMarginTop || getHeaderOffset()
+  lenis.scrollTo(destination, { offset: -offset })
+}
+
+function start(): void {
+  if (lenis) return
+  lenis = new Lenis({ duration: DURATION_SECONDS })
+  tagOverflowElements()
+
+  const raf = (time: number) => {
+    lenis?.raf(time)
+    rafId = lenis ? requestAnimationFrame(raf) : null
+  }
+  rafId = requestAnimationFrame(raf)
+
+  document.addEventListener('click', onAnchorClick)
+}
+
+function stop(): void {
+  if (!lenis) return
+  document.removeEventListener('click', onAnchorClick)
+  if (rafId !== null) cancelAnimationFrame(rafId)
+  rafId = null
+  lenis.destroy()
+  lenis = null
+}
+
+function init(): void {
+  if (reducedMotion.matches) return
+  start()
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init, { once: true })
+} else {
+  init()
+}
+
+reducedMotion.addEventListener('change', () => {
+  if (reducedMotion.matches) stop()
+  else start()
+})

--- a/src/styles/base/reset.css
+++ b/src/styles/base/reset.css
@@ -75,4 +75,27 @@
   a:hover {
     color: var(--color-primary);
   }
+
+  /* Lenis smooth scroll — see src/scripts/smooth-scroll.ts.
+     Classes are added/removed by Lenis at runtime. Rules are inert when
+     the script is not loaded on a page. */
+  html.lenis {
+    height: auto;
+  }
+
+  .lenis.lenis-smooth {
+    scroll-behavior: auto !important;
+  }
+
+  .lenis.lenis-smooth [data-lenis-prevent] {
+    overscroll-behavior: contain;
+  }
+
+  .lenis.lenis-stopped {
+    overflow: hidden;
+  }
+
+  .lenis.lenis-scrolling iframe {
+    pointer-events: none;
+  }
 }


### PR DESCRIPTION
## Summary

Adds wheel/trackpad smooth scrolling to the homepage via [Lenis](https://github.com/darkroomengineering/lenis), mirroring the Framer prototype at [inspirational-lottery-436833.framer.app](https://inspirational-lottery-436833.framer.app/). Scoped to the homepage only via a `<SmoothScroll />` loader component — docs, blog, and other routes keep native scroll.

Implementation choices:

- **Lenis config**: `duration: 0.9` (everything else default). Pulled from the Framer prototype's compiled bundle — its Smooth Scroll component uses `new Lenis({ duration: intensity/10 })` and the prototype sets `intensity: 9`. Scroll-curve A/B against the live prototype settles to the same final position at the same time (~900ms, easeOutExpo).
- **Accessibility**: bails immediately when `prefers-reduced-motion: reduce` matches, and `destroy()`s if the preference flips at runtime. Lenis does not honor this preference by default.
- **Anchor links**: same-origin `a[href*="#"]` clicks are intercepted and scrolled via `lenis.scrollTo`, with the offset read from the target's `scroll-margin-top`, falling back to `.foundation-header.offsetHeight` so sticky-header overlap is avoided.
- **Nested scrollers**: walks the DOM once at init and tags `overflow: auto` elements with `data-lenis-prevent` so they keep native scroll — same approach the Framer component takes.
- **CSS**: 5 standard Lenis rules added under `@layer base` in `reset.css`. They're inert unless `<html>` has the `lenis` class.

## Related Issue

Fixes INTORG-734

## Manual Test

1. Load homepage on desktop with a trackpad or mouse wheel — scroll should feel eased, not snappy. Compare A/B against [the Framer prototype](https://inspirational-lottery-436833.framer.app/) — feel should be near-identical.
2. DevTools → Rendering → emulate `prefers-reduced-motion: reduce` → reload. `<html>` should not have the `lenis` class; scrolling should be native/instant.
3. Navigate to `/about-us`, `/blog`, or any docs page — scroll should be native (Lenis only loads on the homepage).
4. Tab through focusable elements — focus management is unchanged.
5. Mobile / touch — scroll stays native (Lenis's `syncTouch` default of `false`).

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused (6 files)
- [ ] Screenshots for UI changes (smooth scroll is motion-only; see scroll-curve comparison above)