### PR TITLE
fix(LinkButton): remove slot pre-render that caused CSS scoping side …

### DIFF
--- a/src/components/shared/LinkButton.astro
+++ b/src/components/shared/LinkButton.astro
@@ -61,25 +61,15 @@ const targetAttrs = external
 // the link.
 const resolvedHref = ariaDisabled ? undefined : href
 
-const slotHtml = Astro.slots.has('default')
-  ? await Astro.slots.render('default')
-  : ''
-// Strip nested markup (e.g. <Icon/>) and collapse whitespace to get plain link
-// text; fall back to aria-label for icon-only buttons with no text slot.
 const ariaLabel =
   typeof rest['aria-label'] === 'string' ? rest['aria-label'] : ''
-const linkText =
-  slotHtml
-    .replace(/<[^>]*>/g, '')
-    .replace(/\s+/g, ' ')
-    .trim() || ariaLabel
 
 const umamiAttrs = buildUmamiAttrs({
   pathname: Astro.url.pathname,
   lang: routeLocale,
   section: 'link',
   href: resolvedHref,
-  linkText
+  ariaLabel: ariaLabel
 })
 ---
 


### PR DESCRIPTION
…effects

## Summary
`Astro.slots.render('default')` was breaking styling on the website (localhost)

The pre-render was only ever needed to extract plain link text for Umami analytics by stripping tags from the HTML string. Since `aria-label` is already available as a prop string, switching to that entirely sidesteps the pre-render and eliminates the side-effect.

## Related Issue
<!-- Fixes INTORG-123 -->

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
