### PR TITLE
ci: better optimised-image cache handling

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: public/img/optimized
-          key: optimized-images-${{ hashFiles('public/img/**', 'public/uploads/img/original/**') }}
+          key: optimized-images-${{ github.run_id }}
           restore-keys: |
             optimized-images-
 


### PR DESCRIPTION
This pull request makes a minor update to the image cache key in the GitHub Actions workflow. The cache key for optimized images now uses the unique `github.run_id` for each workflow run, which ensures that each run gets a fresh cache and avoids potential issues with stale image assets.

* GitHub Actions workflow: Changed the image cache key in `.github/workflows/pr-checks.yml` from a hash of image files to the unique `github.run_id` for each run.