### PR TITLE
feat(home): generalize scroll-rise animation and apply to more sections

### DIFF
--- a/src/components/shared/PillarsSection.astro
+++ b/src/components/shared/PillarsSection.astro
@@ -33,7 +33,7 @@ const sectionContainerClasses = `
 const headingClasses = `
   pillars-heading
   text-h3 text-center
-  tablet:text-h3-md tablet:pt-[20vh]
+  tablet:text-h3-md tablet:pt-[20vh] tablet:scroll-rise
   desktop:text-h3-lg
   desktop:z-0 desktop:sticky desktop:top-0
   `
@@ -49,9 +49,9 @@ const cardsContainerClasses = `
   `
 //300px (initial offset), 75vh (stagger step), 45vh (sticky pin point), 100px (rise distance)
 const cardDivs = `
-  pillar-card
+  pillar-card scroll-rise
   flex-1 m-0
-  desktop:flex desktop:flex-col
+  desktop:flex desktop:flex-col desktop:animate-none
   desktop:min-h-[var(--card-min-h)]
   desktop:first:mt-[300px]
   desktop:nth-[2]:mt-[calc(300px+75vh)]
@@ -110,18 +110,8 @@ const threePillars = [
        tallest natural content measured per viewport width — 362px at 1200px,
        310px at 2000px. Re-measure if card copy or layout changes. */
     --card-min-h: clamp(310px, calc(440px - 6.5vw), 362px);
-    animation: rise linear forwards;
-    animation-timeline: view();
-    animation-range: 0% 30%;
   }
 
