### PR TITLE
feat(roadmap): add SSR developers tech roadmap [INTORG-737]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,5 +41,3 @@ LINEAR_API_KEY=lin_api_...
 API_SECRET=
 # Optional: overrides the default public-roadmap view id baked into src/linear/env.ts
 # LINEAR_CUSTOM_VIEW_ID=27df73bc-50ec-4fc1-bbb2-d906236a5bbc
-# Optional: only needed to purge the CDN cache after a sync
-# NETLIFY_API_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -30,5 +30,16 @@ ASTRO_PREVIEW_URL=http://localhost:1103
 # STRAPI_DISABLE_GIT_SYNC=true
 # STRAPI_GIT_SYNC_REPO_PATH
 
-#AIRTABLE 
+#AIRTABLE
 AIRTABLE_API_TOKEN=your-api-token
+
+# Developers roadmap (INTORG-737) — Linear -> Netlify Blob sync.
+# Only the sync functions use these; the roadmap page reads the blob.
+# Linear API key (read-only scope is sufficient). Required for the sync to run.
+LINEAR_API_KEY=lin_api_...
+# Bearer token gating POST /api/roadmap-sync. Generate any strong secret.
+API_SECRET=
+# Optional: overrides the default public-roadmap view id baked into src/linear/env.ts
+# LINEAR_CUSTOM_VIEW_ID=27df73bc-50ec-4fc1-bbb2-d906236a5bbc
+# Optional: only needed to purge the CDN cache after a sync
+# NETLIFY_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ Both fetch Linear, overwrite the blob, and purge the CDN cache. The page renders
 
 - **Automatically every 12 hours**, via the scheduled function. This runs on Netlify's cron independently of site builds and traffic.
 - **On demand**, when someone calls the manual endpoint.
-- **Not on build.** Builds do not re-fetch Linear or seed the blob; the blob persists across deploys.
+- **Not on build.** Builds do not re-fetch Linear or seed the blob; the blob persists across deploys. (A deploy _does_ purge the CDN cache via the `purge-roadmap` plugin so code changes render, but it re-renders from the existing blob, not fresh Linear data.)
 - **Not instantly on a Linear edit.** There is no Linear webhook, so a change in Linear appears at the next scheduled sync (within 12h) or whenever the manual endpoint is called. A Linear webhook pointed at the manual endpoint would make this near-instant and is a possible future addition.
 
 ### Triggering a manual sync
@@ -772,6 +772,10 @@ curl -X POST https://<site>/api/roadmap-sync \
 The page sets `Netlify-CDN-Cache-Control: public, max-age=43200, stale-while-revalidate=86400`, so Netlify's CDN caches the rendered HTML for 12 hours. This keeps the page fast, but it means a freshly-synced blob is not visible until that cached HTML is invalidated.
 
 The page also tags its response with `Netlify-Cache-ID: roadmap`. After each write, the sync functions call `purgeCache({ tags: ['roadmap'] })` (from `@netlify/functions`) to invalidate that tag, so the next request re-renders with the new data. A manual sync therefore shows fresh data on the next request.
