### PR TITLE
fix(blog): update border-radius tokens to match Figma

### DIFF
--- a/src/components/blog/BlogPostHeader.astro
+++ b/src/components/blog/BlogPostHeader.astro
@@ -79,7 +79,7 @@ const blogPath = translatePath(
   </div>
   {
     frontmatter.featureImage && (
-      <div class="mb-3xl rounded-3xl overflow-hidden tablet:mb-4xl desktop:mb-5xl">
+      <div class="mb-3xl tablet:mb-4xl desktop:mb-5xl">
         <picture>
           {frontmatter.featureImageMobile && (
             <source
@@ -97,7 +97,7 @@ const blogPath = translatePath(
             loading="eager"
             fetchpriority="high"
             decoding="async"
-            class="w-full h-auto"
+            class="w-full h-auto rounded-3xl"
           />
         </picture>
       </div>

--- a/src/styles/components/prose/blog.css
+++ b/src/styles/components/prose/blog.css
@@ -34,7 +34,7 @@
     img {
       display: block;
       margin-inline: auto;
-      border-radius: var(--spacing-3xl);
+      border-radius: var(--radius-3xl);
     }
 
     /* === Table styles === */
@@ -147,7 +147,7 @@
     }
 
     .video-embed {
-      border-radius: var(--spacing-3xl);
+      border-radius: var(--radius-3xl);
       overflow: hidden;
       margin-block-end: var(--spacing-2xl)
     }


### PR DESCRIPTION
## Summary
The border radius for the blog feature images was too large (48px). This PR corrected it to 24px.

Two places in prose/blog.css (for images and EmbedVideos) were using var(--spacing-3xl) = 48px for border-radius instead of var(--radius-3xl) = 24px. 

## Related Issue
Fixes [INTORG-826](https://linear.app/interledger/issue/INTORG-826/the-corner-radius-should-be-24px-for-the-blog-feature-image)

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
