### PR TITLE
fix(cms): allow inline-code JSX in paragraph blocks [INTORG-793]

### DIFF
--- a/cms/src/utils/contentValidation.test.ts
+++ b/cms/src/utils/contentValidation.test.ts
@@ -44,6 +44,22 @@ describe('validateNoNestedJsx', () => {
     expect(validateNoNestedJsx(content)).toBeUndefined()
   })
 
+  it('ignores a standalone multi-line fenced block', () => {
+    const content = [
+      {
+        __component: 'blocks.paragraph',
+        content: [
+          '```tsx',
+          '<Ambassador name="A" />',
+          '<CalloutText>note</CalloutText>',
+          '```'
+        ].join('\n')
+      }
+    ]
+
+    expect(validateNoNestedJsx(content)).toBeUndefined()
+  })
+
   it('ignores JSX inside inline code spans (INTORG-793)', () => {
     const content = [
       {

--- a/cms/src/utils/contentValidation.test.ts
+++ b/cms/src/utils/contentValidation.test.ts
@@ -44,6 +44,42 @@ describe('validateNoNestedJsx', () => {
     expect(validateNoNestedJsx(content)).toBeUndefined()
   })
 
+  it('ignores JSX inside inline code spans (INTORG-793)', () => {
+    const content = [
+      {
+        __component: 'blocks.paragraph',
+        content:
+          'Use the `<WalletAddress />` component and the `<Blockquote>` tag inline.'
+      }
+    ]
+
+    expect(validateNoNestedJsx(content)).toBeUndefined()
+  })
+
+  it('ignores JSX inside double-backtick inline code', () => {
+    const content = [
+      {
+        __component: 'blocks.paragraph',
+        content: 'Render ``<CalloutText prop="`x`" />`` literally.'
+      }
+    ]
+
+    expect(validateNoNestedJsx(content)).toBeUndefined()
+  })
+
+  it('still flags bare JSX even when other JSX is in inline code', () => {
+    const content = [
+      {
+        __component: 'blocks.paragraph',
+        content: 'Inline `<Safe />` is fine but <Blockquote> is not.'
+      }
+    ]
+
+    const err = validateNoNestedJsx(content)
+    expect(err).toBeInstanceOf(Error)
+    expect(err?.message).toContain('<Blockquote>')
+  })
+
   it('ignores non-paragraph blocks', () => {
     const content = [
       {

--- a/cms/src/utils/contentValidation.ts
+++ b/cms/src/utils/contentValidation.ts
@@ -15,12 +15,25 @@ function stripFencedCodeBlocks(text: string): string {
 }
 
 /**
+ * Strip inline code spans (`…`, ``…``) so JSX/HTML tags written as literal
+ * inline code aren't mistaken for bare JSX. The developers blog routinely uses
+ * inline backticks to show tags like `<wallet-address />` in prose, so the
+ * merged blog must accept the same (INTORG-793).
+ *
+ * Runs after fenced blocks are removed; the remaining backtick runs are inline.
+ */
+function stripInlineCode(text: string): string {
+  return text.replace(/(`+)[\s\S]*?\1/g, '')
+}
+
+/**
  * Validate that no Paragraph block contains bare JSX-like tags.
  *
  * Returns a Strapi `ValidationError` when a `<CapitalLetter...` pattern is
- * found outside fenced code blocks in any blocks.paragraph content field;
- * returns `undefined` otherwise. The Strapi middleware that calls this
- * narrows on the return and translates a returned error into a 400 response.
+ * found outside code (fenced blocks or inline spans) in any blocks.paragraph
+ * content field; returns `undefined` otherwise. The Strapi middleware that
+ * calls this narrows on the return and translates a returned error into a 400
+ * response.
  */
 export function validateNoNestedJsx(
   content: unknown
@@ -35,13 +48,14 @@ export function validateNoNestedJsx(
       continue
     }
 
-    const stripped = stripFencedCodeBlocks(block.content)
+    const stripped = stripInlineCode(stripFencedCodeBlocks(block.content))
     const match = stripped.match(/<([A-Z][a-zA-Z]*)/)
     if (match) {
       return new errors.ValidationError(
         `Paragraph block contains JSX-like tag <${match[1]}>. ` +
-          `Move it to its own top-level block, or wrap it in a code block (\`\`\`) ` +
-          `if it's meant to be displayed as text.`
+          `Move it to its own top-level block, or wrap it in code ` +
+          `(inline \`backticks\` or a \`\`\` fenced block) if it's meant to be ` +
+          `displayed as text.`
       )
     }
   }

--- a/cms/src/utils/contentValidation.ts
+++ b/cms/src/utils/contentValidation.ts
@@ -8,19 +8,12 @@
 import { errors } from '@strapi/utils'
 
 /**
- * Strip fenced code blocks so their contents aren't mistaken for JSX.
- */
-function stripFencedCodeBlocks(text: string): string {
-  return text.replace(/^```[^\n]*\n[\s\S]*?^```/gm, '')
-}
-
-/**
- * Strip inline code spans (`…`, ``…``) so JSX/HTML tags written as literal
- * inline code aren't mistaken for bare JSX. The developers blog routinely uses
- * inline backticks to show tags like `<wallet-address />` in prose, so the
- * merged blog must accept the same (INTORG-793).
- *
- * Runs after fenced blocks are removed; the remaining backtick runs are inline.
+ * Strip backtick-delimited code so JSX/HTML tags written as literal code aren't
+ * mistaken for bare JSX. Covers inline spans (`…`, ``…``) and fenced
+ * (```…```) blocks alike — a fenced block is just a 3-backtick span, so this
+ * single pass over balanced backtick runs handles both. The developers blog
+ * routinely shows tags like `<wallet-address />` inline, so the merged blog
+ * must accept the same (INTORG-793).
  */
 function stripInlineCode(text: string): string {
   return text.replace(/(`+)[\s\S]*?\1/g, '')

--- a/cms/src/utils/contentValidation.ts
+++ b/cms/src/utils/contentValidation.ts
@@ -48,7 +48,7 @@ export function validateNoNestedJsx(
       continue
     }
 
-    const stripped = stripInlineCode(stripFencedCodeBlocks(block.content))
+    const stripped = stripInlineCode(block.content)
     const match = stripped.match(/<([A-Z][a-zA-Z]*)/)
     if (match) {
       return new errors.ValidationError(


### PR DESCRIPTION
## Summary

The paragraph-block save validator (`cms/src/utils/contentValidation.ts`) rejected any `<Capital…>` JSX-like tag in `blocks.paragraph` content unless it sat inside a **fenced** code block. It stripped fenced blocks before the scan but **not inline code spans**, so a tag written as literal inline code — e.g. `` `<wallet-address />` `` — was wrongly flagged and the save failed with a 400.

The developers blog uses inline-code tags throughout, so this blocks the foundation/tech blog merge (INTORG-691).

This adds `stripInlineCode()` (single- and multi-backtick spans) and runs it alongside the fenced-block strip before the JSX scan:

- ✅ inline-code JSX (`` `<MyComponent />` ``) — now allowed
- ✅ fenced-block JSX — still allowed
- 🚫 bare JSX outside any code — still rejected (existing protection preserved)

The error message now points authors to either inline backticks or a fenced block.

## Related Issue

Fixes INTORG-793. Unblocks INTORG-691.

## Manual Test

1. In Strapi admin, edit a blog post and add a **Paragraph** block.
2. In its content, include a tag as inline code, e.g. ``Use the `<wallet-address />` element.``
3. Save — it should save successfully (previously returned a 400 "JSX-like tag" error).
4. Sanity check the guardrail still holds: a bare `<Something>` tag (no backticks, not fenced) should still be rejected on save.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
