### PR TITLE
fix(styles): layer interledger.css :root vars to prevent main-site over…

### DIFF
--- a/src/components/shared/Breadcrumbs.astro
+++ b/src/components/shared/Breadcrumbs.astro
@@ -1,5 +1,5 @@
 ---
-import { buildUmamiAttrs, useTranslations } from '@/utils'
+import { buildUmamiAttrs, useTranslations, stripTrailingSlash } from '@/utils'
 import Icon from '@/components/shared/Icon.astro'
 
 interface BreadcrumbItem {
@@ -12,13 +12,13 @@ interface Props {
 
 const { breadcrumbs } = Astro.props
 const { routeLocale } = Astro.locals
-const currentPath = Astro.url.pathname
+const currentPath = stripTrailingSlash(Astro.url.pathname)
 const t = useTranslations(routeLocale)
 ---
 
 <nav aria-label={t('nav.breadcrumb')}>
   <ol
-    class="flex gap-xs list-none m-0 mb-2xl p-0 desktop:mb-3xl [&_a]:no-underline text-neutral-75 [&_a[aria-current='page']]:text-orchid-100 [&_svg]:text-current"
+    class="flex gap-xs list-none m-0 mb-2xl p-0 desktop:mb-3xl [&_a]:no-underline text-neutral-75 [&_a]:text-neutral-75 [&_a[aria-current='page']]:text-orchid-100 [&_svg]:text-current"
     itemscope
     itemtype="https://schema.org/BreadcrumbList"
   >
@@ -38,7 +38,7 @@ const t = useTranslations(routeLocale)
             <a
               itemprop="item"
               href={crumb.href}
-              class="inline-block p-xs text-body-lg-standard text-inherit rounded-lg border border-transparent focus-visible:outline-none focus-visible:border-orchid-100 hover:text-neutral-900 "
+              class="inline-block p-xs text-body-lg-standard rounded-lg border border-transparent focus-visible:outline-none focus-visible:border-orchid-100 hover:text-neutral-900 "
               aria-current={isCurrent ? 'page' : undefined}
               {...buildUmamiAttrs({
                 pathname: Astro.url.pathname,

--- a/src/styles/interledger.css
+++ b/src/styles/interledger.css
@@ -22,37 +22,38 @@
   font-display: swap;
 }
 
-:root {
-  /* Text size and line height */
-  --step--2: clamp(0.72rem, calc(0.95rem + -0.26vw), 0.89rem);
-  --step--1: clamp(0.9rem, calc(1.03rem + -0.15vw), 1rem);
-  --step-0: clamp(1.13rem, calc(1.13rem + 0vw), 1.13rem);
-  --step-1: clamp(1.27rem, calc(1.22rem + 0.22vw), 1.41rem);
-  --step-2: clamp(1.42rem, calc(1.31rem + 0.51vw), 1.76rem);
-  --step-3: clamp(1.6rem, calc(1.4rem + 0.92vw), 2.2rem);
-  --step-4: clamp(1.8rem, calc(1.47rem + 1.45vw), 2.75rem);
-  --step-5: clamp(2.03rem, calc(1.54rem + 2.16vw), 3.43rem);
-  --space-3xs: clamp(0.31rem, calc(0.31rem + 0vw), 0.31rem);
-  --space-2xs: clamp(0.56rem, calc(0.56rem + 0vw), 0.56rem);
-  --space-xs: clamp(0.88rem, calc(0.88rem + 0vw), 0.88rem);
-  --space-s: clamp(1.13rem, calc(1.13rem + 0vw), 1.13rem);
-  --space-m: clamp(1.69rem, calc(1.69rem + 0vw), 1.69rem);
-  --space-l: clamp(2.25rem, calc(2.25rem + 0vw), 2.25rem);
-  --space-xl: clamp(3.38rem, calc(3.38rem + 0vw), 3.38rem);
-  --space-2xl: clamp(4.5rem, calc(4.5rem + 0vw), 4.5rem);
-  --space-3xl: clamp(6.75rem, calc(6.75rem + 0vw), 6.75rem);
+@layer starlight.base {
+  :root {
+    /* Text size and line height */
+    --step--2: clamp(0.72rem, calc(0.95rem + -0.26vw), 0.89rem);
+    --step--1: clamp(0.9rem, calc(1.03rem + -0.15vw), 1rem);
+    --step-0: clamp(1.13rem, calc(1.13rem + 0vw), 1.13rem);
+    --step-1: clamp(1.27rem, calc(1.22rem + 0.22vw), 1.41rem);
+    --step-2: clamp(1.42rem, calc(1.31rem + 0.51vw), 1.76rem);
+    --step-3: clamp(1.6rem, calc(1.4rem + 0.92vw), 2.2rem);
+    --step-4: clamp(1.8rem, calc(1.47rem + 1.45vw), 2.75rem);
+    --step-5: clamp(2.03rem, calc(1.54rem + 2.16vw), 3.43rem);
+    --space-3xs: clamp(0.31rem, calc(0.31rem + 0vw), 0.31rem);
+    --space-2xs: clamp(0.56rem, calc(0.56rem + 0vw), 0.56rem);
+    --space-xs: clamp(0.88rem, calc(0.88rem + 0vw), 0.88rem);
+    --space-s: clamp(1.13rem, calc(1.13rem + 0vw), 1.13rem);
+    --space-m: clamp(1.69rem, calc(1.69rem + 0vw), 1.69rem);
+    --space-l: clamp(2.25rem, calc(2.25rem + 0vw), 2.25rem);
+    --space-xl: clamp(3.38rem, calc(3.38rem + 0vw), 3.38rem);
+    --space-2xl: clamp(4.5rem, calc(4.5rem + 0vw), 4.5rem);
+    --space-3xl: clamp(6.75rem, calc(6.75rem + 0vw), 6.75rem);
 
-  --sl-text-xs: var(--step--1);
-  --sl-text-sm: var(--step--1);
+    --sl-text-xs: var(--step--1);
+    --sl-text-sm: var(--step--1);
 
-  --sl-nav-height: 4.275rem;
+    --sl-nav-height: 4.275rem;
 
-  --color-primary-fallback: #057972;
-  --color-primary: oklch(51.95% 0.089 187.7);
-  --color-primary-bg-fallback: rgba(7, 121, 114, 0.1);
-  --color-primary-bg: oklch(51.95% 0.089 187.7 / 0.1);
+    --color-primary-fallback: #057972;
+    --color-primary: oklch(51.95% 0.089 187.7);
+    --color-primary-bg-fallback: rgba(7, 121, 114, 0.1);
+    --color-primary-bg: oklch(51.95% 0.089 187.7 / 0.1);
+  }
 }
-
 /* Site header overrides */
 header.header {
   background-color: var(--sl-color-black);

--- a/src/styles/interledger.css
+++ b/src/styles/interledger.css
@@ -22,32 +22,36 @@
   font-display: swap;
 }
 
+:root {
+  /* Text size and line height */
+  --step--2: clamp(0.72rem, calc(0.95rem + -0.26vw), 0.89rem);
+  --step--1: clamp(0.9rem, calc(1.03rem + -0.15vw), 1rem);
+  --step-0: clamp(1.13rem, calc(1.13rem + 0vw), 1.13rem);
+  --step-1: clamp(1.27rem, calc(1.22rem + 0.22vw), 1.41rem);
+  --step-2: clamp(1.42rem, calc(1.31rem + 0.51vw), 1.76rem);
+  --step-3: clamp(1.6rem, calc(1.4rem + 0.92vw), 2.2rem);
+  --step-4: clamp(1.8rem, calc(1.47rem + 1.45vw), 2.75rem);
+  --step-5: clamp(2.03rem, calc(1.54rem + 2.16vw), 3.43rem);
+  --space-3xs: clamp(0.31rem, calc(0.31rem + 0vw), 0.31rem);
+  --space-2xs: clamp(0.56rem, calc(0.56rem + 0vw), 0.56rem);
+  --space-xs: clamp(0.88rem, calc(0.88rem + 0vw), 0.88rem);
+  --space-s: clamp(1.13rem, calc(1.13rem + 0vw), 1.13rem);
+  --space-m: clamp(1.69rem, calc(1.69rem + 0vw), 1.69rem);
+  --space-l: clamp(2.25rem, calc(2.25rem + 0vw), 2.25rem);
+  --space-xl: clamp(3.38rem, calc(3.38rem + 0vw), 3.38rem);
+  --space-2xl: clamp(4.5rem, calc(4.5rem + 0vw), 4.5rem);
+  --space-3xl: clamp(6.75rem, calc(6.75rem + 0vw), 6.75rem);
+
+  --sl-text-xs: var(--step--1);
+  --sl-text-sm: var(--step--1);
+
+  --sl-nav-height: 4.275rem;
+}
+
+/* --color-primary must be layered so it doesn't override the main site's
+   @layer base value when Vite leaks this docs CSS bundle to all routes. */
 @layer starlight.base {
   :root {
-    /* Text size and line height */
-    --step--2: clamp(0.72rem, calc(0.95rem + -0.26vw), 0.89rem);
-    --step--1: clamp(0.9rem, calc(1.03rem + -0.15vw), 1rem);
-    --step-0: clamp(1.13rem, calc(1.13rem + 0vw), 1.13rem);
-    --step-1: clamp(1.27rem, calc(1.22rem + 0.22vw), 1.41rem);
-    --step-2: clamp(1.42rem, calc(1.31rem + 0.51vw), 1.76rem);
-    --step-3: clamp(1.6rem, calc(1.4rem + 0.92vw), 2.2rem);
-    --step-4: clamp(1.8rem, calc(1.47rem + 1.45vw), 2.75rem);
-    --step-5: clamp(2.03rem, calc(1.54rem + 2.16vw), 3.43rem);
-    --space-3xs: clamp(0.31rem, calc(0.31rem + 0vw), 0.31rem);
-    --space-2xs: clamp(0.56rem, calc(0.56rem + 0vw), 0.56rem);
-    --space-xs: clamp(0.88rem, calc(0.88rem + 0vw), 0.88rem);
-    --space-s: clamp(1.13rem, calc(1.13rem + 0vw), 1.13rem);
-    --space-m: clamp(1.69rem, calc(1.69rem + 0vw), 1.69rem);
-    --space-l: clamp(2.25rem, calc(2.25rem + 0vw), 2.25rem);
-    --space-xl: clamp(3.38rem, calc(3.38rem + 0vw), 3.38rem);
-    --space-2xl: clamp(4.5rem, calc(4.5rem + 0vw), 4.5rem);
-    --space-3xl: clamp(6.75rem, calc(6.75rem + 0vw), 6.75rem);
-
-    --sl-text-xs: var(--step--1);
-    --sl-text-sm: var(--step--1);
-
-    --sl-nav-height: 4.275rem;
-
     --color-primary-fallback: #057972;
     --color-primary: oklch(51.95% 0.089 187.7);
     --color-primary-bg-fallback: rgba(7, 121, 114, 0.1);


### PR DESCRIPTION
…ride

## Summary
Unlayered :root rules in interledger.css beat @layer base in the main site's variables.css, causing the styles to leak across all routes in production.

As a result, on the main website, `--color-primary` is inherited from the docs styles instead of using the intended value (orchid-100), making the docs primary color the default for the main site.
<img width="812" height="306" alt="image" src="https://github.com/user-attachments/assets/da78ee5b-889d-4cfd-96b6-6ba452a77bd9" />

- fix `currentPath` is not matching `crumb.href` because of trailing slash
<img width="1117" height="582" alt="image" src="https://github.com/user-attachments/assets/8691e8fe-f0d4-437b-a7aa-35ed3ad3ee5f" />

## Related Issue
<!-- Fixes INTORG-123 -->

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [ ] `pnpm run format`
- [ ] `pnpm run lint`

## PR Checklist

- [ ] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
