### PR TITLE
fix: concurrent upload to strapi by content type

### DIFF
--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -308,7 +308,7 @@ async function updateUploadAltOnce(
 
   if (dryRun) {
     console.log(
-      `   🏷️  [DRY-RUN] Would update alt text for upload #${id} from "${pathSlug}".`
+      `   🏷️  [DRY-RUN] Would update alt text for upload #${id} to "${alt ?? 'null'}" (entry: "${pathSlug}").`
     )
     updatedAltIds.set(id, alt)
     return

--- a/cms/scripts/sync-mdx/syncCoordinator.ts
+++ b/cms/scripts/sync-mdx/syncCoordinator.ts
@@ -140,24 +140,26 @@ export async function syncAll(
     errors: 0
   }
 
-  for (const contentType of Object.keys(ctx.contentTypes) as Array<
-    keyof ContentTypes
-  >) {
-    try {
-      const results = await syncContentType(contentType, ctx, dryRun)
-      allResults.created += results.created
-      allResults.updated += results.updated
-      allResults.deleted += results.deleted
-      allResults.errors += results.errors
-    } catch (error) {
-      // syncContentType doesn't return Error directly (it accumulates errors
-      // into the per-content-type SyncResults), but we keep this guard for
-      // truly unexpected exceptions (programmer bugs, OOM, etc).
-      console.error(
-        `\n❌ Error syncing ${contentType}: ${(error as Error).message}`
-      )
-      allResults.errors++
-    }
+  const perTypeResults = await Promise.all(
+    (Object.keys(ctx.contentTypes) as Array<keyof ContentTypes>).map(
+      (contentType) =>
+        syncContentType(contentType, ctx, dryRun).catch((error) => {
+          // syncContentType doesn't return Error directly (it accumulates errors
+          // into the per-content-type SyncResults), but we keep this guard for
+          // truly unexpected exceptions (programmer bugs, OOM, etc).
+          console.error(
+            `\n❌ Error syncing ${contentType}: ${(error as Error).message}`
+          )
+          return { created: 0, updated: 0, deleted: 0, errors: 1 }
+        })
+    )
+  )
+
+  for (const results of perTypeResults) {
+    allResults.created += results.created
+    allResults.updated += results.updated
+    allResults.deleted += results.deleted
+    allResults.errors += results.errors
   }
 
   return allResults


### PR DESCRIPTION
## Summary
This PR proposes an optimisation to improve strapi sync and dry run actions through concurrency. 

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)
