### PR TITLE
feat(preview): add typography preset reference page [INTORG-726]

### DIFF
--- a/src/components/preview/TypographyPresetRow.astro
+++ b/src/components/preview/TypographyPresetRow.astro
@@ -1,0 +1,35 @@
+---
+import { fontWeightLabel, TYPOGRAPHY_SAMPLE } from '@/data/typography-preview'
+import type { TypographyPreset } from '@/data/typography-preview'
+
+interface Props {
+  preset: TypographyPreset
+}
+
+const { preset } = Astro.props
+---
+
+<div
+  class="typography-preset-row grid grid-cols-1 border-b border-neutral-25 tablet:grid-cols-[240px_1fr]"
+>
+  <dl
+    class="grid grid-cols-[max-content_1fr] gap-x-lg gap-y-xs border-neutral-25 p-lg text-body-sm-standard text-neutral-75 tablet:border-r"
+  >
+    <dt>Font family</dt>
+    <dd>Poppins</dd>
+    <dt>Font style</dt>
+    <dd>{fontWeightLabel(preset.fontWeight)}</dd>
+    <dt>Font size</dt>
+    <dd>{preset.fontSizePx}</dd>
+    <dt>Line height</dt>
+    <dd>{preset.lineHeightPx}</dd>
+    <dt>Class</dt>
+    <dd>
+      <code class="text-neutral-100">{preset.className}</code>
+    </dd>
+  </dl>
+  <div class="p-lg">
+    <p class="mb-sm text-body-sm-standard text-neutral-75">{preset.label}</p>
+    <p class={`font-poppins ${preset.className}`}>{TYPOGRAPHY_SAMPLE}</p>
+  </div>
+</div>

