### PR TITLE
fix(breadcrumbs): clamp long crumb names to 2 lines

### DIFF
--- a/src/components/shared/Breadcrumbs.astro
+++ b/src/components/shared/Breadcrumbs.astro
@@ -48,7 +48,9 @@ const t = useTranslations(routeLocale)
                 linkText: crumb.name
               })}
             >
-              <span itemprop="name">{crumb.name}</span>
+              <span itemprop="name" class="line-clamp-2" title={crumb.name}>
+                {crumb.name}
+              </span>
             </a>
             <meta itemprop="position" content={String(index + 1)} />
           </li>


### PR DESCRIPTION
## Summary
On mobile, the last breadcrumb on the blog page could wrap up to 5 lines for long titles. This PR limits it to a maximum of 2 lines, while preserving full title visibility on larger screens instead of truncating at a fixed width.

<img width="332" height="771" alt="image" src="https://github.com/user-attachments/assets/7b6bd822-8c71-4159-8d3a-cebd157f1323" />
 ⬇️ 
<img width="373" height="798" alt="image" src="https://github.com/user-attachments/assets/7674a514-0ad1-4c37-af14-11b3fdd05887" />

## Related Issue
Fixes [INTORG-825](https://linear.app/interledger/issue/INTORG-825/breadcrumb-menus-should-have-a-limit-for-number-of-characters)

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)
