### PR TITLE
fix(Homepage): correct light-mode text colors and fab button rendering

### DIFF
--- a/src/components/layout/FoundationFooter.astro
+++ b/src/components/layout/FoundationFooter.astro
@@ -120,7 +120,7 @@ const socialLinks: Array<{
       >
         <h5
           id="footer-subscribe-heading"
-          class="mb-md text-h5-md desktop:text-h5-lg"
+          class="mb-md text-h5-md text-neutral-900 desktop:text-h5-lg"
         >
           {t('footer.stay_up_to_date')}
         </h5>
@@ -145,7 +145,7 @@ const socialLinks: Array<{
       >
         <h5
           id="footer-contact-heading"
-          class="mb-md text-h5-md desktop:text-h5-lg"
+          class="mb-md text-h5-md text-neutral-900 desktop:text-h5-lg"
         >
           {t('footer.contact_us')}
         </h5>
@@ -170,7 +170,7 @@ const socialLinks: Array<{
       >
         <h5
           id="footer-social-heading"
-          class="mb-md text-h5-md desktop:text-h5-lg"
+          class="mb-md text-h5-md text-neutral-900 desktop:text-h5-lg"
         >
           {t('footer.social_links')}
         </h5>
@@ -325,7 +325,7 @@ const socialLinks: Array<{
       <a
         href={homeHref}
         aria-label={t('footer.logo_home')}
-        class="inline-block rounded-sm transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-4 focus-visible:outline-none"
+        class="inline-block rounded-sm text-neutral-100 transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-4 focus-visible:outline-none"
         {...footerLink(homeHref, t('footer.logo_home'), t('footer.logo_home'))}
       >
         <InterledgerIcon class="h-10 w-10" />

--- a/src/components/shared/PillarsSection.astro
+++ b/src/components/shared/PillarsSection.astro
@@ -20,7 +20,7 @@ const pillarUmamiAttrs = (href: string) =>
   })
 
 const sectionClasses = `
-  px-lg py-5xl font-poppins bg-ice-indigo-100 
+  px-lg py-5xl font-poppins bg-ice-indigo-100 text-neutral-900
   tablet:py-0 tablet:px-xl tablet:min-h-screen
   desktop:px-5xl
   `

--- a/src/components/shared/buttonVariants.ts
+++ b/src/components/shared/buttonVariants.ts
@@ -59,7 +59,7 @@ export const buttonVariants = cva(
           'focus-visible:border-orchid-100 focus-visible:outline-none'
         ],
         fab: [
-          'self-end rounded-full border -rotate-45',
+          'self-end shrink-0 rounded-full border -rotate-45',
           'tablet:self-center',
           'desktop:self-end',
           'hover:rotate-0',
@@ -121,7 +121,7 @@ export const buttonVariants = cva(
         variant: 'fab',
         mode: 'light',
         class: [
-          'border-neutral-50 text-neutral-900',
+          'border-neutral-75 text-neutral-900',
           'hover:border-neutral-900',
           'focus-visible:outline-solid focus-visible:outline-neutral-900',
           'disabled:text-neutral-50 aria-disabled:text-neutral-50'
@@ -131,7 +131,7 @@ export const buttonVariants = cva(
         variant: 'fab',
         mode: 'dark',
         class: [
-          'border-neutral-75 text-neutral-25',
+          'border-neutral-50 text-neutral-25',
           'hover:border-neutral-0 hover:text-neutral-0',
           'focus-visible:outline-neutral-0 focus-visible:text-neutral-0',
           'disabled:border-neutral-100 disabled:text-neutral-75',
@@ -144,7 +144,7 @@ export const buttonVariants = cva(
       { iconOnly: false, iconSide: 'left', size: 'sm', class: 'pl-md pr-lg' },
       { iconOnly: false, iconSide: 'right', size: 'sm', class: 'pl-lg pr-md' },
       { iconOnly: false, iconSide: 'none', size: 'sm', class: 'px-md' },
-      { variant: 'fab', class: 'py-md px-md' },
+      { variant: 'fab', class: 'aspect-square py-md px-md' },
       // Ghost overrides the boxed-button geometry: no fixed height, no
       // y-padding, no min-width, no rounded corners except on focus, and
       // a tight 4px x-padding regardless of the size variant.


### PR DESCRIPTION
## Summary
- set explicit text colors on footer and pillars section: these elements had no text color set and were inheriting dark-theme
defaults
- fix(button): keep fab circular on tablet
- update border colors for fab-button to match changes in Figma (neutral-75 in light mode, neutral-50 in dark mode)

## Related Issue

Fixes INTORG-757

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
