### PR TITLE
chore: update ADR to reflect how best to handle template pages

### DIFF
--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -18,17 +18,15 @@ Additionally, two concerns must stay separate but coordinate correctly: content 
 
 ### Editor experience in Strapi
 
-Editors create a new page by choosing a template type first: FAQ, grant, profile, or custom page. The template type determines what fields are available and what the page composition looks like — not which section it belongs to.
+Editors create a new page by choosing between the page options (a profile template, a blog template, a grant template, or a custom page, etc.). The template type determines what fields are available and what the page composition looks like — not which section it belongs to.
 
-Once a template is selected, the editor provides a required field before filling in content:
+ALl pages have a common required field:
 
 - **Path** — composed from three parts in the UI: a static `interledger.org` label, a section dropdown (`/`, `/summit`, `/hackathon`), and a free-text slug field for the remaining path. Together these produce the full URL, e.g. `interledger.org/summit/speakers/jane-doe`. The section dropdown is the canonical way an editor assigns a page to a section — no free-text prefix to mistype.
 
-Strapi stores section and slug as separate fields and validates their combination via `beforeCreate`/`beforeUpdate` hooks. Astro verifies the section has a matching `LAYOUT_MAP` entry at build time — a mismatch fails the build.
-
 ### Template type as frontmatter bridge
 
-When an editor creates a page in Strapi, `templateType`, `section`, and `locale` are written into the exported MDX frontmatter. Astro reads these to select the correct collection, layout, and rendering behaviour.
+When an editor creates a page in Strapi, `templateType`, `section`, `slug`, and `locale` are written into the exported MDX frontmatter. Astro reads these to select the correct collection, layout, and rendering behaviour.
 
 Collection entries carry four frontmatter fields that drive routing, layout selection, and filtering:
 
@@ -39,94 +37,31 @@ section: foundation     # set via section dropdown; determines layout component
 locale: en              # drives translation routing and listing view filtering
 ```
 
-### Single catch-all route
+### Routing
 
-All content is served through a single catch-all route:
-
-```
-src/pages/[...slug].astro
-```
+Blogs can be served through `src/pages/blog/[id].astro`, grants can be served through `src/pages/grant/[...page].astro` because they are template pages with specific applications and known URL structures. But template pages that have no single location (like profiles, faqs and report pages) should simply be saved to `src/content/foundation-pages` or `src/content/summit-pages` and served by the appropriate catch-all route like `src/pages/[...page].astro` or `src/pages/summit/[...page].astro`
 
 `getStaticPaths` collects all content collections and builds paths from frontmatter:
 
-```ts
-export async function getStaticPaths() {
-  const allContent = [
-    ...(await getCollection('profiles')),
-    ...(await getCollection('faqs'))
-    // add new collections here when new templates are added
-  ]
-
-  return allContent.map((entry) => ({
-    params: { slug: buildPagePath(entry.data.section, entry.slug) },
-    props: { entry }
-  }))
-}
-```
-
-### Section prefix and layout maps
-
-URL paths are assembled from a `PREFIX_MAP`:
-
-```ts
-export const PREFIX_MAP: Record<Section, string> = {
-  foundation: '',
-  summit: 'summit',
-  hackathon: 'hackathon'
-}
-
-export function buildPagePath(section: Section, slug: string): string {
-  const prefix = PREFIX_MAP[section]
-  return [prefix, slug].filter(Boolean).join('/')
-}
-```
-
-The correct layout component is selected at render time from a `LAYOUT_MAP`:
-
-```ts
-export const LAYOUT_MAP: Record<Section, AstroComponent> = {
-  foundation: FoundationContentPage,
-  summit: SummitContentPage,
-  hackathon: HackathonContentPage
-}
-```
-
-```astro
----
-const { entry } = Astro.props
-const Layout = LAYOUT_MAP[entry.data.section]
----
-
-<Layout slug={entry.slug} contentLocale={entry.data.locale} />
-```
-
-If a `section` value appears in content with no matching entry in `LAYOUT_MAP`, the build fails.
+Pages are rendered using the correct componenents as decided by the `templateType` field.
 
 Build-time validation also checks that the components used in an MDX file are compatible with its declared `templateType`, failing loudly on any mismatch.
 
 ### Listing views via frontmatter filters
 
-Because all profiles share a single collection, listing views filter by frontmatter — no separate collections or route logic required. Locale must always be included as a filter so listing views only surface content in the correct language:
+Because all profiles are disprsed acros the foundation, hackathon and summit general page collections, listing views filter by frontmatter — no separate collections or route logic required. Locale must always be included as a filter so listing views only surface content in the correct language:
 
 ```ts
 const fellows = await getCollection(
-  'profiles',
+  'foundation-pages',
   (entry) =>
-    entry.data.category === 'fellow' && entry.data.locale === currentLocale
+    entry.data.templateType === 'profiles' && entry.data.category === 'fellow' && entry.data.locale === currentLocale
 )
 ```
 
-### Developer ownership surface
-
-Developers own exactly three things:
-
-- **New section** — add to `PREFIX_MAP`, `LAYOUT_MAP`, and create the layout component.
-- **New content collection** — add to `getStaticPaths`.
-- **Template composition** — define the rules for each template type, enforce them at build time, and expose the required fields in Strapi.
-
-Everything else — URL slugs, page content — can be handled directly by editors in Strapi.
-
 ## Alternatives considered
+
+**A flat file approach**  — where each template type has its own collection and Astro renderes them from a single catch-all entry route at `src/pages/[...page].astro`. But then we lose clean nesting where it is appropriate (like for blogs) and it will incur more technical effort to make structural changes acros the code base. All pages share a single route file; the routing surface is less immediately legible than file-based routes.
 
 **Section-first routing (status quo)** — routes split by section, not template. Adding a new section is a structural change and may force template logic to be duplicated per section.
 
@@ -138,14 +73,9 @@ Everything else — URL slugs, page content — can be handled directly by edito
 
 **Positive:**
 
-- Adding a new section is a two-line config change; no route restructuring needed.
 - Editors control URL slugs, template selection, and content entirely from Strapi.
 - Listing views are simple frontmatter filters — no duplication, no separate route logic.
-- A missing `LAYOUT_MAP` entry is a hard build failure, not a silent runtime error.
-- Translations work naturally: shared collections with locale frontmatter, path generation via `buildPagePath`.
 
 **Negative:**
 
-- All pages share a single route file; the routing surface is less immediately legible than file-based routes.
-- `PREFIX_MAP` and `LAYOUT_MAP` must be kept in sync manually — a section added to one but not the other will break the build.
-- Strapi does not validate section/template compatibility by default; mismatches are only caught at build unless `beforeCreate` and `beforeUpdate` lifecycle hooks are added to enforce path prefix rules at save time.
+- Templates can't be clearly delineated collections and get murky amidst the general foundation collection.

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -1,7 +1,7 @@
 # ADR-003: Reusable Page Templates and Cross-Section Routing
 
 **Status:** Proposed
-**Date:** 2026-04-17
+**Date:** 2026-06-29
 **Issue:** [INTORG-560](https://linear.app/interledger/issue/INTORG-560/fellows-creata-id-pages)
 
 ---

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -18,7 +18,7 @@ At time of writing, the known template types fall into three groups:
 - **Floating templates** — FAQ pages, profile pages (fellows, judges, speakers, team members), and report/research pages have no fixed home. They can appear under any section and at any path. These are the templates this ADR primarily addresses.
 - **Tech templates** — the template requirements for the tech/developer section are not yet defined. This ADR assumes they will follow one of the two patterns above once scoped; the design should not foreclose either option.
 
-Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, i.e. how templates are defined) and page rendering (where a page lives and how it looks, i.e. where it's placed in the file system, what layoputs it uses, what components it uses). The bridge between them must be explicit but can be handled in various ways (how we nest the content collections, how we link them to the correct layout for rendering, how best to iterate through collection-driven templates to create views).
+Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, i.e. how templates are defined) and page rendering (where a page lives and how it looks, i.e. where it's placed in the file system, what layouts it uses, what components it uses). The bridge between them must be explicit but can be handled in various ways (how we nest the content collections, how we link them to the correct layout for rendering, how best to iterate through collection-driven templates to create views).
 
 ## Decision
 
@@ -30,104 +30,109 @@ All pages have a common required field:
 
 - **Path** — composed from three parts in the UI: a static `interledger.org` label, a section dropdown (`/`, `/summit`, `/hackathon`), and a free-text slug field for the remaining path. Together these produce the full URL, e.g. `interledger.org/summit/speakers/jane-doe`. The section dropdown is the canonical way an editor assigns a page to a section — no free-text prefix to mistype.
 
-### Template type as frontmatter bridge
+### Collection structure
 
-When an editor creates a page in Strapi, `templateType`, `section`, `slug`, and `locale` are written into the exported MDX frontmatter. The Strapi lifecycle for each content type reads the `section` field to decide which collection directory to write the MDX file to (`src/content/foundation-pages/`, `src/content/summit-pages/`, or `src/content/hackathon-pages/`). Astro then reads the frontmatter to select the correct layout and rendering behaviour.
-
-Collection entries carry four frontmatter fields that drive routing, layout selection, and filtering:
+Floating template types each have their own content collection. The collection name identifies the template — no frontmatter field is needed for this.
 
 ```
