### PR TITLE
feat(podcasts): add podcast page with migrated Drupal episodes

### DIFF
--- a/src/components/shared/Podcast.astro
+++ b/src/components/shared/Podcast.astro
@@ -1,0 +1,15 @@
+---
+interface Props {
+  title: string
+  description: string
+  href: string
+}
+const { title, description, href } = Astro.props
+---
+
+<li>
+  <h3>{title}</h3>
+  <p>{description}</p>
+  <iframe title="Podcast player" class="w-full h-28" loading="lazy" src={href}
+  ></iframe>
+</li>

--- a/src/components/shared/Podcast.astro
+++ b/src/components/shared/Podcast.astro
@@ -1,10 +1,12 @@
 ---
+import type { Podcast } from '@/types/podcast'
+
 interface Props {
-  title: string
-  description: string
-  href: string
+  podcast: Podcast
 }
-const { title, description, href } = Astro.props
+const {
+  podcast: { title, description, href }
+} = Astro.props
 ---
 
 <li>

--- a/src/data/podcasts.ts
+++ b/src/data/podcasts.ts
@@ -1,0 +1,193 @@
+// Holds podcast content migrated from Drupal.
+// Temporary home until the Strapi integration is in place.
+import type { Podcast } from '@/types/podcast'
+
+export const podcasts: Podcast[] = [
+  {
+    title: 'Podcast - s01e01 an Inti/vation',
+    description:
+      'Delve into issues of privacy, surveillance, fair wages, exploitative commerce, and the complexities of navigating financial exchange across borders.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/an-inti-vation-qmjrn/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e02 Loose (Chains) Change',
+    description:
+      'Reimagine the financial structure by which a litter of lottery tickets are used to question the theologies of money, wealth, gain, loss, and hope.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/loose-chains-change/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e03 Parallel Society',
+    description:
+      'Learn more about a game which sheds light on financial traumas, such as behavior patterns and psychological impacts as results of financial exclusions.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/parallel-society/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title:
+      'Podcast - s01e03 Practising financial inclusion in the Global South',
+    description:
+      'Join Smriti Parsheera as she discusses financial inclusion with James Ogada (Busara Center) and Dr. Susan Thomas (XKDR Forum), exploring how collaboration and tailored solutions enhance economic resilience in the Global South.',
+    href: 'https://podcast.interledger.org/@InterledgerSalon/episodes/practising-financial-inlcusion-in-the-global-south/embed/light',
+    series: 'Interledger Salon'
+  },
+  {
+    title: 'Podcast - s01e04 Beyond Currency',
+    description:
+      'Together, host Xiaoji Song and guests Sarah Habib and Anuja Ghosalkar unpack how our differing understandings of money and financial systems shape our access to and engagement with them.',
+    href: 'https://podcast.interledger.org/@InterledgerSalon/episodes/beyond-currency-reimagining-money-and-digital-futures/embed/light',
+    series: 'Interledger Salon'
+  },
+  {
+    title: 'Podcast - s01e04 Bringing Down A Mountain',
+    description:
+      'Discover a docufiction set in the Odia Language, which uses Open Source imagery to reimagine how technology is built, implemented, and affects financial inclusion.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/bringing-down-a-mountain/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e05 Living Archives of Afrofuturist Village Banking',
+    description:
+      "Learn how women in Zambia and South Africa created financial practices to support resilience and respond to their communities' needs.",
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/sikhula-sonke-living-archives-of-afrofuturist-village-banking/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e06 Liminal Matter',
+    description:
+      'Explore the evolution of money from tangible matter into an increasingly immaterial entity as financial systems become more complex.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/liminal-matter/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e07 Taking the train to Digital Financial Inclusion',
+    description:
+      'Discover how students at Bowie State University are shaping the future of Digital Financial Inclusion through open-source technology in partnership with the Interledger Foundation.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/taking-the-train-to-digital-financial-inclusion/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e08  Re/Simulate',
+    description:
+      'Explore how computational simulations of economic models can expose the gaps, pitfalls, and strengths of digital financial systems as strategies become tangible and apparent.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/re-simulate/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e09 Waterworks of Money',
+    description:
+      "Join us as we deep dive into the 'Waterworks of Money', exploring complex topics such as monetary systems, financial structures, and the challenges of literacy and accessibility.",
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/waterworks-of-money/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e10 Why Digital Financial Inclusion Matters',
+    description:
+      'Tune in for a special episode of the FM Podcast, featuring the Interledger Salon! The Salon is a quarterly panel that facilities insightful discussions with leaders in digital financial inclusion.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/why-digital-financial-inclusion-matters/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e11 Interledger on Campus',
+    description:
+      "Let's dive into the Interledger Foundation's integration of open payments into academic curriculums, featuring insights from Dr. Allan Davids  (UCT), Dr. Andrew Mangle (Bowie State University), and Interledger Foundation CEO Briana Marbury.",
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/interledger-on-campus/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e12 Redefining financial inclusion with Chimoney',
+    description:
+      'Sit down with technologist and entrepreneur Uchi Uchibeke as he shares his inspiring journey from Nigeria to Canada and his work with Chimoney, a platform advancing financial inclusion and economic empowerment.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/redefining-financial-inclusion-with-chimoney/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e13 Architecture of Trust',
+    description:
+      'Joran Greef, CEO of Tiger Beetle, takes us through the development of Tiger Beetle as a cutting-edge financial transactions database, highlighting its speed, reliability, and use of open-source technology.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/architecture-of-trust/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e14 Reimagine global payments',
+    description:
+      'Join Sabine Schaller’s conversation with Interledger Protocol co-founders Stefan Thomas and Evan Schwartz as they discuss ILP’s design principles, their vision for a universal payment network, and ideas around automated transactions, Dassi, and ILDCP.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/reimagine-global-payments-with-the-creators-of-the-interledger/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e15 Looking back, Moving forward',
+    description:
+      'Join us in this special episode as we revisit the moments that sparked meaningful discussions and highlighted remarkable progress in narrowing the financial gap.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/looking-back-moving-forward/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e16 From Engineering to Digital Financial Inclusion',
+    description:
+      'In this episode, Santosh shares his firsthand experience of how India’s Unified Payments Interface (UPI) revolutionized the financial landscape, bringing millions into the banking system and enabling seamless digital transactions.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/from-engineering-to-digital-financial-inclusion/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e17 Empowerment through design',
+    description:
+      'Larissa Lamporsad and Kayee Au discuss how trust, simplicity, and dignity shape financial service design, highlighting the importance of cultural relevance and ethical solutions in driving meaningful change in digital finance.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/empowerment-through-design-kumquats-approach-to-financial-inclusion/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e18 Indigenomics and the Digital Future',
+    description:
+      'Carol Ann Hilton discusses Indigenous economic empowerment, blending traditional knowledge with modern tech, and dismantling systemic barriers to participation in this powerful conversation on The Future Money Podcast.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/indigenomics-and-the-digital-future-a-conversation-with-carol-anne-hilton/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title:
+      'Podcast - s01e19 In Conversation with ILF Grantee and Community Member Adam Waring',
+    description:
+      'Ayesha Ware and Chris Lawrence speak with ILF grantee and community member Adam Waring about the recent shutdown of gFam, his thoughts on Web Monetization, and what he’s planning next.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/in-conversation-with-ilf-grantee-and-community-member-adam-waring/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s01e20 Passing on the torch',
+    description:
+      'Meet Kokayi Issa, longtime community member, as he steps in as the new host of The Future Money Podcast. Kokayi shares his journey into digital financial inclusion and his vision for sparking fresh conversations about the future of finance.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/passing-on-the-torch/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title:
+      'Podcast - s02e01 - From big tech to community education: Reimagining how money moves',
+    description:
+      'Podcast - s02e01 - From big tech to community education: Reimagining how money moves',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/from-big-tech/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title: 'Podcast - s02e02 - Voices from the Interledger Summit 2025',
+    description:
+      ' Kokayi traveled to Mexico City for the Interledger Summit. Here, he had the opportunity to catch up with some of our panelists, workshop conveners, and summit participants to talk about what financial inclusion means globally.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/voices-from-the-interledger-summit-2025/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title:
+      'Podcast - s02e03 - From Casual Hang to Cultural Movement and Why Inclusion Matters',
+    description:
+      'Kokayi interviews Modi Oyewole, founder of Swang. An organization that was created out of what was a casual driving range hang and has since developed into a cultural movement in Los Angeles.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/from-casual-hang-to-cultural-movement-and-why-inclusion-matters-modi-oyewole-founder-of-swang/embed/light',
+    series: 'Future Money'
+  },
+  {
+    title:
+      'Podcast - s02e04 - Arts as Civic Infrastructure: Kristina Newman-Scott on Cultivating Equitable Communities',
+    description:
+      'Kokayi talks with Kristina Newman-Scott, the Knight Foundation’s Vice President of Arts, about fostering equitable communities through artistic expression.',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/arts-as-civic-infrastructure-kristina-newman-scott-on-cultivating-equitable-communities/embed/light',
+    series: 'Future Money'
+  }
+]

