### PR TITLE
fix(homepage): tune tablet animated network circle scroll timing  INTORG-822 

### DIFF
--- a/src/components/homepage/AnimatedNetwork.astro
+++ b/src/components/homepage/AnimatedNetwork.astro
@@ -60,6 +60,11 @@ import AnimatedNetworkProblem, {
     /* Pull circle anchor up from the SVG hub (52% of art height). */
     --network-circle-y-nudge: 2vh;
     --network-circle-x-nudge: 0.75vw;
+    /* Scroll-driven circle growth window (cover timeline). */
+    --network-circle-range-start: 35%;
+    --network-circle-range-end: 91%;
+    /* ~80× covers viewport from hub at default; raised on tablet when needed. */
+    --network-circle-max-scale: 80;
     /* Extra top room for scale(1.25) + rotation bleeding into HomepageHero. */
     --network-clip-top: calc(var(--network-hero-overlap) + 22vh);
     /* Negative top inset lets transformed SVG paint above this section's top edge. */
@@ -73,6 +78,15 @@ import AnimatedNetworkProblem, {
 
     [data-component='AnimatedNetwork'] .network-problem-section > div {
       gap: var(--spacing-xl);
+    }
+  }
+
+  @media (min-width: 810px) and (max-width: 1199px) {
+    [data-component='AnimatedNetwork'] {
+      /* Tablet: start sooner, finish earlier, and scale slightly larger to fill the backdrop. */
+      --network-circle-range-start: 5%;
+      --network-circle-range-end: 58%;
+      --network-circle-max-scale: 92;
     }
   }
 
@@ -157,8 +171,6 @@ import AnimatedNetworkProblem, {
     /* Grows via transform scale (not width) to limit compositor layer size on low-end devices. */
     [data-component='AnimatedNetwork'] .growing-circle {
       --network-circle-size: 4vw;
-      /* ~80× covers viewport from hub; 500× inflated document scroll height. */
-      --network-circle-max-scale: 80;
       width: var(--network-circle-size);
       aspect-ratio: 1;
       flex: none;
@@ -170,7 +182,8 @@ import AnimatedNetworkProblem, {
       /* 1ms duration: scroll-driven pattern — timeline controls progress, not duration. */
       animation: growing-circle-grow 1ms linear forwards;
       animation-timeline: --network-track;
-      animation-range: cover 35% cover 91%;
+      animation-range: cover var(--network-circle-range-start) cover
+        var(--network-circle-range-end);
     }
   }
 

--- a/src/scripts/animated-network.test.ts
+++ b/src/scripts/animated-network.test.ts
@@ -6,13 +6,21 @@ import {
 } from './animated-network'
 
 describe('animated-network helpers', () => {
-  it('getCircleProgress maps circle growth animation range', () => {
+  it('getCircleProgress maps default circle growth animation range', () => {
     expect(getCircleProgress(0)).toBe(0)
     expect(getCircleProgress(0.25)).toBe(0)
     expect(getCircleProgress(0.35)).toBe(0)
     expect(getCircleProgress(0.63)).toBeCloseTo(0.5)
     expect(getCircleProgress(0.91)).toBe(1)
     expect(getCircleProgress(1)).toBe(1)
+  })
+
+  it('getCircleProgress accepts custom range (tablet)', () => {
+    expect(getCircleProgress(0.04, 0.05, 0.58)).toBe(0)
+    expect(getCircleProgress(0.05, 0.05, 0.58)).toBe(0)
+    expect(getCircleProgress(0.315, 0.05, 0.58)).toBeCloseTo(0.5)
+    expect(getCircleProgress(0.58, 0.05, 0.58)).toBe(1)
+    expect(getCircleProgress(0.91, 0.05, 0.58)).toBe(1)
   })
 
   it('uses the tablet breakpoint token from tailwind config', () => {

--- a/src/scripts/animated-network.ts
+++ b/src/scripts/animated-network.ts
@@ -19,8 +19,8 @@ const VIEWPORT_NEAR_MARGIN_PX = 200
 const ROTATE_START_DEG = -15
 const ROTATE_END_DEG = 65
 const SCALE = 1.25
-/** Matches `--network-circle-max-scale` in AnimatedNetwork.astro (transform scale factor). */
-const CIRCLE_SCALE_FACTOR = 80
+/** Default max scale — matches `--network-circle-max-scale` in AnimatedNetwork.astro */
+export const CIRCLE_SCALE_FACTOR = 80
 
 const NETWORK_SECTION_SELECTOR = '[data-component="AnimatedNetwork"]'
 
@@ -107,33 +107,71 @@ export function getViewProgress(): number {
   return Math.min(1, Math.max(0, progress))
 }
 
-/** Matches `animation-range: cover 35% cover 91%` in AnimatedNetwork.astro */
-const CIRCLE_ANIMATION_RANGE_START = 0.35
-const CIRCLE_ANIMATION_RANGE_END = 0.91
+/** Default circle range — matches `--network-circle-range-*` in AnimatedNetwork.astro */
+export const CIRCLE_ANIMATION_RANGE_START = 0.35
+export const CIRCLE_ANIMATION_RANGE_END = 0.91
 
 /** View progress slice for circle growth animation range. */
-export function getCircleProgress(viewProgress: number): number {
-  const range = CIRCLE_ANIMATION_RANGE_END - CIRCLE_ANIMATION_RANGE_START
-  return Math.min(
-    1,
-    Math.max(0, (viewProgress - CIRCLE_ANIMATION_RANGE_START) / range)
-  )
+export function getCircleProgress(
+  viewProgress: number,
+  rangeStart = CIRCLE_ANIMATION_RANGE_START,
+  rangeEnd = CIRCLE_ANIMATION_RANGE_END
+): number {
+  const range = rangeEnd - rangeStart
+  return Math.min(1, Math.max(0, (viewProgress - rangeStart) / range))
 }
 
-function getCircleScale(circleProgress: number): number {
-  return 1 + circleProgress * (CIRCLE_SCALE_FACTOR - 1)
+function parseCircleRangePercent(value: string, fallback: number): number {
+  const trimmed = value.trim()
+  if (!trimmed.endsWith('%')) return fallback
+  const parsed = Number.parseFloat(trimmed)
+  return Number.isFinite(parsed) ? parsed / 100 : fallback
+}
+
+/** Read scroll-driven circle range from section CSS variables (tablet overrides). */
+function getCircleRangeFromSection(section: HTMLElement): {
+  start: number
+  end: number
+} {
+  const styles = getComputedStyle(section)
+  return {
+    start: parseCircleRangePercent(
+      styles.getPropertyValue('--network-circle-range-start'),
+      CIRCLE_ANIMATION_RANGE_START
+    ),
+    end: parseCircleRangePercent(
+      styles.getPropertyValue('--network-circle-range-end'),
+      CIRCLE_ANIMATION_RANGE_END
+    )
+  }
+}
+
+function getCircleMaxScaleFromSection(section: HTMLElement): number {
+  const circle = section.querySelector('.growing-circle')
+  const styles = getComputedStyle(
+    circle instanceof HTMLElement ? circle : section
+  )
+  const parsed = Number.parseFloat(
+    styles.getPropertyValue('--network-circle-max-scale')
+  )
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : CIRCLE_SCALE_FACTOR
+}
+
+function getCircleScale(circleProgress: number, maxScale: number): number {
+  return 1 + circleProgress * (maxScale - 1)
 }
 
 function applyReducedMotionState(section: HTMLElement): void {
   const svg = section.querySelector('.network-svg:not(.network-svg--static)')
   const circle = section.querySelector('.growing-circle')
+  const maxScale = getCircleMaxScaleFromSection(section)
 
   if (svg instanceof HTMLElement) {
     svg.style.transform = `rotate(20deg) scale(${SCALE})`
   }
 
   if (circle instanceof HTMLElement) {
-    circle.style.transform = `scale(${CIRCLE_SCALE_FACTOR})`
+    circle.style.transform = `scale(${maxScale})`
     circle.style.opacity = '1'
   }
 }
@@ -150,8 +188,10 @@ function updateNetwork(section: HTMLElement): void {
 
   svg.style.transform = `rotate(${rotate}deg) scale(${SCALE})`
 
-  const circleProgress = getCircleProgress(viewProgress)
-  circle.style.transform = `scale(${getCircleScale(circleProgress)})`
+  const { start, end } = getCircleRangeFromSection(section)
+  const maxScale = getCircleMaxScaleFromSection(section)
+  const circleProgress = getCircleProgress(viewProgress, start, end)
+  circle.style.transform = `scale(${getCircleScale(circleProgress, maxScale)})`
   circle.style.opacity = circleProgress > 0 ? '1' : '0'
 }
 


### PR DESCRIPTION
## Summary

On tablet (810px–1199px), the homepage purple circle backdrop was lagging behind scroll — black showed through before the circle filled the problem section.

This PR tunes the scroll-driven circle animation for tablet only:

- **Starts earlier:** `cover 35%` → `cover 5%`
- **Finishes sooner:** `cover 91%` → `cover 58%` (faster growth over a shorter scroll window)
- **Scales slightly larger at full size:** max scale `80` → `92`

Animation timing and max scale are driven by CSS custom properties (`--network-circle-range-start/end`, `--network-circle-max-scale`). The Firefox JS fallback in `animated-network.ts` reads the same variables so behavior stays consistent across browsers.

Desktop (1200px+) is unchanged.

## Related Issue

Fixes INTORG-___

## Manual Test

1. Open the homepage at a tablet width (810px–1199px), e.g. iPad in devtools.
2. Scroll from the hero into the “network problem” section.
3. Confirm the purple circle:
   - begins growing earlier in the scroll
   - reaches full backdrop coverage before/as the problem copy and video come into view
   - fully covers the background without visible black gaps at the edges
4. Repeat in Firefox (JS fallback path) and Chrome/Safari (scroll-driven animations).
5. At desktop (≥1200px), confirm animation behavior is unchanged from before.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)