### PR TITLE
style(theme): set H3 font-weight to Medium across all breakpoints [INTORG-741]

### DIFF
--- a/src/styles/README.md
+++ b/src/styles/README.md
@@ -330,27 +330,29 @@ The new design system uses **Poppins** (Regular 400 / Medium 500 / SemiBold 600)
 Each style has up to three tiers (Mobile → Tablet → Desktop). Apply via Tailwind's responsive prefixes; the token suffix mirrors the variant prefix:
 
 ```html
-<h1 class="font-poppins text-h1 md:text-h1-md lg:text-h1-lg">Headline</h1>
-<p class="font-poppins text-body-lg-standard md:text-body-lg-standard-md">
+<h1 class="font-poppins text-h1 tablet:text-h1-md desktop:text-h1-lg">
+  Headline
+</h1>
+<p class="font-poppins text-body-lg-standard tablet:text-body-lg-standard-md">
   Body
 </p>
 <small class="font-poppins text-caption">Caption</small>
 ```
 
-Each `text-*` utility carries font-size, line-height, and font-weight together. Breakpoints follow `md:` (≥768px, Tablet) and `lg:` (≥1024px, Desktop) from `tailwind.config.mjs`.
+Each `text-*` utility carries font-size, line-height, and font-weight together. Breakpoints follow `tablet:` (≥810px) and `desktop:` (≥1200px) from `tailwind.config.mjs`. `md:` (≥768px) and `lg:` (≥1024px) are Tailwind defaults retained for legacy code; use `tablet:` / `desktop:` for redesign work.
 
-| Token base              | Mobile (default)   | Tablet (`-md`)   | Desktop (`-lg`)    |
-| ----------------------- | ------------------ | ---------------- | ------------------ |
-| `text-h1`               | 56 / 68 SemiBold   | 70 / 76 SemiBold | 100 / 100 SemiBold |
-| `text-h2`               | 32 / 40 SemiBold   | 36 / 48 SemiBold | 56 / 64 SemiBold   |
-| `text-h3`               | 20 / 28 **Medium** | 28 / 36 Regular  | 40 / 56 Regular    |
-| `text-h4`               | 18 / 28 Regular    | 20 / 30 Regular  | 24 / 34 Regular    |
-| `text-h5`               | 16 / 26 Regular    | 18 / 28 Regular  | 20 / 30 Regular    |
-| `text-body-lg-emphasis` | 15 / 24 Medium     | 16 / 26 Medium   | _(same as -md)_    |
-| `text-body-lg-standard` | 15 / 24 Regular    | 16 / 26 Regular  | _(same as -md)_    |
-| `text-body-sm-emphasis` | 14 / 24 Medium     | _(same)_         | _(same)_           |
-| `text-body-sm-standard` | 14 / 24 Regular    | _(same)_         | _(same)_           |
-| `text-caption`          | 13 / 16 Regular    | _(same)_         | _(same)_           |
+| Token base              | Mobile (default) | Tablet (`-md`)   | Desktop (`-lg`)    |
+| ----------------------- | ---------------- | ---------------- | ------------------ |
+| `text-h1`               | 56 / 68 SemiBold | 70 / 76 SemiBold | 100 / 100 SemiBold |
+| `text-h2`               | 32 / 40 SemiBold | 36 / 48 SemiBold | 56 / 64 SemiBold   |
+| `text-h3`               | 20 / 28 Medium   | 28 / 36 Medium   | 40 / 56 Medium     |
+| `text-h4`               | 18 / 28 Regular  | 20 / 30 Regular  | 24 / 34 Regular    |
+| `text-h5`               | 16 / 26 Regular  | 18 / 28 Regular  | 20 / 30 Regular    |
+| `text-body-lg-emphasis` | 15 / 24 Medium   | 16 / 26 Medium   | _(same as -md)_    |
+| `text-body-lg-standard` | 15 / 24 Regular  | 16 / 26 Regular  | _(same as -md)_    |
+| `text-body-sm-emphasis` | 14 / 24 Medium   | _(same)_         | _(same)_           |
+| `text-body-sm-standard` | 14 / 24 Regular  | _(same)_         | _(same)_           |
+| `text-caption`          | 13 / 16 Regular  | _(same)_         | _(same)_           |
 
 `body-lg-*` only ships mobile + `-md` tokens (Tablet and Desktop are identical in the spec). `body-sm-*` and `caption` are identical across all tiers, so they have a single token each.
 
@@ -361,7 +363,7 @@ The line-heights baked into `text-*` utilities are also exposed as standalone `l
 ```html
 <p class="text-h1 leading-h2">…</p>
 <!-- H1 size + weight, H2 line-height -->
-<div class="leading-h3 md:leading-h3-md lg:leading-h3-lg">…</div>
+<div class="leading-h3 tablet:leading-h3-md desktop:leading-h3-lg">…</div>
 ```
 
 Available: `leading-h{1..5}` (with `-md` / `-lg` tiers), `leading-body-lg` + `leading-body-lg-md`, `leading-body-sm`, `leading-caption`. (`body-lg-emphasis` and `body-lg-standard` share line-heights, so there's a single `leading-body-lg`.)

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -309,17 +309,16 @@
   --text-h2-lg--line-height: 4rem;
   --text-h2-lg--font-weight: 600;
 
-  /* H3: 20/28 (Medium) → 28/36 (Regular) → 40/56 (Regular).
-   */
+  /* H3: 20/28 → 28/36 → 40/56, all Medium */
   --text-h3: 1.25rem;
   --text-h3--line-height: 1.75rem;
   --text-h3--font-weight: 500;
   --text-h3-md: 1.75rem;
   --text-h3-md--line-height: 2.25rem;
-  --text-h3-md--font-weight: 400;
+  --text-h3-md--font-weight: 500;
   --text-h3-lg: 2.5rem;
   --text-h3-lg--line-height: 3.5rem;
-  --text-h3-lg--font-weight: 400;
+  --text-h3-lg--font-weight: 500;
 
   /* H4: 18/28 → 20/30 → 24/34, all Regular */
   --text-h4: 1.125rem;


### PR DESCRIPTION
## Summary

Update the H3 typography tokens so tablet and desktop render at Medium (500), matching the design spec. Mobile was already 500; tablet and desktop were 400.

- `--text-h3-md--font-weight`: `400 → 500`
- `--text-h3-lg--font-weight`: `400 → 500`

Also refresh `src/styles/README.md`: the typography section was claiming `md:` (≥768px) / `lg:` (≥1024px) as the Tablet/Desktop breakpoints, but the redesign uses `tablet:` (≥810px) / `desktop:` (≥1200px) per `tailwind.config.mjs`. The docs and example utility classes now reflect that, with `md:` / `lg:` noted as the legacy aliases.

Visible homepage impact at tablet (≥810px) and desktop (≥1200px): PillarCard h3 elements, StatCard count spans, and any other site element using `tablet:text-h3-md desktop:text-h3-lg`.

## Related Issue

Fixes INTORG-741

## Manual Test

1. `pnpm start`, open the homepage.
2. Resize to ≥810px width — h3 elements in the Pillars and "Real-world progress" stats sections should render at Medium weight (500), not Regular.
3. Resize to ≥1200px width — same headings at the desktop tier should also render Medium.

Verified via agent-browser:
- Mobile (375px): `.text-h3` → `20px / 500` ✓
- Tablet (900px): `.tablet:text-h3-md` → `28px / 500` ✓
- Desktop (1440px): `.desktop:text-h3-lg` → `40px / 500` ✓

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)