+
+This is Netlify _Durable Cache_ (confirmed by the `cache-status: "Netlify Durable"` response header), which persists across deploys by design. The data sync above purges on **data** changes, but a pure **code** change — e.g. editing the inline styles in `RoadmapBoard.astro` — would otherwise deploy successfully and keep serving the old cached HTML for up to 12h, because nothing tied to the deploy calls `purgeCache`. (Symptom: the fix works in `pnpm start` but the deploy preview looks stale.)
+
+The `netlify/plugins/purge-roadmap` build plugin closes that gap. Its `onSuccess` hook calls `purgeCache({ tags: ['roadmap'] })` on every successful deploy, so code/CSS changes show up immediately. It runs in the build context (auto-authenticated, no token) and is scoped to the deploy (preview purges preview, prod purges prod). It is registered as a second `[[plugins]]` entry in `netlify.toml`, separate from `cache-images` (which is a build-time _image_ cache, unrelated to this CDN cache).
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ It represents the **fifth major iteration** of interledger.org. For background o
    - [Translations](#translations)
    - [Image Handling](#image-handling)
 9. [Grantee Data (Airtable Integration)](#grantee-data-airtable-integration)
-10. [Image Optimization](#image-optimization)
+10. [Developers Roadmap (Linear Integration)](#developers-roadmap-linear-integration)
+11. [Image Optimization](#image-optimization)
 
-11. [More Info](#more-info)
+12. [More Info](#more-info)
 
 ## About the Project
 
@@ -734,6 +735,68 @@ pnpm run sync:airtable
 - `AIRTABLE_API_TOKEN` must be set in your environment (see `.env.example`)
 
 The Airtable base ID, table IDs, view ID, and relevant field IDs are pinned as constants at the top of `scripts/import-airtable.ts`. They reference Airtable IDs (stable across renames), not field names — so editors can rename fields in Airtable without breaking the script.
+
+## Developers Roadmap (Linear Integration)
+
+The `/developers/roadmap` page shows a public timeline of tech projects sourced from a Linear custom view. It is server-side rendered (`export const prerender = false`): the page reads a pre-built snapshot from Netlify Blobs at request time and never calls the Linear API itself.
+
+```text
+Linear API ──(sync function)──▶ Netlify Blob ──(SSR read at request time)──▶ /developers/roadmap ──▶ Netlify CDN cache
+```
+
+Two Netlify Functions build the snapshot from Linear and write it to the blob (store `roadmap`, key `roadmap-snapshot`):
+
+- `netlify/functions/roadmap-sync.mts` runs on a 12-hour cron (`0 */12 * * *`, UTC) on Netlify's scheduled-functions infrastructure.
+- `netlify/functions/roadmap-sync-now.mts` is a manual trigger at `POST /api/roadmap-sync`, protected by a bearer `API_SECRET` and rate-limited to once per 5 minutes.
+
+Both fetch Linear, overwrite the blob, and purge the CDN cache. The page renders whatever is in the blob.
+
+### When does the roadmap refresh?
+
+- **Automatically every 12 hours**, via the scheduled function. This runs on Netlify's cron independently of site builds and traffic.
+- **On demand**, when someone calls the manual endpoint.
+- **Not on build.** Builds do not re-fetch Linear or seed the blob; the blob persists across deploys.
+- **Not instantly on a Linear edit.** There is no Linear webhook, so a change in Linear appears at the next scheduled sync (within 12h) or whenever the manual endpoint is called. A Linear webhook pointed at the manual endpoint would make this near-instant and is a possible future addition.
+
+### Triggering a manual sync
+
+There is no UI button. Anyone with the `API_SECRET` can force an immediate refresh:
+
+```sh
+curl -X POST https://<site>/api/roadmap-sync \
+  -H "Authorization: Bearer $API_SECRET"
+```
+
+### CDN caching (important)
+
+The page sets `Netlify-CDN-Cache-Control: public, max-age=43200, stale-while-revalidate=86400`, so Netlify's CDN caches the rendered HTML for 12 hours. This keeps the page fast, but it means a freshly-synced blob is not visible until that cached HTML is invalidated.
+
+The sync functions invalidate it by calling Netlify's cache-purge API after each write, but **only if `NETLIFY_API_TOKEN` is set**. Without that token:
+
+- The blob still updates on schedule.
+- The CDN keeps serving the previously-rendered HTML until its 12h `max-age` expires, then `stale-while-revalidate` re-renders in the background.
+- So a manual sync will not make fresh data appear promptly. If you want an immediate refresh after a sync, `NETLIFY_API_TOKEN` is effectively required.
+
+### Environment variables
+
+| Variable                | Required   | Notes                                                                                 |
+| ----------------------- | ---------- | ------------------------------------------------------------------------------------- |
+| `LINEAR_API_KEY`        | Production | Read-only Linear API key used by the sync functions.                                  |
+| `API_SECRET`            | Production | Bearer token gating `POST /api/roadmap-sync`.                                         |
+| `LINEAR_CUSTOM_VIEW_ID` | No         | Defaults to the public roadmap view, baked into `src/linear/env.ts`. Set to override. |
+| `NETLIFY_API_TOKEN`     | No         | Enables the CDN cache purge after a sync (see above).                                 |
+| `NETLIFY_SITE_ID`       | Auto       | Injected by Netlify at runtime.                                                       |
+
+Only the sync functions read these; the page does not. A missing `LINEAR_API_KEY` fails the sync (logged in Netlify's function logs) without breaking the page.
+
+### Local development
+
+The roadmap page works locally with no secrets:
+
+- `pnpm start` renders the board with a bundled fixture (`src/data/roadmap/fixture.ts`), since `astro dev` has no Blobs runtime.
+- To exercise the real data path, run `netlify dev`, set `LINEAR_API_KEY` in `.env`, then POST to `/api/roadmap-sync` with the bearer `API_SECRET`.
+
+In production, an empty or unreadable blob renders a graceful empty state rather than placeholder data.
 
 ## Image Optimization
 

--- a/README.md
+++ b/README.md
@@ -791,8 +791,12 @@ Only the sync functions read these; the page does not. A missing `LINEAR_API_KEY
 
 The roadmap page works locally with no secrets:
 
-- `pnpm start` renders the board with a bundled fixture (`src/data/roadmap/fixture.ts`), since `astro dev` has no Blobs runtime.
-- To exercise the real data path, run `netlify dev`, set `LINEAR_API_KEY` in `.env`, then POST to `/api/roadmap-sync` with the bearer `API_SECRET`.
+`astro dev` has no Blobs runtime, so the blob read always fails locally and the page falls back to `loadDevSnapshot()` (`src/utils/main/roadmap/devSnapshot.ts`):
+
+- **No `LINEAR_API_KEY`** → renders the bundled fixture (`src/data/roadmap/fixture.ts`), so the page works with zero setup.
+- **`LINEAR_API_KEY` set** → fetches live Linear data directly, under either `pnpm start` or `netlify dev`. (`netlify dev` injects `.env` into `process.env`; `pnpm start` exposes it via `import.meta.env` — the helper reads both.) No manual `/api/roadmap-sync` POST is needed locally.
+
+To avoid re-hitting Linear on every reload or code change, the live snapshot is cached two ways: an in-memory memo for repeat requests, plus a 10-minute on-disk cache in the OS temp dir that survives HMR / dev-server restarts. So Linear is fetched at most once per 10 minutes during local dev. The blob/sync/function path itself still requires `netlify dev`.
 
 In production, an empty or unreadable blob renders a graceful empty state rather than placeholder data.
 

--- a/README.md
+++ b/README.md
@@ -771,11 +771,7 @@ curl -X POST https://<site>/api/roadmap-sync \
 
 The page sets `Netlify-CDN-Cache-Control: public, max-age=43200, stale-while-revalidate=86400`, so Netlify's CDN caches the rendered HTML for 12 hours. This keeps the page fast, but it means a freshly-synced blob is not visible until that cached HTML is invalidated.
 
-The sync functions invalidate it by calling Netlify's cache-purge API after each write, but **only if `NETLIFY_API_TOKEN` is set**. Without that token:
-
-- The blob still updates on schedule.
-- The CDN keeps serving the previously-rendered HTML until its 12h `max-age` expires, then `stale-while-revalidate` re-renders in the background.
-- So a manual sync will not make fresh data appear promptly. If you want an immediate refresh after a sync, `NETLIFY_API_TOKEN` is effectively required.
+The page also tags its response with `Netlify-Cache-ID: roadmap`. After each write, the sync functions call `purgeCache({ tags: ['roadmap'] })` (from `@netlify/functions`) to invalidate that tag, so the next request re-renders with the new data. A manual sync therefore shows fresh data on the next request.
 
 ### Environment variables
 
@@ -784,8 +780,6 @@ The sync functions invalidate it by calling Netlify's cache-purge API after each
 | `LINEAR_API_KEY`        | Production | Read-only Linear API key used by the sync functions.                                  |
 | `API_SECRET`            | Production | Bearer token gating `POST /api/roadmap-sync`.                                         |
 | `LINEAR_CUSTOM_VIEW_ID` | No         | Defaults to the public roadmap view, baked into `src/linear/env.ts`. Set to override. |
-| `NETLIFY_API_TOKEN`     | No         | Enables the CDN cache purge after a sync (see above).                                 |
-| `NETLIFY_SITE_ID`       | Auto       | Injected by Netlify at runtime.                                                       |
 
 Only the sync functions read these; the page does not. A missing `LINEAR_API_KEY` fails the sync (logged in Netlify's function logs) without breaking the page.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,14 @@
 [[plugins]]
   package = "./netlify/plugins/cache-images"
 
+# Local dev only: map the manual roadmap sync trigger to its function.
+# In production the function self-registers at /api/roadmap-sync (see its config).
+[[context.dev.redirects]]
+  from = "/api/roadmap-sync"
+  to = "/.netlify/functions/roadmap-sync-now"
+  status = 200
+  force = true
+
 # Redirect old singular summit routes to plural (EN and ES)
 [[redirects]]
   from = "/summit/:year/talk/:slug"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,14 +6,6 @@
 [[plugins]]
   package = "./netlify/plugins/cache-images"
 
-# Local dev only: map the manual roadmap sync trigger to its function.
-# In production the function self-registers at /api/roadmap-sync (see its config).
-[[context.dev.redirects]]
-  from = "/api/roadmap-sync"
-  to = "/.netlify/functions/roadmap-sync-now"
-  status = 200
-  force = true
-
 # Redirect old singular summit routes to plural (EN and ES)
 [[redirects]]
   from = "/summit/:year/talk/:slug"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,12 @@
 [[plugins]]
   package = "./netlify/plugins/cache-images"
 
+# Purge the roadmap CDN cache tag after each deploy. Durable Cache survives
+# deploys, so without this a code/CSS-only change to /developers/roadmap keeps
+# serving stale HTML until the cache expires. See README "CDN caching".
+[[plugins]]
+  package = "./netlify/plugins/purge-roadmap"
+
 # Redirect old singular summit routes to plural (EN and ES)
 [[redirects]]
   from = "/summit/:year/talk/:slug"

--- a/netlify/functions/roadmap-sync-now.mts
+++ b/netlify/functions/roadmap-sync-now.mts
@@ -23,6 +23,13 @@ export default async function handler(
   req: Request,
   _ctx: Context
 ): Promise<Response> {
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method Not Allowed' }), {
+      status: 405,
+      headers: { Allow: 'POST', 'Content-Type': 'application/json' }
+    })
+  }
+
   const token = (req.headers.get('authorization') ?? '').replace(
     /^Bearer\s+/i,
     ''

--- a/netlify/functions/roadmap-sync-now.mts
+++ b/netlify/functions/roadmap-sync-now.mts
@@ -1,0 +1,79 @@
+import { timingSafeEqual } from 'node:crypto'
+import { getStore } from '@netlify/blobs'
+import type { Context } from '@netlify/functions'
+import { buildSnapshot } from '../../src/linear/build-snapshot'
+import { API_SECRET, isNetlifyDev } from '../../src/linear/env'
+import { purgeRoadmapCache } from './utils/purge-roadmap-cache.mts'
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000
+const RL_KEY = 'sync-rate-limit'
+
+function unauthorized(): Response {
+  return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}
+
+// Manual sync trigger: POST /api/roadmap-sync with `Authorization: Bearer <API_SECRET>`.
+// Rate-limited to once per 5 minutes via the blob store.
+export default async function handler(
+  req: Request,
+  _ctx: Context
+): Promise<Response> {
+  const token = (req.headers.get('authorization') ?? '').replace(
+    /^Bearer\s+/i,
+    ''
+  )
+
+  if (!API_SECRET) return unauthorized()
+
+  const secretBuf = Buffer.from(API_SECRET)
+  const tokenBuf = Buffer.from(token)
+  const authorized =
+    tokenBuf.length === secretBuf.length && timingSafeEqual(tokenBuf, secretBuf)
+  if (!authorized) return unauthorized()
+
+  const store = getStore('roadmap')
+
+  const lastSync = (await store.get(RL_KEY, { type: 'json' })) as {
+    ts: number
+  } | null
+  if (lastSync && Date.now() - lastSync.ts < FIVE_MINUTES_MS) {
+    const retryAfter = Math.ceil(
+      (FIVE_MINUTES_MS - (Date.now() - lastSync.ts)) / 1000
+    )
+    return new Response(
+      JSON.stringify({ error: 'Too Many Requests', retryAfter }),
+      {
+        status: 429,
+        headers: {
+          'Content-Type': 'application/json',
+          'Retry-After': String(retryAfter)
+        }
+      }
+    )
+  }
+  await store.setJSON(RL_KEY, { ts: Date.now() })
+
+  try {
+    const snapshot = await buildSnapshot()
+    await store.setJSON('roadmap-snapshot', snapshot)
+    await purgeRoadmapCache()
+    return new Response(
+      JSON.stringify({ ok: true, generatedAt: snapshot.generatedAt }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  } catch (err) {
+    console.error('[roadmap-sync-now] sync failed', err)
+    return new Response(JSON.stringify({ error: 'Sync failed' }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  }
+}
+
+// In local dev (`netlify dev`), the [[context.dev.redirects]] rule in netlify.toml
+// maps /api/roadmap-sync to this function. Self-registering a path here as well
+// conflicts with that redirect, so set the path only outside dev.
+export const config = isNetlifyDev ? {} : { path: '/api/roadmap-sync' }

--- a/netlify/functions/roadmap-sync-now.mts
+++ b/netlify/functions/roadmap-sync-now.mts
@@ -2,7 +2,6 @@ import { timingSafeEqual } from 'node:crypto'
 import { getStore } from '@netlify/blobs'
 import type { Context } from '@netlify/functions'
 import { buildSnapshot } from '../../src/linear/build-snapshot'
-import { isNetlifyDev } from '../../src/linear/env'
 import { purgeRoadmapCache } from './utils/purge-roadmap-cache.mts'
 
 // Read directly here (not from the shared env module) so the scheduled sync,
@@ -81,7 +80,7 @@ export default async function handler(
   }
 }
 
-// In local dev (`netlify dev`), the [[context.dev.redirects]] rule in netlify.toml
-// maps /api/roadmap-sync to this function. Self-registering a path here as well
-// conflicts with that redirect, so set the path only outside dev.
-export const config = isNetlifyDev ? {} : { path: '/api/roadmap-sync' }
+// Static object literal: Netlify extracts function config by static analysis, so
+// a computed/ternary value here would not register the path (the route would
+// 404). This path works in both `netlify dev` and production.
+export const config = { path: '/api/roadmap-sync' }

--- a/netlify/functions/roadmap-sync-now.mts
+++ b/netlify/functions/roadmap-sync-now.mts
@@ -2,9 +2,12 @@ import { timingSafeEqual } from 'node:crypto'
 import { getStore } from '@netlify/blobs'
 import type { Context } from '@netlify/functions'
 import { buildSnapshot } from '../../src/linear/build-snapshot'
-import { API_SECRET, isNetlifyDev } from '../../src/linear/env'
+import { isNetlifyDev } from '../../src/linear/env'
 import { purgeRoadmapCache } from './utils/purge-roadmap-cache.mts'
 
+// Read directly here (not from the shared env module) so the scheduled sync,
+// which never uses it, doesn't fail at cold start when it is unset.
+const API_SECRET = process.env.API_SECRET ?? ''
 const FIVE_MINUTES_MS = 5 * 60 * 1000
 const RL_KEY = 'sync-rate-limit'
 
@@ -36,6 +39,9 @@ export default async function handler(
 
   const store = getStore('roadmap')
 
+  // Throttle on the last SUCCESSFUL sync. The read-then-write is not atomic, so
+  // two near-simultaneous calls could both pass — acceptable for a secret-gated
+  // manual endpoint.
   const lastSync = (await store.get(RL_KEY, { type: 'json' })) as {
     ts: number
   } | null
@@ -54,12 +60,14 @@ export default async function handler(
       }
     )
   }
-  await store.setJSON(RL_KEY, { ts: Date.now() })
 
   try {
     const snapshot = await buildSnapshot()
     await store.setJSON('roadmap-snapshot', snapshot)
     await purgeRoadmapCache()
+    // Only burn the rate-limit window after a successful sync, so a failed run
+    // (502 below) can be retried immediately.
+    await store.setJSON(RL_KEY, { ts: Date.now() })
     return new Response(
       JSON.stringify({ ok: true, generatedAt: snapshot.generatedAt }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }

--- a/netlify/functions/roadmap-sync.mts
+++ b/netlify/functions/roadmap-sync.mts
@@ -1,0 +1,23 @@
+import { getStore } from '@netlify/blobs'
+import { buildSnapshot } from '../../src/linear/build-snapshot'
+import { purgeRoadmapCache } from './utils/purge-roadmap-cache.mts'
+
+// Scheduled sync: fetch the roadmap from Linear, write it to the blob store, and
+// purge the CDN cache. Runs every 12 hours. Errors are logged so a transient
+// Linear failure surfaces in the Netlify function logs (and the run is retried)
+// without leaving the page broken — it keeps serving the last good blob.
+export default async function handler(): Promise<void> {
+  try {
+    const snapshot = await buildSnapshot()
+    const store = getStore('roadmap')
+    await store.setJSON('roadmap-snapshot', snapshot)
+    await purgeRoadmapCache()
+  } catch (err) {
+    console.error('[roadmap-sync] failed to sync roadmap from Linear', err)
+    throw err
+  }
+}
+
+export const config = {
+  schedule: '0 */12 * * *'
+}

--- a/netlify/functions/utils/purge-roadmap-cache.mts
+++ b/netlify/functions/utils/purge-roadmap-cache.mts
@@ -1,19 +1,9 @@
-import { NETLIFY_SITE_ID, NETLIFY_API_TOKEN } from '../../../src/linear/env'
+import { purgeCache } from '@netlify/functions'
 
-// Purge the CDN-cached /developers/roadmap HTML so the next request re-renders
-// with the freshly-synced blob. No-op when the optional Netlify token is unset.
+// Purge the CDN-cached roadmap HTML so the next request re-renders with the
+// freshly-synced blob. Uses Netlify's built-in function-runtime purge keyed on
+// the `roadmap` cache tag (set as `Netlify-Cache-ID` on the page response), so
+// it needs no API token.
 export async function purgeRoadmapCache(): Promise<void> {
-  if (!NETLIFY_SITE_ID || !NETLIFY_API_TOKEN) return
-
-  await fetch('https://api.netlify.com/api/v1/purge', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${NETLIFY_API_TOKEN}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      site_id: NETLIFY_SITE_ID,
-      paths: ['/developers/roadmap']
-    })
-  })
+  await purgeCache({ tags: ['roadmap'] })
 }

--- a/netlify/functions/utils/purge-roadmap-cache.mts
+++ b/netlify/functions/utils/purge-roadmap-cache.mts
@@ -1,0 +1,19 @@
+import { NETLIFY_SITE_ID, NETLIFY_API_TOKEN } from '../../../src/linear/env'
+
+// Purge the CDN-cached /developers/roadmap HTML so the next request re-renders
+// with the freshly-synced blob. No-op when the optional Netlify token is unset.
+export async function purgeRoadmapCache(): Promise<void> {
+  if (!NETLIFY_SITE_ID || !NETLIFY_API_TOKEN) return
+
+  await fetch('https://api.netlify.com/api/v1/purge', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${NETLIFY_API_TOKEN}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      site_id: NETLIFY_SITE_ID,
+      paths: ['/developers/roadmap']
+    })
+  })
+}

--- a/netlify/plugins/purge-roadmap/index.js
+++ b/netlify/plugins/purge-roadmap/index.js
@@ -1,0 +1,13 @@
+import { purgeCache } from '@netlify/functions'
+
+// The roadmap page is durable-cached at the CDN (see netlify.toml headers and
+// the README's "CDN caching" section). Durable Cache survives deploys, and the
+// only other purge trigger is a data sync — so a code/CSS-only change would keep
+// serving stale HTML until the cache expires. This invalidates the `roadmap`
+// tag on every successful deploy so code changes show up immediately. Scoped to
+// the deploy context (preview purges preview, prod purges prod) and auto-
+// authenticated in the build runtime, so it needs no token.
+export const onSuccess = async () => {
+  await purgeCache({ tags: ['roadmap'] })
+  console.log('[purge-roadmap] purged roadmap CDN cache after deploy')
+}

--- a/netlify/plugins/purge-roadmap/manifest.yml
+++ b/netlify/plugins/purge-roadmap/manifest.yml
@@ -1,0 +1,1 @@
+name: netlify-plugin-purge-roadmap

--- a/netlify/plugins/purge-roadmap/package.json
+++ b/netlify/plugins/purge-roadmap/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "netlify-plugin-purge-roadmap",
+  "version": "1.0.0",
+  "description": "Purge the roadmap CDN cache tag on each deploy so code/CSS changes are not masked by Durable Cache",
+  "type": "module",
+  "main": "index.js"
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@astrojs/sitemap": "^3.7.1",
     "@astrojs/starlight": "^0.38.0",
     "@interledger/docs-design-system": "^0.11.2",
+    "@linear/sdk": "^87.0.0",
+    "@netlify/blobs": "^10.7.9",
     "@tailwindcss/vite": "^4.2.1",
     "@types/showdown": "^2.0.6",
     "astro": "^6.0.2",
@@ -53,6 +55,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@netlify/functions": "^5.3.0",
     "@types/hast": "^3.0.4",
     "@types/markdown-it": "^14.1.2",
     "@types/unist": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11877,8 +11877,6 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-editor-multi-root@47.4.0':
     dependencies:
@@ -12201,8 +12199,6 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-restricted-editing@47.4.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,19 +21,25 @@ importers:
         version: 0.5.10
       '@astrojs/mdx':
         specifier: ^5.0.0
-        version: 5.0.0(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
+        version: 5.0.0(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       '@astrojs/netlify':
         specifier: ^7.0.1
-        version: 7.0.1(@types/node@25.4.0)(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.0.1(@types/node@25.4.0)(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       '@astrojs/sitemap':
         specifier: ^3.7.1
         version: 3.7.1
       '@astrojs/starlight':
         specifier: ^0.38.0
-        version: 0.38.1(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
+        version: 0.38.1(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       '@interledger/docs-design-system':
         specifier: ^0.11.2
         version: 0.11.2
+      '@linear/sdk':
+        specifier: ^87.0.0
+        version: 87.0.0(graphql@17.0.1)
+      '@netlify/blobs':
+        specifier: ^10.7.9
+        version: 10.7.9
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -42,7 +48,7 @@ importers:
         version: 2.0.6
       astro:
         specifier: ^6.0.2
-        version: 6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -75,10 +81,10 @@ importers:
         version: 2.1.0
       starlight-fullview-mode:
         specifier: ^0.2.6
-        version: 0.2.6(@astrojs/starlight@0.38.1(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)))
+        version: 0.2.6(@astrojs/starlight@0.38.1(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)))
       starlight-links-validator:
         specifier: ^0.20.0
-        version: 0.20.0(@astrojs/starlight@0.38.1(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)))(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
+        version: 0.20.0(@astrojs/starlight@0.38.1(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)))(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -95,6 +101,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.3(jiti@2.6.1))
+      '@netlify/functions':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -1778,6 +1787,11 @@ packages:
       typescript:
         optional: true
 
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@hapi/bourne@3.0.0':
     resolution: {integrity: sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==}
 
@@ -2131,6 +2145,10 @@ packages:
   '@lezer/lr@1.4.8':
     resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
 
+  '@linear/sdk@87.0.0':
+    resolution: {integrity: sha512-hYJhmhDIuhu7tyca1T9xZ5y0sf6EiCnFYbdGX3I5kylkGGMrrVszasoIfrkopwBCuJjolFnnVVwqqzCbURVftA==}
+    engines: {node: '>=18.x'}
+
   '@mapbox/node-pre-gyp@2.0.3':
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
     engines: {node: '>=18'}
@@ -2185,12 +2203,12 @@ packages:
   '@netlify/binary-info@1.0.0':
     resolution: {integrity: sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw==}
 
-  '@netlify/blobs@10.7.0':
-    resolution: {integrity: sha512-wuiaKRbRLG/L049yR+7/p7xSKa4jx6JRBnweRYwP6mMYn9D+x/wccPgsxEMtKqthmow6frs7ZSrNYTt9U3yUdQ==}
-    engines: {node: ^14.16.0 || >=16.0.0}
-
   '@netlify/blobs@10.7.1':
     resolution: {integrity: sha512-yxG0vdGz5UmksQV4ZW69sdNR4hooPYH0R8J/JcIBbQLfymm4bbOHwe/dNiW/Rp/NGtJ3W4PZtOkcuz2LhvhmXQ==}
+    engines: {node: ^14.16.0 || >=16.0.0}
+
+  '@netlify/blobs@10.7.9':
+    resolution: {integrity: sha512-NEM8aNAMZCCWBWymomMM/fn5wmPGyGE8pendgsSu5mL7UNz+aXqGcHS0MiHWU/osyg+geiZuS+Rx956SVrMM/w==}
     engines: {node: ^14.16.0 || >=16.0.0}
 
   '@netlify/cache@3.4.1':
@@ -2206,12 +2224,12 @@ packages:
     resolution: {integrity: sha512-xB2ciUJsWFw34DtMMmAh19qGUJy1N5mFAi6yYFFqeBlnd8StSxoUblXcqVZcQJLXm68OAxSxkfGf1qUucIDyMA==}
     engines: {node: '>=20.6.1'}
 
-  '@netlify/dev-utils@4.3.3':
-    resolution: {integrity: sha512-qziF8R9kf7mRNgSpmUH96O0aV1ZiwK4c9ZecFQbDSQuYhgy9GY1WTjiQF0oQnohjTjWNtXhrU39LAeXWNLaBJg==}
-    engines: {node: ^18.14.0 || >=20}
-
   '@netlify/dev-utils@4.4.0':
     resolution: {integrity: sha512-wviHbvbrfinLqUMv1nPN4wquMpDK1aMLzdGMVjaC0Vs74G536bvpk5cYj+KMYk0pr1u+8Ludze0En5O9pi8LuQ==}
+    engines: {node: ^18.14.0 || >=20}
+
+  '@netlify/dev-utils@4.4.6':
+    resolution: {integrity: sha512-P6X+xS3glvhiTX6AAocYvnZtqXtWhvxMX4AdPgv2iw6cXjGL2criUveX7bSjp6DiyHfvQpNdG0ZRpeBEVAFf1g==}
     engines: {node: ^18.14.0 || >=20}
 
   '@netlify/dev@4.16.0':
@@ -2241,6 +2259,10 @@ packages:
     resolution: {integrity: sha512-tpPiLSkQatuexH8AdAZ8RlALvT7ixOE9VhvpkzQGNvihcms8hzmvUDuSxQa7UneTj/sHsdirnXmnJ+nmf+Nx/w==}
     engines: {node: '>=18.0.0'}
 
+  '@netlify/functions@5.3.0':
+    resolution: {integrity: sha512-FP+xCoZMkMOUsKa4UdG/oiK/2md1/TxuXvqqieaMVMgDbFFMaHI8h0oHCViUY73kPbKV6HyzayaSXGYXKpBSoQ==}
+    engines: {node: '>=18.0.0'}
+
   '@netlify/headers-parser@9.0.2':
     resolution: {integrity: sha512-86YEGPxVemhksY1LeSr8NSOyH11RHvYHq+FuBJnTlPZoRDX+TD+0TAxF6lwzAgVTd1VPkyFEHlNgUGqw7aNzRQ==}
     engines: {node: '>=18.14.0'}
@@ -2261,12 +2283,12 @@ packages:
     resolution: {integrity: sha512-pnGsLklHMfx8BKbWsiK8ZZ7h+vfE8Xh5ox0Lq2n0UMJUZL+iLMqXDw4tc3Udp9JxmyC06xBE6yYkOTI82VV0aA==}
     engines: {node: '>=14.8.0'}
 
-  '@netlify/otel@5.1.1':
-    resolution: {integrity: sha512-WCSlOsd0a0Vn+iPC5PYru7rq/5/QpBGnvam6C7cq9DEiTFqfwExNoxk6SWI0T6nI56gkBryaGsENLTEnUue1lg==}
-    engines: {node: ^18.14.0 || >=20.6.1}
-
   '@netlify/otel@5.1.2':
     resolution: {integrity: sha512-tIA8W/rC+Duz815uwoEaFTZ4oiIU478gE180hNREMWefJxBcZoS5GYky808FdGNbML2sxNX56LhkD20rSnUTbg==}
+    engines: {node: ^18.14.0 || >=20.6.1}
+
+  '@netlify/otel@6.0.3':
+    resolution: {integrity: sha512-NIjIjB/aItiXKB6+wzSwfSyYqbNsVSzzlEPryxxTC5ZJiYSYSm82wAOcQ+9VdiufQyZO5t8jzHVPULo7a9L9sQ==}
     engines: {node: ^18.14.0 || >=20.6.1}
 
   '@netlify/redirect-parser@15.0.3':
@@ -2295,6 +2317,10 @@ packages:
 
   '@netlify/types@2.3.0':
     resolution: {integrity: sha512-5gxMWh/S7wr0uHKSTbMv4bjWmWSpwpeLYvErWeVNAPll5/QNFo9aWimMAUuh8ReLY3/fg92XAroVVu7+z27Snw==}
+    engines: {node: ^18.14.0 || >=20}
+
+  '@netlify/types@2.8.0':
+    resolution: {integrity: sha512-8/g0Pt6y6wXj5Ia5eeYLiXhRfWeqZXGXpGFeCiiQdUOem+FPtXdA4+YdGxqzWc7D0AvptKSO01KGeeVWHSu8Kg==}
     engines: {node: ^18.14.0 || >=20}
 
   '@netlify/vite-plugin@2.10.10':
@@ -2339,6 +2365,10 @@ packages:
     resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.217.0':
+    resolution: {integrity: sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -2349,14 +2379,32 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/context-async-hooks@2.7.1':
+    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/core@1.30.1':
     resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/instrumentation@0.203.0':
     resolution: {integrity: sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.217.0':
+    resolution: {integrity: sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -2379,11 +2427,23 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-base@1.30.1':
     resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/sdk-trace-node@1.30.1':
     resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
@@ -2391,8 +2451,18 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/sdk-trace-node@2.7.1':
+    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/semantic-conventions@1.28.0':
     resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
 
   '@oslojs/encoding@1.1.0':
@@ -4355,6 +4425,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/nft@0.29.4':
     resolution: {integrity: sha512-6lLqMNX3TuycBPABycx7A9F1bHQR7kiQln6abjFbPrf5C/05qHM9M5E4PeTE59c7z8g6vHnx1Ioihb2AQl7BTA==}
@@ -4768,6 +4839,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
   attr-accept@2.2.5:
     resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
     engines: {node: '>=4'}
@@ -5056,6 +5130,9 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   ckeditor5@47.4.0:
     resolution: {integrity: sha512-6RTRV2w6nhmBSLBnA0O9QzcBC/Cf74ogziaKHOK61H+PcM6aP3ltb/fNScGyy3NVw3+OzaxjbPF7NSykVmmMMw==}
@@ -6667,6 +6744,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  graphql@17.0.1:
+    resolution: {integrity: sha512-8eWbg5Zcv/8o20nzEjHUGPTj20MLFJjc5kagbIPxbaeGxvFwpitJhemEC/k17n5+UD4M/9ea5rTuce78mELujQ==}
+    engines: {node: ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0}
+
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
@@ -6982,6 +7063,10 @@ packages:
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
+  import-in-the-middle@3.2.0:
+    resolution: {integrity: sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==}
+    engines: {node: '>=18'}
 
   import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
@@ -9447,6 +9532,10 @@ packages:
     resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
     engines: {node: '>=8.6.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   require-package-name@2.0.1:
     resolution: {integrity: sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==}
 
@@ -9988,6 +10077,12 @@ packages:
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
+
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
   style-loader@3.3.4:
     resolution: {integrity: sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==}
@@ -10630,6 +10725,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8flags@4.0.1:
@@ -10854,6 +10950,9 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -11198,12 +11297,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.0(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))':
+  '@astrojs/mdx@5.0.0(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 7.0.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -11217,15 +11316,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/netlify@7.0.1(@types/node@25.4.0)(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)':
+  '@astrojs/netlify@7.0.1(@types/node@25.4.0)(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
       '@astrojs/underscore-redirects': 1.0.1
-      '@netlify/blobs': 10.7.0
-      '@netlify/functions': 5.1.2
+      '@netlify/blobs': 10.7.9
+      '@netlify/functions': 5.3.0
       '@netlify/vite-plugin': 2.10.10(babel-plugin-macros@3.1.0)(rollup@4.57.1)(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vercel/nft': 1.3.2(rollup@4.57.1)
-      astro: 6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       esbuild: 0.27.3
       tinyglobby: 0.2.15
       vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -11276,17 +11375,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.38.1(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))':
+  '@astrojs/starlight@0.38.1(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 7.0.0
-      '@astrojs/mdx': 5.0.0(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
+      '@astrojs/mdx': 5.0.0(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       '@astrojs/sitemap': 3.7.1
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
-      astro-expressive-code: 0.41.6(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
+      astro: 6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro-expressive-code: 0.41.6(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -11709,8 +11808,6 @@ snapshots:
       '@ckeditor/ckeditor5-core': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@ckeditor/ckeditor5-code-block@47.4.0':
     dependencies:
@@ -11780,6 +11877,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-editor-multi-root@47.4.0':
     dependencies:
@@ -12102,6 +12201,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       ckeditor5: 47.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-restricted-editing@47.4.0':
     dependencies:
@@ -12229,6 +12330,8 @@ snapshots:
       '@ckeditor/ckeditor5-engine': 47.4.0
       '@ckeditor/ckeditor5-utils': 47.4.0
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-widget@47.4.0':
     dependencies:
@@ -12993,6 +13096,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@graphql-typed-document-node/core@3.2.0(graphql@17.0.1)':
+    dependencies:
+      graphql: 17.0.1
+
   '@hapi/bourne@3.0.0': {}
 
   '@humanfs/core@0.19.1': {}
@@ -13285,6 +13392,12 @@ snapshots:
     dependencies:
       '@lezer/common': 1.5.1
 
+  '@linear/sdk@87.0.0(graphql@17.0.1)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.1)
+    transitivePeerDependencies:
+      - graphql
+
   '@mapbox/node-pre-gyp@2.0.3':
     dependencies:
       consola: 3.4.2
@@ -13386,18 +13499,18 @@ snapshots:
 
   '@netlify/binary-info@1.0.0': {}
 
-  '@netlify/blobs@10.7.0':
-    dependencies:
-      '@netlify/dev-utils': 4.3.3
-      '@netlify/otel': 5.1.1
-      '@netlify/runtime-utils': 2.3.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@netlify/blobs@10.7.1':
     dependencies:
       '@netlify/dev-utils': 4.4.0
       '@netlify/otel': 5.1.2
+      '@netlify/runtime-utils': 2.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@netlify/blobs@10.7.9':
+    dependencies:
+      '@netlify/dev-utils': 4.4.6
+      '@netlify/otel': 6.0.3
       '@netlify/runtime-utils': 2.3.0
     transitivePeerDependencies:
       - supports-color
@@ -13439,24 +13552,6 @@ snapshots:
       '@electric-sql/pglite': 0.3.16
       pg-gateway: 0.3.0-beta.4
 
-  '@netlify/dev-utils@4.3.3':
-    dependencies:
-      '@whatwg-node/server': 0.10.18
-      ansis: 4.2.0
-      chokidar: 4.0.3
-      decache: 4.6.2
-      dettle: 1.0.5
-      dot-prop: 9.0.0
-      empathic: 2.0.0
-      env-paths: 3.0.0
-      image-size: 2.0.2
-      js-image-generator: 1.0.4
-      parse-gitignore: 2.0.0
-      semver: 7.7.4
-      tmp-promise: 3.0.3
-      uuid: 13.0.0
-      write-file-atomic: 5.0.1
-
   '@netlify/dev-utils@4.4.0':
     dependencies:
       '@whatwg-node/server': 0.10.18
@@ -13474,6 +13569,23 @@ snapshots:
       tmp-promise: 3.0.3
       uuid: 13.0.0
       write-file-atomic: 5.0.1
+
+  '@netlify/dev-utils@4.4.6':
+    dependencies:
+      '@whatwg-node/server': 0.10.18
+      ansis: 4.2.0
+      atomically: 2.1.1
+      chokidar: 4.0.3
+      decache: 4.6.2
+      dettle: 1.0.5
+      dot-prop: 9.0.0
+      empathic: 2.0.0
+      env-paths: 3.0.0
+      image-size: 2.0.2
+      js-image-generator: 1.0.4
+      parse-gitignore: 2.0.0
+      semver: 7.7.4
+      tmp-promise: 3.0.3
 
   '@netlify/dev@4.16.0(rollup@4.57.1)':
     dependencies:
@@ -13582,6 +13694,10 @@ snapshots:
     dependencies:
       '@netlify/types': 2.3.0
 
+  '@netlify/functions@5.3.0':
+    dependencies:
+      '@netlify/types': 2.8.0
+
   '@netlify/headers-parser@9.0.2':
     dependencies:
       '@iarna/toml': 2.2.5
@@ -13623,7 +13739,7 @@ snapshots:
 
   '@netlify/open-api@2.51.0': {}
 
-  '@netlify/otel@5.1.1':
+  '@netlify/otel@5.1.2':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
@@ -13633,13 +13749,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@netlify/otel@5.1.2':
+  '@netlify/otel@6.0.3':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13662,7 +13778,7 @@ snapshots:
 
   '@netlify/runtime@4.1.17':
     dependencies:
-      '@netlify/blobs': 10.7.1
+      '@netlify/blobs': 10.7.9
       '@netlify/cache': 3.4.1
       '@netlify/runtime-utils': 2.3.0
       '@netlify/types': 2.3.0
@@ -13676,6 +13792,8 @@ snapshots:
       mime-types: 3.0.2
 
   '@netlify/types@2.3.0': {}
+
+  '@netlify/types@2.8.0': {}
 
   '@netlify/vite-plugin@2.10.10(babel-plugin-macros@3.1.0)(rollup@4.57.1)(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -13798,9 +13916,17 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
+  '@opentelemetry/api-logs@0.217.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
 
@@ -13809,12 +13935,26 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.28.0
 
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.41.1
+
   '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.203.0
       import-in-the-middle: 1.15.0
       require-in-the-middle: 7.5.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.217.0
+      import-in-the-middle: 3.2.0
+      require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13834,12 +13974,25 @@ snapshots:
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.28.0
 
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
   '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.41.1
 
   '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -13851,7 +14004,16 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
       semver: 7.7.4
 
+  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
+
   '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -17166,12 +17328,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro-expressive-code@0.41.6(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)):
+  astro-expressive-code@0.41.6(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)):
     dependencies:
-      astro: 6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       rehype-expressive-code: 0.41.6
 
-  astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
+  astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 3.0.0
       '@astrojs/internal-helpers': 0.8.0
@@ -17221,7 +17383,7 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
-      unstorage: 1.17.4(@netlify/blobs@10.7.1)
+      unstorage: 1.17.4(@netlify/blobs@10.7.9)
       vfile: 6.0.3
       vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitefu: 1.1.2(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -17277,6 +17439,11 @@ snapshots:
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
+
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
 
   attr-accept@2.2.5: {}
 
@@ -17571,6 +17738,8 @@ snapshots:
       consola: 3.4.2
 
   cjs-module-lexer@1.4.3: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   ckeditor5@47.4.0:
     dependencies:
@@ -19526,6 +19695,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  graphql@17.0.1: {}
+
   gray-matter@4.0.3:
     dependencies:
       js-yaml: 3.14.2
@@ -19999,6 +20170,13 @@ snapshots:
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
       cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
+  import-in-the-middle@3.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
   import-lazy@4.0.0: {}
@@ -22965,6 +23143,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   require-package-name@2.0.1: {}
 
   reselect@4.1.8: {}
@@ -23545,16 +23730,16 @@ snapshots:
 
   stackframe@1.3.4: {}
 
-  starlight-fullview-mode@0.2.6(@astrojs/starlight@0.38.1(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))):
+  starlight-fullview-mode@0.2.6(@astrojs/starlight@0.38.1(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))):
     dependencies:
-      '@astrojs/starlight': 0.38.1(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
+      '@astrojs/starlight': 0.38.1(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       '@iconify-json/mdi': 1.2.3
 
-  starlight-links-validator@0.20.0(@astrojs/starlight@0.38.1(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)))(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)):
+  starlight-links-validator@0.20.0(@astrojs/starlight@0.38.1(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)))(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)):
     dependencies:
-      '@astrojs/starlight': 0.38.1(astro@6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
+      '@astrojs/starlight': 0.38.1(astro@6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       '@types/picomatch': 4.0.2
-      astro: 6.0.3(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.0.3(@netlify/blobs@10.7.9)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.57.1)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-has-property: 3.0.0
@@ -23673,6 +23858,12 @@ snapshots:
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
 
   style-loader@3.3.4(webpack@5.105.2(esbuild@0.27.3)):
     dependencies:
@@ -24189,6 +24380,19 @@ snapshots:
     optionalDependencies:
       '@netlify/blobs': 10.7.1
 
+  unstorage@1.17.4(@netlify/blobs@10.7.9):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.5
+      lru-cache: 11.2.6
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.3
+    optionalDependencies:
+      '@netlify/blobs': 10.7.9
+
   untun@0.1.3:
     dependencies:
       citty: 0.1.6
@@ -24468,6 +24672,8 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  when-exit@2.1.5: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/components/pages/DevelopersRoadmapPage.astro
+++ b/src/components/pages/DevelopersRoadmapPage.astro
@@ -64,15 +64,31 @@ const hasData = projects.some((p) => projectOverlapsWindow(p, start, end))
 
     {
       generatedAt && (
-        <div class="mx-auto max-w-content px-[5%] pt-s text-gray-500">
-          <span>
-            Roadmap data refreshed at:{' '}
-            <time datetime={generatedAt}>
-              {new Date(generatedAt).toUTCString()}
-            </time>
-          </span>
+        <div class="mx-auto max-w-content px-[5%] pt-xs text-left text-step--2 text-gray-700">
+          Roadmap data refreshed at:{' '}
+          <time class="roadmap-refreshed" datetime={generatedAt}>
+            {new Date(generatedAt).toUTCString()}
+          </time>
         </div>
       )
     }
   </main>
 </FoundationPageLayout>
+
+<script>
+  // The page is SSR + CDN-cached, so the server can't know the viewer's locale
+  // or timezone — it renders a UTC fallback (readable without JS). Localize it
+  // here to the visitor's own locale and timezone.
+  document
+    .querySelectorAll<HTMLTimeElement>('time.roadmap-refreshed')
+    .forEach((el) => {
+      const iso = el.getAttribute('datetime')
+      if (!iso) return
+      const date = new Date(iso)
+      if (Number.isNaN(date.getTime())) return
+      el.textContent = date.toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short'
+      })
+    })
+</script>

--- a/src/components/pages/DevelopersRoadmapPage.astro
+++ b/src/components/pages/DevelopersRoadmapPage.astro
@@ -1,6 +1,7 @@
 ---
 import FoundationPageLayout from '@/layouts/FoundationPageLayout.astro'
 import RoadmapBoard from '@/components/roadmap/RoadmapBoard.astro'
+import { roadmapWindow, projectOverlapsWindow } from '@/utils'
 import type { Snapshot } from '@/types/roadmap'
 
 interface Props {
@@ -11,7 +12,11 @@ const { snapshot } = Astro.props
 const projects = snapshot?.projects ?? []
 const teams = snapshot?.teams ?? []
 const generatedAt = snapshot?.generatedAt ?? null
-const hasData = projects.length > 0
+
+// Mirror RoadmapBoard's windowing so the empty state shows when no project falls
+// in the visible window (otherwise the board would render with zero rows).
+const { start, end } = roadmapWindow(new Date())
+const hasData = projects.some((p) => projectOverlapsWindow(p, start, end))
 ---
 
 <FoundationPageLayout

--- a/src/components/pages/DevelopersRoadmapPage.astro
+++ b/src/components/pages/DevelopersRoadmapPage.astro
@@ -1,0 +1,73 @@
+---
+import FoundationPageLayout from '@/layouts/FoundationPageLayout.astro'
+import RoadmapBoard from '@/components/roadmap/RoadmapBoard.astro'
+import type { Snapshot } from '@/types/roadmap'
+
+interface Props {
+  snapshot: Snapshot | null
+}
+
+const { snapshot } = Astro.props
+const projects = snapshot?.projects ?? []
+const teams = snapshot?.teams ?? []
+const generatedAt = snapshot?.generatedAt ?? null
+const hasData = projects.length > 0
+---
+
+<FoundationPageLayout
+  title="Developers Roadmap"
+  description="Track upcoming milestones, work in progress, and completed items across the Interledger open-source ecosystem."
+>
+  <main class="pb-xl">
+    <section
+      class="bg-gradient-primary-fallback bg-gradient-primary py-2xl text-white"
+    >
+      <div class="mx-auto max-w-content min-w-[360px] px-[5%]">
+        <h1 class="text-step-3 font-semibold leading-tight text-white">
+          Developers Roadmap
+        </h1>
+        <p class="mt-xs max-w-[56ch] opacity-90">
+          Track milestones, active work, and shipped items across the
+          Interledger open-source ecosystem.
+        </p>
+      </div>
+    </section>
+
+    <section class="px-[5%] pt-md">
+      {
+        hasData ? (
+          <RoadmapBoard projects={projects} teams={teams} />
+        ) : (
+          <div class="mx-auto max-w-content py-xl text-gray-600">
+            <p>
+              The roadmap could not be loaded right now. Please check back
+              shortly or visit our{' '}
+              <a
+                class="text-primary underline"
+                href="https://github.com/interledger"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub organisation
+              </a>{' '}
+              for the latest project status.
+            </p>
+          </div>
+        )
+      }
+    </section>
+
+    {
+      generatedAt && (
+        <div class="mx-auto max-w-content px-[5%] pt-s text-gray-500">
+          <span>
+            Roadmap data refreshed at:{' '}
+            <time datetime={generatedAt}>
+              {new Date(generatedAt).toUTCString()}
+            </time>
+          </span>
+        </div>
+      )
+    }
+  </main>
+</FoundationPageLayout>

--- a/src/components/roadmap/RoadmapBoard.astro
+++ b/src/components/roadmap/RoadmapBoard.astro
@@ -58,7 +58,10 @@ function fmtDate(iso: string | null | undefined): string {
   try {
     return new Date(iso).toLocaleDateString('en-US', {
       month: 'long',
-      year: 'numeric'
+      year: 'numeric',
+      // Date-only strings parse as UTC midnight; format in UTC so a Jan-1 target
+      // doesn't render as the previous December on a non-UTC host.
+      timeZone: 'UTC'
     })
   } catch {
     return iso ?? ''

--- a/src/components/roadmap/RoadmapBoard.astro
+++ b/src/components/roadmap/RoadmapBoard.astro
@@ -572,12 +572,20 @@ let projectRowIndex = -1
   }
 
   /* Flip the tooltip below the diamond when there isn't room above (set by JS
-     for pins near the sticky header), so the first rows aren't clipped. */
-  .ms-pin--below .ms-pin-name {
+     for pins near the sticky header), so the first rows aren't clipped. These
+     mirror the three reveal triggers so they match the specificity of the
+     rules above; a bare `.ms-pin--below .ms-pin-name` would lose the cascade
+     for `bottom` on hover/focus, leaving the box anchored top and bottom and
+     collapsing its height. */
+  .ms-pin--below:hover .ms-pin-name,
+  .ms-pin--below:focus-visible .ms-pin-name,
+  .ms-pin--below.ms-pin--active .ms-pin-name {
     top: calc(100% + 8px);
     bottom: auto;
   }
-  .ms-pin--below .ms-pin-name::after {
+  .ms-pin--below:hover .ms-pin-name::after,
+  .ms-pin--below:focus-visible .ms-pin-name::after,
+  .ms-pin--below.ms-pin--active .ms-pin-name::after {
     top: auto;
     bottom: 100%;
     border-top-color: transparent;

--- a/src/components/roadmap/RoadmapBoard.astro
+++ b/src/components/roadmap/RoadmapBoard.astro
@@ -627,13 +627,12 @@ let projectRowIndex = -1
       cursor: pointer;
     }
 
-    /* "Full timeline" mode restores the month-column view on mobile. */
+    /* "Full timeline" mode swaps quarter columns for scrollable month columns.
+       The label column stays at the mobile width (130px, inherited) so the
+       narrow viewport keeps room for the timeline to scroll. */
     .board-outer--full .board-header-table,
     .board-outer--full .board {
-      width: max(calc(300px + var(--n-months) * 88px), 100%);
-    }
-    .board-outer--full .col-label {
-      width: 300px;
+      width: max(calc(130px + var(--n-months) * 88px), 100%);
     }
     .board-outer--full .col-month {
       width: 88px;
@@ -652,9 +651,6 @@ let projectRowIndex = -1
       border-right: 1px solid #e8e8e8;
       overflow: visible;
       visibility: visible;
-    }
-    .board-outer--full .proj-name-text {
-      max-width: 240px;
     }
   }
 

--- a/src/components/roadmap/RoadmapBoard.astro
+++ b/src/components/roadmap/RoadmapBoard.astro
@@ -549,6 +549,9 @@ let projectRowIndex = -1
     border-radius: 5px;
     font-size: 0.65rem;
     font-weight: 600;
+    /* Size the box to its content (the pin is only a few px wide, so without
+       this the absolute box collapses and the text spills off the background). */
+    width: max-content;
     white-space: normal;
     max-width: 130px;
     text-align: center;

--- a/src/components/roadmap/RoadmapBoard.astro
+++ b/src/components/roadmap/RoadmapBoard.astro
@@ -1,0 +1,765 @@
+---
+import type { Project, Team } from '@/types/roadmap'
+import {
+  resolveIcon,
+  computeDateRange,
+  roadmapWindow,
+  projectOverlapsWindow,
+  clampRangeToWindow,
+  buildMonths,
+  buildQuarterHeaders,
+  createPositioner,
+  buildGridItems,
+  computeProjectBarProps
+} from '@/utils'
+
+interface Props {
+  projects?: Project[]
+  teams?: Team[]
+}
+
+const { projects = [], teams = [] }: Props = Astro.props
+
+const now = new Date()
+const nowYear = now.getUTCFullYear()
+const nowMonth = now.getUTCMonth()
+const nowQuarter = Math.floor(nowMonth / 3) + 1
+
+// Cap the timeline to the near-term window (current year + next) and drop
+// projects whose activity falls entirely outside it. See roadmapWindow().
+const { start: windowStart, end: windowEnd } = roadmapWindow(now)
+const windowedProjects = projects.filter((p) =>
+  projectOverlapsWindow(p, windowStart, windowEnd)
+)
+
+const dataRange = computeDateRange(windowedProjects)
+const { minDate, maxDate } = clampRangeToWindow(
+  dataRange.minDate,
+  dataRange.maxDate,
+  windowStart,
+  windowEnd
+)
+const months = buildMonths(minDate, maxDate)
+const quarterHeaders = buildQuarterHeaders(months)
+
+const nMonths = months.length
+const nQuarters = quarterHeaders.length
+
+const timelineStart = months[0].start.getTime()
+const timelineEnd = months[months.length - 1].end.getTime()
+const pos = createPositioner(timelineStart, timelineEnd)
+
+const nowLeft = pos.pctLeft(now).toFixed(2)
+
+const gridItems = buildGridItems(windowedProjects, teams)
+
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleDateString('en-US', {
+      month: 'long',
+      year: 'numeric'
+    })
+  } catch {
+    return iso ?? ''
+  }
+}
+
+// Running index over project rows only, used for accessible alternating row
+// colors (team-header rows are styled as distinct bands and don't participate).
+let projectRowIndex = -1
+---
+
+<div
+  class="board-outer isolate mx-auto max-w-content"
+  role="region"
+  aria-label="Project roadmap"
+>
+  <div class="mobile-toggle-wrap hidden justify-end pb-sm max-tablet:flex">
+    <button
+      type="button"
+      class="mobile-toggle-btn cursor-pointer rounded border border-gray-200 bg-gray-50 px-md py-xs text-step--2 text-gray-600 hover:bg-gray-200"
+      aria-pressed="false"
+    >
+      Full timeline
+    </button>
+  </div>
+
+  {
+    /*
+    .board-frame clips children to the border-radius without becoming a scroll
+    container (overflow: clip does not create one, unlike overflow: hidden), so
+    .board-header-sticky can stick relative to the viewport.
+  */
+  }
+  <div
+    class="board-frame overflow-clip rounded-lg border border-gray-200 shadow-sm"
+    style={`--n-months: ${nMonths}; --n-quarters: ${nQuarters}`}
+  >
+    {
+      /*
+      Sticky header lives OUTSIDE .board-scroll so it can pin to the viewport.
+      aria-hidden because column context is conveyed via the visually-hidden
+      <thead> + per-row aria. JS keeps its scrollLeft in sync with .board-scroll.
+    */
+    }
+    <div
+      class="board-header-sticky sticky z-20 border-b-2 border-gray-200 bg-gray-50 top-(--site-header-height) desktop:top-(--site-header-height-desktop)"
+      aria-hidden="true"
+    >
+      <div class="board-header-inner overflow-x-auto">
+        <table
+          class="board-header-table font-titillium text-step--1 text-gray-900"
+        >
+          <colgroup>
+            <col class="col-label" />
+            {months.map(() => <col class="col-month" />)}
+          </colgroup>
+          <thead>
+            <tr>
+              <th
+                class="hd-label sticky left-0 z-5 border-r border-gray-200 bg-gray-50 px-md align-middle text-step--2 font-bold uppercase tracking-wide text-gray-600"
+                rowspan="2"
+              >
+                Team / Project
+              </th>
+
+              {
+                /* Desktop: quarter headers spanning their months. The quarter
+                  divider is a left border (skipped on the first quarter) so it
+                  lands on the exact same boundary + width as the months'
+                  quarter-start border below it. */
+              }
+              {
+                quarterHeaders.map((qh, qi) => (
+                  <th
+                    class:list={[
+                      'hd-quarter hd-quarter--desktop whitespace-nowrap border-b border-gray-300 bg-gray-50 px-md py-xs text-center align-middle text-step--2 font-bold uppercase tracking-wide text-gray-600',
+                      { 'border-l-2 border-l-gray-300': qi > 0 },
+                      {
+                        'hd-quarter--current bg-primary/10! text-primary!':
+                          qh.q === nowQuarter && qh.year === nowYear
+                      }
+                    ]}
+                    colspan={qh.span}
+                  >
+                    {qh.label}
+                  </th>
+                ))
+              }
+
+              {/* Mobile: one column per quarter */}
+              {
+                quarterHeaders.map((qh) => (
+                  <th
+                    class:list={[
+                      'hd-quarter hd-quarter--mobile whitespace-nowrap border-b border-r-2 border-gray-300 bg-gray-50 px-md py-xs text-center align-middle text-step--2 font-bold uppercase tracking-wide text-gray-600',
+                      {
+                        'hd-quarter--current bg-primary/10! text-primary!':
+                          qh.q === nowQuarter && qh.year === nowYear
+                      }
+                    ]}
+                  >
+                    {qh.label}
+                  </th>
+                ))
+              }
+            </tr>
+
+            {/* Month header cells */}
+            <tr>
+              {
+                months.map((m, mi) => (
+                  <th
+                    class:list={[
+                      'hd-month whitespace-nowrap border-r border-gray-200 bg-gray-50 px-sm py-xs text-center align-middle text-step--2 font-medium text-gray-700',
+                      {
+                        // Skip on the first month: the label column's right
+                        // border already divides it, so a 2px left border here
+                        // would double up and misalign with the quarter row.
+                        'hd-month--qstart border-l-2 border-l-gray-300!':
+                          m.isQuarterStart && mi > 0
+                      },
+                      {
+                        'hd-month--current bg-primary/10! font-bold text-primary!':
+                          m.year === nowYear && m.month === nowMonth
+                      }
+                    ]}
+                  >
+                    {m.label}
+                    {m.year === nowYear && m.month === nowMonth && (
+                      <span class="now-badge mx-auto mt-0.5 block w-fit rounded-full bg-primary px-1 py-0.5 text-[0.55rem] font-bold uppercase tracking-wide text-white">
+                        Now
+                      </span>
+                    )}
+                  </th>
+                ))
+              }
+            </tr>
+          </thead>
+        </table>
+      </div>
+    </div>
+
+    {/* Scrollable body — project rows only */}
+    <div class="board-scroll overflow-x-auto">
+      <table
+        class="board font-titillium text-step--1 text-gray-900"
+        style={`--now-pct: ${nowLeft}%`}
+        aria-label="Projects"
+      >
+        <colgroup>
+          <col class="col-label" />
+          {months.map(() => <col class="col-month" />)}
+        </colgroup>
+
+        {
+          /*
+          Visually-hidden column headers give assistive tech proper column
+          associations. Sighted users read the sticky aria-hidden header above.
+        */
+        }
+        <thead class="sr-only">
+          <tr>
+            <th scope="col" rowspan="2">Team / Project</th>
+            {
+              quarterHeaders.map((qh) => (
+                <th scope="colgroup" colspan={qh.span}>
+                  {qh.label}
+                </th>
+              ))
+            }
+          </tr>
+          <tr>
+            {months.map((m) => <th scope="col">{m.label}</th>)}
+          </tr>
+        </thead>
+
+        <tbody>
+          {
+            gridItems.map((item) => {
+              if (item.type === 'team-header') {
+                const { team } = item
+                return (
+                  <tr aria-label={`Team: ${team.name}`}>
+                    <th
+                      class="team-header sticky left-0 z-4 border-y border-gray-300 bg-gray-100 p-0 text-step--2 font-bold uppercase tracking-wider text-gray-700"
+                      scope="rowgroup"
+                    >
+                      <div class="inline-flex items-center gap-sm px-md py-xs">
+                        {team.name}
+                      </div>
+                    </th>
+                    <td
+                      class="team-header-track border-y border-gray-300 bg-gray-100"
+                      colspan={nMonths}
+                    />
+                  </tr>
+                )
+              }
+
+              const { project: proj } = item
+              projectRowIndex++
+              const zebra =
+                projectRowIndex % 2 === 0 ? 'bg-white' : 'bg-gray-50'
+              const iconEmoji = resolveIcon(proj.icon)
+              const {
+                hasDates,
+                barLeft,
+                barWidth,
+                hasCompletedBar,
+                completedBarLeft,
+                completedBarWidth,
+                hasExtension,
+                extensionLeft,
+                extensionWidth,
+                datedMilestones
+              } = computeProjectBarProps(proj, pos)
+
+              return (
+                <tr>
+                  <th
+                    class:list={[
+                      'proj-label sticky left-0 z-4 h-13 border-r border-gray-200 px-md align-middle',
+                      zebra
+                    ]}
+                    scope="row"
+                    title={proj.name}
+                  >
+                    <span class="inline-flex items-center gap-1.5 text-step--1 font-medium leading-snug text-gray-900">
+                      {iconEmoji && (
+                        <span class="shrink-0" aria-hidden="true">
+                          {iconEmoji}
+                        </span>
+                      )}
+                      <span class="proj-name-text overflow-hidden text-ellipsis whitespace-nowrap">
+                        {proj.name}
+                      </span>
+                    </span>
+                  </th>
+
+                  <td
+                    class:list={[
+                      'proj-track relative h-13 overflow-visible align-top',
+                      zebra
+                    ]}
+                    colspan={nMonths}
+                  >
+                    {/* Visually-hidden date summary, always read by screen readers */}
+                    <span class="sr-only">
+                      {' '}
+                      Project
+                      {[
+                        fmtDate(proj.startDate) &&
+                          `starts ${fmtDate(proj.startDate)}`,
+                        fmtDate(proj.targetDate) &&
+                          `target ${fmtDate(proj.targetDate)}`
+                      ]
+                        .filter(Boolean)
+                        .join('; ') || ' has no dates set'}
+                    </span>
+
+                    <div class="now-line" aria-hidden="true" />
+
+                    {hasDates && (
+                      <div
+                        class="proj-bar bg-primary/25 border-primary/70"
+                        aria-hidden="true"
+                        style={`left: ${barLeft}%; width: ${barWidth}%;`}
+                      />
+                    )}
+
+                    {hasExtension && (
+                      <div
+                        class="proj-bar proj-bar--extension border-primary/50"
+                        aria-hidden="true"
+                        style={`left: ${extensionLeft}%; width: ${extensionWidth}%;`}
+                        title="Milestones extend past the project target date"
+                      />
+                    )}
+
+                    {hasCompletedBar && (
+                      <div
+                        class="proj-bar proj-bar--completed bg-primary/15 border-primary/60"
+                        aria-hidden="true"
+                        style={`left: ${completedBarLeft}%; width: ${completedBarWidth}%;`}
+                        title="Completed"
+                      />
+                    )}
+
+                    {/* Milestone diamonds, sorted chronologically so DOM order
+                        matches visual order (matters for screen readers) */}
+                    {[...datedMilestones]
+                      .sort(
+                        (a, b) =>
+                          new Date(a.targetDate!).getTime() -
+                          new Date(b.targetDate!).getTime()
+                      )
+                      .map((ms) => {
+                        const left = pos
+                          .pctLeft(new Date(ms.targetDate!))
+                          .toFixed(2)
+                        return (
+                          <button
+                            type="button"
+                            class="ms-pin"
+                            aria-label={`${ms.name}, target ${fmtDate(ms.targetDate)}`}
+                            style={`left: ${left}%`}
+                            data-umami-event="developers_roadmap:milestone:open"
+                            data-umami-event-project={proj.name}
+                            data-umami-event-milestone={ms.name}
+                          >
+                            <span
+                              class="ms-diamond bg-primary"
+                              aria-hidden="true"
+                            />
+                            <span class="ms-pin-name" aria-hidden="true">
+                              {ms.name}
+                              <span class="ms-pin-date">
+                                {fmtDate(ms.targetDate)}
+                              </span>
+                            </span>
+                          </button>
+                        )
+                      })}
+                  </td>
+                </tr>
+              )
+            })
+          }
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+{
+  /*
+  Scoped CSS is intentionally limited to what Tailwind cannot express cleanly:
+  fixed table column widths + the responsive quarter/month column swap and its
+  "full timeline" toggle state, the milestone tooltip (pseudo-element arrow),
+  scrollbar theming, the duration-bar geometry, and reduced-motion. Everything
+  static is Tailwind utilities above; data-driven positions are inline styles.
+*/
+}
+<style>
+  /* Header + body tables share one column template. */
+  .board-header-table,
+  .board {
+    table-layout: fixed;
+    border-collapse: separate;
+    border-spacing: 0;
+    width: max(calc(300px + var(--n-months) * 88px), 100%);
+  }
+
+  .col-label {
+    width: 300px;
+  }
+  .col-month {
+    width: 88px;
+  }
+
+  .proj-name-text {
+    max-width: 240px;
+  }
+
+  /* Hide the header's scrollbar; JS mirrors it to the body's. */
+  .board-header-inner {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  .board-header-inner::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Body scrollbar, themed with the brand color. */
+  .board-scroll::-webkit-scrollbar {
+    height: 6px;
+  }
+  .board-scroll::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 10em;
+  }
+  .board-scroll::-webkit-scrollbar-thumb {
+    background: var(--color-primary);
+    border-radius: 10em;
+  }
+
+  /* "Today" vertical line. */
+  .now-line {
+    position: absolute;
+    inset-block: 0;
+    left: var(--now-pct);
+    width: 1.5px;
+    background: color-mix(in srgb, var(--color-primary) 45%, transparent);
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  /* Project duration bar geometry (color comes from Tailwind utilities). */
+  .proj-bar {
+    position: absolute;
+    top: 18%;
+    height: 28%;
+    border-radius: 4px;
+    border-style: solid;
+    border-width: 1.5px;
+    pointer-events: none;
+    z-index: 2;
+  }
+  .proj-bar--completed {
+    border-style: dashed;
+  }
+  .proj-bar--extension {
+    background: repeating-linear-gradient(
+      45deg,
+      transparent,
+      transparent 4px,
+      rgba(0, 0, 0, 0.07) 4px,
+      rgba(0, 0, 0, 0.07) 8px
+    );
+    border-style: dashed;
+    border-left: none;
+    border-radius: 0 4px 4px 0;
+  }
+
+  /* Milestone pin. */
+  .ms-pin {
+    position: absolute;
+    inset-block: 0;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: 0.35rem;
+    z-index: 3;
+    background: none;
+    border: none;
+    font: inherit;
+    cursor: default;
+  }
+
+  .ms-diamond {
+    display: block;
+    width: 20px;
+    height: 20px;
+    border-radius: 2px;
+    transform: rotate(45deg);
+    flex-shrink: 0;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    transition: transform 150ms ease;
+  }
+
+  .ms-pin:hover .ms-diamond,
+  .ms-pin:focus-visible .ms-diamond {
+    transform: rotate(45deg) scale(1.3);
+  }
+  .ms-pin:focus-visible {
+    outline: none;
+  }
+  .ms-pin:focus-visible .ms-diamond {
+    box-shadow:
+      0 0 0 2px white,
+      0 0 0 4px var(--color-primary);
+  }
+  .ms-pin:hover,
+  .ms-pin:focus-visible,
+  .ms-pin--active {
+    z-index: 16;
+  }
+
+  /* Tooltip — revealed on hover, keyboard focus, or tap-activation. */
+  .ms-pin-name {
+    display: none;
+  }
+  .ms-pin:hover .ms-pin-name,
+  .ms-pin:focus-visible .ms-pin-name,
+  .ms-pin--active .ms-pin-name {
+    display: block;
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(25, 25, 25, 0.92);
+    color: #fff;
+    padding: 5px 8px;
+    border-radius: 5px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    white-space: normal;
+    max-width: 130px;
+    text-align: center;
+    line-height: 1.3;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+    pointer-events: none;
+  }
+  .ms-pin:hover .ms-pin-name::after,
+  .ms-pin:focus-visible .ms-pin-name::after,
+  .ms-pin--active .ms-pin-name::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: rgba(25, 25, 25, 0.92);
+  }
+
+  /* Flip the tooltip below the diamond when there isn't room above (set by JS
+     for pins near the sticky header), so the first rows aren't clipped. */
+  .ms-pin--below .ms-pin-name {
+    top: calc(100% + 8px);
+    bottom: auto;
+  }
+  .ms-pin--below .ms-pin-name::after {
+    top: auto;
+    bottom: 100%;
+    border-top-color: transparent;
+    border-bottom-color: rgba(25, 25, 25, 0.92);
+  }
+  .ms-pin-date {
+    display: block;
+    margin-top: 2px;
+    opacity: 0.75;
+    font-weight: 400;
+  }
+
+  /* Desktop default: month columns shown, mobile quarter headers hidden. */
+  .hd-quarter--mobile {
+    display: none;
+  }
+
+  /* Mobile: collapse to one column per quarter. */
+  @media (max-width: 809px) {
+    .board-header-table,
+    .board {
+      width: max(calc(130px + var(--n-quarters) * 72px), 100%);
+    }
+    .col-label {
+      width: 130px;
+    }
+    .col-month {
+      width: 0;
+      display: none;
+    }
+    .hd-quarter--desktop {
+      display: none;
+    }
+    .hd-quarter--mobile {
+      display: table-cell;
+      width: 72px;
+    }
+    .hd-month {
+      height: 0;
+      min-height: 0;
+      padding: 0;
+      border: none;
+      overflow: hidden;
+      visibility: hidden;
+    }
+    .proj-name-text {
+      max-width: 96px;
+    }
+    .ms-pin {
+      cursor: pointer;
+    }
+
+    /* "Full timeline" mode restores the month-column view on mobile. */
+    .board-outer--full .board-header-table,
+    .board-outer--full .board {
+      width: max(calc(300px + var(--n-months) * 88px), 100%);
+    }
+    .board-outer--full .col-label {
+      width: 300px;
+    }
+    .board-outer--full .col-month {
+      width: 88px;
+      display: table-column;
+    }
+    .board-outer--full .hd-quarter--desktop {
+      display: table-cell;
+    }
+    .board-outer--full .hd-quarter--mobile {
+      display: none;
+    }
+    .board-outer--full .hd-month {
+      height: auto;
+      min-height: unset;
+      padding: 0.25rem 0.5rem;
+      border-right: 1px solid #e8e8e8;
+      overflow: visible;
+      visibility: visible;
+    }
+    .board-outer--full .proj-name-text {
+      max-width: 240px;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ms-diamond {
+      transition: none;
+    }
+  }
+</style>
+
+<script>
+  // Centre the board so the "today" line sits mid-viewport on load.
+  function centreOnNow() {
+    const boardScroll = document.querySelector<HTMLElement>('.board-scroll')
+    const board = document.querySelector<HTMLElement>('.board')
+    if (!boardScroll || !board) return
+
+    const rawPct = getComputedStyle(board).getPropertyValue('--now-pct').trim()
+    const nowPct = parseFloat(rawPct)
+    if (isNaN(nowPct)) return
+
+    const labelCell = document.querySelector<HTMLElement>('.hd-label')
+    const labelWidth = labelCell?.offsetWidth ?? 300
+    const timelineWidth = board.scrollWidth - labelWidth
+    const nowPxFromBoardLeft = labelWidth + (nowPct / 100) * timelineWidth
+
+    boardScroll.scrollLeft = nowPxFromBoardLeft - boardScroll.clientWidth / 2
+  }
+
+  // Keep the sticky header's horizontal scroll in sync with the body's.
+  function initScrollSync() {
+    const boardScroll = document.querySelector<HTMLElement>('.board-scroll')
+    const headerInner = document.querySelector<HTMLElement>(
+      '.board-header-inner'
+    )
+    if (!boardScroll || !headerInner) return
+    let syncing = false
+    boardScroll.addEventListener('scroll', () => {
+      if (syncing) return
+      syncing = true
+      headerInner.scrollLeft = boardScroll.scrollLeft
+      syncing = false
+    })
+    headerInner.addEventListener('scroll', () => {
+      if (syncing) return
+      syncing = true
+      boardScroll.scrollLeft = headerInner.scrollLeft
+      syncing = false
+    })
+  }
+
+  // Toggle quarter view ↔ full month view on mobile.
+  document
+    .querySelectorAll<HTMLButtonElement>('.mobile-toggle-btn')
+    .forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const outer = btn.closest<HTMLElement>('.board-outer')
+        if (!outer) return
+        const isFull = outer.classList.toggle('board-outer--full')
+        btn.textContent = isFull ? 'Quarter view' : 'Full timeline'
+        btn.setAttribute('aria-pressed', String(isFull))
+        requestAnimationFrame(centreOnNow)
+      })
+    })
+
+  // Approx tooltip height + arrow + gap. If a pin has less room than this above
+  // it (down to the sticky header's bottom), flip the tooltip below so it isn't
+  // covered by the header or clipped at the top of the scroll viewport.
+  const TOOLTIP_CLEARANCE = 72
+
+  function positionTooltip(pin: HTMLElement) {
+    const header = document.querySelector<HTMLElement>('.board-header-sticky')
+    const headerBottom = header?.getBoundingClientRect().bottom ?? 0
+    const roomAbove = pin.getBoundingClientRect().top - headerBottom
+    pin.classList.toggle('ms-pin--below', roomAbove < TOOLTIP_CLEARANCE)
+  }
+
+  // Reveal the tooltip on tap (mobile/touch); hover/focus are handled in CSS.
+  // positionTooltip runs for all three so the flip is decided before it shows.
+  document.querySelectorAll<HTMLElement>('.ms-pin').forEach((pin) => {
+    pin.addEventListener('mouseenter', () => positionTooltip(pin))
+    pin.addEventListener('focus', () => positionTooltip(pin))
+    pin.addEventListener('click', (e) => {
+      e.stopPropagation()
+      const nowActive = !pin.classList.contains('ms-pin--active')
+      document
+        .querySelectorAll('.ms-pin--active')
+        .forEach((p) => p.classList.remove('ms-pin--active'))
+      if (nowActive) {
+        positionTooltip(pin)
+        pin.classList.add('ms-pin--active')
+      }
+    })
+  })
+
+  document.addEventListener('click', () => {
+    document
+      .querySelectorAll('.ms-pin--active')
+      .forEach((p) => p.classList.remove('ms-pin--active'))
+  })
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      initScrollSync()
+      centreOnNow()
+    })
+  } else {
+    initScrollSync()
+    centreOnNow()
+  }
+</script>

--- a/src/data/roadmap/fixture.ts
+++ b/src/data/roadmap/fixture.ts
@@ -1,9 +1,9 @@
 import type { Snapshot } from '@/types/roadmap'
 
-// Placeholder roadmap data for the presentation-first migration (INTORG-737).
-// Shapes match the live Linear snapshot so swapping in a build-time fetch later
-// (pending Sarah's data-approach decision) touches only the data layer, not the
-// board. Dates are bounded to 2026–2027 per Sarah's INTORG-636 windowing note.
+// Local-dev fallback for the roadmap page. `astro dev` has no Netlify Blobs
+// runtime, so the SSR page renders this instead of the live snapshot (see
+// src/pages/developers/roadmap.astro). The shape mirrors the real Linear
+// snapshot; dates are illustrative and sit in the current timeline window.
 export const ROADMAP_FIXTURE: Snapshot = {
   generatedAt: '2026-06-22T00:00:00.000Z',
   teams: [

--- a/src/data/roadmap/fixture.ts
+++ b/src/data/roadmap/fixture.ts
@@ -1,0 +1,228 @@
+import type { Snapshot } from '@/types/roadmap'
+
+// Placeholder roadmap data for the presentation-first migration (INTORG-737).
+// Shapes match the live Linear snapshot so swapping in a build-time fetch later
+// (pending Sarah's data-approach decision) touches only the data layer, not the
+// board. Dates are bounded to 2026–2027 per Sarah's INTORG-636 windowing note.
+export const ROADMAP_FIXTURE: Snapshot = {
+  generatedAt: '2026-06-22T00:00:00.000Z',
+  teams: [
+    {
+      id: 'team-rafiki',
+      name: 'Rafiki',
+      key: 'RAF',
+      color: null,
+      childrenIds: [],
+      projectCount: 3
+    },
+    {
+      id: 'team-open-payments',
+      name: 'Open Payments',
+      key: 'OP',
+      color: null,
+      childrenIds: ['team-op-tooling'],
+      projectCount: 2
+    },
+    {
+      id: 'team-op-tooling',
+      name: 'Open Payments Tooling',
+      key: 'OPT',
+      color: null,
+      childrenIds: [],
+      projectCount: 1
+    },
+    {
+      id: 'team-web-monetization',
+      name: 'Web Monetization',
+      key: 'WM',
+      color: null,
+      childrenIds: [],
+      projectCount: 2
+    }
+  ],
+  projects: [
+    {
+      id: 'proj-rafiki-v1',
+      name: 'Rafiki v1 GA',
+      description: 'General availability release of the Rafiki node.',
+      color: null,
+      state: 'started',
+      icon: 'Rocket',
+      priority: 1,
+      progress: 0.6,
+      sortOrder: 1,
+      startDate: '2026-01-15',
+      targetDate: '2026-09-30',
+      completedAt: null,
+      url: null,
+      team: { id: 'team-rafiki', name: 'Rafiki', key: 'RAF', color: null },
+      milestones: [
+        { id: 'ms-raf-beta', name: 'Beta cut', targetDate: '2026-04-15' },
+        {
+          id: 'ms-raf-rc',
+          name: 'Release candidate',
+          targetDate: '2026-08-01'
+        },
+        { id: 'ms-raf-audit', name: 'Security audit', targetDate: '2026-11-15' }
+      ]
+    },
+    {
+      id: 'proj-rafiki-telemetry',
+      name: 'Telemetry & observability',
+      description: 'Operational metrics and tracing for Rafiki operators.',
+      color: null,
+      state: 'started',
+      icon: 'Chart',
+      priority: 2,
+      progress: 0.3,
+      sortOrder: 2,
+      startDate: '2026-05-01',
+      targetDate: '2027-02-28',
+      completedAt: null,
+      url: null,
+      team: { id: 'team-rafiki', name: 'Rafiki', key: 'RAF', color: null },
+      milestones: [
+        {
+          id: 'ms-tel-dash',
+          name: 'Operator dashboard',
+          targetDate: '2026-10-01'
+        }
+      ]
+    },
+    {
+      id: 'proj-rafiki-admin',
+      name: 'Admin UI refresh',
+      description: 'Completed refresh of the Rafiki admin interface.',
+      color: null,
+      state: 'completed',
+      icon: 'Dashboard',
+      priority: 3,
+      progress: 1,
+      sortOrder: 3,
+      startDate: '2026-01-01',
+      targetDate: null,
+      completedAt: '2026-03-20',
+      url: null,
+      team: { id: 'team-rafiki', name: 'Rafiki', key: 'RAF', color: null },
+      milestones: []
+    },
+    {
+      id: 'proj-op-spec',
+      name: 'Open Payments spec 1.1',
+      description: 'Next minor revision of the Open Payments specification.',
+      color: null,
+      state: 'started',
+      icon: 'NotePad',
+      priority: 1,
+      progress: 0.5,
+      sortOrder: 1,
+      startDate: '2026-02-01',
+      targetDate: '2026-12-15',
+      completedAt: null,
+      url: null,
+      team: {
+        id: 'team-open-payments',
+        name: 'Open Payments',
+        key: 'OP',
+        color: null
+      },
+      milestones: [
+        { id: 'ms-op-draft', name: 'Public draft', targetDate: '2026-06-01' },
+        {
+          id: 'ms-op-review',
+          name: 'Community review',
+          targetDate: '2026-10-01'
+        }
+      ]
+    },
+    {
+      id: 'proj-op-sdk',
+      name: 'TypeScript SDK',
+      description: 'First-party Open Payments client SDK.',
+      color: null,
+      state: 'started',
+      icon: 'CodeBlock',
+      priority: 2,
+      progress: 0.2,
+      sortOrder: 1,
+      startDate: '2026-07-01',
+      targetDate: '2027-04-30',
+      completedAt: null,
+      url: null,
+      team: {
+        id: 'team-op-tooling',
+        name: 'Open Payments Tooling',
+        key: 'OPT',
+        color: null
+      },
+      milestones: [
+        { id: 'ms-sdk-alpha', name: 'Alpha', targetDate: '2026-11-01' }
+      ]
+    },
+    {
+      id: 'proj-wm-extension',
+      name: 'Web Monetization extension 1.0',
+      description: 'Stable release of the browser extension.',
+      color: null,
+      state: 'started',
+      icon: 'Chrome',
+      priority: 1,
+      progress: 0.75,
+      sortOrder: 1,
+      startDate: '2026-01-01',
+      targetDate: '2026-07-31',
+      completedAt: null,
+      url: null,
+      team: {
+        id: 'team-web-monetization',
+        name: 'Web Monetization',
+        key: 'WM',
+        color: null
+      },
+      milestones: [
+        { id: 'ms-wm-beta', name: 'Public beta', targetDate: '2026-05-01' }
+      ]
+    },
+    {
+      id: 'proj-wm-publisher',
+      name: 'Publisher tools',
+      description: 'Tooling for content publishers adopting Web Monetization.',
+      color: null,
+      state: 'started',
+      icon: 'Write',
+      priority: 2,
+      progress: 0.1,
+      sortOrder: 2,
+      startDate: '2026-09-01',
+      targetDate: '2027-06-30',
+      completedAt: null,
+      url: null,
+      team: {
+        id: 'team-web-monetization',
+        name: 'Web Monetization',
+        key: 'WM',
+        color: null
+      },
+      milestones: []
+    },
+    {
+      id: 'proj-research',
+      name: 'Interledger research initiatives',
+      description: 'Cross-cutting research not tied to a single team.',
+      color: null,
+      state: 'started',
+      icon: 'Education',
+      priority: 3,
+      progress: 0.4,
+      sortOrder: 1,
+      startDate: '2026-03-01',
+      targetDate: '2026-12-31',
+      completedAt: null,
+      url: null,
+      team: null,
+      milestones: [
+        { id: 'ms-res-paper', name: 'Whitepaper', targetDate: '2026-09-15' }
+      ]
+    }
+  ]
+}

--- a/src/linear/build-snapshot.ts
+++ b/src/linear/build-snapshot.ts
@@ -142,9 +142,10 @@ type ProjectIssueTeamsQueryResult = {
 }
 
 const PROJECT_LABELS_QUERY = `
-  query FetchProjectLabels {
-    projectLabels {
+  query FetchProjectLabels($first: Int!, $after: String) {
+    projectLabels(first: $first, after: $after) {
       nodes { id name }
+      pageInfo { hasNextPage endCursor }
     }
   }
 `
@@ -152,6 +153,7 @@ const PROJECT_LABELS_QUERY = `
 type ProjectLabelsQueryResult = {
   projectLabels: {
     nodes: Array<{ id: string; name: string }>
+    pageInfo: { hasNextPage: boolean; endCursor: string | null }
   }
 }
 
@@ -212,15 +214,28 @@ async function fetchTeams(): Promise<TeamsQueryResult['teams']['nodes']> {
 }
 
 async function fetchPublicLabelIds(): Promise<Set<string>> {
-  const result = await withRetry(() =>
-    linear.client.request<ProjectLabelsQueryResult, Record<string, never>>(
-      PROJECT_LABELS_QUERY
+  const ids = new Set<string>()
+  let hasNextPage = true
+  let endCursor: string | null = null
+
+  // Paginated: Linear connections default to 50 nodes, and if a workspace has
+  // more than 50 project labels with `public` past the first page, an unpaginated
+  // query would miss it and drop every project from the roadmap.
+  while (hasNextPage) {
+    const result = await withRetry(() =>
+      linear.client.request<
+        ProjectLabelsQueryResult,
+        { first: number; after: string | null }
+      >(PROJECT_LABELS_QUERY, { first: 50, after: endCursor })
     )
-  )
-  const ids = result.projectLabels.nodes
-    .filter((l) => l.name.toLowerCase() === 'public')
-    .map((l) => l.id)
-  return new Set(ids)
+    for (const label of result.projectLabels.nodes) {
+      if (label.name.toLowerCase() === 'public') ids.add(label.id)
+    }
+    hasNextPage = result.projectLabels.pageInfo.hasNextPage
+    endCursor = result.projectLabels.pageInfo.endCursor
+  }
+
+  return ids
 }
 
 async function fetchProjectIssueTeamCounts(

--- a/src/linear/build-snapshot.ts
+++ b/src/linear/build-snapshot.ts
@@ -1,0 +1,384 @@
+import { linear } from './client'
+import { LINEAR_CUSTOM_VIEW_ID } from './env'
+import type { Snapshot, Team, Project } from '../types/roadmap'
+
+// ---------------------------------------------------------------------------
+// GraphQL queries
+// ---------------------------------------------------------------------------
+
+const TEAMS_QUERY = `
+  query FetchTeams($first: Int!, $after: String) {
+    teams(first: $first, after: $after) {
+      nodes {
+        id
+        name
+        key
+        color
+        children { id }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`
+
+type TeamsQueryResult = {
+  teams: {
+    nodes: Array<{
+      id: string
+      name: string
+      key: string
+      color: string | null
+      children: Array<{ id: string }>
+    }>
+    pageInfo: { hasNextPage: boolean; endCursor: string | null }
+  }
+}
+
+const CUSTOM_VIEW_QUERY = `
+  query FetchCustomView($id: String!, $after: String) {
+    customView(id: $id) {
+      projects(first: 50, after: $after) {
+        nodes {
+          id
+          name
+          description
+          state
+          color
+          icon
+          priority
+          startDate
+          targetDate
+          completedAt
+          progress
+          url
+          sortOrder
+          teams {
+            nodes { id name key color }
+          }
+          projectMilestones {
+            nodes {
+              id
+              name
+              targetDate
+              sortOrder
+            }
+          }
+          labelIds
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`
+
+type ViewProjectNode = {
+  id: string
+  name: string
+  description: string | null
+  state: string
+  color: string | null
+  icon: string | null
+  priority: number
+  startDate: string | null
+  targetDate: string | null
+  completedAt: string | null
+  progress: number
+  url: string | null
+  sortOrder: number
+  teams: {
+    nodes: Array<{
+      id: string
+      name: string
+      key: string
+      color: string | null
+    }>
+  }
+  projectMilestones: {
+    nodes: Array<{
+      id: string
+      name: string
+      targetDate: string | null
+      sortOrder: number
+    }>
+  }
+  labelIds: string[]
+}
+
+type CustomViewQueryResult = {
+  customView: {
+    projects: {
+      nodes: ViewProjectNode[]
+      pageInfo: { hasNextPage: boolean; endCursor: string | null }
+    }
+  } | null
+}
+
+// Fetched separately to avoid blowing Linear's query-complexity limit when
+// issues are nested inside a paginated projects list.
+const PROJECT_ISSUE_TEAMS_QUERY = `
+  query FetchProjectIssueTeams($id: String!, $after: String) {
+    project(id: $id) {
+      issues(first: 100, after: $after) {
+        nodes { team { id } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+`
+
+type ProjectIssueTeamsQueryResult = {
+  project: {
+    issues: {
+      nodes: Array<{ team: { id: string } | null }>
+      pageInfo: { hasNextPage: boolean; endCursor: string | null }
+    }
+  } | null
+}
+
+const PROJECT_LABELS_QUERY = `
+  query FetchProjectLabels {
+    projectLabels {
+      nodes { id name }
+    }
+  }
+`
+
+type ProjectLabelsQueryResult = {
+  projectLabels: {
+    nodes: Array<{ id: string; name: string }>
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Retry helper — retries transient 5xx errors with exponential backoff
+// ---------------------------------------------------------------------------
+
+function isTransientError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  const status = (err as unknown as Record<string, unknown>).status
+  if (typeof status === 'number' && status >= 500) return true
+  if (/GraphQL Error \(Code: 5\d\d\)/.test(err.message)) return true
+  return false
+}
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  retries = 3,
+  delayMs = 2000
+): Promise<T> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (!isTransientError(err) || attempt === retries) throw err
+      const wait = delayMs * 2 ** attempt
+      await new Promise((r) => setTimeout(r, wait))
+    }
+  }
+  throw new Error('Retry loop exited unexpectedly')
+}
+
+// ---------------------------------------------------------------------------
+// Fetch helpers
+// ---------------------------------------------------------------------------
+
+async function fetchTeams(): Promise<TeamsQueryResult['teams']['nodes']> {
+  const all: TeamsQueryResult['teams']['nodes'] = []
+  let hasNextPage = true
+  let endCursor: string | null = null
+
+  while (hasNextPage) {
+    const result = await withRetry(() =>
+      linear.client.request<
+        TeamsQueryResult,
+        { first: number; after: string | null }
+      >(TEAMS_QUERY, {
+        first: 50,
+        after: endCursor
+      })
+    )
+    all.push(...result.teams.nodes)
+    hasNextPage = result.teams.pageInfo.hasNextPage
+    endCursor = result.teams.pageInfo.endCursor
+  }
+
+  return all
+}
+
+async function fetchPublicLabelIds(): Promise<Set<string>> {
+  const result = await withRetry(() =>
+    linear.client.request<ProjectLabelsQueryResult, Record<string, never>>(
+      PROJECT_LABELS_QUERY
+    )
+  )
+  const ids = result.projectLabels.nodes
+    .filter((l) => l.name.toLowerCase() === 'public')
+    .map((l) => l.id)
+  return new Set(ids)
+}
+
+async function fetchProjectIssueTeamCounts(
+  projectId: string
+): Promise<Map<string, number>> {
+  const counts = new Map<string, number>()
+  let hasNextPage = true
+  let endCursor: string | null = null
+
+  while (hasNextPage) {
+    const result = await withRetry(() =>
+      linear.client.request<
+        ProjectIssueTeamsQueryResult,
+        { id: string; after: string | null }
+      >(PROJECT_ISSUE_TEAMS_QUERY, { id: projectId, after: endCursor })
+    )
+    const issues = result.project?.issues
+    if (!issues) break
+    for (const node of issues.nodes) {
+      if (!node.team?.id) continue
+      counts.set(node.team.id, (counts.get(node.team.id) ?? 0) + 1)
+    }
+    hasNextPage = issues.pageInfo.hasNextPage
+    endCursor = issues.pageInfo.endCursor
+  }
+
+  return counts
+}
+
+async function fetchViewProjects(viewId: string): Promise<ViewProjectNode[]> {
+  const all: ViewProjectNode[] = []
+  let hasNextPage = true
+  let endCursor: string | null = null
+
+  while (hasNextPage) {
+    const result = await withRetry(() =>
+      linear.client.request<
+        CustomViewQueryResult,
+        { id: string; after: string | null }
+      >(CUSTOM_VIEW_QUERY, {
+        id: viewId,
+        after: endCursor
+      })
+    )
+
+    if (!result.customView) {
+      throw new Error(
+        `Custom view ${viewId} not found in Linear. Check LINEAR_CUSTOM_VIEW_ID.`
+      )
+    }
+
+    all.push(...result.customView.projects.nodes)
+    hasNextPage = result.customView.projects.pageInfo.hasNextPage
+    endCursor = result.customView.projects.pageInfo.endCursor
+  }
+
+  return all
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function buildSnapshot(): Promise<Snapshot> {
+  const viewId = LINEAR_CUSTOM_VIEW_ID
+
+  const [teamNodes, viewProjects, publicLabelIds] = await Promise.all([
+    fetchTeams(),
+    fetchViewProjects(viewId),
+    fetchPublicLabelIds()
+  ])
+
+  // Fetch issue-team counts only for multi-team projects to stay under
+  // Linear's query complexity limit.
+  const multiTeamProjects = viewProjects.filter((p) => p.teams.nodes.length > 1)
+  const issueCountEntries = await Promise.all(
+    multiTeamProjects.map(async (p) => {
+      const counts = await fetchProjectIssueTeamCounts(p.id)
+      return [p.id, counts] as const
+    })
+  )
+  const issueCountsByProjectId = new Map(issueCountEntries)
+
+  function dominantTeam(
+    p: ViewProjectNode
+  ): ViewProjectNode['teams']['nodes'][number] | null {
+    if (p.teams.nodes.length === 0) return null
+    if (p.teams.nodes.length === 1) return p.teams.nodes[0]
+    const counts = issueCountsByProjectId.get(p.id) ?? new Map<string, number>()
+    let best = p.teams.nodes[0]
+    let bestCount = counts.get(best.id) ?? 0
+    for (const t of p.teams.nodes.slice(1)) {
+      const c = counts.get(t.id) ?? 0
+      if (c > bestCount) {
+        best = t
+        bestCount = c
+      }
+    }
+    return best
+  }
+
+  const projects: Project[] = viewProjects
+    .filter((p) => p.state !== 'completed' && p.state !== 'cancelled')
+    .filter((p) => p.labelIds.some((id) => publicLabelIds.has(id)))
+    .map((p) => {
+      const primaryTeam = dominantTeam(p)
+      return {
+        id: p.id,
+        name: p.name,
+        description: p.description,
+        state: p.state,
+        color: p.color,
+        icon: p.icon,
+        priority: p.priority ?? 0,
+        progress: p.progress ?? 0,
+        sortOrder: p.sortOrder ?? 0,
+        startDate: p.startDate ?? null,
+        targetDate: p.targetDate ?? null,
+        completedAt: p.completedAt ?? null,
+        url: p.url,
+        team: primaryTeam
+          ? {
+              id: primaryTeam.id,
+              name: primaryTeam.name,
+              key: primaryTeam.key,
+              color: primaryTeam.color
+            }
+          : null,
+        milestones: p.projectMilestones.nodes
+          .slice()
+          .sort((a, b) => a.sortOrder - b.sortOrder)
+          .map((m) => ({
+            id: m.id,
+            name: m.name,
+            targetDate: m.targetDate ?? null
+          }))
+      }
+    })
+
+  const teams: Team[] = teamNodes
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((t) => ({
+      id: t.id,
+      name: t.name,
+      key: t.key,
+      color: t.color,
+      childrenIds: t.children.map((c) => c.id),
+      projectCount: projects.filter((p) => p.team?.id === t.id).length
+    }))
+
+  console.log(
+    `Fetched ${teams.length} teams and ${projects.length} projects from Linear at ${new Date().toISOString()}`
+  )
+
+  return {
+    generatedAt: new Date().toISOString(),
+    teams,
+    projects
+  }
+}

--- a/src/linear/client.ts
+++ b/src/linear/client.ts
@@ -1,0 +1,6 @@
+import { LinearClient } from '@linear/sdk'
+import { LINEAR_API_KEY } from './env'
+
+export const linear = new LinearClient({
+  apiKey: LINEAR_API_KEY || undefined
+})

--- a/src/linear/env.ts
+++ b/src/linear/env.ts
@@ -30,8 +30,6 @@ export const LINEAR_CUSTOM_VIEW_ID =
 // Bearer token for the manual POST /api/roadmap-sync trigger.
 export const API_SECRET = requireEnv('API_SECRET')
 
-// Optional: Netlify Personal Access Token for purging the CDN cache after a sync.
-export const NETLIFY_API_TOKEN = process.env.NETLIFY_API_TOKEN ?? null
-
-// Auto-injected by Netlify; set manually for local `netlify dev`.
-export const NETLIFY_SITE_ID = process.env.NETLIFY_SITE_ID ?? null
+// Note: CDN cache purging uses Netlify's token-free purgeCache() from the
+// function runtime (see netlify/functions/utils/purge-roadmap-cache.mts), so no
+// NETLIFY_API_TOKEN / NETLIFY_SITE_ID is needed.

--- a/src/linear/env.ts
+++ b/src/linear/env.ts
@@ -8,9 +8,6 @@
 // returning null.
 const isProd = import.meta.env?.PROD !== false
 
-// Netlify CLI sets NETLIFY_DEV=true when running `netlify dev` locally.
-export const isNetlifyDev = process.env.NETLIFY_DEV === 'true'
-
 function requireEnv(name: string): string {
   const value = process.env[name]
   if (!value && isProd) {

--- a/src/linear/env.ts
+++ b/src/linear/env.ts
@@ -27,8 +27,11 @@ export const LINEAR_API_KEY = requireEnv('LINEAR_API_KEY')
 export const LINEAR_CUSTOM_VIEW_ID =
   process.env.LINEAR_CUSTOM_VIEW_ID ?? '27df73bc-50ec-4fc1-bbb2-d906236a5bbc'
 
-// Bearer token for the manual POST /api/roadmap-sync trigger.
-export const API_SECRET = requireEnv('API_SECRET')
+// Note: API_SECRET is intentionally NOT exported here. It is only used by the
+// manual roadmap-sync-now function, which reads it directly. Keeping it out of
+// this shared module means the scheduled sync (which imports LINEAR_CUSTOM_VIEW_ID
+// from here via build-snapshot) does not fail at cold start when API_SECRET is
+// unset, since it never uses it.
 
 // Note: CDN cache purging uses Netlify's token-free purgeCache() from the
 // function runtime (see netlify/functions/utils/purge-roadmap-cache.mts), so no

--- a/src/linear/env.ts
+++ b/src/linear/env.ts
@@ -1,0 +1,37 @@
+// Server-only environment config for the roadmap Linear sync. Imported by the
+// build-snapshot module and the Netlify sync functions ONLY — never by the
+// roadmap page, so a missing LINEAR_API_KEY fails the sync job loudly without
+// breaking page rendering (the page reads the blob and shows an empty state).
+
+// Vite sets PROD; in the Netlify Function runtime import.meta.env is undefined,
+// so this defaults to true — missing required vars throw rather than silently
+// returning null.
+const isProd = import.meta.env?.PROD !== false
+
+// Netlify CLI sets NETLIFY_DEV=true when running `netlify dev` locally.
+export const isNetlifyDev = process.env.NETLIFY_DEV === 'true'
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value && isProd) {
+    throw new Error(`${name} is required in production`)
+  }
+  return value ?? ''
+}
+
+// Linear API key for fetching roadmap data (read-only scope is sufficient).
+export const LINEAR_API_KEY = requireEnv('LINEAR_API_KEY')
+
+// Linear custom view that defines the public roadmap. Non-secret, so it ships as
+// a default (the "Tech Team Roadmap" view from INTORG-636) and can be overridden.
+export const LINEAR_CUSTOM_VIEW_ID =
+  process.env.LINEAR_CUSTOM_VIEW_ID ?? '27df73bc-50ec-4fc1-bbb2-d906236a5bbc'
+
+// Bearer token for the manual POST /api/roadmap-sync trigger.
+export const API_SECRET = requireEnv('API_SECRET')
+
+// Optional: Netlify Personal Access Token for purging the CDN cache after a sync.
+export const NETLIFY_API_TOKEN = process.env.NETLIFY_API_TOKEN ?? null
+
+// Auto-injected by Netlify; set manually for local `netlify dev`.
+export const NETLIFY_SITE_ID = process.env.NETLIFY_SITE_ID ?? null

--- a/src/pages/developers/roadmap.astro
+++ b/src/pages/developers/roadmap.astro
@@ -7,6 +7,35 @@ import { ROADMAP_FIXTURE } from '@/data/roadmap/fixture'
 import { tryCatchAsync } from '@/utils'
 import type { Snapshot } from '@/types/roadmap'
 
+// Cached for the dev server's lifetime so reloads don't re-hit Linear on every
+// request. Dev-only; production never calls loadDevSnapshot().
+let liveDevSnapshot: Snapshot | undefined
+
+// Dev data source. Prefers live Linear data when a key is configured (so devs see
+// real content with just `netlify dev`, no manual sync) and falls back to the
+// bundled fixture otherwise. The dynamic import keeps build-snapshot — and its
+// required-env check in src/linear/env.ts — out of the production page runtime.
+async function loadDevSnapshot(): Promise<Snapshot | null> {
+  if (liveDevSnapshot) return liveDevSnapshot
+  if (process.env.LINEAR_API_KEY) {
+    const live = await tryCatchAsync(async () => {
+      const { buildSnapshot } = await import('@/linear/build-snapshot')
+      return buildSnapshot()
+    })
+    if (live instanceof Error) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[roadmap] dev: live Linear fetch failed, using fixture',
+        live
+      )
+    } else if (live) {
+      liveDevSnapshot = live
+      return live
+    }
+  }
+  return ROADMAP_FIXTURE
+}
+
 // SSR (INTORG-737): read the roadmap snapshot from Netlify Blobs at request time.
 // The scheduled sync function (netlify/functions/roadmap-sync) populates the store
 // from Linear; the CDN caches this rendered HTML between syncs (see the header below).
@@ -17,13 +46,15 @@ const result = await tryCatchAsync(async () => {
   })) as Snapshot | null
 })
 
-// Fall back to the bundled fixture only in local dev (plain `astro dev` has no
-// Netlify Blobs runtime, so getStore throws). In production a missing/failed blob
-// renders the page's empty state rather than placeholder data.
+// Local dev: the blob is usually empty (no scheduled sync has run), so source the
+// data here instead of making a dev hit the manual /api/roadmap-sync endpoint. With
+// LINEAR_API_KEY set we fetch Linear directly; otherwise we render the bundled
+// fixture so the page works with zero setup. In production a missing/failed blob
+// renders the empty state rather than placeholder data.
 const snapshot: Snapshot | null =
   result instanceof Error || !result
     ? import.meta.env.DEV
-      ? ROADMAP_FIXTURE
+      ? await loadDevSnapshot()
       : null
     : result
 

--- a/src/pages/developers/roadmap.astro
+++ b/src/pages/developers/roadmap.astro
@@ -1,0 +1,36 @@
+---
+export const prerender = false
+
+import { getStore } from '@netlify/blobs'
+import DevelopersRoadmapPage from '@/components/pages/DevelopersRoadmapPage.astro'
+import { ROADMAP_FIXTURE } from '@/data/roadmap/fixture'
+import { tryCatchAsync } from '@/utils'
+import type { Snapshot } from '@/types/roadmap'
+
+// SSR (INTORG-737): read the roadmap snapshot from Netlify Blobs at request time.
+// The scheduled sync function (netlify/functions/roadmap-sync) populates the store
+// from Linear; the CDN caches this rendered HTML between syncs (see the header below).
+const result = await tryCatchAsync(async () => {
+  const store = getStore('roadmap')
+  return (await store.get('roadmap-snapshot', {
+    type: 'json'
+  })) as Snapshot | null
+})
+
+// Fall back to the bundled fixture only in local dev (plain `astro dev` has no
+// Netlify Blobs runtime, so getStore throws). In production a missing/failed blob
+// renders the page's empty state rather than placeholder data.
+const snapshot: Snapshot | null =
+  result instanceof Error || !result
+    ? import.meta.env.DEV
+      ? ROADMAP_FIXTURE
+      : null
+    : result
+
+Astro.response.headers.set(
+  'Netlify-CDN-Cache-Control',
+  'public, max-age=43200, stale-while-revalidate=86400'
+)
+---
+
+<DevelopersRoadmapPage snapshot={snapshot} />

--- a/src/pages/developers/roadmap.astro
+++ b/src/pages/developers/roadmap.astro
@@ -3,38 +3,8 @@ export const prerender = false
 
 import { getStore } from '@netlify/blobs'
 import DevelopersRoadmapPage from '@/components/pages/DevelopersRoadmapPage.astro'
-import { ROADMAP_FIXTURE } from '@/data/roadmap/fixture'
-import { tryCatchAsync } from '@/utils'
+import { tryCatchAsync, loadDevSnapshot } from '@/utils'
 import type { Snapshot } from '@/types/roadmap'
-
-// Cached for the dev server's lifetime so reloads don't re-hit Linear on every
-// request. Dev-only; production never calls loadDevSnapshot().
-let liveDevSnapshot: Snapshot | undefined
-
-// Dev data source. Prefers live Linear data when a key is configured (so devs see
-// real content with just `netlify dev`, no manual sync) and falls back to the
-// bundled fixture otherwise. The dynamic import keeps build-snapshot — and its
-// required-env check in src/linear/env.ts — out of the production page runtime.
-async function loadDevSnapshot(): Promise<Snapshot | null> {
-  if (liveDevSnapshot) return liveDevSnapshot
-  if (process.env.LINEAR_API_KEY) {
-    const live = await tryCatchAsync(async () => {
-      const { buildSnapshot } = await import('@/linear/build-snapshot')
-      return buildSnapshot()
-    })
-    if (live instanceof Error) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        '[roadmap] dev: live Linear fetch failed, using fixture',
-        live
-      )
-    } else if (live) {
-      liveDevSnapshot = live
-      return live
-    }
-  }
-  return ROADMAP_FIXTURE
-}
 
 // SSR (INTORG-737): read the roadmap snapshot from Netlify Blobs at request time.
 // The scheduled sync function (netlify/functions/roadmap-sync) populates the store

--- a/src/pages/developers/roadmap.astro
+++ b/src/pages/developers/roadmap.astro
@@ -31,6 +31,8 @@ Astro.response.headers.set(
   'Netlify-CDN-Cache-Control',
   'public, max-age=43200, stale-while-revalidate=86400'
 )
+// Cache tag so the sync functions can purge just this page via purgeCache({ tags }).
+Astro.response.headers.set('Netlify-Cache-ID', 'roadmap')
 ---
 
 <DevelopersRoadmapPage snapshot={snapshot} />

--- a/src/types/roadmap.ts
+++ b/src/types/roadmap.ts
@@ -1,0 +1,38 @@
+export interface Milestone {
+  id: string
+  name: string
+  targetDate: string | null
+}
+
+export interface Team {
+  id: string
+  name: string
+  key: string
+  color: string | null
+  childrenIds: string[]
+  projectCount: number
+}
+
+export interface Project {
+  id: string
+  name: string
+  description: string | null
+  color: string | null
+  state: string
+  icon: string | null
+  priority: number
+  progress: number
+  sortOrder: number
+  startDate: string | null
+  targetDate: string | null
+  completedAt: string | null
+  url: string | null
+  team: { id: string; name: string; key: string; color: string | null } | null
+  milestones: Milestone[]
+}
+
+export interface Snapshot {
+  generatedAt: string
+  teams: Team[]
+  projects: Project[]
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -140,3 +140,29 @@ export {
   type CanonicalMeta,
   type HreflangMeta
 } from './main/seoMeta'
+
+// Main site: Roadmap (developers tech roadmap timeline)
+export {
+  createPositioner,
+  type TimelinePositioner
+} from './main/roadmap/timeline'
+export {
+  monthStart,
+  monthEnd,
+  computeDateRange,
+  roadmapWindow,
+  projectOverlapsWindow,
+  clampRangeToWindow
+} from './main/roadmap/dateRange'
+export {
+  buildMonths,
+  buildQuarterHeaders,
+  type MonthEntry,
+  type QuarterHeader
+} from './main/roadmap/grid'
+export { buildGridItems, type GridItem } from './main/roadmap/grouping'
+export {
+  computeProjectBarProps,
+  type ProjectBarProps
+} from './main/roadmap/projectBar'
+export { resolveIcon } from './main/roadmap/icons'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -166,3 +166,4 @@ export {
   type ProjectBarProps
 } from './main/roadmap/projectBar'
 export { resolveIcon } from './main/roadmap/icons'
+export { loadDevSnapshot } from './main/roadmap/devSnapshot'

--- a/src/utils/main/roadmap/dateRange.test.ts
+++ b/src/utils/main/roadmap/dateRange.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeDateRange,
+  monthStart,
+  monthEnd,
+  roadmapWindow,
+  projectOverlapsWindow,
+  clampRangeToWindow
+} from './dateRange'
+import { makeProject } from './test-fixtures'
+
+describe('monthStart / monthEnd', () => {
+  it('returns the first instant of the month (UTC)', () => {
+    expect(monthStart(2026, 0).toISOString()).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  it('returns the last instant of the month (UTC)', () => {
+    expect(monthEnd(2026, 1).toISOString()).toBe('2026-02-28T23:59:59.999Z')
+  })
+})
+
+describe('computeDateRange', () => {
+  it('falls back to now…now+1yr when there are no projects', () => {
+    const { minDate, maxDate } = computeDateRange([])
+    expect(maxDate.getUTCFullYear() - minDate.getUTCFullYear()).toBe(1)
+  })
+
+  it('spans the earliest and latest project dates', () => {
+    const projects = [
+      makeProject({ startDate: '2026-03-01', targetDate: '2026-08-01' }),
+      makeProject({
+        id: 'p2',
+        startDate: '2026-01-15',
+        targetDate: '2026-05-01'
+      })
+    ]
+    const { minDate, maxDate } = computeDateRange(projects)
+    expect(minDate.toISOString()).toBe('2026-01-15T00:00:00.000Z')
+    expect(maxDate.toISOString()).toBe('2026-08-01T00:00:00.000Z')
+  })
+
+  it('includes milestone target dates in the range', () => {
+    const projects = [
+      makeProject({
+        startDate: '2026-02-01',
+        targetDate: '2026-04-01',
+        milestones: [{ id: 'm1', name: 'M1', targetDate: '2026-11-01' }]
+      })
+    ]
+    const { maxDate } = computeDateRange(projects)
+    expect(maxDate.toISOString()).toBe('2026-11-01T00:00:00.000Z')
+  })
+
+  it('ignores null milestone dates', () => {
+    const projects = [
+      makeProject({
+        startDate: '2026-02-01',
+        targetDate: '2026-04-01',
+        milestones: [{ id: 'm1', name: 'M1', targetDate: null }]
+      })
+    ]
+    const { maxDate } = computeDateRange(projects)
+    expect(maxDate.toISOString()).toBe('2026-04-01T00:00:00.000Z')
+  })
+})
+
+describe('roadmapWindow', () => {
+  it('spans the current calendar year through the end of the next', () => {
+    const { start, end } = roadmapWindow(new Date(Date.UTC(2026, 5, 24)))
+    expect(start.toISOString()).toBe('2026-01-01T00:00:00.000Z')
+    expect(end.toISOString()).toBe('2027-12-31T23:59:59.999Z')
+  })
+
+  it('advances with the year (never goes stale)', () => {
+    const { start, end } = roadmapWindow(new Date(Date.UTC(2027, 0, 1)))
+    expect(start.getUTCFullYear()).toBe(2027)
+    expect(end.getUTCFullYear()).toBe(2028)
+  })
+})
+
+describe('projectOverlapsWindow', () => {
+  const start = new Date(Date.UTC(2026, 0, 1))
+  const end = new Date(Date.UTC(2027, 11, 31, 23, 59, 59, 999))
+
+  it('keeps a project spanning into the window', () => {
+    const p = makeProject({ startDate: '2023-01-01', targetDate: '2026-06-01' })
+    expect(projectOverlapsWindow(p, start, end)).toBe(true)
+  })
+
+  it('drops a project entirely before the window', () => {
+    const p = makeProject({ startDate: '2023-01-01', targetDate: '2024-12-31' })
+    expect(projectOverlapsWindow(p, start, end)).toBe(false)
+  })
+
+  it('drops a project entirely after the window', () => {
+    const p = makeProject({ startDate: '2028-01-01', targetDate: '2028-06-01' })
+    expect(projectOverlapsWindow(p, start, end)).toBe(false)
+  })
+
+  it('keeps an undated project (rendered as a no-bar row)', () => {
+    expect(projectOverlapsWindow(makeProject(), start, end)).toBe(true)
+  })
+
+  it('keeps a project that only overlaps via a milestone', () => {
+    const p = makeProject({
+      startDate: '2023-01-01',
+      targetDate: '2024-01-01',
+      milestones: [{ id: 'm', name: 'late', targetDate: '2026-03-01' }]
+    })
+    expect(projectOverlapsWindow(p, start, end)).toBe(true)
+  })
+})
+
+describe('clampRangeToWindow', () => {
+  const start = new Date(Date.UTC(2026, 0, 1))
+  const end = new Date(Date.UTC(2027, 11, 31, 23, 59, 59, 999))
+
+  it('clamps a wider data range to the window bounds', () => {
+    const { minDate, maxDate } = clampRangeToWindow(
+      new Date('2023-05-01'),
+      new Date('2029-01-01'),
+      start,
+      end
+    )
+    expect(minDate).toBe(start)
+    expect(maxDate).toBe(end)
+  })
+
+  it('leaves a narrower data range untouched', () => {
+    const dMin = new Date('2026-03-01')
+    const dMax = new Date('2026-09-01')
+    const { minDate, maxDate } = clampRangeToWindow(dMin, dMax, start, end)
+    expect(minDate).toBe(dMin)
+    expect(maxDate).toBe(dMax)
+  })
+})

--- a/src/utils/main/roadmap/dateRange.ts
+++ b/src/utils/main/roadmap/dateRange.ts
@@ -1,0 +1,84 @@
+import type { Project } from '@/types/roadmap'
+
+export function monthStart(year: number, month: number): Date {
+  return new Date(Date.UTC(year, month, 1))
+}
+
+export function monthEnd(year: number, month: number): Date {
+  return new Date(Date.UTC(year, month + 1, 0, 23, 59, 59, 999))
+}
+
+function projectDates(proj: Project): Date[] {
+  const dates: Date[] = []
+  if (proj.startDate) dates.push(new Date(proj.startDate))
+  if (proj.targetDate) dates.push(new Date(proj.targetDate))
+  if (proj.completedAt) dates.push(new Date(proj.completedAt))
+  for (const ms of proj.milestones) {
+    if (ms.targetDate) dates.push(new Date(ms.targetDate))
+  }
+  return dates
+}
+
+export function computeDateRange(projects: Project[]): {
+  minDate: Date
+  maxDate: Date
+} {
+  const allDates = projects.flatMap(projectDates)
+
+  const fallbackStart = new Date()
+  const fallbackEnd = new Date(fallbackStart)
+  fallbackEnd.setUTCFullYear(fallbackEnd.getUTCFullYear() + 1)
+
+  return {
+    minDate: allDates.length
+      ? new Date(Math.min(...allDates.map((d) => d.getTime())))
+      : fallbackStart,
+    maxDate: allDates.length
+      ? new Date(Math.max(...allDates.map((d) => d.getTime())))
+      : fallbackEnd
+  }
+}
+
+// The roadmap timeline is capped to a near-term window so old/long-running
+// projects don't stretch the axis back years and leave most rows looking empty
+// (Sarah's INTORG-636 note: "if we start in 2024, most projects look like they
+// have nothing going on"). The window is the current calendar year plus the next
+// one — i.e. 2026–2027 today — derived from `now` so it never goes stale.
+export function roadmapWindow(now: Date): { start: Date; end: Date } {
+  const year = now.getUTCFullYear()
+  return {
+    start: new Date(Date.UTC(year, 0, 1)),
+    end: new Date(Date.UTC(year + 1, 11, 31, 23, 59, 59, 999))
+  }
+}
+
+// A project belongs in the windowed view if its date span overlaps the window.
+// Undated projects are kept (they render as a labelled row with no bar and don't
+// affect the column range); projects whose activity is entirely outside the
+// window are dropped.
+export function projectOverlapsWindow(
+  proj: Project,
+  start: Date,
+  end: Date
+): boolean {
+  const dates = projectDates(proj)
+  if (dates.length === 0) return true
+  const times = dates.map((d) => d.getTime())
+  const min = Math.min(...times)
+  const max = Math.max(...times)
+  return max >= start.getTime() && min <= end.getTime()
+}
+
+// Clamp a data-derived range into the window bounds so the axis never extends
+// past it, while still shrinking to the data when the data is narrower.
+export function clampRangeToWindow(
+  minDate: Date,
+  maxDate: Date,
+  start: Date,
+  end: Date
+): { minDate: Date; maxDate: Date } {
+  return {
+    minDate: minDate < start ? start : minDate,
+    maxDate: maxDate > end ? end : maxDate
+  }
+}

--- a/src/utils/main/roadmap/devSnapshot.ts
+++ b/src/utils/main/roadmap/devSnapshot.ts
@@ -1,0 +1,78 @@
+import type { Snapshot } from '@/types/roadmap'
+import { tryCatchAsync } from '../../shared/tryCatch'
+
+// Dev-only snapshot source for /developers/roadmap. Plain `astro dev` has no
+// Netlify Blobs runtime, so the page can't read the production snapshot; this
+// fetches live Linear data when a key is configured and otherwise serves the
+// bundled fixture. Works under both `pnpm start` and `netlify dev`.
+
+// Re-fetch Linear at most once per window. The in-memory memo covers repeat
+// requests within one module instance; the on-disk cache bridges across HMR /
+// module reloads so a code edit doesn't force a fresh fetch on the next load.
+const DEV_CACHE_TTL_MS = 10 * 60 * 1000
+const DEV_CACHE_FILENAME = 'ilf-roadmap-dev-snapshot.json'
+
+let memo: Snapshot | undefined
+
+async function devCachePath(): Promise<string> {
+  const { tmpdir } = await import('node:os')
+  const { join } = await import('node:path')
+  return join(tmpdir(), DEV_CACHE_FILENAME)
+}
+
+// A missing, stale, or corrupt cache is not an error here — it just means we
+// fetch fresh, so all those cases collapse to null.
+async function readDiskCache(): Promise<Snapshot | null> {
+  const result = await tryCatchAsync(async () => {
+    const { readFile, stat } = await import('node:fs/promises')
+    const path = await devCachePath()
+    const ageMs = Date.now() - (await stat(path)).mtimeMs
+    if (ageMs > DEV_CACHE_TTL_MS) return null
+    return JSON.parse(await readFile(path, 'utf8')) as Snapshot
+  })
+  return result instanceof Error ? null : result
+}
+
+async function writeDiskCache(snapshot: Snapshot): Promise<void> {
+  // Best-effort: a failed write just means the next load re-fetches.
+  await tryCatchAsync(async () => {
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(await devCachePath(), JSON.stringify(snapshot), 'utf8')
+  })
+}
+
+async function loadFixture(): Promise<Snapshot> {
+  const { ROADMAP_FIXTURE } = await import('@/data/roadmap/fixture')
+  return ROADMAP_FIXTURE
+}
+
+export async function loadDevSnapshot(): Promise<Snapshot> {
+  if (memo) return memo
+
+  // `netlify dev` injects .env into process.env; plain `astro dev` only exposes
+  // it via import.meta.env. Read both so live data works under either command.
+  const apiKey = process.env.LINEAR_API_KEY || import.meta.env.LINEAR_API_KEY
+  if (!apiKey) return loadFixture()
+  // build-snapshot's Linear client reads the key from process.env at import
+  // time (src/linear/env.ts), so bridge the astro dev value across first.
+  process.env.LINEAR_API_KEY = apiKey
+
+  const cached = await readDiskCache()
+  if (cached) {
+    memo = cached
+    return cached
+  }
+
+  const live = await tryCatchAsync(async () => {
+    const { buildSnapshot } = await import('@/linear/build-snapshot')
+    return buildSnapshot()
+  })
+  if (live instanceof Error) {
+    console.warn('[roadmap] dev: live Linear fetch failed, using fixture', live)
+    return loadFixture()
+  }
+
+  memo = live
+  await writeDiskCache(live)
+  return live
+}

--- a/src/utils/main/roadmap/grid.test.ts
+++ b/src/utils/main/roadmap/grid.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { buildMonths, buildQuarterHeaders } from './grid'
+
+describe('buildMonths', () => {
+  it('emits one entry per month, inclusive of both ends', () => {
+    const months = buildMonths(
+      new Date(Date.UTC(2026, 0, 1)),
+      new Date(Date.UTC(2026, 2, 15))
+    )
+    expect(months.map((m) => m.label)).toEqual(['Jan', 'Feb', 'Mar'])
+  })
+
+  it('crosses the year boundary', () => {
+    const months = buildMonths(
+      new Date(Date.UTC(2026, 10, 1)),
+      new Date(Date.UTC(2027, 1, 1))
+    )
+    expect(months).toHaveLength(4)
+    expect(months[3]).toMatchObject({ year: 2027, month: 1 })
+  })
+
+  it('flags quarter starts and assigns 1-based columns (label = col 1)', () => {
+    const months = buildMonths(
+      new Date(Date.UTC(2026, 0, 1)),
+      new Date(Date.UTC(2026, 3, 1))
+    )
+    expect(months[0]).toMatchObject({ month: 0, isQuarterStart: true, col: 2 })
+    expect(months[3]).toMatchObject({ month: 3, isQuarterStart: true, col: 5 })
+  })
+})
+
+describe('buildQuarterHeaders', () => {
+  it('groups months into quarter spans labelled by quarter and year', () => {
+    const months = buildMonths(
+      new Date(Date.UTC(2026, 0, 1)),
+      new Date(Date.UTC(2026, 4, 1))
+    )
+    const headers = buildQuarterHeaders(months)
+    expect(headers).toEqual([
+      { label: 'Q1 2026', q: 1, year: 2026, colStart: 2, span: 3 },
+      { label: 'Q2 2026', q: 2, year: 2026, colStart: 5, span: 2 }
+    ])
+  })
+
+  it('does not merge the same quarter number across different years', () => {
+    const months = buildMonths(
+      new Date(Date.UTC(2026, 0, 1)),
+      new Date(Date.UTC(2027, 0, 1))
+    )
+    const headers = buildQuarterHeaders(months)
+    const q1s = headers.filter((h) => h.q === 1)
+    expect(q1s.map((h) => h.year)).toEqual([2026, 2027])
+  })
+})

--- a/src/utils/main/roadmap/grid.ts
+++ b/src/utils/main/roadmap/grid.ts
@@ -1,0 +1,74 @@
+import { monthStart, monthEnd } from './dateRange'
+
+export interface MonthEntry {
+  label: string
+  year: number
+  month: number // 0-11
+  start: Date
+  end: Date
+  isQuarterStart: boolean
+  col: number // 1-based; col 1 = label, months start at col 2
+}
+
+export interface QuarterHeader {
+  label: string
+  q: number
+  year: number
+  colStart: number
+  span: number
+}
+
+export function buildMonths(minDate: Date, maxDate: Date): MonthEntry[] {
+  const months: MonthEntry[] = []
+  let cm = minDate.getUTCMonth()
+  let cmy = minDate.getUTCFullYear()
+  const endYear = maxDate.getUTCFullYear()
+  const endMonth = maxDate.getUTCMonth()
+
+  while (cmy < endYear || (cmy === endYear && cm <= endMonth)) {
+    months.push({
+      label: new Date(Date.UTC(cmy, cm, 1)).toLocaleString('en-US', {
+        month: 'short'
+      }),
+      year: cmy,
+      month: cm,
+      start: monthStart(cmy, cm),
+      end: monthEnd(cmy, cm),
+      isQuarterStart: cm % 3 === 0,
+      col: months.length + 2
+    })
+    cm++
+    if (cm > 11) {
+      cm = 0
+      cmy++
+    }
+  }
+
+  return months
+}
+
+export function buildQuarterHeaders(months: MonthEntry[]): QuarterHeader[] {
+  const headers: QuarterHeader[] = []
+  let mi = 0
+
+  while (mi < months.length) {
+    const m = months[mi]
+    const q = Math.floor(m.month / 3) + 1
+    let span = 0
+    while (mi + span < months.length) {
+      const nm = months[mi + span]
+      if (Math.floor(nm.month / 3) + 1 !== q || nm.year !== m.year) break
+      span++
+    }
+    headers.push({
+      label: `Q${q} ${m.year}`,
+      q,
+      year: m.year,
+      colStart: m.col,
+      span
+    })
+    mi += span
+  }
+
+  return headers
+}

--- a/src/utils/main/roadmap/grid.ts
+++ b/src/utils/main/roadmap/grid.ts
@@ -28,7 +28,8 @@ export function buildMonths(minDate: Date, maxDate: Date): MonthEntry[] {
   while (cmy < endYear || (cmy === endYear && cm <= endMonth)) {
     months.push({
       label: new Date(Date.UTC(cmy, cm, 1)).toLocaleString('en-US', {
-        month: 'short'
+        month: 'short',
+        timeZone: 'UTC'
       }),
       year: cmy,
       month: cm,

--- a/src/utils/main/roadmap/grouping.test.ts
+++ b/src/utils/main/roadmap/grouping.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { buildGridItems } from './grouping'
+import { makeProject, makeTeam } from './test-fixtures'
+
+describe('buildGridItems', () => {
+  it('emits a team header followed by its projects, sorted by sortOrder', () => {
+    const team = makeTeam({ id: 't1', name: 'Rafiki' })
+    const projects = [
+      makeProject({
+        id: 'b',
+        sortOrder: 2,
+        team: { id: 't1', name: 'Rafiki', key: 'RAF', color: null }
+      }),
+      makeProject({
+        id: 'a',
+        sortOrder: 1,
+        team: { id: 't1', name: 'Rafiki', key: 'RAF', color: null }
+      })
+    ]
+    const items = buildGridItems(projects, [team])
+    expect(
+      items.map((i) =>
+        i.type === 'team-header' ? `team:${i.team.name}` : i.project.id
+      )
+    ).toEqual(['team:Rafiki', 'a', 'b'])
+  })
+
+  it('pulls sub-team projects under their parent team', () => {
+    const parent = makeTeam({
+      id: 'parent',
+      name: 'Parent',
+      childrenIds: ['child']
+    })
+    const child = makeTeam({ id: 'child', name: 'Child' })
+    const projects = [
+      makeProject({
+        id: 'cp',
+        team: { id: 'child', name: 'Child', key: 'C', color: null }
+      })
+    ]
+    const items = buildGridItems(projects, [parent, child])
+    // Child is not a root team, so only the parent header appears.
+    const headers = items.filter((i) => i.type === 'team-header')
+    expect(headers).toHaveLength(1)
+    expect(headers[0].type === 'team-header' && headers[0].team.name).toBe(
+      'Parent'
+    )
+  })
+
+  it('skips teams that have no projects', () => {
+    const empty = makeTeam({ id: 'empty', name: 'Empty' })
+    expect(buildGridItems([], [empty])).toEqual([])
+  })
+
+  it('appends projects with no team after the grouped ones', () => {
+    const team = makeTeam({ id: 't1', name: 'Rafiki' })
+    const projects = [
+      makeProject({
+        id: 'grouped',
+        team: { id: 't1', name: 'Rafiki', key: 'R', color: null }
+      }),
+      makeProject({ id: 'orphan', team: null })
+    ]
+    const items = buildGridItems(projects, [team])
+    const last = items[items.length - 1]
+    expect(last.type === 'project' && last.project.id).toBe('orphan')
+  })
+
+  it('assigns running 1-based row numbers across headers and projects', () => {
+    const team = makeTeam({ id: 't1', name: 'A' })
+    const projects = [
+      makeProject({
+        id: 'a',
+        sortOrder: 1,
+        team: { id: 't1', name: 'A', key: 'A', color: null }
+      }),
+      makeProject({
+        id: 'b',
+        sortOrder: 2,
+        team: { id: 't1', name: 'A', key: 'A', color: null }
+      })
+    ]
+    const items = buildGridItems(projects, [team])
+    expect(items.map((i) => i.row)).toEqual([1, 2, 3])
+  })
+})

--- a/src/utils/main/roadmap/grouping.ts
+++ b/src/utils/main/roadmap/grouping.ts
@@ -1,0 +1,61 @@
+import type { Project, Team } from '@/types/roadmap'
+
+// Purely structural: a flat, ordered list of team-header and project rows. It
+// carries no per-team/per-project color from Linear — RoadmapBoard applies
+// accessible alternating row colors instead, per Sarah's INTORG-636 / INTORG-737
+// feedback (Linear colors were flagged for insufficient contrast).
+export type GridItem =
+  | { type: 'team-header'; team: Team; row: number }
+  | { type: 'project'; project: Project; row: number }
+
+export function buildGridItems(projects: Project[], teams: Team[]): GridItem[] {
+  const teamMap = new Map(teams.map((t) => [t.id, t]))
+  const allChildIds = new Set(teams.flatMap((t) => t.childrenIds))
+  const rootTeams = teams.filter((t) => !allChildIds.has(t.id))
+
+  const projectsByTeamId = new Map<string, Project[]>()
+  for (const proj of projects) {
+    if (!proj.team) continue
+    const tid = proj.team.id
+    if (!projectsByTeamId.has(tid)) projectsByTeamId.set(tid, [])
+    projectsByTeamId.get(tid)!.push(proj)
+  }
+
+  function collectTeamProjects(teamId: string): Project[] {
+    const team = teamMap.get(teamId)
+    if (!team) return []
+    const own = projectsByTeamId.get(teamId) ?? []
+    const fromChildren = team.childrenIds.flatMap(
+      (cid) => projectsByTeamId.get(cid) ?? []
+    )
+    return [...own, ...fromChildren].sort((a, b) => a.sortOrder - b.sortOrder)
+  }
+
+  const gridItems: GridItem[] = []
+  let currentRow = 1
+
+  for (const rootTeam of rootTeams) {
+    const teamProjects = collectTeamProjects(rootTeam.id)
+    if (teamProjects.length === 0) continue
+    gridItems.push({ type: 'team-header', team: rootTeam, row: currentRow })
+    currentRow++
+    for (const proj of teamProjects) {
+      gridItems.push({ type: 'project', project: proj, row: currentRow })
+      currentRow++
+    }
+  }
+
+  const assignedIds = new Set(
+    gridItems.flatMap((i) => (i.type === 'project' ? [i.project.id] : []))
+  )
+  const uncategorised = projects
+    .filter((p) => !assignedIds.has(p.id))
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+
+  for (const proj of uncategorised) {
+    gridItems.push({ type: 'project', project: proj, row: currentRow })
+    currentRow++
+  }
+
+  return gridItems
+}

--- a/src/utils/main/roadmap/icons.test.ts
+++ b/src/utils/main/roadmap/icons.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { resolveIcon } from './icons'
+
+describe('resolveIcon', () => {
+  it('maps a Linear icon name to an emoji', () => {
+    expect(resolveIcon('Rocket')).toBe('🚀')
+  })
+
+  it('maps a Slack-style shortcode to a flag emoji', () => {
+    expect(resolveIcon(':flag-za:')).toBe('🇿🇦')
+  })
+
+  it('passes through a raw emoji', () => {
+    expect(resolveIcon('🎯')).toBe('🎯')
+  })
+
+  it('returns null for an unknown name', () => {
+    expect(resolveIcon('NotARealIcon')).toBeNull()
+  })
+
+  it('returns null for null/empty input', () => {
+    expect(resolveIcon(null)).toBeNull()
+    expect(resolveIcon(undefined)).toBeNull()
+    expect(resolveIcon('')).toBeNull()
+  })
+})

--- a/src/utils/main/roadmap/icons.ts
+++ b/src/utils/main/roadmap/icons.ts
@@ -1,0 +1,55 @@
+const LINEAR_ICON_EMOJI: Record<string, string> = {
+  AiDocument: '📄',
+  AlarmClock: '⏰',
+  Asterisk: '✳️',
+  Basket: '🧺',
+  Bookmark: '🔖',
+  Bug: '🐛',
+  Calendar: '📅',
+  Chart: '📊',
+  Chrome: '🌐',
+  CodeBlock: '💻',
+  CreditCard: '💳',
+  Dashboard: '📊',
+  Direction: '➡️',
+  Dollar: '💲',
+  DollarBill: '💵',
+  Education: '🎓',
+  Favorite: '⭐',
+  GitHub: '🐙',
+  Golf: '⛳',
+  Hack: '💻',
+  IssueStatusBacklog: '⏳',
+  Leaf: '🍃',
+  Lock: '🔒',
+  Mic: '🎤',
+  MobilePhone: '📱',
+  Modem: '📡',
+  MoneyStack: '💰',
+  NotePad: '📝',
+  Phone: '📞',
+  Project: '📁',
+  Robot: '🤖',
+  Rocket: '🚀',
+  Routing: '🔀',
+  Shrug: '🤷',
+  Stadium: '🏟️',
+  Surfer: '🏄',
+  Users: '👥',
+  Write: '✍️'
+}
+
+const SLACK_EMOJI: Record<string, string> = {
+  ':flag-ca:': '🇨🇦',
+  ':flag-eu:': '🇪🇺',
+  ':flag-za:': '🇿🇦',
+  ':us:': '🇺🇸'
+}
+
+export function resolveIcon(icon: string | null | undefined): string | null {
+  if (!icon) return null
+  if (SLACK_EMOJI[icon]) return SLACK_EMOJI[icon]
+  if (LINEAR_ICON_EMOJI[icon]) return LINEAR_ICON_EMOJI[icon]
+  if (/\p{Emoji_Presentation}/u.test(icon)) return icon
+  return null
+}

--- a/src/utils/main/roadmap/projectBar.test.ts
+++ b/src/utils/main/roadmap/projectBar.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { computeProjectBarProps } from './projectBar'
+import { createPositioner } from './timeline'
+import { makeProject } from './test-fixtures'
+
+const pos = createPositioner(Date.UTC(2026, 0, 1), Date.UTC(2027, 0, 1))
+
+describe('computeProjectBarProps', () => {
+  it('reports a duration bar when both start and target dates are set', () => {
+    const props = computeProjectBarProps(
+      makeProject({ startDate: '2026-01-01', targetDate: '2026-07-01' }),
+      pos
+    )
+    expect(props.hasDates).toBe(true)
+    expect(props.barLeft).toBe('0.00')
+    expect(Number(props.barWidth)).toBeGreaterThan(0)
+  })
+
+  it('has no duration bar when dates are missing', () => {
+    const props = computeProjectBarProps(makeProject(), pos)
+    expect(props.hasDates).toBe(false)
+    expect(props.barLeft).toBeNull()
+    expect(props.barWidth).toBeNull()
+  })
+
+  it('renders a completed bar when there is a start + completedAt but no target', () => {
+    const props = computeProjectBarProps(
+      makeProject({
+        startDate: '2026-02-01',
+        targetDate: null,
+        completedAt: '2026-05-01'
+      }),
+      pos
+    )
+    expect(props.hasCompletedBar).toBe(true)
+    expect(props.completedBarLeft).not.toBeNull()
+  })
+
+  it('adds an extension when a milestone lands beyond the target date', () => {
+    const props = computeProjectBarProps(
+      makeProject({
+        startDate: '2026-01-01',
+        targetDate: '2026-06-01',
+        milestones: [{ id: 'm1', name: 'late', targetDate: '2026-10-01' }]
+      }),
+      pos
+    )
+    expect(props.hasExtension).toBe(true)
+    expect(props.extensionWidth).not.toBeNull()
+  })
+
+  it('keeps only milestones that have a target date', () => {
+    const props = computeProjectBarProps(
+      makeProject({
+        startDate: '2026-01-01',
+        targetDate: '2026-06-01',
+        milestones: [
+          { id: 'm1', name: 'dated', targetDate: '2026-03-01' },
+          { id: 'm2', name: 'undated', targetDate: null }
+        ]
+      }),
+      pos
+    )
+    expect(props.datedMilestones.map((m) => m.id)).toEqual(['m1'])
+  })
+})

--- a/src/utils/main/roadmap/projectBar.test.ts
+++ b/src/utils/main/roadmap/projectBar.test.ts
@@ -16,6 +16,32 @@ describe('computeProjectBarProps', () => {
     expect(Number(props.barWidth)).toBeGreaterThan(0)
   })
 
+  it('clamps a bar that spans beyond the window so left + width never exceeds 100%', () => {
+    // Spans well before and after the 2026 window. An unclamped width here would
+    // overflow the track and create phantom horizontal scroll (breaks the sticky
+    // label column). Both endpoints clamp to [0,100], so the bar fills the window.
+    const props = computeProjectBarProps(
+      makeProject({ startDate: '2024-01-01', targetDate: '2028-06-01' }),
+      pos
+    )
+    expect(props.barLeft).toBe('0.00')
+    expect(Number(props.barLeft) + Number(props.barWidth)).toBeLessThanOrEqual(
+      100
+    )
+    expect(props.barWidth).toBe('100.00')
+  })
+
+  it('keeps a bar starting before the window within bounds', () => {
+    const props = computeProjectBarProps(
+      makeProject({ startDate: '2023-06-01', targetDate: '2026-07-01' }),
+      pos
+    )
+    expect(props.barLeft).toBe('0.00')
+    expect(Number(props.barLeft) + Number(props.barWidth)).toBeLessThanOrEqual(
+      100
+    )
+  })
+
   it('has no duration bar when dates are missing', () => {
     const props = computeProjectBarProps(makeProject(), pos)
     expect(props.hasDates).toBe(false)

--- a/src/utils/main/roadmap/projectBar.ts
+++ b/src/utils/main/roadmap/projectBar.ts
@@ -1,0 +1,80 @@
+import type { Project, Milestone } from '@/types/roadmap'
+import type { TimelinePositioner } from './timeline'
+
+export interface ProjectBarProps {
+  hasDates: boolean
+  barLeft: string | null
+  barWidth: string | null
+  hasCompletedBar: boolean
+  completedBarLeft: string | null
+  completedBarWidth: string | null
+  hasExtension: boolean
+  extensionLeft: string | null
+  extensionWidth: string | null
+  datedMilestones: Milestone[]
+}
+
+export function computeProjectBarProps(
+  proj: Project,
+  pos: TimelinePositioner
+): ProjectBarProps {
+  const hasDates = !!(proj.startDate && proj.targetDate)
+  const barLeft = hasDates
+    ? pos.pctLeft(new Date(proj.startDate!)).toFixed(2)
+    : null
+  const barWidth = hasDates
+    ? pos
+        .pctWidth(new Date(proj.startDate!), new Date(proj.targetDate!))
+        .toFixed(2)
+    : null
+
+  const datedMilestones = proj.milestones.filter((ms) => ms.targetDate)
+
+  const hasCompletedBar = !!(
+    proj.startDate &&
+    !proj.targetDate &&
+    proj.completedAt
+  )
+  const completedBarLeft = hasCompletedBar
+    ? pos.pctLeft(new Date(proj.startDate!)).toFixed(2)
+    : null
+  const completedBarWidth = hasCompletedBar
+    ? pos
+        .pctWidth(new Date(proj.startDate!), new Date(proj.completedAt!))
+        .toFixed(2)
+    : null
+
+  const lastMilestoneDate =
+    datedMilestones.length > 0
+      ? new Date(
+          Math.max(
+            ...datedMilestones.map((ms) => new Date(ms.targetDate!).getTime())
+          )
+        )
+      : null
+
+  const hasExtension =
+    hasDates &&
+    lastMilestoneDate !== null &&
+    lastMilestoneDate > new Date(proj.targetDate!)
+  const extensionLeft = hasExtension
+    ? pos.pctLeft(new Date(proj.targetDate!)).toFixed(2)
+    : null
+  const extensionWidth =
+    hasExtension && lastMilestoneDate
+      ? pos.pctWidth(new Date(proj.targetDate!), lastMilestoneDate).toFixed(2)
+      : null
+
+  return {
+    hasDates,
+    barLeft,
+    barWidth,
+    hasCompletedBar,
+    completedBarLeft,
+    completedBarWidth,
+    hasExtension,
+    extensionLeft,
+    extensionWidth,
+    datedMilestones
+  }
+}

--- a/src/utils/main/roadmap/projectBar.ts
+++ b/src/utils/main/roadmap/projectBar.ts
@@ -14,18 +14,33 @@ export interface ProjectBarProps {
   datedMilestones: Milestone[]
 }
 
+// Keep a sliver visible for in-window bars whose span rounds to ~0%.
+const MIN_VISIBLE_WIDTH = 0.5
+
+// A bar runs from `start` to `end`, but both endpoints are clamped to the
+// visible window (pctLeft is 0–100), and the width is the gap between them. This
+// guarantees `left + width <= 100`, so a project that starts before or ends after
+// the window can't render a bar wider than the track. An unclamped width here
+// would overflow the track, inflate the scroll container's scrollWidth, and break
+// the sticky label column (the column releases once you scroll past the table).
+function clampedBar(
+  pos: TimelinePositioner,
+  start: Date,
+  end: Date
+): { left: string; width: string } {
+  const left = pos.pctLeft(start)
+  const right = pos.pctLeft(end)
+  const width = Math.min(Math.max(right - left, MIN_VISIBLE_WIDTH), 100 - left)
+  return { left: left.toFixed(2), width: Math.max(width, 0).toFixed(2) }
+}
+
 export function computeProjectBarProps(
   proj: Project,
   pos: TimelinePositioner
 ): ProjectBarProps {
   const hasDates = !!(proj.startDate && proj.targetDate)
-  const barLeft = hasDates
-    ? pos.pctLeft(new Date(proj.startDate!)).toFixed(2)
-    : null
-  const barWidth = hasDates
-    ? pos
-        .pctWidth(new Date(proj.startDate!), new Date(proj.targetDate!))
-        .toFixed(2)
+  const bar = hasDates
+    ? clampedBar(pos, new Date(proj.startDate!), new Date(proj.targetDate!))
     : null
 
   const datedMilestones = proj.milestones.filter((ms) => ms.targetDate)
@@ -35,13 +50,8 @@ export function computeProjectBarProps(
     !proj.targetDate &&
     proj.completedAt
   )
-  const completedBarLeft = hasCompletedBar
-    ? pos.pctLeft(new Date(proj.startDate!)).toFixed(2)
-    : null
-  const completedBarWidth = hasCompletedBar
-    ? pos
-        .pctWidth(new Date(proj.startDate!), new Date(proj.completedAt!))
-        .toFixed(2)
+  const completedBar = hasCompletedBar
+    ? clampedBar(pos, new Date(proj.startDate!), new Date(proj.completedAt!))
     : null
 
   const lastMilestoneDate =
@@ -57,24 +67,21 @@ export function computeProjectBarProps(
     hasDates &&
     lastMilestoneDate !== null &&
     lastMilestoneDate > new Date(proj.targetDate!)
-  const extensionLeft = hasExtension
-    ? pos.pctLeft(new Date(proj.targetDate!)).toFixed(2)
-    : null
-  const extensionWidth =
+  const extension =
     hasExtension && lastMilestoneDate
-      ? pos.pctWidth(new Date(proj.targetDate!), lastMilestoneDate).toFixed(2)
+      ? clampedBar(pos, new Date(proj.targetDate!), lastMilestoneDate)
       : null
 
   return {
     hasDates,
-    barLeft,
-    barWidth,
+    barLeft: bar?.left ?? null,
+    barWidth: bar?.width ?? null,
     hasCompletedBar,
-    completedBarLeft,
-    completedBarWidth,
+    completedBarLeft: completedBar?.left ?? null,
+    completedBarWidth: completedBar?.width ?? null,
     hasExtension,
-    extensionLeft,
-    extensionWidth,
+    extensionLeft: extension?.left ?? null,
+    extensionWidth: extension?.width ?? null,
     datedMilestones
   }
 }

--- a/src/utils/main/roadmap/test-fixtures.ts
+++ b/src/utils/main/roadmap/test-fixtures.ts
@@ -1,0 +1,36 @@
+import type { Project, Team } from '@/types/roadmap'
+
+// Test-only factories. Not exported through the utils barrel.
+
+export function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'p1',
+    name: 'Project',
+    description: null,
+    color: null,
+    state: 'started',
+    icon: null,
+    priority: 0,
+    progress: 0,
+    sortOrder: 0,
+    startDate: null,
+    targetDate: null,
+    completedAt: null,
+    url: null,
+    team: null,
+    milestones: [],
+    ...overrides
+  }
+}
+
+export function makeTeam(overrides: Partial<Team> = {}): Team {
+  return {
+    id: 't1',
+    name: 'Team',
+    key: 'TEAM',
+    color: null,
+    childrenIds: [],
+    projectCount: 0,
+    ...overrides
+  }
+}

--- a/src/utils/main/roadmap/timeline.test.ts
+++ b/src/utils/main/roadmap/timeline.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { createPositioner } from './timeline'
+
+const START = Date.UTC(2026, 0, 1)
+const END = Date.UTC(2027, 0, 1)
+
+describe('createPositioner', () => {
+  const pos = createPositioner(START, END)
+
+  it('returns 0% at the timeline start and 100% at the end', () => {
+    expect(pos.pctLeft(new Date(START))).toBe(0)
+    expect(pos.pctLeft(new Date(END))).toBe(100)
+  })
+
+  it('clamps dates outside the range to 0–100', () => {
+    expect(pos.pctLeft(new Date(Date.UTC(2020, 0, 1)))).toBe(0)
+    expect(pos.pctLeft(new Date(Date.UTC(2030, 0, 1)))).toBe(100)
+  })
+
+  it('positions a mid-range date proportionally', () => {
+    const mid = createPositioner(0, 100).pctLeft(new Date(50))
+    expect(mid).toBeCloseTo(50)
+  })
+
+  it('enforces a minimum visible width of 0.5%', () => {
+    const d = new Date(START)
+    expect(pos.pctWidth(d, d)).toBe(0.5)
+  })
+
+  it('computes width proportional to the span', () => {
+    const p = createPositioner(0, 100)
+    expect(p.pctWidth(new Date(10), new Date(40))).toBeCloseTo(30)
+  })
+})

--- a/src/utils/main/roadmap/timeline.ts
+++ b/src/utils/main/roadmap/timeline.ts
@@ -1,0 +1,28 @@
+export interface TimelinePositioner {
+  timelineStart: number
+  timelineEnd: number
+  totalMs: number
+  pctLeft(date: Date): number
+  pctWidth(start: Date, end: Date): number
+}
+
+export function createPositioner(
+  timelineStart: number,
+  timelineEnd: number
+): TimelinePositioner {
+  const totalMs = timelineEnd - timelineStart
+  return {
+    timelineStart,
+    timelineEnd,
+    totalMs,
+    pctLeft(date: Date): number {
+      return Math.max(
+        0,
+        Math.min(100, ((date.getTime() - timelineStart) / totalMs) * 100)
+      )
+    },
+    pctWidth(start: Date, end: Date): number {
+      return Math.max(((end.getTime() - start.getTime()) / totalMs) * 100, 0.5)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Brings the public tech roadmap over from the standalone `interledger.org-developers` repo into v5, following Adi's merged PR #215. It is an SSR page at `/developers/roadmap` that reads a Linear snapshot from Netlify Blobs at request time. Two sync functions keep that snapshot fresh from the Linear API (details below), and the CDN caches the rendered HTML in between so in production the page itself never calls Linear.

- A timeline board grouped by team, with project duration bars, completed/extension bars, and milestone diamonds.
- Alternating row colors instead of Linear's per-project colors. This fixes the contrast issues Sarah raised on INTORG-636.
- A sticky header row, horizontal scrolling with a frozen left label column, and a quarter/full-timeline toggle on mobile.
- Umami analytics on milestone interactions.
- The timeline is capped to the current and next year, so older projects don't stretch the axis back years and leave rows looking empty.

Data wiring:

- The page reads the snapshot with `@netlify/blobs`. The `@linear/sdk` snapshot builder is ported from the source repo.
- `roadmap-sync` runs on a 12h cron. `roadmap-sync-now` is a manual `POST /api/roadmap-sync` (bearer auth, rate limited) for forcing an immediate refresh in deployed environments. Both fetch Linear, write the blob, and purge the CDN cache.
- Local dev needs no secrets and no manual sync. With no key set, the page renders a bundled fixture so it works with zero setup. Set `LINEAR_API_KEY` and the dev page fetches Linear directly under either `pnpm start` or `netlify dev` (the helper reads the key from both `process.env` and `import.meta.env`). The live snapshot is cached in-memory plus a 10-minute on-disk cache that survives HMR/restarts, so Linear is hit at most once per 10 min in dev. The env vars and the manual POST endpoint only matter for deployed environments; production shows an empty state until the blob is populated.

Caching:

- The page is served via Netlify Durable Cache (`Netlify-CDN-Cache-Control`, 12h), tagged `roadmap`. Durable Cache persists across deploys by design, so the data syncs purge the `roadmap` tag whenever they write the blob.
- Because Durable Cache survives deploys, a code/CSS-only change would otherwise keep serving stale HTML until the cache expired. The new `netlify/plugins/purge-roadmap` build plugin closes that gap: its `onSuccess` hook purges the `roadmap` tag on every deploy, so code changes show up immediately. It runs in the build context (auto-authenticated, deploy-scoped).

## Related Issue

Fixes INTORG-737

## Manual Test

- Fixture: `pnpm start`, open `/developers/roadmap`. The board renders with bundled fixture data, no secrets required.
- Live data: set `LINEAR_API_KEY` in `.env`, run `pnpm start` (or `netlify dev`), open `/developers/roadmap`. The page fetches Linear directly — no POST needed — and caches the result for 10 min so reloads/edits don't re-fetch.
- Cache purge on deploy: after a deploy, the Netlify build log shows `[purge-roadmap] purged roadmap CDN cache after deploy`, and the page reflects code changes without a manual sync.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [ ] Scope is focused
- [x] Screenshots for UI changes

<img width="850" height="415" alt="Screenshot 2026-06-25 at 3 44 49 PM" src="https://github.com/user-attachments/assets/25452612-f47f-4fc2-b4f0-a4b29ddf4dcb" />

<img width="451" height="788" alt="Screenshot 2026-06-25 at 3 45 04 PM" src="https://github.com/user-attachments/assets/ba83aa38-7800-42d6-973e-bc800258fe9c" />

<img width="385" height="728" alt="Screenshot 2026-06-25 at 3 45 17 PM" src="https://github.com/user-attachments/assets/b17755ee-f386-4a25-ad43-665c46e03fc1" />

