### PR TITLE
fix(home): improve homepage hero Stefan photo positioning [INTORG-658]

### DIFF
--- a/src/components/homepage/AnimatedNetwork.astro
+++ b/src/components/homepage/AnimatedNetwork.astro
@@ -47,16 +47,12 @@ import AnimatedNetworkProblem, {
     <div class="network-problem relative z-3">
       <AnimatedNetworkProblem class="relative z-3" />
     </div>
-
-    <div class="network-stage-spacer hidden tablet:block" aria-hidden="true">
-    </div>
   </div>
 </section>
 
 <style>
   [data-component='AnimatedNetwork'] {
     view-timeline: --network-track block;
-    --network-stage-height: 115vh;
     --network-hero-overlap: 10vh;
     /* Fraction from art top where problem copy begins (tracks SVG hub ~52%). */
     --network-problem-start: 0.78;
@@ -89,13 +85,8 @@ import AnimatedNetworkProblem, {
   @media (min-width: 810px) {
     [data-component='AnimatedNetwork'] .network-stage {
       container-type: inline-size;
-      min-height: var(--network-stage-height);
+      overflow: visible;
     }
-  }
-
-  [data-component='AnimatedNetwork'] .network-stage-spacer {
-    flex: 1 1 auto;
-    min-height: 0;
   }
 
   [data-component='AnimatedNetwork'] .network-art {

--- a/src/components/pages/HomepageHero.astro
+++ b/src/components/pages/HomepageHero.astro
@@ -49,7 +49,7 @@ const heroUmami = (href: string, linkText: string) =>
   aria-labelledby="home-hero-title"
 >
   <div
-    class="pointer-events-none absolute top-full left-0 right-0 h-screen -z-10 bg-neutral-150"
+    class="pointer-events-none absolute top-full left-0 right-0 -z-10 bg-neutral-150"
     aria-hidden="true"
   >
   </div>

--- a/src/components/pages/HomepageHero.astro
+++ b/src/components/pages/HomepageHero.astro
@@ -189,7 +189,10 @@ const heroUmami = (href: string, linkText: string) =>
   @media (min-width: 810px) {
     [data-component='HomepageHero'] {
       --hero-stefan-object-x: 78%;
-      --hero-stefan-object-y: 70%;
+      --hero-stefan-object-y: top;
+      --hero-stefan-offset-x: 0;
+      /* Negative = shift photo up to trim source headroom; height calc keeps bottom filled. */
+      --hero-stefan-offset-y: -18vh;
     }
 
     [data-component='HomepageHero']::before,
@@ -210,9 +213,14 @@ const heroUmami = (href: string, linkText: string) =>
     [data-component='HomepageHero'] .hero-stefan-photo {
       display: block;
       width: 100%;
-      height: 100%;
+      height: calc(100% - var(--hero-stefan-offset-y));
       object-fit: cover;
       object-position: var(--hero-stefan-object-x) var(--hero-stefan-object-y);
+      transform: translate(
+        var(--hero-stefan-offset-x),
+        var(--hero-stefan-offset-y)
+      );
+      transform-origin: top center;
     }
   }
 
@@ -233,7 +241,6 @@ const heroUmami = (href: string, linkText: string) =>
     }
 
     [data-component='HomepageHero'] .hero-stefan-photo {
-      transform: translateX(var(--hero-stefan-offset-x));
       transform-origin: right top;
     }
   }
@@ -241,7 +248,6 @@ const heroUmami = (href: string, linkText: string) =>
   @media (min-width: 1880px) {
     [data-component='HomepageHero'] {
       --hero-stefan-object-x: 80%;
-      --hero-stefan-object-y: 76%;
     }
   }
 


### PR DESCRIPTION
## Summary
Top-anchors the Stefan Thomas hero photo with a negative vertical offset so the subject stays visible when the viewport height shrinks, trimming excess headroom in the source image. 

## Related Issue
Fixes [INTORG-658](https://linear.app/interledger/issue/INTORG-658/create-home-page-hero)

## Manual Test
- Open homepage at tablet+ widths; resize viewport height and confirm Stefan’s face stays in frame without excessive space above his head
- Scroll through the animated network section at ~1518px width; confirm no large purple gap below “The Problem We’re Solving” before the next section
- Verify hero gradient masks and animated network scroll behavior still look correct on Chrome and Firefox

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)


