### PR TITLE
fix(home): fix CTA buttons being cropped on overflow

### DIFF
--- a/src/components/pages/HomepageHero.astro
+++ b/src/components/pages/HomepageHero.astro
@@ -45,7 +45,7 @@ const heroUmami = (href: string, linkText: string) =>
 <section
   data-component="HomepageHero"
   data-umami-component="homepage-hero"
-  class="relative isolate bg-black text-white tablet:h-[90dvh] tablet:min-h-[90dvh] tablet:overflow-visible"
+  class="relative isolate bg-black text-white tablet:min-h-[90dvh]"
   aria-labelledby="home-hero-title"
 >
   <div


### PR DESCRIPTION
## Summary
At some screen zoom settings (+200% for me) the CTA buttons on the home page hero are getting cropped

## Related Issue
[INTORG-791](https://linear.app/interledger/issue/INTORG-791/home-page-hero-cta-buttons-are-being-cropped-on-overflow)

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