--- a/src/pages/podcasts.astro
+++ b/src/pages/podcasts.astro
@@ -3,29 +3,7 @@ import CalloutText from '@/components/shared/CalloutText.astro'
 import HeroSection from '@/components/shared/HeroSection.astro'
 import Podcast from '@/components/shared/Podcast.astro'
 import FoundationPageLayout from '@/layouts/FoundationPageLayout.astro'
-
-const podcasts = [
-  {
-    title: 'podcast 1',
-    description: 'This is the description for podcast no 1',
-    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/from-casual-hang-to-cultural-movement-and-why-inclusion-matters-modi-oyewole-founder-of-swang/embed/light'
-  },
-  {
-    title: 'podcast 2',
-    description: 'This is the description for podcast no 2',
-    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/arts-as-civic-infrastructure-kristina-newman-scott-on-cultivating-equitable-communities/embed/light'
-  },
-  {
-    title: 'podcast 3',
-    description: 'This is the description for podcast no 3',
-    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/from-casual-hang-to-cultural-movement-and-why-inclusion-matters-modi-oyewole-founder-of-swang/embed/light'
-  },
-  {
-    title: 'podcast 4',
-    description: 'This is the description for podcast no 4',
-    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/arts-as-civic-infrastructure-kristina-newman-scott-on-cultivating-equitable-communities/embed/light'
-  }
-]
+import { podcasts } from '@/data/podcasts'
 ---
 
 <FoundationPageLayout