-  @media (min-width: 810px) {
-    .pillars-heading {
-      animation: rise linear forwards;
-      animation-timeline: view();
-      animation-range: 0% 30%;
-    }
-  }
   @media (min-width: 1200px) {
     section:focus-within .pillar-card {
       position: static;
@@ -137,9 +127,6 @@ const threePillars = [
     section:focus-within .pillars-heading {
       position: static;
     }
-    .pillar-card {
-      animation: none;
-    }
     .pillars-heading {
       animation: shrink linear forwards;
       animation-timeline: scroll();
@@ -147,7 +134,6 @@ const threePillars = [
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .pillar-card,
     .pillars-heading {
       animation: none;
     }
@@ -170,14 +156,6 @@ const threePillars = [
     }
   }
 
-  @keyframes rise {
-    0% {
-      transform: translateY(100px);
-    }
-    100% {
-      transform: translateY(0);
-    }
-  }
   @keyframes shrink {
     from {
       scale: 1;

--- a/src/components/shared/PillarsSection.astro
+++ b/src/components/shared/PillarsSection.astro
@@ -147,11 +147,8 @@ const threePillars = [
       .pillars-heading {
         position: static;
       }
-      section:focus-within ul {
+      section ul {
         align-items: stretch;
-      }
-      section:focus-within .pillar-card article {
-        height: 100%;
       }
     }
   }

--- a/src/components/shared/PillarsSection.astro
+++ b/src/components/shared/PillarsSection.astro
@@ -33,7 +33,7 @@ const sectionContainerClasses = `
 const headingClasses = `
   pillars-heading
   text-h3 text-center
-  tablet:text-h3-md tablet:pt-[20vh] tablet:scroll-rise
+  tablet:text-h3-md tablet:pt-[20vh] tablet:animate-rise-in-view
   desktop:text-h3-lg
   desktop:z-0 desktop:sticky desktop:top-0
   `
@@ -49,7 +49,7 @@ const cardsContainerClasses = `
   `
 //300px (initial offset), 75vh (stagger step), 45vh (sticky pin point), 100px (rise distance)
 const cardDivs = `
-  pillar-card scroll-rise
+  pillar-card animate-rise-in-view
   flex-1 m-0
   desktop:flex desktop:flex-col desktop:animate-none
   desktop:min-h-[var(--card-min-h)]

--- a/src/components/shared/StatCard.astro
+++ b/src/components/shared/StatCard.astro
@@ -30,7 +30,7 @@ const hideContents: 'true' | undefined = ariaLabel ? 'true' : undefined
 
 <li
   aria-label={ariaLabel}
-  class="flex w-[227px] flex-col items-center gap-sm p-lg scroll-rise tablet:w-[251px] desktop:w-[290px] desktop:items-start desktop:p-xl"
+  class="flex w-[227px] flex-col items-center gap-sm p-lg animate-rise-in-view tablet:w-[251px] desktop:w-[290px] desktop:items-start desktop:p-xl"
 >
   <div class="flex items-start gap-sm" aria-hidden={hideContents}>
     <AnimatedNumber

--- a/src/components/shared/StatCard.astro
+++ b/src/components/shared/StatCard.astro
@@ -30,7 +30,7 @@ const hideContents: 'true' | undefined = ariaLabel ? 'true' : undefined
 
 <li
   aria-label={ariaLabel}
-  class="flex w-[227px] flex-col items-center gap-sm p-lg tablet:w-[251px] desktop:w-[290px] desktop:items-start desktop:p-xl"
+  class="flex w-[227px] flex-col items-center gap-sm p-lg scroll-rise tablet:w-[251px] desktop:w-[290px] desktop:items-start desktop:p-xl"
 >
   <div class="flex items-start gap-sm" aria-hidden={hideContents}>
     <AnimatedNumber

--- a/src/components/shared/StatsSection.astro
+++ b/src/components/shared/StatsSection.astro
@@ -36,11 +36,13 @@ const sectionClasses = twMerge(
       class="flex w-full flex-col items-center gap-xl text-center desktop:flex-1 desktop:items-start desktop:text-left"
     >
       <h2
-        class="font-poppins text-h2 tablet:text-h2-md desktop:text-h2-lg desktop:max-w-[685px]"
+        class="font-poppins text-h2 tablet:text-h2-md tablet:scroll-rise desktop:text-h2-lg desktop:max-w-[685px]"
       >
         <slot name="heading" />
       </h2>
-      <div class="font-poppins text-h5 tablet:text-h5-md desktop:text-h5-lg">
+      <div
+        class="font-poppins text-h5 tablet:text-h5-md tablet:scroll-rise desktop:text-h5-lg"
+      >
         <slot />
       </div>
     </div>

--- a/src/components/shared/StatsSection.astro
+++ b/src/components/shared/StatsSection.astro
@@ -36,12 +36,12 @@ const sectionClasses = twMerge(
       class="flex w-full flex-col items-center gap-xl text-center desktop:flex-1 desktop:items-start desktop:text-left"
     >
       <h2
-        class="font-poppins text-h2 tablet:text-h2-md tablet:scroll-rise desktop:text-h2-lg desktop:max-w-[685px]"
+        class="font-poppins text-h2 tablet:text-h2-md tablet:animate-rise-in-view desktop:text-h2-lg desktop:max-w-[685px]"
       >
         <slot name="heading" />
       </h2>
       <div
-        class="font-poppins text-h5 tablet:text-h5-md tablet:scroll-rise desktop:text-h5-lg"
+        class="font-poppins text-h5 tablet:text-h5-md tablet:animate-rise-in-view desktop:text-h5-lg"
       >
         <slot />
       </div>

--- a/src/components/shared/TextMediaSection.astro
+++ b/src/components/shared/TextMediaSection.astro
@@ -59,14 +59,14 @@ const innerClasses = twMerge(
 const textColumnClasses = twMerge(
   'flex flex-col items-stretch gap-xl',
   'tablet:items-start',
-  '[&>*]:tablet:scroll-rise',
+  '[&>*]:tablet:animate-rise-in-view',
   'desktop:flex-1 desktop:min-w-0',
   '[&_h2]:font-poppins [&_h2]:text-h2 tablet:[&_h2]:text-h2-md desktop:[&_h2]:text-h2-lg',
   '[&_p]:font-poppins [&_p]:text-h5 tablet:[&_p]:text-h5-md desktop:[&_p]:text-h5-lg',
   theme === 'dark' && '[&_p]:text-neutral-25'
 )
 
-const mediaColumnClasses = 'tablet:scroll-rise desktop:shrink-0'
+const mediaColumnClasses = 'tablet:animate-rise-in-view desktop:shrink-0'
 ---
 
 <section

--- a/src/components/shared/TextMediaSection.astro
+++ b/src/components/shared/TextMediaSection.astro
@@ -59,13 +59,14 @@ const innerClasses = twMerge(
 const textColumnClasses = twMerge(
   'flex flex-col items-stretch gap-xl',
   'tablet:items-start',
+  '[&>*]:tablet:scroll-rise',
   'desktop:flex-1 desktop:min-w-0',
   '[&_h2]:font-poppins [&_h2]:text-h2 tablet:[&_h2]:text-h2-md desktop:[&_h2]:text-h2-lg',
   '[&_p]:font-poppins [&_p]:text-h5 tablet:[&_p]:text-h5-md desktop:[&_p]:text-h5-lg',
   theme === 'dark' && '[&_p]:text-neutral-25'
 )
 
-const mediaColumnClasses = 'desktop:shrink-0'
+const mediaColumnClasses = 'tablet:scroll-rise desktop:shrink-0'
 ---
 
 <section

--- a/src/styles/README.md
+++ b/src/styles/README.md
@@ -18,14 +18,16 @@ src/styles/
 │   ├── typography.css        # Font-face declarations
 │   ├── reset.css            # Tailwind Preflight + keyframes + element styles
 │   └── variables.css        # Runtime vars: --color-primary base, dependent vars, pillar overrides
-└── components/              # Component layer - overridable by utilities
-    ├── navigation.css       # Breadcrumb nav styles
-    └── prose/              # Prose variants by content type
-        ├── default.css      # Default prose (all pages)
-        ├── base-typography.css  # Common h2, h3, p, lists
-        ├── foundation.css   # [data-prose] specific
-        ├── blog.css        # [data-prose-blog] specific
-        └── summit.css      # [data-prose-summit] specific
+├── components/              # Component layer - overridable by utilities
+│   ├── navigation.css       # Breadcrumb nav styles
+│   └── prose/              # Prose variants by content type
+│       ├── default.css      # Default prose (all pages)
+│       ├── base-typography.css  # Common h2, h3, p, lists
+│       ├── foundation.css   # [data-prose] specific
+│       ├── blog.css        # [data-prose-blog] specific
+│       └── summit.css      # [data-prose-summit] specific
+└── utilities/              # Utilities layer - custom @utility definitions
+    └── animations.css       # Scroll-driven animation utilities (animate-rise-in-view, etc.)
 ```
 
 ## Critical: Import Order
@@ -45,7 +47,10 @@ src/styles/
 3. **Components layer** (`components/**/*.css`)
    - Prose styles, navigation, etc.
    - Can be overridden by utility classes
-   - Must load last
+
+4. **Utilities layer** (`utilities/*.css`)
+   - Custom `@utility` definitions for behaviors that can't be expressed as a `@theme` token alone (e.g. scroll-driven animations that need `animation-timeline` / `animation-range` / reduced-motion branches alongside the `animation` shorthand)
+   - `@utility` rules are placed in `@layer utilities` automatically and win over component styles regardless of import order — keeping these imports last is for readability, not cascade priority
 
 ## Pillar Theming System
 
@@ -464,6 +469,26 @@ Edit `base/variables.css` - change `--color-primary` in `:root`.
 1. If it fits a @theme namespace (`--color-*`, `--text-*`, `--spacing-*`, `--radius-*`, `--shadow-*`, `--animate-*`): add to `theme.css`
 2. If it needs selectors or depends on other vars: add to `base/variables.css`
 3. Use in components via `var(--your-variable)` or as a Tailwind utility class
+
+### Add a Custom Utility
+
+Use `@utility` in `src/styles/utilities/` when a single `@theme` token isn't enough — e.g. an animation needing `animation-timeline`, `animation-range`, or a `prefers-reduced-motion` branch:
+
+```css
+/* src/styles/utilities/animations.css */
+@utility animate-rise-in-view {
+  animation: var(--animate-scroll-rise);
+  animation-timeline: view();
+  animation-range: 0% 30%;
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+```
+
+Import the new file from `tailwind.css` so it lands in the utilities layer.
+
+**Don't name a `@utility` the same as an existing `--<namespace>-*` token** (e.g. `@utility animate-fade-in` alongside `--animate-fade-in`) — they collide and the `@utility` can be silently dropped. Either use a different class name (as `animate-rise-in-view` does, consuming `--animate-scroll-rise` via `var()`) or skip the token.
 
 ### Override Component Style
 

--- a/src/styles/base/reset.css
+++ b/src/styles/base/reset.css
@@ -48,6 +48,14 @@
       transform: rotate(-360deg);
     }
   }
+  @keyframes rise {
+    0% {
+      transform: translateY(100px);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
 
   /* Custom element styles extending Preflight */
   html {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -58,6 +58,9 @@
 @import './components/prose/summit.css';
 @import './components/navigation.css';
 
+/* Utilities layer - custom @utility definitions */
+@import './utilities/animations.css';
+
 /* @interledger/docs-design-system's ilf-docs.css ships three unlayered rules
    with universal-ish selectors (:focus-visible, img, and thead first-row
    corners). Starlight auto-registers an Astro middleware that imports its

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -104,6 +104,7 @@
   --animate-zoom: zoom 2s forwards;
   --animate-clockwise: clockwise 22s linear infinite;
   --animate-anticlockwise: anticlockwise 22s linear infinite;
+  --animate-scroll-rise: rise cubic-bezier(0.33, 1, 0.68, 1) forwards;
 }
 
 /* ────────────────────────────────────────────────────────────────────────────

--- a/src/styles/utilities/animations.css
+++ b/src/styles/utilities/animations.css
@@ -11,7 +11,8 @@ Scroll-rise: rises 100px into place over the first 30% of the element's viewport
 }
 
 @utility scroll-rise {
-  animation: rise linear forwards;
+  /* Easing approximates an overdamped spring (stiffness 300, damping 60, mass 1.5). */
+  animation: rise cubic-bezier(0.33, 1, 0.68, 1) forwards;
   animation-timeline: view();
   animation-range: 0% 30%;
 

--- a/src/styles/utilities/animations.css
+++ b/src/styles/utilities/animations.css
@@ -1,18 +1,9 @@
 /* Reusable scroll-driven animation utility.
-Scroll-rise: rises 100px into place over the first 30% of the element's viewport entry.  */
+animate-rise-in-view: rises 100px into place over the first 30% of the element's viewport entry.  */
 
-@keyframes rise {
-  0% {
-    transform: translateY(100px);
-  }
-  100% {
-    transform: translateY(0);
-  }
-}
-
-@utility scroll-rise {
+@utility animate-rise-in-view {
   /* Easing approximates an overdamped spring (stiffness 300, damping 60, mass 1.5). */
-  animation: rise cubic-bezier(0.33, 1, 0.68, 1) forwards;
+  animation: var(--animate-scroll-rise);
   animation-timeline: view();
   animation-range: 0% 30%;
 

--- a/src/styles/utilities/animations.css
+++ b/src/styles/utilities/animations.css
@@ -5,7 +5,7 @@ animate-rise-in-view: rises 100px into place over the first 30% of the element's
   /* Easing approximates an overdamped spring (stiffness 300, damping 60, mass 1.5). */
   animation: var(--animate-scroll-rise);
   animation-timeline: view();
-  animation-range: 0% 30%;
+  animation-range: 0% 35%;
 
   @media (prefers-reduced-motion: reduce) {
     animation: none;

--- a/src/styles/utilities/animations.css
+++ b/src/styles/utilities/animations.css
@@ -1,0 +1,21 @@
+/* Reusable scroll-driven animation utility.
+Scroll-rise: rises 100px into place over the first 30% of the element's viewport entry.  */
+
+@keyframes rise {
+  0% {
+    transform: translateY(100px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@utility scroll-rise {
+  animation: rise linear forwards;
+  animation-timeline: view();
+  animation-range: 0% 30%;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
-  extract `scroll-rise` into reusable Tailwind @utility
-  apply `scroll-rise` to stats and text-media sections 
- soften the easing — replaced linear with cubic-bezier for the scroll-rise animation

- (small fix:) even PillarCard heights under reduced motion 
 

## Related Issue
Fixes INTORG-740

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)