--- a/src/data/typography-preview.test.ts
+++ b/src/data/typography-preview.test.ts
@@ -40,7 +40,7 @@ function parseLengthToPx(value: string): number {
 function parseThemeTextTokens(css: string): Map<string, ThemeTextToken> {
   const tokens = new Map<string, Partial<ThemeTextToken>>()
 
-  for (const match of css.matchAll(/^  --text-([\w-]+):\s*([^;]+);/gm)) {
+  for (const match of css.matchAll(/^ {2}--text-([\w-]+):\s*([^;]+);/gm)) {
     const [, name, value] = match
 
     if (name.endsWith('--line-height')) {
@@ -95,7 +95,10 @@ function expectPresetMatchesTheme(
   const tokenName = classNameToTokenName(preset.className)
   const themeToken = themeTokens.get(tokenName)
 
-  expect(themeToken, `Missing theme.css token for ${preset.className}`).toBeDefined()
+  expect(
+    themeToken,
+    `Missing theme.css token for ${preset.className}`
+  ).toBeDefined()
   expect(preset.fontSizePx).toBe(themeToken!.fontSizePx)
   expect(preset.lineHeightPx).toBe(themeToken!.lineHeightPx)
   expect(preset.fontWeight).toBe(themeToken!.fontWeight)

--- a/src/data/typography-preview.test.ts
+++ b/src/data/typography-preview.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import tailwindConfig from '../../tailwind.config.mjs'
+import {
+  TYPOGRAPHY_PRESETS_BY_TIER,
+  TYPOGRAPHY_TIER_HEADINGS,
+  TYPOGRAPHY_TIER_ORDER,
+  type TypographyPreset
+} from './typography-preview'
+
+const REM_BASE_PX = 16
+const THEME_CSS_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../styles/theme.css'
+)
+
+type ThemeTextToken = {
+  fontSizePx: number
+  lineHeightPx: number
+  fontWeight: number
+}
+
+function parseLengthToPx(value: string): number {
+  const trimmed = value.trim()
+
+  if (trimmed.endsWith('rem')) {
+    return Math.round(parseFloat(trimmed) * REM_BASE_PX)
+  }
+
+  if (trimmed.endsWith('px')) {
+    return Math.round(parseFloat(trimmed))
+  }
+
+  throw new Error(`Unsupported length unit in theme.css: ${value}`)
+}
+
+/** Parses `--text-*` font-size, line-height, and font-weight tokens from theme.css. */
+function parseThemeTextTokens(css: string): Map<string, ThemeTextToken> {
+  const tokens = new Map<string, Partial<ThemeTextToken>>()
+
+  for (const match of css.matchAll(/^  --text-([\w-]+):\s*([^;]+);/gm)) {
+    const [, name, value] = match
+
+    if (name.endsWith('--line-height')) {
+      const tokenName = name.slice(0, -'--line-height'.length)
+      const token = tokens.get(tokenName) ?? {}
+      token.lineHeightPx = parseLengthToPx(value)
+      tokens.set(tokenName, token)
+      continue
+    }
+
+    if (name.endsWith('--font-weight')) {
+      const tokenName = name.slice(0, -'--font-weight'.length)
+      const token = tokens.get(tokenName) ?? {}
+      token.fontWeight = Number.parseInt(value.trim(), 10)
+      tokens.set(tokenName, token)
+      continue
+    }
+
+    if (name.includes('--')) continue
+    if (name.startsWith('step-') || value.includes('clamp(')) continue
+
+    const token = tokens.get(name) ?? {}
+    token.fontSizePx = parseLengthToPx(value)
+    tokens.set(name, token)
+  }
+
+  const complete = new Map<string, ThemeTextToken>()
+
+  for (const [name, token] of tokens) {
+    if (
+      token.fontSizePx === undefined ||
+      token.lineHeightPx === undefined ||
+      token.fontWeight === undefined
+    ) {
+      throw new Error(`Incomplete --text-${name} token set in theme.css`)
+    }
+
+    complete.set(name, token as ThemeTextToken)
+  }
+
+  return complete
+}
+
+function classNameToTokenName(className: string): string {
+  return className.replace(/^text-/, '')
+}
+
+function expectPresetMatchesTheme(
+  preset: TypographyPreset,
+  themeTokens: Map<string, ThemeTextToken>
+): void {
+  const tokenName = classNameToTokenName(preset.className)
+  const themeToken = themeTokens.get(tokenName)
+
+  expect(themeToken, `Missing theme.css token for ${preset.className}`).toBeDefined()
+  expect(preset.fontSizePx).toBe(themeToken!.fontSizePx)
+  expect(preset.lineHeightPx).toBe(themeToken!.lineHeightPx)
+  expect(preset.fontWeight).toBe(themeToken!.fontWeight)
+}
+
+describe('typography-preview parity with theme.css', () => {
+  const themeTokens = parseThemeTextTokens(readFileSync(THEME_CSS_PATH, 'utf8'))
+
+  it('maps every preset className to a complete theme.css text token', () => {
+    for (const tier of TYPOGRAPHY_TIER_ORDER) {
+      for (const preset of TYPOGRAPHY_PRESETS_BY_TIER[tier]) {
+        expectPresetMatchesTheme(preset, themeTokens)
+      }
+    }
+  })
+
+  it('uses redesign breakpoint labels from tailwind.config.mjs', () => {
+    const { tablet, desktop } = tailwindConfig.theme.extend.screens
+
+    expect(TYPOGRAPHY_TIER_HEADINGS.mobile.breakpoint).toContain('< 810px')
+    expect(TYPOGRAPHY_TIER_HEADINGS.tablet.breakpoint).toContain(tablet)
+    expect(TYPOGRAPHY_TIER_HEADINGS.desktop.breakpoint).toContain(desktop)
+  })
+})

--- a/src/data/typography-preview.ts
+++ b/src/data/typography-preview.ts
@@ -12,8 +12,7 @@ export interface TypographyPreset {
   lineHeightPx: number
 }
 
-export const TYPOGRAPHY_SAMPLE =
-  'The quick brown fox jumps over the lazy dog'
+export const TYPOGRAPHY_SAMPLE = 'The quick brown fox jumps over the lazy dog'
 
 export const TYPOGRAPHY_TIER_HEADINGS: Record<
   TypographyTier,
@@ -24,18 +23,50 @@ export const TYPOGRAPHY_TIER_HEADINGS: Record<
   desktop: { title: 'Desktop', breakpoint: '1200px+ (desktop: / *-lg tokens)' }
 }
 
-export function fontWeightLabel(weight: TypographyPreset['fontWeight']): string {
+export function fontWeightLabel(
+  weight: TypographyPreset['fontWeight']
+): string {
   if (weight === 600) return 'SemiBold'
   if (weight === 500) return 'Medium'
   return 'Regular'
 }
 
 const MOBILE_PRESETS: TypographyPreset[] = [
-  { label: 'H1', className: 'text-h1', fontWeight: 600, fontSizePx: 56, lineHeightPx: 68 },
-  { label: 'H2', className: 'text-h2', fontWeight: 600, fontSizePx: 32, lineHeightPx: 40 },
-  { label: 'H3', className: 'text-h3', fontWeight: 500, fontSizePx: 20, lineHeightPx: 28 },
-  { label: 'H4', className: 'text-h4', fontWeight: 400, fontSizePx: 18, lineHeightPx: 28 },
-  { label: 'H5', className: 'text-h5', fontWeight: 400, fontSizePx: 16, lineHeightPx: 26 },
+  {
+    label: 'H1',
+    className: 'text-h1',
+    fontWeight: 600,
+    fontSizePx: 56,
+    lineHeightPx: 68
+  },
+  {
+    label: 'H2',
+    className: 'text-h2',
+    fontWeight: 600,
+    fontSizePx: 32,
+    lineHeightPx: 40
+  },
+  {
+    label: 'H3',
+    className: 'text-h3',
+    fontWeight: 500,
+    fontSizePx: 20,
+    lineHeightPx: 28
+  },
+  {
+    label: 'H4',
+    className: 'text-h4',
+    fontWeight: 400,
+    fontSizePx: 18,
+    lineHeightPx: 28
+  },
+  {
+    label: 'H5',
+    className: 'text-h5',
+    fontWeight: 400,
+    fontSizePx: 16,
+    lineHeightPx: 26
+  },
   {
     label: 'Body LG emphasis',
     className: 'text-body-lg-emphasis',
@@ -74,11 +105,41 @@ const MOBILE_PRESETS: TypographyPreset[] = [
 ]
 
 const TABLET_PRESETS: TypographyPreset[] = [
-  { label: 'H1', className: 'text-h1-md', fontWeight: 600, fontSizePx: 70, lineHeightPx: 76 },
-  { label: 'H2', className: 'text-h2-md', fontWeight: 600, fontSizePx: 36, lineHeightPx: 48 },
-  { label: 'H3', className: 'text-h3-md', fontWeight: 500, fontSizePx: 28, lineHeightPx: 36 },
-  { label: 'H4', className: 'text-h4-md', fontWeight: 400, fontSizePx: 20, lineHeightPx: 30 },
-  { label: 'H5', className: 'text-h5-md', fontWeight: 400, fontSizePx: 18, lineHeightPx: 28 },
+  {
+    label: 'H1',
+    className: 'text-h1-md',
+    fontWeight: 600,
+    fontSizePx: 70,
+    lineHeightPx: 76
+  },
+  {
+    label: 'H2',
+    className: 'text-h2-md',
+    fontWeight: 600,
+    fontSizePx: 36,
+    lineHeightPx: 48
+  },
+  {
+    label: 'H3',
+    className: 'text-h3-md',
+    fontWeight: 500,
+    fontSizePx: 28,
+    lineHeightPx: 36
+  },
+  {
+    label: 'H4',
+    className: 'text-h4-md',
+    fontWeight: 400,
+    fontSizePx: 20,
+    lineHeightPx: 30
+  },
+  {
+    label: 'H5',
+    className: 'text-h5-md',
+    fontWeight: 400,
+    fontSizePx: 18,
+    lineHeightPx: 28
+  },
   {
     label: 'Body LG emphasis',
     className: 'text-body-lg-emphasis-md',
@@ -117,11 +178,41 @@ const TABLET_PRESETS: TypographyPreset[] = [
 ]
 
 const DESKTOP_PRESETS: TypographyPreset[] = [
-  { label: 'H1', className: 'text-h1-lg', fontWeight: 600, fontSizePx: 100, lineHeightPx: 100 },
-  { label: 'H2', className: 'text-h2-lg', fontWeight: 600, fontSizePx: 56, lineHeightPx: 64 },
-  { label: 'H3', className: 'text-h3-lg', fontWeight: 500, fontSizePx: 40, lineHeightPx: 56 },
-  { label: 'H4', className: 'text-h4-lg', fontWeight: 400, fontSizePx: 24, lineHeightPx: 34 },
-  { label: 'H5', className: 'text-h5-lg', fontWeight: 400, fontSizePx: 20, lineHeightPx: 30 },
+  {
+    label: 'H1',
+    className: 'text-h1-lg',
+    fontWeight: 600,
+    fontSizePx: 100,
+    lineHeightPx: 100
+  },
+  {
+    label: 'H2',
+    className: 'text-h2-lg',
+    fontWeight: 600,
+    fontSizePx: 56,
+    lineHeightPx: 64
+  },
+  {
+    label: 'H3',
+    className: 'text-h3-lg',
+    fontWeight: 500,
+    fontSizePx: 40,
+    lineHeightPx: 56
+  },
+  {
+    label: 'H4',
+    className: 'text-h4-lg',
+    fontWeight: 400,
+    fontSizePx: 24,
+    lineHeightPx: 34
+  },
+  {
+    label: 'H5',
+    className: 'text-h5-lg',
+    fontWeight: 400,
+    fontSizePx: 20,
+    lineHeightPx: 30
+  },
   {
     label: 'Body LG emphasis',
     className: 'text-body-lg-emphasis-md',
@@ -159,12 +250,14 @@ const DESKTOP_PRESETS: TypographyPreset[] = [
   }
 ]
 
-export const TYPOGRAPHY_PRESETS_BY_TIER: Record<TypographyTier, TypographyPreset[]> =
-  {
-    mobile: MOBILE_PRESETS,
-    tablet: TABLET_PRESETS,
-    desktop: DESKTOP_PRESETS
-  }
+export const TYPOGRAPHY_PRESETS_BY_TIER: Record<
+  TypographyTier,
+  TypographyPreset[]
+> = {
+  mobile: MOBILE_PRESETS,
+  tablet: TABLET_PRESETS,
+  desktop: DESKTOP_PRESETS
+}
 
 export const TYPOGRAPHY_TIER_ORDER: TypographyTier[] = [
   'mobile',

--- a/src/data/typography-preview.ts
+++ b/src/data/typography-preview.ts
@@ -1,0 +1,173 @@
+/** Typography preset catalog for the internal /preview/typography page. Values mirror @theme tokens in src/styles/theme.css. */
+
+export type TypographyTier = 'mobile' | 'tablet' | 'desktop'
+
+export interface TypographyPreset {
+  /** Short label shown in the preview column (e.g. H1). */
+  label: string
+  /** Tailwind `text-*` utility for this tier. */
+  className: string
+  fontWeight: 400 | 500 | 600
+  fontSizePx: number
+  lineHeightPx: number
+}
+
+export const TYPOGRAPHY_SAMPLE =
+  'The quick brown fox jumps over the lazy dog'
+
+export const TYPOGRAPHY_TIER_HEADINGS: Record<
+  TypographyTier,
+  { title: string; breakpoint: string }
+> = {
+  mobile: { title: 'Mobile', breakpoint: '< 810px (base tokens)' },
+  tablet: { title: 'Tablet', breakpoint: '810px+ (tablet: / *-md tokens)' },
+  desktop: { title: 'Desktop', breakpoint: '1200px+ (desktop: / *-lg tokens)' }
+}
+
+export function fontWeightLabel(weight: TypographyPreset['fontWeight']): string {
+  if (weight === 600) return 'SemiBold'
+  if (weight === 500) return 'Medium'
+  return 'Regular'
+}
+
+const MOBILE_PRESETS: TypographyPreset[] = [
+  { label: 'H1', className: 'text-h1', fontWeight: 600, fontSizePx: 56, lineHeightPx: 68 },
+  { label: 'H2', className: 'text-h2', fontWeight: 600, fontSizePx: 32, lineHeightPx: 40 },
+  { label: 'H3', className: 'text-h3', fontWeight: 500, fontSizePx: 20, lineHeightPx: 28 },
+  { label: 'H4', className: 'text-h4', fontWeight: 400, fontSizePx: 18, lineHeightPx: 28 },
+  { label: 'H5', className: 'text-h5', fontWeight: 400, fontSizePx: 16, lineHeightPx: 26 },
+  {
+    label: 'Body LG emphasis',
+    className: 'text-body-lg-emphasis',
+    fontWeight: 500,
+    fontSizePx: 15,
+    lineHeightPx: 24
+  },
+  {
+    label: 'Body LG standard',
+    className: 'text-body-lg-standard',
+    fontWeight: 400,
+    fontSizePx: 15,
+    lineHeightPx: 24
+  },
+  {
+    label: 'Body SM emphasis',
+    className: 'text-body-sm-emphasis',
+    fontWeight: 500,
+    fontSizePx: 14,
+    lineHeightPx: 24
+  },
+  {
+    label: 'Body SM standard',
+    className: 'text-body-sm-standard',
+    fontWeight: 400,
+    fontSizePx: 14,
+    lineHeightPx: 24
+  },
+  {
+    label: 'Caption',
+    className: 'text-caption',
+    fontWeight: 400,
+    fontSizePx: 13,
+    lineHeightPx: 16
+  }
+]
+
+const TABLET_PRESETS: TypographyPreset[] = [
+  { label: 'H1', className: 'text-h1-md', fontWeight: 600, fontSizePx: 70, lineHeightPx: 76 },
+  { label: 'H2', className: 'text-h2-md', fontWeight: 600, fontSizePx: 36, lineHeightPx: 48 },
+  { label: 'H3', className: 'text-h3-md', fontWeight: 500, fontSizePx: 28, lineHeightPx: 36 },
+  { label: 'H4', className: 'text-h4-md', fontWeight: 400, fontSizePx: 20, lineHeightPx: 30 },
+  { label: 'H5', className: 'text-h5-md', fontWeight: 400, fontSizePx: 18, lineHeightPx: 28 },
+  {
+    label: 'Body LG emphasis',
+    className: 'text-body-lg-emphasis-md',
+    fontWeight: 500,
+    fontSizePx: 16,
+    lineHeightPx: 26
+  },
+  {
+    label: 'Body LG standard',
+    className: 'text-body-lg-standard-md',
+    fontWeight: 400,
+    fontSizePx: 16,
+    lineHeightPx: 26
+  },
+  {
+    label: 'Body SM emphasis',
+    className: 'text-body-sm-emphasis',
+    fontWeight: 500,
+    fontSizePx: 14,
+    lineHeightPx: 24
+  },
+  {
+    label: 'Body SM standard',
+    className: 'text-body-sm-standard',
+    fontWeight: 400,
+    fontSizePx: 14,
+    lineHeightPx: 24
+  },
+  {
+    label: 'Caption',
+    className: 'text-caption',
+    fontWeight: 400,
+    fontSizePx: 13,
+    lineHeightPx: 16
+  }
+]
+
+const DESKTOP_PRESETS: TypographyPreset[] = [
+  { label: 'H1', className: 'text-h1-lg', fontWeight: 600, fontSizePx: 100, lineHeightPx: 100 },
+  { label: 'H2', className: 'text-h2-lg', fontWeight: 600, fontSizePx: 56, lineHeightPx: 64 },
+  { label: 'H3', className: 'text-h3-lg', fontWeight: 500, fontSizePx: 40, lineHeightPx: 56 },
+  { label: 'H4', className: 'text-h4-lg', fontWeight: 400, fontSizePx: 24, lineHeightPx: 34 },
+  { label: 'H5', className: 'text-h5-lg', fontWeight: 400, fontSizePx: 20, lineHeightPx: 30 },
+  {
+    label: 'Body LG emphasis',
+    className: 'text-body-lg-emphasis-md',
+    fontWeight: 500,
+    fontSizePx: 16,
+    lineHeightPx: 26
+  },
+  {
+    label: 'Body LG standard',
+    className: 'text-body-lg-standard-md',
+    fontWeight: 400,
+    fontSizePx: 16,
+    lineHeightPx: 26
+  },
+  {
+    label: 'Body SM emphasis',
+    className: 'text-body-sm-emphasis',
+    fontWeight: 500,
+    fontSizePx: 14,
+    lineHeightPx: 24
+  },
+  {
+    label: 'Body SM standard',
+    className: 'text-body-sm-standard',
+    fontWeight: 400,
+    fontSizePx: 14,
+    lineHeightPx: 24
+  },
+  {
+    label: 'Caption',
+    className: 'text-caption',
+    fontWeight: 400,
+    fontSizePx: 13,
+    lineHeightPx: 16
+  }
+]
+
+export const TYPOGRAPHY_PRESETS_BY_TIER: Record<TypographyTier, TypographyPreset[]> =
+  {
+    mobile: MOBILE_PRESETS,
+    tablet: TABLET_PRESETS,
+    desktop: DESKTOP_PRESETS
+  }
+
+export const TYPOGRAPHY_TIER_ORDER: TypographyTier[] = [
+  'mobile',
+  'tablet',
+  'desktop'
+]

--- a/src/data/typography-preview.ts
+++ b/src/data/typography-preview.ts
@@ -1,4 +1,4 @@
-/** Typography preset catalog for the internal /preview/typography page. Values mirror @theme tokens in src/styles/theme.css. */
+/** Typography preset catalog for the internal /preview/typography page. Displayed px values mirror @theme tokens in src/styles/theme.css — kept in sync by typography-preview.test.ts. */
 
 export type TypographyTier = 'mobile' | 'tablet' | 'desktop'
 

--- a/src/pages/preview/typography/index.astro
+++ b/src/pages/preview/typography/index.astro
@@ -1,0 +1,63 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro'
+import TypographyPresetRow from '@/components/preview/TypographyPresetRow.astro'
+import {
+  TYPOGRAPHY_PRESETS_BY_TIER,
+  TYPOGRAPHY_TIER_HEADINGS,
+  TYPOGRAPHY_TIER_ORDER
+} from '@/data/typography-preview'
+
+const containerClass = 'mx-auto max-w-(--max-content-width) px-lg'
+---
+
+<BaseLayout title="Typography Preview">
+  <Fragment slot="head">
+    <meta name="robots" content="noindex, nofollow" />
+  </Fragment>
+
+  <main class="py-2xl">
+    <div class={containerClass}>
+      <h1 class="font-poppins mb-lg text-h2">Typography</h1>
+      <p class="mb-2xl text-body-lg-standard">
+        Internal reference for Poppins text presets from
+        <code>src/styles/theme.css</code>. SEO-excluded and not linked from any
+        nav. Each tier shows the token sizes used at that breakpoint — apply
+        with responsive prefixes in production (e.g.
+        <code>text-h2 tablet:text-h2-md desktop:text-h2-lg</code>).
+      </p>
+
+      <nav aria-label="Sections" class="mb-2xl">
+        <ul class="flex flex-wrap gap-md list-none [&>li>a]:underline">
+          {
+            TYPOGRAPHY_TIER_ORDER.map((tier) => (
+              <li>
+                <a href={`#${tier}`}>{TYPOGRAPHY_TIER_HEADINGS[tier].title}</a>
+              </li>
+            ))
+          }
+          <li><a href="/preview/ui-components">UI components</a></li>
+        </ul>
+      </nav>
+    </div>
+
+    {
+      TYPOGRAPHY_TIER_ORDER.map((tier) => (
+        <section id={tier} class="mb-3xl">
+          <div class={`${containerClass} mb-lg`}>
+            <h2 class="font-poppins text-h3">
+              {TYPOGRAPHY_TIER_HEADINGS[tier].title}
+            </h2>
+            <p class="mt-xs text-body-sm-standard text-neutral-75">
+              {TYPOGRAPHY_TIER_HEADINGS[tier].breakpoint}
+            </p>
+          </div>
+          <div class={`${containerClass} border-t border-neutral-25`}>
+            {TYPOGRAPHY_PRESETS_BY_TIER[tier].map((preset) => (
+              <TypographyPresetRow preset={preset} />
+            ))}
+          </div>
+        </section>
+      ))
+    }
+  </main>
+</BaseLayout>

--- a/src/pages/preview/ui-components.astro
+++ b/src/pages/preview/ui-components.astro
@@ -27,6 +27,7 @@ const containerClass = `mx-auto max-w-(--max-content-width) px-lg`
           <li><a href="#buttons">Buttons</a></li>
           <li><a href="#text-media-section">Text + media section</a></li>
           <li><a href="#pillars-section">Pillars Section</a></li>
+          <li><a href="/preview/typography">Typography</a></li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
## Summary

Adds an internal typography reference page at `/preview/typography`


## Related Issue

Fixes INTORG-726

## Manual Test

- [ ] Open `/preview/typography` — page loads with Tailwind styles (Poppins, spacing, grid layout)
- [ ] Confirm three sections: Mobile, Tablet, Desktop — anchor nav jumps to each

## Checks

- [ ] `pnpm run format`
- [ ] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
