### PR TITLE
fix(home): stats section order

### DIFF
--- a/src/components/pages/HomePage.astro
+++ b/src/components/pages/HomePage.astro
@@ -103,6 +103,10 @@ const stats: StatItem[] = [
         class="mx-auto h-auto w-full max-w-[426px] desktop:mx-0"
       />
     </TextMediaSection>
+    <StatsSection ariaLabel={t('home.stats.heading')} stats={stats}>
+      <Fragment slot="heading">{t('home.stats.heading')}</Fragment>
+      <p>{t('home.stats.body')}</p>
+    </StatsSection>
     <TextMediaSection
       mediaSide="right"
       theme="light"
@@ -132,10 +136,6 @@ const stats: StatItem[] = [
         class="h-auto max-w-full"
       />
     </TextMediaSection>
-    <StatsSection ariaLabel={t('home.stats.heading')} stats={stats}>
-      <Fragment slot="heading">{t('home.stats.heading')}</Fragment>
-      <p>{t('home.stats.body')}</p>
-    </StatsSection>
     <LogoCarousel />
   </main>
 </FoundationPageLayout>


### PR DESCRIPTION
## Summary
Moved Stats section to it's correct place

## Related Issue


## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [ ] `pnpm run format`
- [ ] `pnpm run lint`
<img width="1466" height="832" alt="Screenshot 2026-05-25 at 12 21 26 PM" src="https://github.com/user-attachments/assets/237eee7e-8a22-487c-a0a1-ee7dad258e08" />

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