@@ -36,11 +14,11 @@ const podcasts = [
   <HeroSection title="F|M podcast" content="with Kokayi Walker" />
   <main data-prose class="p-2xl max-w-content m-auto">
     <section aria-label="About the podcast">
-      <CalloutText
-        >Future Money is a podcast exploring the evolving intersections of
+      <CalloutText>
+        Future Money is a podcast exploring the evolving intersections of
         technology, finance, and culture, because finance touches every industry
-        and every life.</CalloutText
-      >
+        and every life.
+      </CalloutText>
       <p>
         At its core Future Money is about self-sovereignty and empowerment:
         reimagining how people, especially those in underserved communities and
@@ -54,15 +32,7 @@ const podcasts = [
     <section aria-labelledby="podcast-heading">
       <h2 id="podcast-heading">Podcast episodes</h2>
       <ul class="list-none m-0 p-0" role="list">
-        {
-          podcasts.map((podcast) => (
-            <Podcast
-              title={podcast.title}
-              description={podcast.description}
-              href={podcast.href}
-            />
-          ))
-        }
+        {podcasts.map((podcast) => <Podcast podcast={podcast} />)}
       </ul>
     </section>
   </main>

--- a/src/pages/podcasts.astro
+++ b/src/pages/podcasts.astro
@@ -1,0 +1,69 @@
+---
+import CalloutText from '@/components/shared/CalloutText.astro'
+import HeroSection from '@/components/shared/HeroSection.astro'
+import Podcast from '@/components/shared/Podcast.astro'
+import FoundationPageLayout from '@/layouts/FoundationPageLayout.astro'
+
+const podcasts = [
+  {
+    title: 'podcast 1',
+    description: 'This is the description for podcast no 1',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/from-casual-hang-to-cultural-movement-and-why-inclusion-matters-modi-oyewole-founder-of-swang/embed/light'
+  },
+  {
+    title: 'podcast 2',
+    description: 'This is the description for podcast no 2',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/arts-as-civic-infrastructure-kristina-newman-scott-on-cultivating-equitable-communities/embed/light'
+  },
+  {
+    title: 'podcast 3',
+    description: 'This is the description for podcast no 3',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/from-casual-hang-to-cultural-movement-and-why-inclusion-matters-modi-oyewole-founder-of-swang/embed/light'
+  },
+  {
+    title: 'podcast 4',
+    description: 'This is the description for podcast no 4',
+    href: 'https://podcast.interledger.org/@futuremoneypodcast/episodes/arts-as-civic-infrastructure-kristina-newman-scott-on-cultivating-equitable-communities/embed/light'
+  }
+]
+---
+
+<FoundationPageLayout
+  title="Podcasts"
+  description="Brought to you by the Interledger Foundation the F|M Podcast is a place where we invite people of all backgrounds and disciplines to change the status quo and provoke new ways of thinking about what digital financial futures are possible."
+  headerTheme="light"
+>
+  <HeroSection title="F|M podcast" content="with Kokayi Walker" />
+  <main data-prose class="p-2xl max-w-content m-auto">
+    <section aria-label="About the podcast">
+      <CalloutText
+        >Future Money is a podcast exploring the evolving intersections of
+        technology, finance, and culture, because finance touches every industry
+        and every life.</CalloutText
+      >
+      <p>
+        At its core Future Money is about self-sovereignty and empowerment:
+        reimagining how people, especially those in underserved communities and
+        those who are underbanked or unbanked, access, manage, and grow their
+        financial lives. Each episode engages founders, creatives, innovators,
+        and thought leaders in conversations that bridge their past experiences,
+        their present work, and their visions for the future of their industries
+        and the world at large.
+      </p>
+    </section>
+    <section aria-labelledby="podcast-heading">
+      <h2 id="podcast-heading">Podcast episodes</h2>
+      <ul class="list-none m-0 p-0" role="list">
+        {
+          podcasts.map((podcast) => (
+            <Podcast
+              title={podcast.title}
+              description={podcast.description}
+              href={podcast.href}
+            />
+          ))
+        }
+      </ul>
+    </section>
+  </main>
+</FoundationPageLayout>

--- a/src/types/podcast.ts
+++ b/src/types/podcast.ts
@@ -1,0 +1,6 @@
+export interface Podcast {
+  title: string
+  description: string
+  href: string
+  series: 'Future Money' | 'Interledger Salon'
+}


### PR DESCRIPTION
## Summary
- Add a new `/podcasts` page listing F|M podcast episodes. 
- Introduce a reusable `Podcast` component and a shared `Podcast` type in `src/types/`.
- Migrate the full podcast episode list from the legacy Drupal site into `src/data/podcasts.ts` as a temporary home until the Strapi integration lands.

## Scope (phase 1)
Per the ticket, this is the **bare-minimum** phase 1 implementation that mirrors what we have on Drupal:
- The `Podcast` component intentionally holds only the embed and the description — no extra styling investment.
- The `/podcasts` page is a simple list of those components.
- The goal is to unblock migrating the existing podcast data; 
- **EN only**. The page won't need translations;

Richer presentation and the Strapi-backed content model come in later phases.

## Related Issue
Fixes INTORG-693
Fixes INTORG-657

## Manual Test
Migrates the podcasts from https://interledger.org/podcast

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
