### PR TITLE
fix(home): resolve animated network overscroll and hero overlap [INTORG-761]

### DIFF
--- a/src/components/homepage/AnimatedNetwork.astro
+++ b/src/components/homepage/AnimatedNetwork.astro
@@ -25,7 +25,10 @@ import AnimatedNetworkProblem, {
   class="relative isolate z-0 flex flex-col bg-neutral-150"
 >
   <div class="network-stage relative flex flex-col">
-    <figure class="network-art hidden tablet:block" aria-hidden="true">
+    <figure
+      class="network-art pointer-events-none hidden tablet:block"
+      aria-hidden="true"
+    >
       <img
         src="/img/homepage/hero-animated-network.svg"
         alt=""
@@ -57,8 +60,11 @@ import AnimatedNetworkProblem, {
     /* Fraction from art top where problem copy begins (tracks SVG hub ~52%). */
     --network-problem-start: 0.78;
     --network-svg-aspect: calc(3186 / 1920);
-    /* Extra top room for scale(1.25) + rotation; bottom edge clips SVG and disc in-section. */
-    --network-clip-top: calc(var(--network-hero-overlap) + 18vh);
+    /* Pull circle anchor up from the SVG hub (52% of art height). */
+    --network-circle-y-nudge: 2vh;
+    /* Extra top room for scale(1.25) + rotation bleeding into HomepageHero. */
+    --network-clip-top: calc(var(--network-hero-overlap) + 22vh);
+    /* Negative top inset lets transformed SVG paint above this section's top edge. */
     clip-path: inset(calc(-1 * var(--network-clip-top)) 0 0 0);
   }
 
@@ -82,7 +88,6 @@ import AnimatedNetworkProblem, {
     [data-component='AnimatedNetwork'] .network-stage {
       container-type: inline-size;
       min-height: var(--network-stage-height);
-      overflow: visible;
     }
   }
 
@@ -93,9 +98,12 @@ import AnimatedNetworkProblem, {
 
   [data-component='AnimatedNetwork'] .network-art {
     position: relative;
+    z-index: 1;
     flex-shrink: 0;
     margin-top: calc(-1 * var(--network-hero-overlap));
     width: 100%;
+    /* Must stay visible so rotate/scale paint can bleed into HomepageHero below tablet. */
+    overflow: visible;
   }
 
   /*
@@ -136,13 +144,12 @@ import AnimatedNetworkProblem, {
     }
   }
 
-  /* Same hub as .network-svg transform-origin (50% / 52%) — moves with image reflow on resize. */
+  /* Hub at SVG registration point (50% / 52%) — nudge pulls anchor up from there. */
   [data-component='AnimatedNetwork'] .circle-anchor {
     display: none;
     position: absolute;
-    top: 52%;
     left: 50%;
-    z-index: 1;
+    z-index: 2;
     transform: translate(-50%, -50%);
     pointer-events: none;
   }
@@ -150,13 +157,15 @@ import AnimatedNetworkProblem, {
   @media (min-width: 810px) {
     [data-component='AnimatedNetwork'] .circle-anchor {
       display: block;
+      /* % is art height; nudge subtracts viewport height to move hub up. */
+      top: calc(52% - var(--network-circle-y-nudge));
     }
 
     /* Grows via transform scale (not width) to limit compositor layer size on low-end devices. */
     [data-component='AnimatedNetwork'] .growing-circle {
       --network-circle-size: 4vw;
-      /* 4vw × scale covers viewport; ~375 when vmax≈vw, 500 is safe headroom. */
-      --network-circle-max-scale: 500;
+      /* ~80× covers viewport from hub; 500× inflated document scroll height. */
+      --network-circle-max-scale: 80;
       width: var(--network-circle-size);
       aspect-ratio: 1;
       flex: none;

--- a/src/components/homepage/AnimatedNetwork.astro
+++ b/src/components/homepage/AnimatedNetwork.astro
@@ -62,6 +62,7 @@ import AnimatedNetworkProblem, {
     --network-svg-aspect: calc(3186 / 1920);
     /* Pull circle anchor up from the SVG hub (52% of art height). */
     --network-circle-y-nudge: 2vh;
+    --network-circle-x-nudge: 0.75vw;
     /* Extra top room for scale(1.25) + rotation bleeding into HomepageHero. */
     --network-clip-top: calc(var(--network-hero-overlap) + 22vh);
     /* Negative top inset lets transformed SVG paint above this section's top edge. */
@@ -144,11 +145,11 @@ import AnimatedNetworkProblem, {
     }
   }
 
-  /* Hub at SVG registration point (50% / 52%) — nudge pulls anchor up from there. */
+  /* Hub at SVG registration point (50% / 52%) — nudge adjusts anchor from there. */
   [data-component='AnimatedNetwork'] .circle-anchor {
     display: none;
     position: absolute;
-    left: 50%;
+    left: calc(50% + var(--network-circle-x-nudge));
     z-index: 2;
     transform: translate(-50%, -50%);
     pointer-events: none;
@@ -177,7 +178,7 @@ import AnimatedNetworkProblem, {
       /* 1ms duration: scroll-driven pattern — timeline controls progress, not duration. */
       animation: growing-circle-grow 1ms linear forwards;
       animation-timeline: --network-track;
-      animation-range: cover 50% cover 100%;
+      animation-range: cover 35% cover 91%;
     }
   }
 

--- a/src/components/pages/HomepageHero.astro
+++ b/src/components/pages/HomepageHero.astro
@@ -45,7 +45,7 @@ const heroUmami = (href: string, linkText: string) =>
 <section
   data-component="HomepageHero"
   data-umami-component="homepage-hero"
-  class="relative isolate bg-black text-white tablet:h-[90dvh] tablet:min-h-[90dvh]"
+  class="relative isolate bg-black text-white tablet:h-[90dvh] tablet:min-h-[90dvh] tablet:overflow-visible"
   aria-labelledby="home-hero-title"
 >
   <div

--- a/src/scripts/animated-network.test.ts
+++ b/src/scripts/animated-network.test.ts
@@ -6,11 +6,12 @@ import {
 } from './animated-network'
 
 describe('animated-network helpers', () => {
-  it('getCircleProgress maps second half of view progress', () => {
+  it('getCircleProgress maps circle growth animation range', () => {
     expect(getCircleProgress(0)).toBe(0)
     expect(getCircleProgress(0.25)).toBe(0)
-    expect(getCircleProgress(0.5)).toBe(0)
-    expect(getCircleProgress(0.75)).toBe(0.5)
+    expect(getCircleProgress(0.35)).toBe(0)
+    expect(getCircleProgress(0.63)).toBeCloseTo(0.5)
+    expect(getCircleProgress(0.91)).toBe(1)
     expect(getCircleProgress(1)).toBe(1)
   })
 

--- a/src/scripts/animated-network.ts
+++ b/src/scripts/animated-network.ts
@@ -20,7 +20,7 @@ const ROTATE_START_DEG = -15
 const ROTATE_END_DEG = 65
 const SCALE = 1.25
 /** Matches `--network-circle-max-scale` in AnimatedNetwork.astro (transform scale factor). */
-const CIRCLE_SCALE_FACTOR = 500
+const CIRCLE_SCALE_FACTOR = 80
 
 const NETWORK_SECTION_SELECTOR = '[data-component="AnimatedNetwork"]'
 

--- a/src/scripts/animated-network.ts
+++ b/src/scripts/animated-network.ts
@@ -107,9 +107,17 @@ export function getViewProgress(): number {
   return Math.min(1, Math.max(0, progress))
 }
 
-/** View progress slice for `animation-range: cover 50% cover 100%`. */
+/** Matches `animation-range: cover 35% cover 91%` in AnimatedNetwork.astro */
+const CIRCLE_ANIMATION_RANGE_START = 0.35
+const CIRCLE_ANIMATION_RANGE_END = 0.91
+
+/** View progress slice for circle growth animation range. */
 export function getCircleProgress(viewProgress: number): number {
-  return Math.min(1, Math.max(0, (viewProgress - 0.5) / 0.5))
+  const range = CIRCLE_ANIMATION_RANGE_END - CIRCLE_ANIMATION_RANGE_START
+  return Math.min(
+    1,
+    Math.max(0, (viewProgress - CIRCLE_ANIMATION_RANGE_START) / range)
+  )
 }
 
 function getCircleScale(circleProgress: number): number {


### PR DESCRIPTION
## Summary

Fixes homepage overscroll caused by the animated network section’s growing circle. 

## Related Issue

Fixes INTORG-761

## Manual Test

- [ ] **810px+:** Scroll to the bottom of the homepage — no extra empty scroll past the footer
- [ ] Scroll through the animated network — purple circle grows to cover the problem block; copy stays readable
- [ ] Hero → network transition — network SVG overlaps the hero bottom (Stefan photo / fade), not clipped
- [ ] **Firefox** (JS fallback): circle + SVG animation still work; no overscroll regression
- [ ] **Reduced motion:** end state renders without broken layout

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
