### PR TITLE
Jm/intorg 784 translucent nav INTORG-784

### DIFF
--- a/src/components/pages/HomePage.astro
+++ b/src/components/pages/HomePage.astro
@@ -51,9 +51,10 @@ const stats: StatItem[] = [
 <FoundationPageLayout
   title={t('site.title')}
   description={t('site.description')}
+  bodyClass="flex flex-col min-h-full min-w-[360px] overflow-x-clip bg-black"
 >
   <SmoothScroll />
-  <main data-umami-component="foundation-home-page">
+  <main class="bg-black" data-umami-component="foundation-home-page">
     <HomepageHero pageLang={pageLang} pathname={Astro.url.pathname} />
     <AnimatedNetwork />
     <PillarsSection />

--- a/src/components/pages/HomepageHero.astro
+++ b/src/components/pages/HomepageHero.astro
@@ -45,7 +45,7 @@ const heroUmami = (href: string, linkText: string) =>
 <section
   data-component="HomepageHero"
   data-umami-component="homepage-hero"
-  class="relative isolate bg-black text-white tablet:min-h-[90dvh]"
+  class="relative isolate -mt-(--site-header-height) bg-black pt-(--site-header-height) text-white desktop:-mt-(--site-header-height-desktop) desktop:pt-(--site-header-height-desktop) tablet:h-[90dvh] tablet:min-h-[90dvh] tablet:overflow-visible"
   aria-labelledby="home-hero-title"
 >
   <div

--- a/src/layouts/FoundationPageLayout.astro
+++ b/src/layouts/FoundationPageLayout.astro
@@ -16,7 +16,11 @@ interface Props {
   datePublished?: string
   headerTheme?: 'light' | 'dark'
   pageTheme?: 'light' | 'dark'
+  bodyClass?: string
 }
+
+const defaultBodyClass =
+  "flex flex-col min-h-full min-w-[360px] overflow-x-clip before:content-[''] before:fixed before:inset-0 before:-z-10 before:bg-[url('/img/bg-swirl.svg')] before:bg-repeat before:bg-[length:150%] before:blur-[150px] before:opacity-25 before:transform-gpu max-[430px]:before:hidden"
 
 const {
   title,
@@ -26,7 +30,8 @@ const {
   canonicalURL,
   datePublished,
   headerTheme = 'dark',
-  pageTheme = 'light'
+  pageTheme = 'light',
+  bodyClass = defaultBodyClass
 } = Astro.props
 ---
 
@@ -38,7 +43,7 @@ const {
   canonicalURL={canonicalURL}
   datePublished={datePublished}
   theme={pageTheme}
-  bodyClass="flex flex-col min-h-full min-w-[360px] overflow-x-clip before:content-[''] before:fixed before:inset-0 before:-z-10 before:bg-[url('/img/bg-swirl.svg')] before:bg-repeat before:bg-[length:150%] before:blur-[150px] before:opacity-25 before:transform-gpu max-[430px]:before:hidden"
+  bodyClass={bodyClass}
 >
   <Fragment slot="head">
     <slot name="head" />

--- a/src/styles/components/navigation.css
+++ b/src/styles/components/navigation.css
@@ -104,14 +104,6 @@
   }
 }
 
-.foundation-header[data-theme='dark']:has([data-offscreen='false']) {
-  background-color: #0d0d0d;
-}
-
-.foundation-header[data-theme='light']:has([data-offscreen='false']) {
-  background-color: #ffffff;
-}
-
 /* Logo wordmark: white on dark headers, purple on light foundation header */
 .foundation-logo-wordmark {
   fill: #ffffff;
@@ -121,16 +113,44 @@
   fill: #4f1072;
 }
 
-.foundation-header[data-theme='dark'] {
-  background-color: #0d0d0d;
-  color: var(--color-neutral-50);
-  box-shadow: none;
+/* Mobile/tablet: solid bar + drawer (hamburger layout). */
+@media (max-width: 1199px) {
+  .foundation-header[data-theme='dark'] {
+    background-color: #0d0d0d;
+    color: var(--color-neutral-50);
+    box-shadow: none;
+  }
+
+  .foundation-header[data-theme='light'] {
+    background-color: #ffffff;
+    color: black;
+    box-shadow: var(--shadow);
+  }
+
+  .foundation-header[data-theme='dark']:has([data-offscreen='false']) {
+    background-color: #0d0d0d;
+  }
+
+  .foundation-header[data-theme='light']:has([data-offscreen='false']) {
+    background-color: #ffffff;
+  }
 }
 
-.foundation-header[data-theme='light'] {
-  background-color: #ffffff;
-  color: black;
-  box-shadow: var(--shadow);
+/* Desktop: translucent bar; dropdown panels keep their own solid backgrounds. */
+@media (min-width: 1200px) {
+  .foundation-header[data-theme='dark'] {
+    background-color: rgb(13 13 13 / 0.7);
+    backdrop-filter: blur(10px);
+    color: var(--color-neutral-50);
+    box-shadow: none;
+  }
+
+  .foundation-header[data-theme='light'] {
+    background-color: rgb(255 255 255 / 0.7);
+    backdrop-filter: blur(10px);
+    color: black;
+    box-shadow: var(--shadow);
+  }
 }
 
 .foundation-header[data-theme='dark'] [data-component='HamburgerButton'] {

--- a/src/styles/components/navigation.css
+++ b/src/styles/components/navigation.css
@@ -140,6 +140,7 @@
 @media (min-width: 1200px) {
   .foundation-header[data-theme='dark'] {
     background-color: rgb(13 13 13 / 0.7);
+    -webkit-backdrop-filter: blur(10px);
     backdrop-filter: blur(10px);
     color: var(--color-neutral-50);
     box-shadow: none;
@@ -147,6 +148,7 @@
 
   .foundation-header[data-theme='light'] {
     background-color: rgb(255 255 255 / 0.7);
+    -webkit-backdrop-filter: blur(10px);
     backdrop-filter: blur(10px);
     color: black;
     box-shadow: var(--shadow);


### PR DESCRIPTION
## Summary
Desktop nav uses 70% opacity + `backdrop-filter: blur(10px)`; mobile/tablet stays solid. Homepage hero/body set to black so the translucent bar sits over dark content at the top.

## Related Issue
Fixes INTORG-784

## Manual Test
- Desktop (≥1200px): nav translucent with blur over homepage hero
- Mobile/tablet (≤1199px): nav + drawer solid
- Homepage top: dark behind nav, not light swirl

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)