### PR TITLE
fix(home): support reduced motion for animated network section [INTORG-762]

### DIFF
--- a/src/components/homepage/AnimatedNetwork.astro
+++ b/src/components/homepage/AnimatedNetwork.astro
@@ -5,7 +5,8 @@
  * over the same scroll. Both effects share the section's view-timeline so they
  * stay in lockstep. Driven by the scroll-driven animations API where supported;
  * Firefox and other browsers without `animation-timeline: view()` use the JS
- * fallback in src/scripts/animated-network.ts. Reduced motion uses the end state.
+ * fallback in src/scripts/animated-network.ts. Reduced motion hides the art on
+ * tablet+ and shows the problem block in-flow with a solid purple background.
  *
  * Below 810px (tablet:): problem copy in-flow; network SVG is the HomepageHero background.
  * From 810px: scroll animation, circle, and problem block anchored to the art.
@@ -199,15 +200,20 @@ import AnimatedNetworkProblem, {
   }
 
   @media (prefers-reduced-motion: reduce) and (min-width: 810px) {
-    [data-component='AnimatedNetwork'] .network-svg:not(.network-svg--static) {
-      animation: none;
-      transform: rotate(20deg) scale(1.25);
+    [data-component='AnimatedNetwork'] {
+      clip-path: none;
     }
 
-    [data-component='AnimatedNetwork'] .growing-circle {
-      animation: none;
-      opacity: 1;
-      transform: scale(var(--network-circle-max-scale));
+    [data-component='AnimatedNetwork'] .network-art {
+      display: none;
+    }
+
+    [data-component='AnimatedNetwork'] .network-problem {
+      margin-top: 0;
+    }
+
+    [data-component='AnimatedNetwork'] .network-problem-section {
+      background-color: var(--color-royal-purple-100);
     }
   }
 </style>

--- a/src/scripts/animated-network.ts
+++ b/src/scripts/animated-network.ts
@@ -273,10 +273,10 @@ function attachScrollController(
 }
 
 function syncScrollController(): void {
-  const { tabletUp } = getMediaQueries()
+  const { tabletUp, reducedMotion } = getMediaQueries()
   const section = getNetworkSection()
 
-  if (!section?.isConnected || !tabletUp.matches) {
+  if (!section?.isConnected || !tabletUp.matches || reducedMotion.matches) {
     destroyScrollController()
     return
   }
@@ -306,6 +306,9 @@ export function initAnimatedNetwork(): () => void {
   }
 
   getMediaQueries().tabletUp.addEventListener('change', onTabletChange, {
+    signal
+  })
+  getMediaQueries().reducedMotion.addEventListener('change', onTabletChange, {
     signal
   })
   window.addEventListener('pagehide', () => destroyScrollController(), {


### PR DESCRIPTION
## Summary

fixed from 
<img width="1386" height="842" alt="image" src="https://github.com/user-attachments/assets/6f0d057b-9446-45eb-bf3f-5df24a6455de" />


to
<img width="1206" height="860" alt="image" src="https://github.com/user-attachments/assets/d6ab3bd6-98cb-42d2-b107-3229f663bf3e" />


When `prefers-reduced-motion: reduce` is active on tablet+, the animated network section now hides the decorative SVG and growing circle, resets the problem block to normal document flow, and restores the solid purple background. This removes the oversized layout gap that appeared above “The Problem We’re Solving” while keeping the full scroll animation for users without reduced motion. The JS scroll controller is also skipped when reduced motion is enabled.

## Related Issue
Fixes [INTORG-762](https://linear.app/interledger/issue/INTORG-762/network-animation-support-reduced-motion)

## Manual Test
- Enable “Reduce motion” in OS settings, open homepage at tablet+ width, and confirm the problem section follows the hero directly with a purple background and no network SVG gap
- Disable reduced motion and confirm the scroll-driven network animation and circle still work on Chrome and Firefox
- Toggle reduced motion at runtime and confirm layout updates without a refresh

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)

