### PR TITLE
fix(scroll): keep Lenis scroll limit in sync on reflow

### DIFF
--- a/src/scripts/smooth-scroll.ts
+++ b/src/scripts/smooth-scroll.ts
@@ -63,9 +63,10 @@ function start(): void {
   refreshHeaderOffset()
   lenis = new Lenis({
     duration: DURATION_SECONDS,
-    autoRaf: true,
-    // ResizeObserver in Lenis triggers layout reads; window resize is enough here.
-    autoResize: false
+    autoRaf: true
+    // autoResize (default true) recomputes Lenis's scroll limit on reflow
+    // (zoom, late-loading media). Without it the limit goes stale and
+    // wheel/key scrolling can't reach the bottom of a taller page.
   })
 
   window.addEventListener('resize', refreshHeaderOffset, { passive: true })


### PR DESCRIPTION
## Summary
Fix scrolling issues on the home page caused by zooming

## Related Issue
Fixes [INTORG-790](https://linear.app/interledger/issue/INTORG-790/fix-scrolling-issues-on-the-home-page)

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