-templateType: profile   # selects components and layout
-category: fellow        # used by listing views to filter within a collection
-section: foundation     # set via section dropdown; determines which collection the lifecycle writes to
-locale: en              # drives translation routing and listing view filtering
+src/content/
+  profiles/         # all profile pages across all sections
+  faqs/             # all FAQ pages across all sections
+  reports/          # all report/research pages across all sections
+  foundation-pages/ # custom pages specific to the Foundation section
+  summit-pages/     # custom pages specific to the Summit section
+  hackathon-pages/  # custom pages specific to the Hackathon section
 ```
 
-A mismatch between the `section` field and the actual collection the file is in (e.g. a file in `summit-pages/` with `section: foundation`) is a build-time error.
-
-### Schema shape
-
-Each template type maps to a distinct Zod schema. These are composed into a discriminated union at the collection level, so Astro validates each entry against the correct branch at build time:
+Each collection has its own flat Zod schema matched to its template:
 
 ```ts
-const profileSchema = z.object({
-  templateType: z.literal('profile'),
-  category: z.enum(['fellow', 'judge', 'speaker', 'team']),
+// src/schemas/content.ts
+
+export const profileFrontmatterSchema = z.object({
   pathSlug: pathSlugSchema(),
+  section: z.enum(['foundation', 'summit', 'hackathon']),
+  category: z.enum(['fellow', 'judge', 'speaker', 'team']),
   name: z.string().min(1),
   photo: z.string().nullable(),
   photoAlt: z.string().nullable().optional(),
   tagline: z.string().nullable().optional(),
-  section: z.enum(['foundation', 'summit', 'hackathon']),
   locale: z.string().optional(),
   localizes: z.string().optional()
 })
 
-const faqPageSchema = z.object({
-  templateType: z.literal('faq'),
-  title: z.string().min(1),
+export const faqFrontmatterSchema = z.object({
   pathSlug: pathSlugSchema(),
   section: z.enum(['foundation', 'summit', 'hackathon']),
+  title: z.string().min(1),
   locale: z.string().optional(),
   localizes: z.string().optional()
 })
 
-const customPageSchema = z.object({
-  templateType: z.literal('custom')
-  // ... existing foundation/summit page fields
-})
-
-export const foundationPageFrontmatterSchema = z.discriminatedUnion(
-  'templateType',
-  [
-    profileSchema,
-    faqPageSchema,
-    customPageSchema
-    // ...
-  ]
-)
+// foundation-pages, summit-pages, hackathon-pages keep their existing schemas
 ```
 
-Note: `getCollection` filter callbacks do not narrow the return type — a type guard is needed after filtering to get the correct per-template TypeScript type rather than the full union.
+The `section` field is set from the section dropdown in Strapi. The Strapi lifecycle for each content type always writes MDX to its own collection directory — `profiles/` for profiles, `faqs/` for FAQs, etc. The `section` field is metadata used by catch-all routes to filter entries for their section; it does not control where the lifecycle writes.
 
 ### Routing
 
-Blogs can be served through `src/pages/blog/[id].astro`, grants can be served through `src/pages/grant/[...page].astro` because they are template pages with specific applications and known URL structures. But template pages that have no single location (like profiles, faqs and report pages) should simply be saved to `src/content/foundation-pages`, `src/content/summit-pages`, or `src/content/hackathon-pages` and served by the appropriate catch-all route like `src/pages/[...page].astro`, `src/pages/summit/[...page].astro`, or `src/pages/hackathon/[...page].astro`.
+Fixed-location templates keep their own route files (`src/pages/blog/[id].astro`, `src/pages/grant/[...page].astro`).
 
-`getStaticPaths` in each catch-all route queries its own section collection and builds paths from the `pathSlug` and `locale` frontmatter fields. No cross-collection merging is needed.
-
-Pages are rendered using the correct components as decided by a `switch` on `templateType` in the section renderer (e.g. `FoundationContentPage.astro`). Each branch renders a dedicated template component (`<ProfilePage />`, `<FaqPage />`, etc.) which receives the entry data as props.
-
-Template components enforce allowed MDX components by passing only the relevant component map to `<MdxContent components={...} />`. If an MDX file uses a component not in its template's map, it fails visibly at build time rather than silently rendering nothing.
-
-### Listing views via frontmatter filters
-
-Because all profiles are dispersed across the foundation, hackathon and summit general page collections, listing views filter by frontmatter — no separate collections or route logic required. Locale must always be included as a filter so listing views only surface content in the correct language.
-
-`getCollection`'s filter callback does not narrow the TypeScript type, so callers chain a type guard after filtering to get the correctly-typed entries rather than the full union:
+Floating template pages and section-specific custom pages are served by section catch-all routes (`src/pages/[...page].astro`, `src/pages/summit/[...page].astro`, `src/pages/hackathon/[...page].astro`). Each catch-all's `getStaticPaths` queries its own section-specific custom page collection and all floating template collections filtered by `section`, then merges the results:
 
 ```ts
-import { isProfileEntry } from '@/utils'
+// src/pages/[...page].astro
+export async function getStaticPaths() {
+  const [customPages, profiles, faqs, reports] = await Promise.all([
+    getCollection('foundation-pages'),
+    getCollection('profiles', (e) => e.data.section === 'foundation'),
+    getCollection('faqs', (e) => e.data.section === 'foundation'),
+    getCollection('reports', (e) => e.data.section === 'foundation')
+  ])
 
-const allFoundationPages = await getCollection('foundation-pages')
-
-const fellows = allFoundationPages
-  .filter(
-    (entry) =>
-      entry.data.templateType === 'profile' &&
-      entry.data.category === 'fellow' &&
-      entry.data.locale === currentLocale
+  return [...customPages, ...profiles, ...faqs, ...reports].flatMap((entry) =>
+    getLocalizedPathsFromEntry(entry)
   )
-  .filter(isProfileEntry) // narrows CollectionEntry<'foundation-pages'> to the profile branch
+}
 ```
 
-`isProfileEntry` is a standard TypeScript type predicate: `(entry): entry is CollectionEntry<'foundation-pages'> & { data: ProfileFrontmatterType } => entry.data.templateType === 'profile'`. One guard per template type lives in `src/utils/`.
+A build-time check asserts that no two entries across the merged collections share the same `pathSlug` + `locale` combination, catching collisions before they produce silent routing bugs.
+
+Pages are rendered by switching on `entry.collection` in the section renderer. Because `collection` is a literal type on `CollectionEntry`, TypeScript narrows `entry.data` correctly in each branch without a type guard:
+
+```ts
+switch (entry.collection) {
+  case 'profiles':         return <ProfilePage entry={entry} />
+  case 'faqs':             return <FaqPage entry={entry} />
+  case 'reports':          return <ReportPage entry={entry} />
+  case 'foundation-pages': return <FoundationContentPage entry={entry} />
+}
+```
+
+Each template component passes only the MDX components relevant to its template to `<MdxContent components={...} />`. An MDX file that uses a component outside its template's map will fail visibly at build time.
+
+### Listing views
+
+Listing views query the template-type collection directly and filter by `category`, `section`, and `locale`. No type guards are needed because the collection already has a single schema:
+
+```ts
+const fellows = await getCollection(
+  'profiles',
+  (entry) =>
+    entry.data.category === 'fellow' &&
+    entry.data.section === 'foundation' &&
+    entry.data.locale === currentLocale
+)
+// entry.data is ProfileFrontmatterType — no further narrowing needed
+```
 
 ## Alternatives considered
 
-**Separate collections per template type** (e.g. `foundation-profiles`, `summit-profiles`, `foundation-faqs`, `summit-faqs`) — each collection has a clean single schema and `getCollection` returns the right type without a type guard. Rejected because with N template types across M sections this produces N×M collections; the catch-all route must query and merge all of them, and `content.config.ts` grows with every new template type added.
+**Section-level collections with a discriminated union schema** — all template types (profiles, FAQs, reports, custom pages) live in `foundation-pages`, `summit-pages`, and `hackathon-pages`, with a discriminant field in frontmatter selecting the schema branch per entry. Rejected because the union grows with every new template type, TypeScript inference at the collection boundary is finicky, and listing views require a type guard to recover the per-template type after filtering.
 
-**A flat file approach** — where each template type has its own collection and Astro renders them from a single catch-all entry route at `src/pages/[...page].astro`. But then we lose clean nesting where it is appropriate (like for blogs) and it will incur more technical effort to make structural changes across the code base.
+**Section-specific template collections** (e.g. `foundation-profiles`, `summit-profiles`, `foundation-faqs`, `summit-faqs`) — each combination of section and template gets its own collection. Clean schemas and no section filtering needed at query time, but produces N×M collections as template types and sections grow; `content.config.ts` and `getStaticPaths` must be updated for every new combination.
+
+**A flat file approach** — a single catch-all route and a single collection for all pages. Loses the clean nesting that is appropriate for blogs and grants, and makes structural routing changes harder.
 
 **Section-first routing (status quo)** — routes split by section, not template. Adding a new section is a structural change and may force template logic to be duplicated per section.
 
@@ -137,19 +142,20 @@ const fellows = allFoundationPages
 
 ## Migration
 
-The existing `ambassadors` Strapi content type and `src/content/ambassadors/` collection will migrate to the generic `profile` template type with `category: fellow` and `section: foundation`. The Strapi lifecycle will be updated to write to `src/content/foundation-pages/`. The `ambassadors` collection and its dedicated route (`src/pages/grant/fellowship/[id].astro`) will be removed once migration is complete.
+The existing `ambassadors` Strapi content type and `src/content/ambassadors/` collection will migrate to the `profiles` collection with `category: fellow` and `section: foundation`. The Strapi lifecycle will be updated to write to `src/content/profiles/`. The `ambassadors` collection and its dedicated route (`src/pages/grant/fellowship/[id].astro`) will be removed once migration is complete.
 
 ## Consequences
 
 **Positive:**
 
 - Editors control URL slugs, template selection, and content entirely from Strapi.
-- Listing views are simple frontmatter filters — no duplication, no separate route logic.
-- Adding a new template type means a new Strapi content type and a new Zod branch — no new collections or route files.
-- The discriminated union schema enforces correct fields per template type at build time.
+- Each collection has a single, flat schema — no discriminated union complexity.
+- `getCollection('profiles')` returns correctly-typed profiles with no type guard. Listing views are a straightforward filter.
+- File organisation is semantically meaningful on disk: all profiles together, all FAQs together.
+- Adding a new template type means a new Strapi content type, a new collection, and a new `case` in the renderer — no changes to existing collections or schemas.
+- The renderer switches on `entry.collection`, which TypeScript narrows automatically.
 
 **Negative:**
 
-- Templates can't be clearly delineated collections and get murky amidst the general foundation collection.
-- The section-level collection contains a mix of template types; browsing `src/content/foundation-pages/` on disk doesn't immediately tell you a file's template type.
-- `getCollection` filter callbacks don't narrow TypeScript types; listing views require an explicit type guard per template type.
+- Catch-all `getStaticPaths` queries multiple collections and merges them — more code than querying a single collection, though it is contained to one place per section.
+- PathSlug collisions across collections (e.g. a `profiles` entry and a `foundation-pages` entry sharing the same slug for the same section) are possible and must be caught by a build-time check.

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -12,58 +12,122 @@ Templates must work across all three sections without duplicating template types
 
 **Single-instance templates** (e.g. FAQ) must generate correct routes and layouts regardless of section. **Collection-driven templates** (e.g. profiles) must also power listing and summary views — filtering by category and locale — without duplicating content or route logic.
 
+At time of writing, the known template types fall into three groups:
+
+- **Fixed-location templates** — blog and grant pages have a predictable URL structure and a dedicated section of the site. These are served from their own route files (`src/pages/blog/`, `src/pages/grant/`).
+- **Floating templates** — FAQ pages, profile pages (fellows, judges, speakers, team members), and report/research pages have no fixed home. They can appear under any section and at any path. These are the templates this ADR primarily addresses.
+- **Tech templates** — the template requirements for the tech/developer section are not yet defined. This ADR assumes they will follow one of the two patterns above once scoped; the design should not foreclose either option.
+
 Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, i.e. how templates are defined) and page rendering (where a page lives and how it looks, i.e. where it's placed in the file system, what layoputs it uses, what components it uses). The bridge between them must be explicit but can be handled in various ways (how we nest the content collections, how we link them to the correct layout for rendering, how best to iterate through collection-driven templates to create views).
 
 ## Decision
 
 ### Editor experience in Strapi
 
-Editors create a new page by choosing between the page options (a profile template, a blog template, a grant template, or a custom page, etc.). The template type determines what fields are available and what the page composition looks like — not which section it belongs to.
+Editors create a new page by choosing between the page options (a profile template, a blog template, a grant template, or a custom page, etc.). Each template type is its own Strapi content type with its own field schema and MDX export lifecycle. The template type determines what fields are available and what the page composition looks like — not which section it belongs to.
 
-ALl pages have a common required field:
+All pages have a common required field:
 
 - **Path** — composed from three parts in the UI: a static `interledger.org` label, a section dropdown (`/`, `/summit`, `/hackathon`), and a free-text slug field for the remaining path. Together these produce the full URL, e.g. `interledger.org/summit/speakers/jane-doe`. The section dropdown is the canonical way an editor assigns a page to a section — no free-text prefix to mistype.
 
 ### Template type as frontmatter bridge
 
-When an editor creates a page in Strapi, `templateType`, `section`, `slug`, and `locale` are written into the exported MDX frontmatter. Astro reads these to select the correct collection, layout, and rendering behaviour.
+When an editor creates a page in Strapi, `templateType`, `section`, `slug`, and `locale` are written into the exported MDX frontmatter. The Strapi lifecycle for each content type reads the `section` field to decide which collection directory to write the MDX file to (`src/content/foundation-pages/`, `src/content/summit-pages/`, or `src/content/hackathon-pages/`). Astro then reads the frontmatter to select the correct layout and rendering behaviour.
 
 Collection entries carry four frontmatter fields that drive routing, layout selection, and filtering:
 
 ```
 templateType: profile   # selects components and layout
 category: fellow        # used by listing views to filter within a collection
-section: foundation     # set via section dropdown; determines layout component
+section: foundation     # set via section dropdown; determines which collection the lifecycle writes to
 locale: en              # drives translation routing and listing view filtering
 ```
 
-### Routing
+A mismatch between the `section` field and the actual collection the file is in (e.g. a file in `summit-pages/` with `section: foundation`) is a build-time error.
 
-Blogs can be served through `src/pages/blog/[id].astro`, grants can be served through `src/pages/grant/[...page].astro` because they are template pages with specific applications and known URL structures. But template pages that have no single location (like profiles, faqs and report pages) should simply be saved to `src/content/foundation-pages` or `src/content/summit-pages` and served by the appropriate catch-all route like `src/pages/[...page].astro` or `src/pages/summit/[...page].astro`
+### Schema shape
 
-`getStaticPaths` collects all content collections and builds paths from frontmatter:
-
-Pages are rendered using the correct componenents as decided by the `templateType` field.
-
-Build-time validation also checks that the components used in an MDX file are compatible with its declared `templateType`, failing loudly on any mismatch.
-
-### Listing views via frontmatter filters
-
-Because all profiles are disprsed acros the foundation, hackathon and summit general page collections, listing views filter by frontmatter — no separate collections or route logic required. Locale must always be included as a filter so listing views only surface content in the correct language:
+Each template type maps to a distinct Zod schema. These are composed into a discriminated union at the collection level, so Astro validates each entry against the correct branch at build time:
 
 ```ts
-const fellows = await getCollection(
-  'foundation-pages',
-  (entry) =>
-    entry.data.templateType === 'profiles' &&
-    entry.data.category === 'fellow' &&
-    entry.data.locale === currentLocale
+const profileSchema = z.object({
+  templateType: z.literal('profile'),
+  category: z.enum(['fellow', 'judge', 'speaker', 'team']),
+  pathSlug: pathSlugSchema(),
+  name: z.string().min(1),
+  photo: z.string().nullable(),
+  photoAlt: z.string().nullable().optional(),
+  tagline: z.string().nullable().optional(),
+  section: z.enum(['foundation', 'summit', 'hackathon']),
+  locale: z.string().optional(),
+  localizes: z.string().optional()
+})
+
+const faqPageSchema = z.object({
+  templateType: z.literal('faq'),
+  title: z.string().min(1),
+  pathSlug: pathSlugSchema(),
+  section: z.enum(['foundation', 'summit', 'hackathon']),
+  locale: z.string().optional(),
+  localizes: z.string().optional()
+})
+
+const customPageSchema = z.object({
+  templateType: z.literal('custom')
+  // ... existing foundation/summit page fields
+})
+
+export const foundationPageFrontmatterSchema = z.discriminatedUnion(
+  'templateType',
+  [
+    profileSchema,
+    faqPageSchema,
+    customPageSchema
+    // ...
+  ]
 )
 ```
 
+Note: `getCollection` filter callbacks do not narrow the return type — a type guard is needed after filtering to get the correct per-template TypeScript type rather than the full union.
+
+### Routing
+
+Blogs can be served through `src/pages/blog/[id].astro`, grants can be served through `src/pages/grant/[...page].astro` because they are template pages with specific applications and known URL structures. But template pages that have no single location (like profiles, faqs and report pages) should simply be saved to `src/content/foundation-pages`, `src/content/summit-pages`, or `src/content/hackathon-pages` and served by the appropriate catch-all route like `src/pages/[...page].astro`, `src/pages/summit/[...page].astro`, or `src/pages/hackathon/[...page].astro`.
+
+`getStaticPaths` in each catch-all route queries its own section collection and builds paths from the `pathSlug` and `locale` frontmatter fields. No cross-collection merging is needed.
+
+Pages are rendered using the correct components as decided by a `switch` on `templateType` in the section renderer (e.g. `FoundationContentPage.astro`). Each branch renders a dedicated template component (`<ProfilePage />`, `<FaqPage />`, etc.) which receives the entry data as props.
+
+Template components enforce allowed MDX components by passing only the relevant component map to `<MdxContent components={...} />`. If an MDX file uses a component not in its template's map, it fails visibly at build time rather than silently rendering nothing.
+
+### Listing views via frontmatter filters
+
+Because all profiles are dispersed across the foundation, hackathon and summit general page collections, listing views filter by frontmatter — no separate collections or route logic required. Locale must always be included as a filter so listing views only surface content in the correct language.
+
+`getCollection`'s filter callback does not narrow the TypeScript type, so callers chain a type guard after filtering to get the correctly-typed entries rather than the full union:
+
+```ts
+import { isProfileEntry } from '@/utils'
+
+const allFoundationPages = await getCollection('foundation-pages')
+
+const fellows = allFoundationPages
+  .filter(
+    (entry) =>
+      entry.data.templateType === 'profile' &&
+      entry.data.category === 'fellow' &&
+      entry.data.locale === currentLocale
+  )
+  .filter(isProfileEntry) // narrows CollectionEntry<'foundation-pages'> to the profile branch
+```
+
+`isProfileEntry` is a standard TypeScript type predicate: `(entry): entry is CollectionEntry<'foundation-pages'> & { data: ProfileFrontmatterType } => entry.data.templateType === 'profile'`. One guard per template type lives in `src/utils/`.
+
 ## Alternatives considered
 
-**A flat file approach** — where each template type has its own collection and Astro renderes them from a single catch-all entry route at `src/pages/[...page].astro`. But then we lose clean nesting where it is appropriate (like for blogs) and it will incur more technical effort to make structural changes acros the code base. All pages share a single route file; the routing surface is less immediately legible than file-based routes.
+**Separate collections per template type** (e.g. `foundation-profiles`, `summit-profiles`, `foundation-faqs`, `summit-faqs`) — each collection has a clean single schema and `getCollection` returns the right type without a type guard. Rejected because with N template types across M sections this produces N×M collections; the catch-all route must query and merge all of them, and `content.config.ts` grows with every new template type added.
+
+**A flat file approach** — where each template type has its own collection and Astro renders them from a single catch-all entry route at `src/pages/[...page].astro`. But then we lose clean nesting where it is appropriate (like for blogs) and it will incur more technical effort to make structural changes across the code base.
 
 **Section-first routing (status quo)** — routes split by section, not template. Adding a new section is a structural change and may force template logic to be duplicated per section.
 
@@ -71,13 +135,21 @@ const fellows = await getCollection(
 
 **Strapi-led template+section compatibility** — dynamic UI restrictions are not reliably achievable with Strapi's conditional field support. Validation will need to be enforced at build time instead.
 
+## Migration
+
+The existing `ambassadors` Strapi content type and `src/content/ambassadors/` collection will migrate to the generic `profile` template type with `category: fellow` and `section: foundation`. The Strapi lifecycle will be updated to write to `src/content/foundation-pages/`. The `ambassadors` collection and its dedicated route (`src/pages/grant/fellowship/[id].astro`) will be removed once migration is complete.
+
 ## Consequences
 
 **Positive:**
 
 - Editors control URL slugs, template selection, and content entirely from Strapi.
 - Listing views are simple frontmatter filters — no duplication, no separate route logic.
+- Adding a new template type means a new Strapi content type and a new Zod branch — no new collections or route files.
+- The discriminated union schema enforces correct fields per template type at build time.
 
 **Negative:**
 
 - Templates can't be clearly delineated collections and get murky amidst the general foundation collection.
+- The section-level collection contains a mix of template types; browsing `src/content/foundation-pages/` on disk doesn't immediately tell you a file's template type.
+- `getCollection` filter callbacks don't narrow TypeScript types; listing views require an explicit type guard per template type.

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -1,96 +1,135 @@
-# ADR-003: Reusable page templates and cross-section routing
+# ADR-003: Reusable Page Templates and Cross-Section Routing
 
 **Status:** Proposed
 **Date:** 2026-04-17
 **Issue:** [INTORG-560](https://linear.app/interledger/issue/INTORG-560/fellows-creata-id-pages)
 
+---
+
 ## Context
 
-The redesign moves to a template-based approach: grant pages, FAQs, and profiles each follow a fixed structure. The site also splits into three sections — Foundation, Summit, and Hackathon — after the hackathon becomes a separate microsite.
+The redesign moves to a template-based approach: grant pages, FAQs, and profiles each follow a fixed structure. The site splits into three sections — Foundation (the main site) and two microsites, Summit and Hackathon.
 
-Templates must work across all three sections without duplicating template types in Strapi. Two problems make this non-trivial:
+The core architectural challenge is that **template type and site section are independent concerns**. An FAQ is an FAQ whether it lives at `/faq` or `/hackathon/faq`. These two dimensions must stay independent while still producing correct URLs, layouts, and routing in Astro.
+
+Two specific problems make this non-trivial:
 
 **Single-instance templates** (e.g. FAQ) must generate correct routes and layouts regardless of section. **Collection-driven templates** (e.g. profiles) must also power listing and summary views — filtering by category and locale — without duplicating content or route logic.
 
-At time of writing, the known template types fall into three groups:
+### Template types
 
-- **Fixed-location templates** — blog and grant pages have a predictable URL structure and a dedicated section of the site. These are served from their own route files (`src/pages/blog/`, `src/pages/grant/`).
-- **Floating templates** — FAQ pages, profile pages (fellows, judges, speakers, team members), and report/research pages have no fixed home. They can appear under any section and at any path. These are the templates this ADR primarily addresses.
-- **Tech templates** — the template requirements for the tech/developer section are not yet defined. This ADR assumes they will follow one of the two patterns above once scoped; the design should not foreclose either option.
+At time of writing, known template types fall into three groups:
 
-Additionally, two concerns must stay separate but coordinate correctly: content composition (what components make up a page, i.e. how templates are defined) and page rendering (where a page lives and how it looks, i.e. where it's placed in the file system, what layouts it uses, what components it uses). The bridge between them must be explicit but can be handled in various ways (how we nest the content collections, how we link them to the correct layout for rendering, how best to iterate through collection-driven templates to create views).
+**Fixed-location templates** — blog and grant pages have a predictable URL structure and a dedicated section of the site. They are served from their own route files (`src/pages/blog/`, `src/pages/grant/`) and are not addressed further by this ADR.
+
+**Cross-section templates** — FAQ pages, profile pages (fellows, judges, speakers, team members), and report/research pages have no fixed home. They can appear under any section and at any path. These are the primary subject of this ADR.
+
+**Tech templates** — the template requirements for the tech/developer section (e.g. `/interledger-protocol`, `/open-payments`, `/web-monetization`) are not yet fully defined, as these pages sit at flat top-level paths rather than a predictable nested structure. This ADR assumes they will follow one of the two patterns above once scoped.
+
+This ADR addresses how content collections are structured, how they link to the correct layout, and how routing iterates over collection-driven templates to produce the correct static paths.
+
+---
+
+## Design Principles
+
+Three fields capture everything needed to identify, store, and route any page:
+
+| Concern                | Source of truth                 |
+| ---------------------- | ------------------------------- |
+| What is this page?     | Collection (i.e. template type) |
+| Where does it belong?  | `section` field in frontmatter  |
+| What URL does it have? | `section` + `pathSlug`          |
+
+Two invariants follow from this:
+
+> **The collection identifies what the content is. The section identifies where the content belongs.**
+
+> **The `section` field is metadata only. It controls routing but never where content is stored.**
+
+---
 
 ## Decision
 
 ### Editor experience in Strapi
 
-Editors create a new page by choosing between the page options (a profile template, a blog template, a grant template, or a custom page, etc.). Each template type is its own Strapi content type with its own field schema and MDX export lifecycle. The template type determines what fields are available and what the page composition looks like — not which section it belongs to.
+Editors create a new page by choosing a template type (profile, FAQ, report, custom page, etc.). Each template type is its own Strapi content type with its own field schema and MDX export lifecycle. The template type determines what fields are available and what the page looks like — not which section it belongs to.
 
-All pages have a common required field:
+Editors never think about which Astro collection their content lands in. Storage is an implementation detail derived from the template type they selected.
 
-- **Path** — composed from three parts in the UI: a static `interledger.org` label, a section dropdown (`/`, `/summit`, `/hackathon`), and a free-text slug field for the remaining path. Together these produce the full URL, e.g. `interledger.org/summit/speakers/jane-doe`. The section dropdown is the canonical way an editor assigns a page to a section — no free-text prefix to mistype.
+All pages share one common required field:
 
-### Collection structure
+**Path** — composed from three parts in the Strapi UI:
 
-Floating template types each have their own content collection. The collection name identifies the template — no frontmatter field is needed for this.
+1. A static `interledger.org` label.
+2. A section dropdown: `/` (Foundation), `/summit`, or `/hackathon`.
+3. A free-text slug for the remaining path.
+
+Together these produce a full URL, e.g. `interledger.org/summit/speakers/jane-doe`. The section dropdown is the canonical way to assign a page to a section — no free-text prefix to mistype, and no ambiguity about which site a page belongs to.
+
+### Content storage
+
+Each cross-section template type has its own Astro content collection. The collection name is the template type — no additional frontmatter discriminant is needed.
 
 ```
 src/content/
-  profiles/         # all profile pages across all sections
-  faqs/             # all FAQ pages across all sections
-  reports/          # all report/research pages across all sections
-  foundation-pages/ # custom pages specific to the Foundation section
-  summit-pages/     # custom pages specific to the Summit section
-  hackathon-pages/  # custom pages specific to the Hackathon section
+  profiles/           # all profile pages across all sections
+  faqs/               # all FAQ pages across all sections
+  reports/            # all report/research pages across all sections
+  foundation-pages/   # custom pages specific to the Foundation section
+  summit-pages/       # custom pages specific to the Summit section
+  hackathon-pages/    # custom pages specific to the Hackathon section
 ```
 
-Each collection has its own flat Zod schema matched to its template:
+Each collection has its own flat Zod schema matched to its template, giving correct TypeScript inference with no discriminated union complexity.
+
+The Strapi lifecycle for each content type always writes MDX to its own collection directory — profiles always go to `src/content/profiles/`, FAQs always go to `src/content/faqs/`. The `section` field stored in frontmatter is metadata used by Astro routing; it does not affect where files are written.
+
+### Cross-section template registry
+
+To avoid each catch-all route manually listing every cross-section collection (and to ensure a newly added template type is not silently omitted from one section), all cross-section template types are registered in one place:
 
 ```ts
-// src/schemas/content.ts
+// src/lib/templates.ts
 
-export const profileFrontmatterSchema = z.object({
-  pathSlug: pathSlugSchema(),
-  section: z.enum(['foundation', 'summit', 'hackathon']),
-  category: z.enum(['fellow', 'judge', 'speaker', 'team']),
-  name: z.string().min(1),
-  photo: z.string().nullable(),
-  photoAlt: z.string().nullable().optional(),
-  tagline: z.string().nullable().optional(),
-  locale: z.string().optional(),
-  localizes: z.string().optional()
-})
+import type { CollectionKey } from 'astro:content'
 
-export const faqFrontmatterSchema = z.object({
-  pathSlug: pathSlugSchema(),
-  section: z.enum(['foundation', 'summit', 'hackathon']),
-  title: z.string().min(1),
-  locale: z.string().optional(),
-  localizes: z.string().optional()
-})
+export const crossSectionCollections = [
+  'profiles',
+  'faqs',
+  'reports'
+] as const satisfies readonly CollectionKey[]
 
-// foundation-pages, summit-pages, hackathon-pages keep their existing schemas
+export type CrossSectionCollection = (typeof crossSectionCollections)[number]
 ```
 
-The `section` field is set from the section dropdown in Strapi. The Strapi lifecycle for each content type always writes MDX to its own collection directory — `profiles/` for profiles, `faqs/` for FAQs, etc. The `section` field is metadata used by catch-all routes to filter entries for their section; it does not control where the lifecycle writes.
+Adding a new cross-section template type means adding one entry here. The catch-all routes, routing logic, and `getStaticPaths` all derive from this registry automatically.
 
 ### Routing
 
-Fixed-location templates keep their own route files (`src/pages/blog/[id].astro`, `src/pages/grant/[...page].astro`).
+Fixed-location templates keep their dedicated route files (`src/pages/blog/[id].astro`, `src/pages/grant/[...page].astro`).
 
-Floating template pages and section-specific custom pages are served by section catch-all routes (`src/pages/[...page].astro`, `src/pages/summit/[...page].astro`, `src/pages/hackathon/[...page].astro`). Each catch-all's `getStaticPaths` queries its own section-specific custom page collection and all floating template collections filtered by `section`, then merges the results:
+Cross-section template pages and section-specific custom pages are served by section catch-all routes:
+
+- `src/pages/[...page].astro` — Foundation
+- `src/pages/summit/[...page].astro` — Summit
+- `src/pages/hackathon/[...page].astro` — Hackathon
+
+Each catch-all's `getStaticPaths` queries its own section-specific custom page collection and all cross-section collections filtered by `section`, using the registry so no collection needs to be added manually to each route file:
 
 ```ts
 // src/pages/[...page].astro
-export async function getStaticPaths() {
-  const [customPages, profiles, faqs, reports] = await Promise.all([
-    getCollection('foundation-pages'),
-    getCollection('profiles', (e) => e.data.section === 'foundation'),
-    getCollection('faqs', (e) => e.data.section === 'foundation'),
-    getCollection('reports', (e) => e.data.section === 'foundation')
-  ])
+import { crossSectionCollections } from '@/lib/templates'
 
-  return [...customPages, ...profiles, ...faqs, ...reports].flatMap((entry) =>
+export async function getStaticPaths() {
+  const crossSectionEntries = await Promise.all(
+    crossSectionCollections.map((collection) =>
+      getCollection(collection, (e) => e.data.section === 'foundation')
+    )
+  )
+
+  const customPages = await getCollection('foundation-pages')
+
+  return [...customPages, ...crossSectionEntries.flat()].flatMap((entry) =>
     getLocalizedPathsFromEntry(entry)
   )
 }
@@ -98,7 +137,9 @@ export async function getStaticPaths() {
 
 A build-time check asserts that no two entries across the merged collections share the same `pathSlug` + `locale` combination, catching collisions before they produce silent routing bugs.
 
-Pages are rendered by switching on `entry.collection` in the section renderer. Because `collection` is a literal type on `CollectionEntry`, TypeScript narrows `entry.data` correctly in each branch without a type guard:
+### Rendering
+
+Pages are rendered by switching on `entry.collection` in the section renderer. Because `collection` is a literal type on `CollectionEntry`, TypeScript narrows `entry.data` automatically in each branch — no type guard required:
 
 ```ts
 switch (entry.collection) {
@@ -109,53 +150,71 @@ switch (entry.collection) {
 }
 ```
 
-Each template component passes only the MDX components relevant to its template to `<MdxContent components={...} />`. An MDX file that uses a component outside its template's map will fail visibly at build time.
+Each template component passes only the MDX components relevant to its template to `<MdxContent components={...} />`. An MDX file that uses a component outside its template's allowed set will fail visibly at build time.
 
-### Listing views
+A separate `templateType` frontmatter field is not needed. The collection is already the discriminant for both TypeScript narrowing and renderer dispatch. Adding a separate field would duplicate information.
 
-Listing views query the template-type collection directly and filter by `category`, `section`, and `locale`. No type guards are needed because the collection already has a single schema:
+### Listing and summary views
+
+Listing views query the template-type collection directly and filter by `category`, `section`, and `locale`. Because all profiles live in a single `profiles` collection, a listing never searches unrelated custom pages or FAQ entries:
 
 ```ts
 const fellows = await getCollection(
   'profiles',
   (entry) =>
-    entry.data.category === 'fellow' &&
-    entry.data.section === 'foundation' &&
-    entry.data.locale === currentLocale
+    entry.data.category === 'fellow' && entry.data.locale === currentLocale
 )
 // entry.data is ProfileFrontmatterType — no further narrowing needed
 ```
 
-## Alternatives considered
+---
 
-**Section-level collections with a discriminated union schema** — all template types (profiles, FAQs, reports, custom pages) live in `foundation-pages`, `summit-pages`, and `hackathon-pages`, with a discriminant field in frontmatter selecting the schema branch per entry. Rejected because the union grows with every new template type, TypeScript inference at the collection boundary is finicky, and listing views require a type guard to recover the per-template type after filtering.
+## Adding a new cross-section template type
 
-**Section-specific template collections** (e.g. `foundation-profiles`, `summit-profiles`, `foundation-faqs`, `summit-faqs`) — each combination of section and template gets its own collection. Clean schemas and no section filtering needed at query time, but produces N×M collections as template types and sections grow; `content.config.ts` and `getStaticPaths` must be updated for every new combination.
+1. Create a Strapi content type with the required field schema.
+2. Create the Astro content collection and its Zod schema.
+3. Add the collection name to `crossSectionCollections` in `src/lib/templates.ts`.
+4. Add a `case` for it in each section renderer's switch statement.
 
-**A flat file approach** — a single catch-all route and a single collection for all pages. Loses the clean nesting that is appropriate for blogs and grants, and makes structural routing changes harder.
+No changes are needed to `getStaticPaths`, existing collections, or existing schemas.
 
-**Section-first routing (status quo)** — routes split by section, not template. Adding a new section is a structural change and may force template logic to be duplicated per section.
+---
 
-**Separate collections per profile category** — a `fellows` collection, a `judges` collection, etc. Requires a developer change for every new category.
+## Alternatives Considered
 
-**Strapi-led template+section compatibility** — dynamic UI restrictions are not reliably achievable with Strapi's conditional field support. Validation will need to be enforced at build time instead.
+**Section-level collections with a discriminated union schema** — all template types live in `foundation-pages`, `summit-pages`, and `hackathon-pages` with a discriminant field selecting the schema branch. Rejected because the union grows with every new template type, TypeScript inference at the collection boundary is unreliable, and listing views require a type guard to recover per-template types after filtering.
+
+**Section-specific template collections** (e.g. `foundation-profiles`, `summit-profiles`) — each combination of section and template gets its own collection. Clean schemas and no section filtering at query time, but produces N×M collections as template types and sections grow. `content.config.ts` and `getStaticPaths` must be updated for every new combination.
+
+**A single flat collection** — one catch-all route and one collection for all pages. Loses the clean per-template typing that makes listing views simple, and makes structural routing changes harder.
+
+**Section-first routing (status quo)** — routes split by section rather than template. Adding a new section forces template logic to be duplicated across section route files.
+
+**Separate collections per profile category** — a `fellows` collection, a `judges` collection, etc. Requires a developer change for every new category, and makes cross-category queries awkward.
+
+**Strapi-led template-section compatibility enforcement** — dynamic UI restrictions are not reliably achievable with Strapi's conditional field support. Validation is enforced at build time instead.
+
+---
 
 ## Migration
 
 The existing `ambassadors` Strapi content type and `src/content/ambassadors/` collection will migrate to the `profiles` collection with `category: fellow` and `section: foundation`. The Strapi lifecycle will be updated to write to `src/content/profiles/`. The `ambassadors` collection and its dedicated route (`src/pages/grant/fellowship/[id].astro`) will be removed once migration is complete.
 
+---
+
 ## Consequences
 
 **Positive:**
 
-- Editors control URL slugs, template selection, and content entirely from Strapi.
+- Editors control URL slugs, template selection, and content entirely from Strapi. Storage is invisible to them.
 - Each collection has a single, flat schema — no discriminated union complexity.
 - `getCollection('profiles')` returns correctly-typed profiles with no type guard. Listing views are a straightforward filter.
 - File organisation is semantically meaningful on disk: all profiles together, all FAQs together.
-- Adding a new template type means a new Strapi content type, a new collection, and a new `case` in the renderer — no changes to existing collections or schemas.
-- The renderer switches on `entry.collection`, which TypeScript narrows automatically.
+- The cross-section template registry means adding a new template type is a localized change — one registry entry, one new collection, one new renderer `case`. No changes to existing collections, schemas, or route files.
+- `entry.collection` is the single source of truth for both TypeScript narrowing and renderer dispatch. A separate `templateType` frontmatter field is unnecessary.
+- Because template types are grouped by collection rather than section, listing views query only the content they need.
 
 **Negative:**
 
-- Catch-all `getStaticPaths` queries multiple collections and merges them — more code than querying a single collection, though it is contained to one place per section.
-- PathSlug collisions across collections (e.g. a `profiles` entry and a `foundation-pages` entry sharing the same slug for the same section) are possible and must be caught by a build-time check.
+- Each catch-all `getStaticPaths` queries multiple collections and merges them — more code than querying a single collection, though it is contained to one place per section and driven by the shared registry.
+- `pathSlug` collisions across collections (e.g. a `profiles` entry and a `foundation-pages` entry sharing the same slug within the same section) are possible and must be caught by a build-time check.

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -73,8 +73,11 @@ Each cross-section template type has its own Astro content collection. The colle
 ```
 src/content/
   profiles/           # all profile pages across all sections
-  faqs/               # all FAQ pages across all sections
+    es/               # Spanish-locale profiles
+  faq/                # all FAQ pages across all sections
+    es/               # Spanish-locale FAQs
   reports/            # all report/research pages across all sections
+      es/             # Spanish-locale reports
   foundation-pages/   # custom pages specific to the Foundation section
   summit-pages/       # custom pages specific to the Summit section
   hackathon-pages/    # custom pages specific to the Hackathon section
@@ -82,7 +85,9 @@ src/content/
 
 Each collection has its own flat Zod schema matched to its template, giving correct TypeScript inference with no discriminated union complexity.
 
-The Strapi lifecycle for each content type always writes MDX to its own collection directory — profiles always go to `src/content/profiles/`, FAQs always go to `src/content/faqs/`. The `section` field stored in frontmatter is metadata used by Astro routing; it does not affect where files are written.
+**Locale organisation within collections:** locale variants live in subdirectories of the collection directory. The default (English) locale files sit directly under the collection root (e.g. `src/content/faq/`); translated files go into a subdirectory named after the locale (e.g. `src/content/faq/es/`). A `locale` frontmatter field is required on every entry.
+
+The Strapi lifecycle for each content type always writes MDX to its own collection directory, placing files in the correct locale subdirectory — profiles always go to `src/content/profiles/` (or `src/content/profiles/es/` for Spanish), FAQs always go to `src/content/faq/` (or `src/content/faq/es/`). The `section` field stored in frontmatter is metadata used by Astro routing; it does not affect where files are written.
 
 ### Cross-section template registry
 
@@ -95,7 +100,7 @@ import type { CollectionKey } from 'astro:content'
 
 export const crossSectionCollections = [
   'profiles',
-  'faqs',
+  'faq',
   'reports'
 ] as const satisfies readonly CollectionKey[]
 
@@ -114,7 +119,7 @@ Cross-section template pages and section-specific custom pages are served by sec
 - `src/pages/summit/[...page].astro` — Summit
 - `src/pages/hackathon/[...page].astro` — Hackathon
 
-Each catch-all's `getStaticPaths` queries its own section-specific custom page collection and all cross-section collections filtered by `section`, using the registry so no collection needs to be added manually to each route file:
+Each catch-all's `getStaticPaths` queries its own section-specific custom page collection and all cross-section collections filtered by `section`, using the registry so no collection needs to be added manually to each route file. Filtering and path generation are both locale-aware: every entry carries a `locale` frontmatter field for that purpose.
 
 ```ts
 // src/pages/[...page].astro
@@ -144,7 +149,7 @@ Pages are rendered by switching on `entry.collection` in the section renderer. B
 ```ts
 switch (entry.collection) {
   case 'profiles':         return <ProfilePage entry={entry} />
-  case 'faqs':             return <FaqPage entry={entry} />
+  case 'faq':              return <FaqPage entry={entry} />
   case 'reports':          return <ReportPage entry={entry} />
   case 'foundation-pages': return <FoundationContentPage entry={entry} />
 }
@@ -208,8 +213,8 @@ The existing `ambassadors` Strapi content type and `src/content/ambassadors/` co
 
 - Editors control URL slugs, template selection, and content entirely from Strapi. Storage is invisible to them.
 - Each collection has a single, flat schema — no discriminated union complexity.
-- `getCollection('profiles')` returns correctly-typed profiles with no type guard. Listing views are a straightforward filter.
-- File organisation is semantically meaningful on disk: all profiles together, all FAQs together.
+- `getCollection('profiles')` returns correctly-typed profiles with no type guard. Listing views are a straightforward filter on `section`, `category`, and `locale`.
+- File organisation is semantically meaningful on disk: all profiles together, all FAQs together, locale variants clearly separated by subdirectory (`faq/`, `faq/es/`).
 - The cross-section template registry means adding a new template type is a localized change — one registry entry, one new collection, one new renderer `case`. No changes to existing collections, schemas, or route files.
 - `entry.collection` is the single source of truth for both TypeScript narrowing and renderer dispatch. A separate `templateType` frontmatter field is unnecessary.
 - Because template types are grouped by collection rather than section, listing views query only the content they need.

--- a/docs/decisions/003-reusable-page-templates-and-routing.md
+++ b/docs/decisions/003-reusable-page-templates-and-routing.md
@@ -55,13 +55,15 @@ Because all profiles are disprsed acros the foundation, hackathon and summit gen
 const fellows = await getCollection(
   'foundation-pages',
   (entry) =>
-    entry.data.templateType === 'profiles' && entry.data.category === 'fellow' && entry.data.locale === currentLocale
+    entry.data.templateType === 'profiles' &&
+    entry.data.category === 'fellow' &&
+    entry.data.locale === currentLocale
 )
 ```
 
 ## Alternatives considered
 
-**A flat file approach**  — where each template type has its own collection and Astro renderes them from a single catch-all entry route at `src/pages/[...page].astro`. But then we lose clean nesting where it is appropriate (like for blogs) and it will incur more technical effort to make structural changes acros the code base. All pages share a single route file; the routing surface is less immediately legible than file-based routes.
+**A flat file approach** — where each template type has its own collection and Astro renderes them from a single catch-all entry route at `src/pages/[...page].astro`. But then we lose clean nesting where it is appropriate (like for blogs) and it will incur more technical effort to make structural changes acros the code base. All pages share a single route file; the routing surface is less immediately legible than file-based routes.
 
 **Section-first routing (status quo)** — routes split by section, not template. Adding a new section is a structural change and may force template logic to be duplicated per section.
 


### PR DESCRIPTION
## Summary
<!-- What changed and why -->

Updates ADR-003 to document how to approach content templates; routing, rendering, and listing views.

I updated the ADR directly since it was never accepted and was a placeholder while we waited for more information as the design progressed.

## Related Issue
<!-- Fixes INTORG-123 -->

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
