### PR TITLE
feat(blog): add image block with responsive variants and full-view [INTORG-766]

### DIFF
--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -165,8 +165,31 @@ export default {
       aside[aria-labelledby="additional-information"]:nth-child(2) { display: none !important; }
       /* TEMP UI Fix: enum dropdowns should show all options without scrolling */
       [role="listbox"] { max-height: none !important; }
+      /* TEMP UI Fix: image block — divider between asset row and options row */
+      [data-image-block-divider="true"] {
+        border-top: 1px solid #dcdce4;
+        margin-top: 1.5rem;
+        padding-top: 1.5rem;
+      }
     `
     document.head.appendChild(style)
+
+    // TEMP UI Fix: image block layout has no separator row type; mark options panel via DOM
+    function applyImageBlockSeparators() {
+      for (const altInput of document.querySelectorAll<HTMLInputElement>(
+        'input[name$=".altText"]'
+      )) {
+        let node: HTMLElement | null = altInput
+        for (let depth = 0; depth < 15 && node; depth++) {
+          const prev = node.previousElementSibling
+          if (prev?.querySelector('[aria-label="Image"]')) {
+            node.setAttribute('data-image-block-divider', 'true')
+            break
+          }
+          node = node.parentElement
+        }
+      }
+    }
 
     // TEMP UI Fix: apply DOM tweaks (MutationObserver, no polling)
     function applyUITweaks() {
@@ -258,6 +281,8 @@ export default {
           break
         }
       }
+
+      applyImageBlockSeparators()
 
       // TEMP UI Fix: rename Save to Publish for consistency
       const buttons = document.querySelectorAll('button')

--- a/cms/src/api/foundation-blog-post/content-types/foundation-blog-post/schema.json
+++ b/cms/src/api/foundation-blog-post/content-types/foundation-blog-post/schema.json
@@ -120,7 +120,11 @@
     },
     "content": {
       "type": "dynamiczone",
-      "components": ["blocks.paragraph", "blocks.video-embed"],
+      "components": [
+        "blocks.paragraph",
+        "blocks.video-embed",
+        "blocks.image-block"
+      ],
       "pluginOptions": { "i18n": { "localized": true } }
     },
     "articleBio": {

--- a/cms/src/components/blocks/image-block.json
+++ b/cms/src/components/blocks/image-block.json
@@ -1,0 +1,43 @@
+{
+  "collectionName": "components_blocks_image_blocks",
+  "info": {
+    "displayName": "Image Block",
+    "icon": "picture",
+    "description": "Standalone image with optional responsive variants, outline, and full-view support"
+  },
+  "options": {},
+  "attributes": {
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "tabletImage": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": ["images"]
+    },
+    "mobileImage": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": ["images"]
+    },
+    "altText": {
+      "type": "string",
+      "required": false
+    },
+    "needsFullView": {
+      "type": "boolean",
+      "required": true,
+      "default": false
+    },
+    "needsOutline": {
+      "type": "boolean",
+      "required": true,
+      "default": false
+    }
+  }
+}

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -678,6 +678,14 @@ async function configureFieldLabels(strapi: StrapiInstance) {
       imagePosition: 'Image Position',
       attribution: 'Image Attribution'
     },
+    'blocks.image-block': {
+      image: 'Image',
+      tabletImage: 'Tablet image variant (optional)',
+      mobileImage: 'Mobile image variant (optional)',
+      altText: 'Image alt text',
+      needsFullView: 'Needs full view',
+      needsOutline: 'Needs outline'
+    },
     'shared.category': {
       categoryValue: 'Category'
     },
@@ -701,6 +709,18 @@ async function configureFieldLabels(strapi: StrapiInstance) {
       category:
         'Option A: show ambassadors by category (leave ambassadors empty)',
       ambassadors: 'Option B: pick ambassadors manually (leave category empty)'
+    },
+    'blocks.image-block': {
+      tabletImage:
+        'Use if your image needs different proportions or cropping on medium-sized screens.',
+      mobileImage:
+        'Use if your image needs different proportions or cropping on small screens.',
+      altText:
+        'Describe the image if it conveys information. Leave blank if the image is purely decorative.',
+      needsFullView:
+        'Enable for complex images, diagrams, or anything where fine detail matters.',
+      needsOutline:
+        'Enable if the image has a white or light background and needs a boundary to separate it from blending into the page.'
     }
   }
 
@@ -913,6 +933,18 @@ async function configureLayouts(strapi: StrapiInstance) {
         { name: 'imagePosition', size: 6 }
       ],
       [{ name: 'content', size: 12 }]
+    ],
+    'blocks.image-block': [
+      [
+        { name: 'image', size: 4 },
+        { name: 'tabletImage', size: 4 },
+        { name: 'mobileImage', size: 4 }
+      ],
+      [
+        { name: 'altText', size: 4 },
+        { name: 'needsFullView', size: 4 },
+        { name: 'needsOutline', size: 4 }
+      ]
     ],
     'blocks.blockquote': [
       [{ name: 'quote', size: 12 }],

--- a/cms/src/serializers/blocks/image-block.serializer.test.ts
+++ b/cms/src/serializers/blocks/image-block.serializer.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { serialize } from './image-block.serializer'
+
+describe('image-block serializer', () => {
+  it('serializes src and alt from image alternativeText', () => {
+    const result = serialize({
+      image: { url: '/uploads/photo.jpg', alternativeText: 'A photo' }
+    })
+
+    expect(result).toBe('<ImageBlock src="/uploads/photo.jpg" alt="A photo" />')
+  })
+
+  it('prefers altText over image alternativeText', () => {
+    const result = serialize({
+      image: { url: '/uploads/photo.jpg', alternativeText: 'Fallback alt' },
+      altText: 'Explicit alt'
+    })
+
+    expect(result).toContain('alt="Explicit alt"')
+  })
+
+  it('defaults alt to empty string when neither altText nor alternativeText is set', () => {
+    const result = serialize({ image: { url: '/uploads/photo.jpg' } })
+
+    expect(result).toContain('alt=""')
+  })
+
+  it('includes tabletSrc and mobileSrc when present', () => {
+    const result = serialize({
+      image: { url: '/uploads/desktop.jpg' },
+      tabletImage: { url: '/uploads/tablet.jpg' },
+      mobileImage: { url: '/uploads/mobile.jpg' }
+    })
+
+    expect(result).toContain('tabletSrc="/uploads/tablet.jpg"')
+    expect(result).toContain('mobileSrc="/uploads/mobile.jpg"')
+  })
+
+  it('omits tabletSrc and mobileSrc when not provided', () => {
+    const result = serialize({ image: { url: '/uploads/desktop.jpg' } })
+
+    expect(result).not.toContain('tabletSrc')
+    expect(result).not.toContain('mobileSrc')
+  })
+
+  it('omits needsFullView and needsOutline when false or unset', () => {
+    const result = serialize({
+      image: { url: '/uploads/photo.jpg' },
+      needsFullView: false,
+      needsOutline: false
+    })
+
+    expect(result).not.toContain('needsFullView')
+    expect(result).not.toContain('needsOutline')
+  })
+
+  it('includes needsFullView when true', () => {
+    const result = serialize({
+      image: { url: '/uploads/photo.jpg' },
+      needsFullView: true
+    })
+
+    expect(result).toContain('needsFullView={true}')
+  })
+
+  it('includes needsOutline when true', () => {
+    const result = serialize({
+      image: { url: '/uploads/photo.jpg' },
+      needsOutline: true
+    })
+
+    expect(result).toContain('needsOutline={true}')
+  })
+
+  it('escapes special characters in alt text', () => {
+    const result = serialize({
+      image: { url: '/uploads/photo.jpg' },
+      altText: 'Q&A: "Live" Session'
+    })
+
+    expect(result).toContain('alt="Q&amp;A: &quot;Live&quot; Session"')
+    expect(result).not.toContain('\\"')
+  })
+
+  it('produces a self-closing ImageBlock tag', () => {
+    const result = serialize({ image: { url: '/uploads/photo.jpg' } })
+
+    expect(result).toMatch(/^<ImageBlock .* \/>$/)
+  })
+
+  it('throws when image is missing', () => {
+    expect(() => serialize({})).toThrow('ImageBlock block is missing image')
+  })
+
+  it('throws when image has no url', () => {
+    expect(() => serialize({ image: { alternativeText: 'No URL' } })).toThrow(
+      'ImageBlock block is missing image'
+    )
+  })
+})

--- a/cms/src/serializers/blocks/image-block.serializer.ts
+++ b/cms/src/serializers/blocks/image-block.serializer.ts
@@ -1,0 +1,28 @@
+import { getImageUrl } from '../../utils'
+import { escDouble as esc } from '../shared'
+
+interface ImageBlockBlock {
+  image?: { url?: string; alternativeText?: string }
+  tabletImage?: { url?: string; alternativeText?: string }
+  mobileImage?: { url?: string; alternativeText?: string }
+  altText?: string
+  needsFullView?: boolean
+  needsOutline?: boolean
+}
+
+export function serialize(block: ImageBlockBlock): string {
+  const src = getImageUrl(block.image)
+  if (!src) throw new Error('ImageBlock block is missing image')
+
+  const alt = block.altText ?? block.image?.alternativeText ?? ''
+  const tabletSrc = getImageUrl(block.tabletImage)
+  const mobileSrc = getImageUrl(block.mobileImage)
+
+  const attrs: string[] = [`src="${esc(src)}"`, `alt="${esc(alt)}"`]
+  if (tabletSrc) attrs.push(`tabletSrc="${esc(tabletSrc)}"`)
+  if (mobileSrc) attrs.push(`mobileSrc="${esc(mobileSrc)}"`)
+  if (block.needsFullView) attrs.push('needsFullView={true}')
+  if (block.needsOutline) attrs.push('needsOutline={true}')
+
+  return `<ImageBlock ${attrs.join(' ')} />`
+}

--- a/cms/src/serializers/blocks/index.ts
+++ b/cms/src/serializers/blocks/index.ts
@@ -16,6 +16,7 @@ import { serialize as calloutText } from './callout-text.serializer'
 import { serialize as ctaStrip } from './cta-strip.serializer'
 import { serialize as pdfEmbed } from './pdf-embed.serializer'
 import { serialize as videoEmbed } from './video-embed.serializer'
+import { serialize as imageBlock } from './image-block.serializer'
 
 const SERIALIZERS: Record<string, (block: unknown) => string> = {
   'blocks.cards-grid': cardsGrid,
@@ -30,7 +31,8 @@ const SERIALIZERS: Record<string, (block: unknown) => string> = {
   'blocks.callout-text': calloutText,
   'blocks.cta-strip': ctaStrip,
   'blocks.pdf-embed': pdfEmbed,
-  'blocks.video-embed': videoEmbed
+  'blocks.video-embed': videoEmbed,
+  'blocks.image-block': imageBlock
 }
 
 export function serializeContent(

--- a/cms/src/utils/contentPopulate.ts
+++ b/cms/src/utils/contentPopulate.ts
@@ -30,7 +30,10 @@ const FOUNDATION_PAGE_BLOCKS = {
 
 const FOUNDATION_BLOG_BLOCKS = {
   'blocks.paragraph': {},
-  'blocks.video-embed': {}
+  'blocks.video-embed': {},
+  'blocks.image-block': {
+    populate: { image: true, tabletImage: true, mobileImage: true }
+  }
 } as const
 
 /** Populate config for foundation-page and summit-page content fields. */

--- a/cms/types/generated/components.d.ts
+++ b/cms/types/generated/components.d.ts
@@ -424,6 +424,27 @@ export interface BlocksCtaStrip extends Struct.ComponentSchema {
   }
 }
 
+export interface BlocksImageBlock extends Struct.ComponentSchema {
+  collectionName: 'components_blocks_image_blocks'
+  info: {
+    description: 'Standalone image with optional responsive variants, outline, and full-view support'
+    displayName: 'Image Block'
+    icon: 'picture'
+  }
+  attributes: {
+    altText: Schema.Attribute.String
+    image: Schema.Attribute.Media<'images'> & Schema.Attribute.Required
+    mobileImage: Schema.Attribute.Media<'images'>
+    needsFullView: Schema.Attribute.Boolean &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<false>
+    needsOutline: Schema.Attribute.Boolean &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<false>
+    tabletImage: Schema.Attribute.Media<'images'>
+  }
+}
+
 export interface BlocksImageRow extends Struct.ComponentSchema {
   collectionName: 'components_blocks_image_rows'
   info: {
@@ -836,6 +857,7 @@ declare module '@strapi/strapi' {
       'blocks.carousel-item': BlocksCarouselItem
       'blocks.cta-banner': BlocksCtaBanner
       'blocks.cta-strip': BlocksCtaStrip
+      'blocks.image-block': BlocksImageBlock
       'blocks.image-row': BlocksImageRow
       'blocks.paragraph': BlocksParagraph
       'blocks.pdf-embed': BlocksPdfEmbed

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -547,7 +547,7 @@ export interface ApiFoundationBlogPostFoundationBlogPost
         }
       }>
     content: Schema.Attribute.DynamicZone<
-      ['blocks.paragraph', 'blocks.video-embed']
+      ['blocks.paragraph', 'blocks.video-embed', 'blocks.image-block']
     > &
       Schema.Attribute.SetPluginOptions<{
         i18n: {

--- a/src/components/blocks/DynamicZone.astro
+++ b/src/components/blocks/DynamicZone.astro
@@ -19,6 +19,7 @@ import BlockquoteBlock from './BlockquoteBlock.astro'
 import CalloutTextBlock from './CalloutTextBlock.astro'
 import PdfEmbedBlock from './PdfEmbedBlock.astro'
 import VideoEmbedBlock from './VideoEmbedBlock.astro'
+import ImageBlock from './ImageBlock.astro'
 
 interface Block {
   __component: string
@@ -44,7 +45,8 @@ const componentMap: Record<string, any> = {
   'blocks.blockquote': BlockquoteBlock,
   'blocks.callout-text': CalloutTextBlock,
   'blocks.pdf-embed': PdfEmbedBlock,
-  'blocks.video-embed': VideoEmbedBlock
+  'blocks.video-embed': VideoEmbedBlock,
+  'blocks.image-block': ImageBlock
 }
 
 const resolvedBlocks = blocks

--- a/src/components/blocks/ImageBlock.astro
+++ b/src/components/blocks/ImageBlock.astro
@@ -36,119 +36,154 @@ const TABLET_MQ = '(max-width: 1199px)'
 <figure class="my-0">
   <picture>
     {/* Mobile variant (max-width: 809px) */}
-    {mobile && mobile.avifVariants.length > 0 && (
-      <source
-        type="image/avif"
-        srcset={srcset(mobile.avifVariants)}
-        sizes="100vw"
-        media={MOBILE_MQ}
-      />
-    )}
-    {mobile && mobile.variants.length > 0 && (
-      <source
-        type="image/webp"
-        srcset={srcset(mobile.variants)}
-        sizes="100vw"
-        media={MOBILE_MQ}
-      />
-    )}
-    {mobile && !mobile.variants.length && mobile.avifFullSrc && (
-      <source type="image/avif" srcset={mobile.avifFullSrc} media={MOBILE_MQ} />
-    )}
-    {mobile && !mobile.variants.length && mobile.fullSrc && (
-      <source type="image/webp" srcset={mobile.fullSrc} media={MOBILE_MQ} />
-    )}
+    {
+      mobile && mobile.avifVariants.length > 0 && (
+        <source
+          type="image/avif"
+          srcset={srcset(mobile.avifVariants)}
+          sizes="100vw"
+          media={MOBILE_MQ}
+        />
+      )
+    }
+    {
+      mobile && mobile.variants.length > 0 && (
+        <source
+          type="image/webp"
+          srcset={srcset(mobile.variants)}
+          sizes="100vw"
+          media={MOBILE_MQ}
+        />
+      )
+    }
+    {
+      mobile && !mobile.variants.length && mobile.avifFullSrc && (
+        <source
+          type="image/avif"
+          srcset={mobile.avifFullSrc}
+          media={MOBILE_MQ}
+        />
+      )
+    }
+    {
+      mobile && !mobile.variants.length && mobile.fullSrc && (
+        <source type="image/webp" srcset={mobile.fullSrc} media={MOBILE_MQ} />
+      )
+    }
     {/* Fallback: no optimized variants exist — use original URL directly */}
-    {mobileSrc && !mobile?.variants.length && !mobile?.fullSrc && (
-      <source srcset={mobileSrc} media={MOBILE_MQ} />
-    )}
+    {
+      mobileSrc && !mobile?.variants.length && !mobile?.fullSrc && (
+        <source srcset={mobileSrc} media={MOBILE_MQ} />
+      )
+    }
 
     {/* Tablet variant (max-width: 1199px, after mobile has already matched) */}
-    {tablet && tablet.avifVariants.length > 0 && (
-      <source
-        type="image/avif"
-        srcset={srcset(tablet.avifVariants)}
-        sizes="100vw"
-        media={TABLET_MQ}
-      />
-    )}
-    {tablet && tablet.variants.length > 0 && (
-      <source
-        type="image/webp"
-        srcset={srcset(tablet.variants)}
-        sizes="100vw"
-        media={TABLET_MQ}
-      />
-    )}
-    {tablet && !tablet.variants.length && tablet.avifFullSrc && (
-      <source type="image/avif" srcset={tablet.avifFullSrc} media={TABLET_MQ} />
-    )}
-    {tablet && !tablet.variants.length && tablet.fullSrc && (
-      <source type="image/webp" srcset={tablet.fullSrc} media={TABLET_MQ} />
-    )}
+    {
+      tablet && tablet.avifVariants.length > 0 && (
+        <source
+          type="image/avif"
+          srcset={srcset(tablet.avifVariants)}
+          sizes="100vw"
+          media={TABLET_MQ}
+        />
+      )
+    }
+    {
+      tablet && tablet.variants.length > 0 && (
+        <source
+          type="image/webp"
+          srcset={srcset(tablet.variants)}
+          sizes="100vw"
+          media={TABLET_MQ}
+        />
+      )
+    }
+    {
+      tablet && !tablet.variants.length && tablet.avifFullSrc && (
+        <source
+          type="image/avif"
+          srcset={tablet.avifFullSrc}
+          media={TABLET_MQ}
+        />
+      )
+    }
+    {
+      tablet && !tablet.variants.length && tablet.fullSrc && (
+        <source type="image/webp" srcset={tablet.fullSrc} media={TABLET_MQ} />
+      )
+    }
     {/* Fallback: no optimized variants exist — use original URL directly */}
-    {tabletSrc && !tablet?.variants.length && !tablet?.fullSrc && (
-      <source srcset={tabletSrc} media={TABLET_MQ} />
-    )}
+    {
+      tabletSrc && !tablet?.variants.length && !tablet?.fullSrc && (
+        <source srcset={tabletSrc} media={TABLET_MQ} />
+      )
+    }
 
     {/* Desktop (default — no media query, catches everything else) */}
-    {desktop.avifVariants.length > 0 && (
-      <source
-        type="image/avif"
-        srcset={srcset(desktop.avifVariants)}
-        sizes="100vw"
-      />
-    )}
-    {desktop.variants.length > 0 && (
-      <source
-        type="image/webp"
-        srcset={srcset(desktop.variants)}
-        sizes="100vw"
-      />
-    )}
-    {desktop.avifFullSrc && !desktop.avifVariants.length && (
-      <source type="image/avif" srcset={desktop.avifFullSrc} />
-    )}
-    {desktop.fullSrc && !desktop.variants.length && (
-      <source type="image/webp" srcset={desktop.fullSrc} />
-    )}
+    {
+      desktop.avifVariants.length > 0 && (
+        <source
+          type="image/avif"
+          srcset={srcset(desktop.avifVariants)}
+          sizes="100vw"
+        />
+      )
+    }
+    {
+      desktop.variants.length > 0 && (
+        <source
+          type="image/webp"
+          srcset={srcset(desktop.variants)}
+          sizes="100vw"
+        />
+      )
+    }
+    {
+      desktop.avifFullSrc && !desktop.avifVariants.length && (
+        <source type="image/avif" srcset={desktop.avifFullSrc} />
+      )
+    }
+    {
+      desktop.fullSrc && !desktop.variants.length && (
+        <source type="image/webp" srcset={desktop.fullSrc} />
+      )
+    }
 
     <img
       src={src}
       alt={alt}
       loading="lazy"
       decoding="async"
-      class:list={[
-        'w-full rounded',
-        needsOutline && 'ring-1 ring-neutral-25'
-      ]}
+      class:list={['w-full rounded', needsOutline && 'ring-1 ring-neutral-25']}
     />
   </picture>
 
-  {needsFullView && (
-    <figcaption class="mt-space-2xs text-right">
-      <a
-        href={src}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="inline-flex items-center gap-space-3xs text-step--1 text-neutral-75 hover:text-primary underline-offset-2 hover:underline transition-colors"
-      >
-        View full image
-        <svg
-          aria-hidden="true"
-          viewBox="0 0 18 18"
-          class="h-3 w-3 shrink-0"
-          fill="none"
+  {
+    needsFullView && (
+      <figcaption class="mt-space-2xs text-right">
+        <a
+          href={src}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-space-3xs text-step--1 text-neutral-75 hover:text-primary underline-offset-2 hover:underline transition-colors"
         >
-          <path
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M7 3H3a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4M11 1h6m0 0v6m0-6L7 11"
-          />
-        </svg>
-      </a>
-    </figcaption>
-  )}
+          View full image
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 18 18"
+            class="h-3 w-3 shrink-0"
+            fill="none"
+          >
+            <path
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M7 3H3a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4M11 1h6m0 0v6m0-6L7 11"
+            />
+          </svg>
+        </a>
+      </figcaption>
+    )
+  }
 </figure>

--- a/src/components/blocks/ImageBlock.astro
+++ b/src/components/blocks/ImageBlock.astro
@@ -1,5 +1,6 @@
 ---
 import { getOptimizedImage } from '@/utils'
+import ResponsiveSources from '@/components/shared/ResponsiveSources.astro'
 
 interface Props {
   src: string
@@ -23,10 +24,6 @@ const desktop = getOptimizedImage(src)
 const tablet = tabletSrc ? getOptimizedImage(tabletSrc) : null
 const mobile = mobileSrc ? getOptimizedImage(mobileSrc) : null
 
-function srcset(variants: { src: string; width: number }[]): string {
-  return variants.map((v) => `${v.src} ${v.width}w`).join(', ')
-}
-
 // Breakpoints from tailwind.config.mjs: tablet=810px, desktop=1200px
 // Sources are ordered narrow-first so the first matching <source> wins.
 const MOBILE_MQ = '(max-width: 809px)'
@@ -35,119 +32,9 @@ const TABLET_MQ = '(max-width: 1199px)'
 
 <figure class="my-0">
   <picture>
-    {/* Mobile variant (max-width: 809px) */}
-    {
-      mobile && mobile.avifVariants.length > 0 && (
-        <source
-          type="image/avif"
-          srcset={srcset(mobile.avifVariants)}
-          sizes="100vw"
-          media={MOBILE_MQ}
-        />
-      )
-    }
-    {
-      mobile && mobile.variants.length > 0 && (
-        <source
-          type="image/webp"
-          srcset={srcset(mobile.variants)}
-          sizes="100vw"
-          media={MOBILE_MQ}
-        />
-      )
-    }
-    {
-      mobile && !mobile.variants.length && mobile.avifFullSrc && (
-        <source
-          type="image/avif"
-          srcset={mobile.avifFullSrc}
-          media={MOBILE_MQ}
-        />
-      )
-    }
-    {
-      mobile && !mobile.variants.length && mobile.fullSrc && (
-        <source type="image/webp" srcset={mobile.fullSrc} media={MOBILE_MQ} />
-      )
-    }
-    {/* Fallback: no optimized variants exist — use original URL directly */}
-    {
-      mobileSrc && !mobile?.variants.length && !mobile?.fullSrc && (
-        <source srcset={mobileSrc} media={MOBILE_MQ} />
-      )
-    }
-
-    {/* Tablet variant (max-width: 1199px, after mobile has already matched) */}
-    {
-      tablet && tablet.avifVariants.length > 0 && (
-        <source
-          type="image/avif"
-          srcset={srcset(tablet.avifVariants)}
-          sizes="100vw"
-          media={TABLET_MQ}
-        />
-      )
-    }
-    {
-      tablet && tablet.variants.length > 0 && (
-        <source
-          type="image/webp"
-          srcset={srcset(tablet.variants)}
-          sizes="100vw"
-          media={TABLET_MQ}
-        />
-      )
-    }
-    {
-      tablet && !tablet.variants.length && tablet.avifFullSrc && (
-        <source
-          type="image/avif"
-          srcset={tablet.avifFullSrc}
-          media={TABLET_MQ}
-        />
-      )
-    }
-    {
-      tablet && !tablet.variants.length && tablet.fullSrc && (
-        <source type="image/webp" srcset={tablet.fullSrc} media={TABLET_MQ} />
-      )
-    }
-    {/* Fallback: no optimized variants exist — use original URL directly */}
-    {
-      tabletSrc && !tablet?.variants.length && !tablet?.fullSrc && (
-        <source srcset={tabletSrc} media={TABLET_MQ} />
-      )
-    }
-
-    {/* Desktop (default — no media query, catches everything else) */}
-    {
-      desktop.avifVariants.length > 0 && (
-        <source
-          type="image/avif"
-          srcset={srcset(desktop.avifVariants)}
-          sizes="100vw"
-        />
-      )
-    }
-    {
-      desktop.variants.length > 0 && (
-        <source
-          type="image/webp"
-          srcset={srcset(desktop.variants)}
-          sizes="100vw"
-        />
-      )
-    }
-    {
-      desktop.avifFullSrc && !desktop.avifVariants.length && (
-        <source type="image/avif" srcset={desktop.avifFullSrc} />
-      )
-    }
-    {
-      desktop.fullSrc && !desktop.variants.length && (
-        <source type="image/webp" srcset={desktop.fullSrc} />
-      )
-    }
+    <ResponsiveSources image={mobile} rawSrc={mobileSrc} media={MOBILE_MQ} />
+    <ResponsiveSources image={tablet} rawSrc={tabletSrc} media={TABLET_MQ} />
+    <ResponsiveSources image={desktop} />
 
     <img
       src={src}

--- a/src/components/blocks/ImageBlock.astro
+++ b/src/components/blocks/ImageBlock.astro
@@ -1,0 +1,154 @@
+---
+import { getOptimizedImage } from '@/utils'
+
+interface Props {
+  src: string
+  alt?: string
+  tabletSrc?: string
+  mobileSrc?: string
+  needsFullView?: boolean
+  needsOutline?: boolean
+}
+
+const {
+  src,
+  alt = '',
+  tabletSrc,
+  mobileSrc,
+  needsFullView = false,
+  needsOutline = false
+} = Astro.props
+
+const desktop = getOptimizedImage(src)
+const tablet = tabletSrc ? getOptimizedImage(tabletSrc) : null
+const mobile = mobileSrc ? getOptimizedImage(mobileSrc) : null
+
+function srcset(variants: { src: string; width: number }[]): string {
+  return variants.map((v) => `${v.src} ${v.width}w`).join(', ')
+}
+
+// Breakpoints from tailwind.config.mjs: tablet=810px, desktop=1200px
+// Sources are ordered narrow-first so the first matching <source> wins.
+const MOBILE_MQ = '(max-width: 809px)'
+const TABLET_MQ = '(max-width: 1199px)'
+---
+
+<figure class="my-0">
+  <picture>
+    {/* Mobile variant (max-width: 809px) */}
+    {mobile && mobile.avifVariants.length > 0 && (
+      <source
+        type="image/avif"
+        srcset={srcset(mobile.avifVariants)}
+        sizes="100vw"
+        media={MOBILE_MQ}
+      />
+    )}
+    {mobile && mobile.variants.length > 0 && (
+      <source
+        type="image/webp"
+        srcset={srcset(mobile.variants)}
+        sizes="100vw"
+        media={MOBILE_MQ}
+      />
+    )}
+    {mobile && !mobile.variants.length && mobile.avifFullSrc && (
+      <source type="image/avif" srcset={mobile.avifFullSrc} media={MOBILE_MQ} />
+    )}
+    {mobile && !mobile.variants.length && mobile.fullSrc && (
+      <source type="image/webp" srcset={mobile.fullSrc} media={MOBILE_MQ} />
+    )}
+    {/* Fallback: no optimized variants exist — use original URL directly */}
+    {mobileSrc && !mobile?.variants.length && !mobile?.fullSrc && (
+      <source srcset={mobileSrc} media={MOBILE_MQ} />
+    )}
+
+    {/* Tablet variant (max-width: 1199px, after mobile has already matched) */}
+    {tablet && tablet.avifVariants.length > 0 && (
+      <source
+        type="image/avif"
+        srcset={srcset(tablet.avifVariants)}
+        sizes="100vw"
+        media={TABLET_MQ}
+      />
+    )}
+    {tablet && tablet.variants.length > 0 && (
+      <source
+        type="image/webp"
+        srcset={srcset(tablet.variants)}
+        sizes="100vw"
+        media={TABLET_MQ}
+      />
+    )}
+    {tablet && !tablet.variants.length && tablet.avifFullSrc && (
+      <source type="image/avif" srcset={tablet.avifFullSrc} media={TABLET_MQ} />
+    )}
+    {tablet && !tablet.variants.length && tablet.fullSrc && (
+      <source type="image/webp" srcset={tablet.fullSrc} media={TABLET_MQ} />
+    )}
+    {/* Fallback: no optimized variants exist — use original URL directly */}
+    {tabletSrc && !tablet?.variants.length && !tablet?.fullSrc && (
+      <source srcset={tabletSrc} media={TABLET_MQ} />
+    )}
+
+    {/* Desktop (default — no media query, catches everything else) */}
+    {desktop.avifVariants.length > 0 && (
+      <source
+        type="image/avif"
+        srcset={srcset(desktop.avifVariants)}
+        sizes="100vw"
+      />
+    )}
+    {desktop.variants.length > 0 && (
+      <source
+        type="image/webp"
+        srcset={srcset(desktop.variants)}
+        sizes="100vw"
+      />
+    )}
+    {desktop.avifFullSrc && !desktop.avifVariants.length && (
+      <source type="image/avif" srcset={desktop.avifFullSrc} />
+    )}
+    {desktop.fullSrc && !desktop.variants.length && (
+      <source type="image/webp" srcset={desktop.fullSrc} />
+    )}
+
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      decoding="async"
+      class:list={[
+        'w-full rounded',
+        needsOutline && 'ring-1 ring-neutral-25'
+      ]}
+    />
+  </picture>
+
+  {needsFullView && (
+    <figcaption class="mt-space-2xs text-right">
+      <a
+        href={src}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-space-3xs text-step--1 text-neutral-75 hover:text-primary underline-offset-2 hover:underline transition-colors"
+      >
+        View full image
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 18 18"
+          class="h-3 w-3 shrink-0"
+          fill="none"
+        >
+          <path
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M7 3H3a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4M11 1h6m0 0v6m0-6L7 11"
+          />
+        </svg>
+      </a>
+    </figcaption>
+  )}
+</figure>

--- a/src/components/pages/DevelopersBlogPostPage.astro
+++ b/src/components/pages/DevelopersBlogPostPage.astro
@@ -5,6 +5,7 @@ import CommunityLinksDevelopers from '@/components/blog/CommunityLinksDevelopers
 import DevelopersBlogLayout from '@/layouts/DevelopersBlogLayout.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import OptimizedImage from '@/components/shared/OptimizedImage.astro'
+import ImageBlock from '@/components/blocks/ImageBlock.astro'
 
 interface Props {
   slug: string
@@ -44,6 +45,6 @@ const blogPath = translatePath(
   <Fragment slot="disclaimer">
     <TranslationDisclaimer isVisible={isFallback} />
   </Fragment>
-  <MdxContent components={{ img: OptimizedImage }} />
+  <MdxContent components={{ img: OptimizedImage, ImageBlock }} />
   <CommunityLinksDevelopers />
 </DevelopersBlogLayout>

--- a/src/components/pages/FoundationBlogPostPage.astro
+++ b/src/components/pages/FoundationBlogPostPage.astro
@@ -15,7 +15,8 @@ import Blockquote from '@/components/shared/Blockquote.astro'
 import Paragraph from '@/components/blocks/Paragraph.astro'
 import VideoEmbed from '@/components/shared/VideoEmbed.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
-import OptimizedImage from '../shared/OptimizedImage.astro'
+import OptimizedImage from '@/components/shared/OptimizedImage.astro'
+import ImageBlock from '@/components/blocks/ImageBlock.astro'
 
 interface Props {
   slug: string
@@ -63,7 +64,8 @@ const relatedPosts = (mdxData.relatedArticles ?? [])
       img: OptimizedImage,
       Blockquote,
       Paragraph,
-      VideoEmbed
+      VideoEmbed,
+      ImageBlock
     }}
   />
   <Fragment slot="after-article">

--- a/src/components/shared/ResponsiveSources.astro
+++ b/src/components/shared/ResponsiveSources.astro
@@ -1,0 +1,49 @@
+---
+import { buildImageSrcset, type OptimizedImage } from '@/utils'
+
+interface Props {
+  image: OptimizedImage | null
+  /** Original (un-optimized) URL — rendered as a last-resort <source> when no variant or fullSrc exists. */
+  rawSrc?: string
+  media?: string
+  sizes?: string
+}
+
+const { image, rawSrc, media, sizes = '100vw' } = Astro.props
+---
+
+{
+  image && image.avifVariants.length > 0 && (
+    <source
+      type="image/avif"
+      srcset={buildImageSrcset(image.avifVariants)}
+      sizes={sizes}
+      media={media}
+    />
+  )
+}
+{
+  image && image.variants.length > 0 && (
+    <source
+      type="image/webp"
+      srcset={buildImageSrcset(image.variants)}
+      sizes={sizes}
+      media={media}
+    />
+  )
+}
+{
+  image && !image.variants.length && image.avifFullSrc && (
+    <source type="image/avif" srcset={image.avifFullSrc} media={media} />
+  )
+}
+{
+  image && !image.variants.length && image.fullSrc && (
+    <source type="image/webp" srcset={image.fullSrc} media={media} />
+  )
+}
+{
+  rawSrc && !image?.variants.length && !image?.fullSrc && (
+    <source srcset={rawSrc} media={media} />
+  )
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -114,7 +114,8 @@ export {
   hasOptimizedVariants,
   IMAGE_URL_PATHS,
   TARGET_WIDTHS,
-  pathToSegments
+  pathToSegments,
+  type OptimizedImage
 } from './main/images'
 
 // Main site: Ambassadors


### PR DESCRIPTION
## Summary
Adds a new `Image Block` dynamic zone component for foundation blog posts. Editors can upload a main image with optional tablet and mobile variants (served via responsive `<picture>` sources), add alt text, enable an outline for light-background images, and enable a "View full image" link that opens the original in a new tab.

CMS: Strapi schema, populate config, MDX serializer, admin field labels/descriptions, and 3-column edit layout.
Frontend: `ImageBlock.astro` registered in `DynamicZone`, `FoundationBlogPostPage`, and `DevelopersBlogPostPage`.

## Related Issue
Fixes INTORG-766

## Manual Test
1. In Strapi, open a Foundation Blog Post and add an **Image Block** to the content zone
2. Upload a main image; optionally upload tablet/mobile variants
3. Toggle **Needs outline** and/or **Needs full view**
4. Save — verify the MDX file is regenerated with `<ImageBlock ... />`
5. On the blog page: confirm the image renders, outline appears when set, and "View full image" opens the original in a new tab
6. Resize the viewport to confirm mobile/tablet variants switch correctly

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)

<img width="2154" height="956" alt="image" src="https://github.com/user-attachments/assets/bf0d1e85-b168-4600-bd5d-6a705527264f" />
