### PR TITLE
feat: grant page template base

### DIFF
--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -5,12 +5,14 @@ import {
   buildPagePayload,
   buildBlogPayload,
   buildAmbassadorPayload,
+  buildGrantPagePayload,
   type StrapiUploadContext
 } from './mdxTransformer'
 import {
   ambassadorFrontmatterSchema,
   foundationBlogFrontmatterSchema,
   foundationPageFrontmatterSchema,
+  grantPageFrontmatterSchema,
   summitPageFrontmatterSchema
 } from './siteSchemas'
 // Side-effect imports: register component handlers
@@ -57,6 +59,7 @@ export interface ContentTypeConfig {
 
 export interface ContentTypes {
   'foundation-pages': ContentTypeConfig
+  'grant-pages': ContentTypeConfig
   'summit-pages': ContentTypeConfig
   'foundation-blog-posts': ContentTypeConfig
   ambassadors: ContentTypeConfig
@@ -110,6 +113,13 @@ export function buildContentTypes(
   const pageAltIds = new Map<number, string | null>()
 
   return {
+    'grant-pages': {
+      dir: getContentPath(projectRoot, 'grantPages'),
+      apiId: 'grant-pages',
+      schema: grantPageFrontmatterSchema,
+      buildPayload: (mdx, _strapi, _existing, _dryRun) =>
+        buildGrantPagePayload(grantPageFrontmatterSchema, mdx)
+    },
     ambassadors: {
       dir: getContentPath(projectRoot, 'ambassadors'),
       apiId: 'ambassadors',

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -25,16 +25,46 @@ vi.mock('./siteSchemas', async () => {
     localizes: z.string().optional(),
     locale: z.string().optional()
   })
+  const grantCtaStripSchema = z.object({
+    heading: z.string(),
+    description: z.string(),
+    buttonText: z.string(),
+    buttonLink: z.string()
+  })
+  const grantPageSchema = z.object({
+    title: z.string().min(1, 'title is required'),
+    pathSlug: z.string().min(1, 'pathSlug is required'),
+    description: z.string().min(1, 'description is required'),
+    primaryCta: z
+      .object({
+        text: z.string(),
+        link: z.string(),
+        external: z.boolean().optional()
+      })
+      .optional(),
+    ctaStrip: grantCtaStripSchema,
+    metaDescription: z.string().optional(),
+    metaImage: z.string().optional(),
+    canonicalUrl: z.string().optional(),
+    localizes: z.string().optional(),
+    locale: z.string().optional()
+  })
   return {
     foundationPageFrontmatterSchema: pageSchema,
-    summitPageFrontmatterSchema: pageSchema
+    summitPageFrontmatterSchema: pageSchema,
+    grantPageFrontmatterSchema: grantPageSchema
   }
 })
 
-import { getEntryField, buildPagePayload } from './mdxTransformer'
+import {
+  getEntryField,
+  buildPagePayload,
+  buildGrantPagePayload
+} from './mdxTransformer'
 import {
   foundationPageFrontmatterSchema,
-  summitPageFrontmatterSchema
+  summitPageFrontmatterSchema,
+  grantPageFrontmatterSchema
 } from './siteSchemas'
 import type { StrapiEntry } from './strapiClient'
 import { createMdxFile } from './test-utils'
@@ -651,6 +681,379 @@ describe('buildPagePayload', () => {
         __component: 'blocks.callout-text',
         content: 'Nota importante.'
       })
+    })
+  })
+})
+
+// Helpers for grant-page tests
+const baseGrantFrontmatter = {
+  title: 'On-Campus Grant',
+  description: 'Funding for campus programmes.',
+  ctaStrip: {
+    heading: 'Apply now',
+    description: 'Deadline approaching.',
+    buttonText: 'Start application',
+    buttonLink: 'https://example.com/apply'
+  }
+}
+
+// Maps grant-page MDX frontmatter to the Strapi grant-page payload shape.
+// Key risks: CTA field name translation (buttonText→primaryButtonText, etc.)
+// and optional primaryCta / seo being omitted when absent.
+describe('buildGrantPagePayload', () => {
+  describe('error handling', () => {
+    it('returns Error when title is missing', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: {
+          description: 'Some description',
+          ctaStrip: baseGrantFrontmatter.ctaStrip
+        }
+      })
+
+      const result = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect(result).toBeInstanceOf(Error)
+    })
+
+    it('returns Error when description is missing', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: {
+          title: 'On-Campus Grant',
+          ctaStrip: baseGrantFrontmatter.ctaStrip
+        }
+      })
+
+      const result = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect(result).toBeInstanceOf(Error)
+    })
+
+    it('returns Error when ctaStrip is missing', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: { title: 'On-Campus Grant', description: 'Funding.' }
+      })
+
+      const result = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect(result).toBeInstanceOf(Error)
+    })
+  })
+
+  describe('base payload fields', () => {
+    it('includes title from frontmatter', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).title).toBe('On-Campus Grant')
+    })
+
+    it('includes pathSlug from mdx file', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).pathSlug).toBe(
+        'education/on-campus'
+      )
+    })
+
+    it('includes description from frontmatter', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).description).toBe(
+        'Funding for campus programmes.'
+      )
+    })
+
+    it('includes publishedAt timestamp', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect(typeof (payload as Record<string, unknown>).publishedAt).toBe(
+        'string'
+      )
+    })
+  })
+
+  // CTA strip field names differ between MDX frontmatter and the Strapi
+  // blocks.cta-strip component. Wrong mapping here silently wipes button text.
+  describe('CTA strip field mapping', () => {
+    it('maps buttonText to primaryButtonText', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      const ctaStrip = (payload as Record<string, unknown>).ctaStrip as Record<
+        string,
+        unknown
+      >
+      expect(ctaStrip.primaryButtonText).toBe('Start application')
+    })
+
+    it('maps buttonLink to primaryButtonLink', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      const ctaStrip = (payload as Record<string, unknown>).ctaStrip as Record<
+        string,
+        unknown
+      >
+      expect(ctaStrip.primaryButtonLink).toBe('https://example.com/apply')
+    })
+
+    it('sets default color to purple', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      const ctaStrip = (payload as Record<string, unknown>).ctaStrip as Record<
+        string,
+        unknown
+      >
+      expect(ctaStrip.color).toBe('purple')
+    })
+
+    it('includes heading and description from ctaStrip frontmatter', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      const ctaStrip = (payload as Record<string, unknown>).ctaStrip as Record<
+        string,
+        unknown
+      >
+      expect(ctaStrip.heading).toBe('Apply now')
+      expect(ctaStrip.description).toBe('Deadline approaching.')
+    })
+  })
+
+  describe('optional primaryCta', () => {
+    it('is not included in payload when absent', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect(Object.prototype.hasOwnProperty.call(payload, 'primaryCta')).toBe(
+        false
+      )
+    })
+
+    it('is included with correct fields when present', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: {
+          ...baseGrantFrontmatter,
+          primaryCta: {
+            text: 'Apply Now',
+            link: 'https://example.com/apply',
+            external: true
+          }
+        }
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).primaryCta).toEqual({
+        text: 'Apply Now',
+        link: 'https://example.com/apply',
+        external: true,
+        style: 'primary'
+      })
+    })
+
+    it('defaults external to false when not specified', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: {
+          ...baseGrantFrontmatter,
+          primaryCta: { text: 'Apply Now', link: 'https://example.com/apply' }
+        }
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      const primaryCta = (payload as Record<string, unknown>)
+        .primaryCta as Record<string, unknown>
+      expect(primaryCta.external).toBe(false)
+    })
+  })
+
+  // SEO fields are optional; the block should only appear when at least one is set.
+  describe('SEO fields', () => {
+    it('seo is not included when no SEO frontmatter fields are set', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect(Object.prototype.hasOwnProperty.call(payload, 'seo')).toBe(false)
+    })
+
+    it('seo is included when metaDescription is set', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: {
+          ...baseGrantFrontmatter,
+          metaDescription: 'SEO description for the grant page.'
+        }
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).seo).toMatchObject({
+        metaDescription: 'SEO description for the grant page.'
+      })
+    })
+
+    it('seo is included when metaImage is set', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: {
+          ...baseGrantFrontmatter,
+          metaImage: '/img/grant-og.png'
+        }
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).seo).toMatchObject({
+        metaImage: '/img/grant-og.png'
+      })
+    })
+
+    it('seo is included when canonicalUrl is set', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: {
+          ...baseGrantFrontmatter,
+          canonicalUrl: 'https://interledger.org/grant/education/on-campus'
+        }
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).seo).toMatchObject({
+        canonicalUrl: 'https://interledger.org/grant/education/on-campus'
+      })
+    })
+  })
+
+  describe('programOverview', () => {
+    it('is set from mdx.content when body is present', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter,
+        content: '## Eligibility\n\n- Accredited institutions'
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).programOverview).toBe(
+        '## Eligibility\n\n- Accredited institutions'
+      )
+    })
+
+    it('is null when mdx body is empty', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter,
+        content: ''
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).programOverview).toBeNull()
+    })
+
+    it('is null when mdx body is whitespace only', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter,
+        content: '   \n\n   '
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).programOverview).toBeNull()
     })
   })
 })

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -972,8 +972,7 @@ describe('buildGrantPagePayload', () => {
       expect((payload as Record<string, unknown>).primaryCta).toEqual({
         text: 'Apply Now',
         link: 'https://example.com/apply',
-        external: true,
-        style: 'primary'
+        external: true
       })
     })
 

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -956,7 +956,7 @@ describe('buildGrantPagePayload', () => {
   })
 
   describe('optional primaryCta', () => {
-    it('is not included in payload when absent', async () => {
+    it('is null in payload when absent', async () => {
       const mdx = createMdxFile({
         pathSlug: 'education/on-campus',
         frontmatter: baseGrantFrontmatter
@@ -966,9 +966,7 @@ describe('buildGrantPagePayload', () => {
         grantPageFrontmatterSchema,
         mdx
       )
-      expect(Object.prototype.hasOwnProperty.call(payload, 'primaryCta')).toBe(
-        false
-      )
+      expect((payload as Record<string, unknown>).primaryCta).toBeNull()
     })
 
     it('is included with correct fields when present', async () => {
@@ -1014,9 +1012,11 @@ describe('buildGrantPagePayload', () => {
     })
   })
 
-  // SEO fields are optional; the block should only appear when at least one is set.
+  // Only metaDescription is synced to Strapi's seo component.
+  // metaImage requires a media upload ID (not a URL) so it is not synced;
+  // canonicalUrl is not currently supported by the grant-page sync.
   describe('SEO fields', () => {
-    it('seo is not included when no SEO frontmatter fields are set', async () => {
+    it('seo is null when metaDescription is not set', async () => {
       const mdx = createMdxFile({
         pathSlug: 'education/on-campus',
         frontmatter: baseGrantFrontmatter
@@ -1026,10 +1026,27 @@ describe('buildGrantPagePayload', () => {
         grantPageFrontmatterSchema,
         mdx
       )
-      expect(Object.prototype.hasOwnProperty.call(payload, 'seo')).toBe(false)
+      expect((payload as Record<string, unknown>).seo).toBeNull()
     })
 
-    it('seo is included when metaDescription is set', async () => {
+    it('seo is null even when only metaImage or canonicalUrl are set', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: {
+          ...baseGrantFrontmatter,
+          metaImage: '/img/grant-og.png',
+          canonicalUrl: 'https://interledger.org/grant/education/on-campus'
+        }
+      })
+
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      expect((payload as Record<string, unknown>).seo).toBeNull()
+    })
+
+    it('seo contains metaDescription when metaDescription is set', async () => {
       const mdx = createMdxFile({
         pathSlug: 'education/on-campus',
         frontmatter: {
@@ -1042,44 +1059,8 @@ describe('buildGrantPagePayload', () => {
         grantPageFrontmatterSchema,
         mdx
       )
-      expect((payload as Record<string, unknown>).seo).toMatchObject({
+      expect((payload as Record<string, unknown>).seo).toEqual({
         metaDescription: 'SEO description for the grant page.'
-      })
-    })
-
-    it('seo is included when metaImage is set', async () => {
-      const mdx = createMdxFile({
-        pathSlug: 'education/on-campus',
-        frontmatter: {
-          ...baseGrantFrontmatter,
-          metaImage: '/img/grant-og.png'
-        }
-      })
-
-      const payload = await buildGrantPagePayload(
-        grantPageFrontmatterSchema,
-        mdx
-      )
-      expect((payload as Record<string, unknown>).seo).toMatchObject({
-        metaImage: '/img/grant-og.png'
-      })
-    })
-
-    it('seo is included when canonicalUrl is set', async () => {
-      const mdx = createMdxFile({
-        pathSlug: 'education/on-campus',
-        frontmatter: {
-          ...baseGrantFrontmatter,
-          canonicalUrl: 'https://interledger.org/grant/education/on-campus'
-        }
-      })
-
-      const payload = await buildGrantPagePayload(
-        grantPageFrontmatterSchema,
-        mdx
-      )
-      expect((payload as Record<string, unknown>).seo).toMatchObject({
-        canonicalUrl: 'https://interledger.org/grant/education/on-campus'
       })
     })
   })

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -29,7 +29,10 @@ vi.mock('./siteSchemas', async () => {
     heading: z.string(),
     description: z.string(),
     buttonText: z.string(),
-    buttonLink: z.string()
+    buttonLink: z.string(),
+    color: z.enum(['purple', 'green']).default('purple'),
+    secondaryButtonText: z.string().optional(),
+    secondaryButtonLink: z.string().optional()
   })
   const grantPageSchema = z.object({
     title: z.string().min(1, 'title is required'),
@@ -878,6 +881,58 @@ describe('buildGrantPagePayload', () => {
       >
       expect(ctaStrip.heading).toBe('Apply now')
       expect(ctaStrip.description).toBe('Deadline approaching.')
+    })
+
+    it('passes through color when set to green', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: {
+          ...baseGrantFrontmatter,
+          ctaStrip: { ...baseGrantFrontmatter.ctaStrip, color: 'green' }
+        }
+      })
+
+      const payload = await buildGrantPagePayload(grantPageFrontmatterSchema, mdx)
+      const ctaStrip = (payload as Record<string, unknown>)
+        .ctaStrip as Record<string, unknown>
+      expect(ctaStrip.color).toBe('green')
+    })
+
+    it('does not include secondary button fields when absent', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: baseGrantFrontmatter
+      })
+
+      const payload = await buildGrantPagePayload(grantPageFrontmatterSchema, mdx)
+      const ctaStrip = (payload as Record<string, unknown>)
+        .ctaStrip as Record<string, unknown>
+      expect(
+        Object.prototype.hasOwnProperty.call(ctaStrip, 'secondaryButtonText')
+      ).toBe(false)
+      expect(
+        Object.prototype.hasOwnProperty.call(ctaStrip, 'secondaryButtonLink')
+      ).toBe(false)
+    })
+
+    it('includes secondary button fields when provided', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'education/on-campus',
+        frontmatter: {
+          ...baseGrantFrontmatter,
+          ctaStrip: {
+            ...baseGrantFrontmatter.ctaStrip,
+            secondaryButtonText: 'Learn more',
+            secondaryButtonLink: 'https://example.com/info'
+          }
+        }
+      })
+
+      const payload = await buildGrantPagePayload(grantPageFrontmatterSchema, mdx)
+      const ctaStrip = (payload as Record<string, unknown>)
+        .ctaStrip as Record<string, unknown>
+      expect(ctaStrip.secondaryButtonText).toBe('Learn more')
+      expect(ctaStrip.secondaryButtonLink).toBe('https://example.com/info')
     })
   })
 

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -157,7 +157,7 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.title).toBe('About Us')
+      expect((payload as Record<string, unknown>).title).toBe('About Us')
     })
 
     it('includes slug from mdx file', async () => {
@@ -172,7 +172,7 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.pathSlug).toBe('about-page')
+      expect((payload as Record<string, unknown>).pathSlug).toBe('about-page')
     })
 
     it('includes publishedAt timestamp', async () => {
@@ -187,8 +187,10 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.publishedAt).toBeDefined()
-      expect(typeof payload.publishedAt).toBe('string')
+      expect((payload as Record<string, unknown>).publishedAt).toBeDefined()
+      expect(typeof (payload as Record<string, unknown>).publishedAt).toBe(
+        'string'
+      )
     })
 
     it('accepts optional schema fields (description, heroImage, sections)', async () => {
@@ -215,8 +217,8 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.title).toBe('About')
-      expect(payload.pathSlug).toBe('about')
+      expect((payload as Record<string, unknown>).title).toBe('About')
+      expect((payload as Record<string, unknown>).pathSlug).toBe('about')
     })
   })
 
@@ -239,7 +241,7 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.hero).toEqual({
+      expect((payload as Record<string, unknown>).hero).toEqual({
         title: 'Welcome',
         description: 'Learn about us'
       })
@@ -261,7 +263,7 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.hero).toEqual({
+      expect((payload as Record<string, unknown>).hero).toEqual({
         title: 'About Page',
         description: 'Description only'
       })
@@ -282,7 +284,7 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.hero).toEqual({
+      expect((payload as Record<string, unknown>).hero).toEqual({
         title: 'Hero Only',
         description: ''
       })
@@ -307,7 +309,7 @@ describe('buildPagePayload', () => {
         existingEntry
       )
 
-      expect(payload.hero).toEqual({
+      expect((payload as Record<string, unknown>).hero).toEqual({
         title: 'Existing Hero',
         description: 'Kept intact'
       })
@@ -326,7 +328,7 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.hero).toBeUndefined()
+      expect((payload as Record<string, unknown>).hero).toBeUndefined()
     })
 
     // MDX hero fields take precedence over Strapi — intentional override
@@ -351,7 +353,7 @@ describe('buildPagePayload', () => {
         existingEntry
       )
 
-      expect(payload.hero).toEqual({
+      expect((payload as Record<string, unknown>).hero).toEqual({
         title: 'New Hero',
         description: 'New desc'
       })
@@ -373,7 +375,7 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.content).toEqual([
+      expect((payload as Record<string, unknown>).content).toEqual([
         {
           __component: 'blocks.paragraph',
           content: '## Heading\n\nParagraph text'
@@ -399,7 +401,7 @@ describe('buildPagePayload', () => {
         existingEntry
       )
 
-      expect(payload.content).toEqual([
+      expect((payload as Record<string, unknown>).content).toEqual([
         { __component: 'blocks.paragraph', content: 'Existing' }
       ])
     })
@@ -423,7 +425,7 @@ describe('buildPagePayload', () => {
         existingEntry
       )
 
-      expect(payload.content).toEqual([
+      expect((payload as Record<string, unknown>).content).toEqual([
         { __component: 'blocks.paragraph', content: 'Kept' }
       ])
     })
@@ -440,7 +442,7 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.content).toBeUndefined()
+      expect((payload as Record<string, unknown>).content).toBeUndefined()
     })
 
     it('overrides existing content when mdx has body', async () => {
@@ -461,7 +463,7 @@ describe('buildPagePayload', () => {
         existingEntry
       )
 
-      expect(payload.content).toEqual([
+      expect((payload as Record<string, unknown>).content).toEqual([
         { __component: 'blocks.paragraph', content: 'New content' }
       ])
     })
@@ -479,7 +481,7 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.content).toBeUndefined()
+      expect((payload as Record<string, unknown>).content).toBeUndefined()
     })
   })
 
@@ -497,9 +499,9 @@ describe('buildPagePayload', () => {
         null
       )
 
-      expect(payload.title).toBe('Schedule')
-      expect(payload.pathSlug).toBe('schedule')
-      expect(payload.content).toEqual([
+      expect((payload as Record<string, unknown>).title).toBe('Schedule')
+      expect((payload as Record<string, unknown>).pathSlug).toBe('schedule')
+      expect((payload as Record<string, unknown>).content).toEqual([
         { __component: 'blocks.paragraph', content: 'Summit content' }
       ])
     })
@@ -532,7 +534,7 @@ describe('buildPagePayload', () => {
         parserCtx
       )
 
-      expect(payload.content).toEqual([
+      expect((payload as Record<string, unknown>).content).toEqual([
         {
           __component: 'blocks.ambassador',
           ambassador: { connect: [{ documentId: 'doc-alice' }] }
@@ -591,7 +593,7 @@ describe('buildPagePayload', () => {
         parserCtx
       )
 
-      expect(payload.content).toEqual([
+      expect((payload as Record<string, unknown>).content).toEqual([
         {
           __component: 'blocks.blockquote',
           quote: 'Una cita.',
@@ -632,7 +634,7 @@ describe('buildPagePayload', () => {
       )
 
       expect(resolveRelation).toHaveBeenCalledWith('ambassadors', 'alice')
-      expect(payload.content).toEqual([
+      expect((payload as Record<string, unknown>).content).toEqual([
         {
           __component: 'blocks.ambassador',
           ambassador: { connect: [{ documentId: 'doc-alice' }] }
@@ -672,7 +674,9 @@ describe('buildPagePayload', () => {
         parserCtx
       )
 
-      const content = payload.content as Array<Record<string, unknown>>
+      const content = (payload as Record<string, unknown>).content as Array<
+        Record<string, unknown>
+      >
       expect(content).toHaveLength(3)
       expect(content[0]).toMatchObject({ __component: 'blocks.paragraph' })
       expect(content[1]).toMatchObject({
@@ -892,9 +896,14 @@ describe('buildGrantPagePayload', () => {
         }
       })
 
-      const payload = await buildGrantPagePayload(grantPageFrontmatterSchema, mdx)
-      const ctaStrip = (payload as Record<string, unknown>)
-        .ctaStrip as Record<string, unknown>
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      const ctaStrip = (payload as Record<string, unknown>).ctaStrip as Record<
+        string,
+        unknown
+      >
       expect(ctaStrip.color).toBe('green')
     })
 
@@ -904,9 +913,14 @@ describe('buildGrantPagePayload', () => {
         frontmatter: baseGrantFrontmatter
       })
 
-      const payload = await buildGrantPagePayload(grantPageFrontmatterSchema, mdx)
-      const ctaStrip = (payload as Record<string, unknown>)
-        .ctaStrip as Record<string, unknown>
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      const ctaStrip = (payload as Record<string, unknown>).ctaStrip as Record<
+        string,
+        unknown
+      >
       expect(
         Object.prototype.hasOwnProperty.call(ctaStrip, 'secondaryButtonText')
       ).toBe(false)
@@ -928,9 +942,14 @@ describe('buildGrantPagePayload', () => {
         }
       })
 
-      const payload = await buildGrantPagePayload(grantPageFrontmatterSchema, mdx)
-      const ctaStrip = (payload as Record<string, unknown>)
-        .ctaStrip as Record<string, unknown>
+      const payload = await buildGrantPagePayload(
+        grantPageFrontmatterSchema,
+        mdx
+      )
+      const ctaStrip = (payload as Record<string, unknown>).ctaStrip as Record<
+        string,
+        unknown
+      >
       expect(ctaStrip.secondaryButtonText).toBe('Learn more')
       expect(ctaStrip.secondaryButtonLink).toBe('https://example.com/info')
     })

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -423,7 +423,13 @@ export async function buildGrantPagePayload(
       description: ctaStripFm.description,
       primaryButtonText: ctaStripFm.buttonText,
       primaryButtonLink: ctaStripFm.buttonLink,
-      color: 'purple' as const
+      color: ctaStripFm.color,
+      ...(ctaStripFm.secondaryButtonText
+        ? { secondaryButtonText: ctaStripFm.secondaryButtonText }
+        : {}),
+      ...(ctaStripFm.secondaryButtonLink
+        ? { secondaryButtonLink: ctaStripFm.secondaryButtonLink }
+        : {})
     }
 
     const seo =

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -434,9 +434,15 @@ export async function buildGrantPagePayload(
     const seo =
       parsed.metaDescription || parsed.metaImage || parsed.canonicalUrl
         ? {
-            metaDescription: parsed.metaDescription ?? null,
-            metaImage: parsed.metaImage ?? null,
-            canonicalUrl: parsed.canonicalUrl ?? null
+            ...(parsed.metaDescription != null
+              ? { metaDescription: parsed.metaDescription }
+              : {}),
+            ...(parsed.metaImage != null
+              ? { metaImage: parsed.metaImage }
+              : {}),
+            ...(parsed.canonicalUrl != null
+              ? { canonicalUrl: parsed.canonicalUrl }
+              : {})
           }
         : null
 

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -431,29 +431,18 @@ export async function buildGrantPagePayload(
         : {})
     }
 
-    const seo =
-      parsed.metaDescription || parsed.metaImage || parsed.canonicalUrl
-        ? {
-            ...(parsed.metaDescription != null
-              ? { metaDescription: parsed.metaDescription }
-              : {}),
-            ...(parsed.metaImage != null
-              ? { metaImage: parsed.metaImage }
-              : {}),
-            ...(parsed.canonicalUrl != null
-              ? { canonicalUrl: parsed.canonicalUrl }
-              : {})
-          }
-        : null
+    const seo = parsed.metaDescription
+      ? { metaDescription: parsed.metaDescription }
+      : null
 
     return {
       title: parsed.title,
       pathSlug: parsed.pathSlug,
       description: parsed.description,
       programOverview: (mdx.content || '').trim() || null,
-      ...(primaryCta ? { primaryCta } : {}),
+      primaryCta,
       ctaStrip,
-      ...(seo ? { seo } : {}),
+      seo,
       publishedAt: new Date().toISOString()
     }
   })

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -412,8 +412,7 @@ export async function buildGrantPagePayload(
       ? {
           text: parsed.primaryCta.text,
           link: parsed.primaryCta.link,
-          external: parsed.primaryCta.external ?? false,
-          style: 'primary'
+          external: parsed.primaryCta.external ?? false
         }
       : null
 

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -18,7 +18,10 @@
 import type { MDXFile } from './mdxTypes'
 import type { StrapiClient, StrapiEntry } from './strapiClient'
 import type { FrontmatterSchema } from './config'
-import type { foundationBlogFrontmatterSchema } from '@site/schemas/content'
+import type {
+  foundationBlogFrontmatterSchema,
+  grantPageFrontmatterSchema
+} from '@site/schemas/content'
 import { parseMdxToBlocks, type ParserContext } from './mdxBlockParser'
 import { MdxParserError } from './parserErrors'
 import { normalizeInlineImages } from './normalizeImages'
@@ -387,6 +390,59 @@ export async function buildAmbassadorPayload(
       category: nullOrValue(mdx.frontmatter.category),
       tagline: nullOrValue(mdx.frontmatter.tagline),
       quote: nullOrValue(mdx.frontmatter.quote),
+      publishedAt: new Date().toISOString()
+    }
+  })
+}
+
+/**
+ * Builds a Strapi payload for a grant-page MDX file.
+ *
+ * Maps frontmatter fields and MDX body to the grant-page Strapi schema.
+ * No image resolution needed — grant pages contain no managed media fields.
+ */
+export async function buildGrantPagePayload(
+  schema: typeof grantPageFrontmatterSchema,
+  mdx: MDXFile
+): Promise<Record<string, unknown> | Error> {
+  return tryCatchAsync(async () => {
+    const parsed = schema.parse({ ...mdx.frontmatter, pathSlug: mdx.pathSlug })
+
+    const primaryCta = parsed.primaryCta
+      ? {
+          text: parsed.primaryCta.text,
+          link: parsed.primaryCta.link,
+          external: parsed.primaryCta.external ?? false,
+          style: 'primary'
+        }
+      : null
+
+    const ctaStripFm = parsed.ctaStrip
+    const ctaStrip = {
+      heading: ctaStripFm.heading,
+      description: ctaStripFm.description,
+      primaryButtonText: ctaStripFm.buttonText,
+      primaryButtonLink: ctaStripFm.buttonLink,
+      color: 'purple' as const
+    }
+
+    const seo =
+      parsed.metaDescription || parsed.metaImage || parsed.canonicalUrl
+        ? {
+            metaDescription: parsed.metaDescription ?? null,
+            metaImage: parsed.metaImage ?? null,
+            canonicalUrl: parsed.canonicalUrl ?? null
+          }
+        : null
+
+    return {
+      title: parsed.title,
+      pathSlug: parsed.pathSlug,
+      description: parsed.description,
+      programOverview: (mdx.content || '').trim() || null,
+      ...(primaryCta ? { primaryCta } : {}),
+      ctaStrip,
+      ...(seo ? { seo } : {}),
       publishedAt: new Date().toISOString()
     }
   })

--- a/cms/scripts/sync-mdx/siteSchemas.ts
+++ b/cms/scripts/sync-mdx/siteSchemas.ts
@@ -1,6 +1,7 @@
 export {
   ambassadorFrontmatterSchema,
   foundationPageFrontmatterSchema,
+  grantPageFrontmatterSchema,
   summitPageFrontmatterSchema,
   foundationBlogFrontmatterSchema
 } from '@site/schemas/content'

--- a/cms/src/api/grant-page/content-types/grant-page/lifecycles.ts
+++ b/cms/src/api/grant-page/content-types/grant-page/lifecycles.ts
@@ -4,7 +4,6 @@ import {
   type PageData,
   PATHS,
   MATTER_STRINGIFY_OPTIONS,
-  htmlToMarkdown,
   seoFrontmatter,
   GRANT_PAGE_CONTENT_POPULATE
 } from '../../../../utils'
@@ -60,7 +59,7 @@ function generateGrantPageMDX(
           }
         }
       : {}),
-    ...(ctaStrip?.heading
+    ...(ctaStrip
       ? {
           ctaStrip: {
             heading: ctaStrip.heading,
@@ -75,9 +74,7 @@ function generateGrantPageMDX(
     locale
   }
 
-  const body = grantPage.programOverview
-    ? htmlToMarkdown(grantPage.programOverview)
-    : ''
+  const body = grantPage.programOverview ?? ''
 
   return matter.stringify(
     body ? `\n${body}\n` : '',

--- a/cms/src/api/grant-page/content-types/grant-page/lifecycles.ts
+++ b/cms/src/api/grant-page/content-types/grant-page/lifecycles.ts
@@ -19,6 +19,9 @@ interface CtaStrip {
   description?: string
   primaryButtonText?: string
   primaryButtonLink?: string
+  secondaryButtonText?: string
+  secondaryButtonLink?: string
+  color?: string
 }
 
 interface GrantPageData extends PageData {
@@ -37,6 +40,10 @@ function generateGrantPageMDX(
   const locale = page.locale ?? 'en'
   const isLocalized = locale !== 'en'
   const { localizes: preservedLocalizes, ...restPreserved } = preservedFields
+  // metaDescription is owned by the Strapi seo component. Strip it from the
+  // preserved pass-through so that deleting the seo field in Strapi removes it
+  // from the MDX rather than leaving the old value behind.
+  delete (restPreserved as Record<string, unknown>).metaDescription
   const localizesValue =
     (isLocalized && englishSlug ? englishSlug : undefined) ?? preservedLocalizes
 
@@ -65,7 +72,14 @@ function generateGrantPageMDX(
             heading: ctaStrip.heading,
             description: ctaStrip.description ?? '',
             buttonText: ctaStrip.primaryButtonText ?? '',
-            buttonLink: ctaStrip.primaryButtonLink ?? ''
+            buttonLink: ctaStrip.primaryButtonLink ?? '',
+            color: ctaStrip.color ?? 'purple',
+            ...(ctaStrip.secondaryButtonText
+              ? { secondaryButtonText: ctaStrip.secondaryButtonText }
+              : {}),
+            ...(ctaStrip.secondaryButtonLink
+              ? { secondaryButtonLink: ctaStrip.secondaryButtonLink }
+              : {})
           }
         }
       : {}),

--- a/cms/src/api/grant-page/content-types/grant-page/lifecycles.ts
+++ b/cms/src/api/grant-page/content-types/grant-page/lifecycles.ts
@@ -40,10 +40,11 @@ function generateGrantPageMDX(
   const locale = page.locale ?? 'en'
   const isLocalized = locale !== 'en'
   const { localizes: preservedLocalizes, ...restPreserved } = preservedFields
-  // metaDescription is owned by the Strapi seo component. Strip it from the
-  // preserved pass-through so that deleting the seo field in Strapi removes it
-  // from the MDX rather than leaving the old value behind.
+  // Fields owned by Strapi components must be explicitly deleted from
+  // restPreserved so that removing them in Strapi clears them from the MDX
+  // rather than leaving the old value behind.
   delete (restPreserved as Record<string, unknown>).metaDescription
+  delete (restPreserved as Record<string, unknown>).primaryCta
   const localizesValue =
     (isLocalized && englishSlug ? englishSlug : undefined) ?? preservedLocalizes
 

--- a/cms/src/api/grant-page/content-types/grant-page/lifecycles.ts
+++ b/cms/src/api/grant-page/content-types/grant-page/lifecycles.ts
@@ -1,0 +1,96 @@
+import matter from 'gray-matter'
+import {
+  createPageLifecycle,
+  type PageData,
+  PATHS,
+  MATTER_STRINGIFY_OPTIONS,
+  htmlToMarkdown,
+  seoFrontmatter,
+  GRANT_PAGE_CONTENT_POPULATE
+} from '../../../../utils'
+
+interface CtaLink {
+  text?: string
+  link?: string
+  external?: boolean
+}
+
+interface CtaStrip {
+  heading?: string
+  description?: string
+  primaryButtonText?: string
+  primaryButtonLink?: string
+}
+
+interface GrantPageData extends PageData {
+  description?: string
+  programOverview?: string
+  primaryCta?: CtaLink | null
+  ctaStrip?: CtaStrip | null
+}
+
+function generateGrantPageMDX(
+  page: PageData,
+  preservedFields: Record<string, unknown>,
+  englishSlug?: string
+): string {
+  const grantPage = page as GrantPageData
+  const locale = page.locale ?? 'en'
+  const isLocalized = locale !== 'en'
+  const { localizes: preservedLocalizes, ...restPreserved } = preservedFields
+  const localizesValue =
+    (isLocalized && englishSlug ? englishSlug : undefined) ?? preservedLocalizes
+
+  const ctaStrip = grantPage.ctaStrip
+  const primaryCta = grantPage.primaryCta
+
+  const frontmatter: Record<string, unknown> = {
+    ...restPreserved,
+    title: page.title,
+    pathSlug: page.pathSlug,
+    description: grantPage.description ?? '',
+    ...(primaryCta?.text && primaryCta?.link
+      ? {
+          primaryCta: {
+            text: primaryCta.text,
+            link: primaryCta.link,
+            ...(primaryCta.external != null
+              ? { external: primaryCta.external }
+              : {})
+          }
+        }
+      : {}),
+    ...(ctaStrip?.heading
+      ? {
+          ctaStrip: {
+            heading: ctaStrip.heading,
+            description: ctaStrip.description ?? '',
+            buttonText: ctaStrip.primaryButtonText ?? '',
+            buttonLink: ctaStrip.primaryButtonLink ?? ''
+          }
+        }
+      : {}),
+    ...seoFrontmatter(page.seo as { metaDescription?: string } | undefined),
+    ...(localizesValue ? { localizes: localizesValue } : {}),
+    locale
+  }
+
+  const body = grantPage.programOverview
+    ? htmlToMarkdown(grantPage.programOverview)
+    : ''
+
+  return matter.stringify(
+    body ? `\n${body}\n` : '',
+    frontmatter,
+    MATTER_STRINGIFY_OPTIONS
+  )
+}
+
+export default createPageLifecycle({
+  contentTypeUid: 'api::grant-page.grant-page',
+  outputDir: `${PATHS.CONTENT_ROOT}/${PATHS.CONTENT.grantPages}`,
+  populate: GRANT_PAGE_CONTENT_POPULATE as unknown as Parameters<
+    typeof createPageLifecycle
+  >[0]['populate'],
+  generateMDX: generateGrantPageMDX
+})

--- a/cms/src/api/grant-page/content-types/grant-page/schema.json
+++ b/cms/src/api/grant-page/content-types/grant-page/schema.json
@@ -61,7 +61,7 @@
     "primaryCta": {
       "type": "component",
       "repeatable": false,
-      "component": "shared.cta-link",
+      "component": "shared.primary-cta-link",
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/cms/src/api/grant-page/content-types/grant-page/schema.json
+++ b/cms/src/api/grant-page/content-types/grant-page/schema.json
@@ -1,0 +1,93 @@
+{
+  "kind": "collectionType",
+  "collectionName": "grant-pages",
+  "info": {
+    "singularName": "grant-page",
+    "pluralName": "grant-pages",
+    "displayName": "Grant Page",
+    "description": "Individual grant program pages. Path slug is relative to /grant/ — e.g. education/on-campus → /grant/education/on-campus."
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "pathSlug": {
+      "type": "string",
+      "required": true,
+      "unique": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "description": "Path relative to /grant/. Examples: education/on-campus → /grant/education/on-campus; overview → /grant/overview. No leading slash."
+    },
+    "description": {
+      "type": "text",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "description": "Short description used for SEO and card text. Aim for 120–160 characters."
+    },
+    "programOverview": {
+      "type": "customField",
+      "customField": "plugin::ckeditor5.CKEditor",
+      "options": {
+        "preset": "defaultMarkdown"
+      },
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "primaryCta": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.cta-link",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "ctaStrip": {
+      "type": "component",
+      "repeatable": false,
+      "component": "blocks.cta-strip",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "seo": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.seo",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    }
+  }
+}

--- a/cms/src/api/grant-page/controllers/grant-page.ts
+++ b/cms/src/api/grant-page/controllers/grant-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::grant-page.grant-page')

--- a/cms/src/api/grant-page/routes/grant-page.ts
+++ b/cms/src/api/grant-page/routes/grant-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreRouter('api::grant-page.grant-page')

--- a/cms/src/api/grant-page/services/grant-page.ts
+++ b/cms/src/api/grant-page/services/grant-page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreService('api::grant-page.grant-page')

--- a/cms/src/components/shared/primary-cta-link.json
+++ b/cms/src/components/shared/primary-cta-link.json
@@ -1,0 +1,37 @@
+{
+  "collectionName": "components_shared_primary_cta_links",
+  "info": {
+    "displayName": "Primary CTA Link"
+  },
+  "options": {},
+  "attributes": {
+    "link": {
+      "type": "string",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "text": {
+      "type": "string",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "external": {
+      "type": "boolean",
+      "default": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    }
+  },
+  "config": {}
+}

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -5,6 +5,7 @@ import {
   scheduleGitSync,
   validateGitSyncRepoOnStartup,
   validateNoNestedJsx,
+  validateGrantPagePrimaryCta,
   normalizeNavigationInput,
   LOCALES,
   shouldSkipMdxExport
@@ -1089,6 +1090,44 @@ export default {
           CONTENT_MANAGER_PATTERN.test(ctx.url ?? '')
         ) {
           const validationErr = validateNoNestedJsx(ctx.request?.body?.content)
+          if (validationErr) {
+            ctx.status = 400
+            ctx.body = {
+              data: null,
+              error: {
+                status: 400,
+                name: 'ValidationError',
+                message: validationErr.message
+              }
+            }
+            return
+          }
+        }
+        await next()
+      }
+    )
+
+    // Validate required fields within optional grant-page components on save.
+    // Strapi's partial update validator skips required-field checks on PUT,
+    // so this middleware fills the gap for the primaryCta component.
+    const GRANT_PAGE_PATTERN =
+      /\/content-manager\/collection-types\/api::grant-page\.grant-page/
+    strapi.server?.use?.(
+      async (
+        ctx: {
+          method?: string
+          url?: string
+          request?: { body?: unknown }
+          status?: number
+          body?: unknown
+        },
+        next: () => Promise<void>
+      ) => {
+        if (
+          (ctx.method === 'PUT' || ctx.method === 'POST') &&
+          GRANT_PAGE_PATTERN.test(ctx.url ?? '')
+        ) {
+          const validationErr = validateGrantPagePrimaryCta(ctx.request?.body)
           if (validationErr) {
             ctx.status = 400
             ctx.body = {

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -528,6 +528,15 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     'api::summit-navigation.summit-navigation': {
       mainMenu: 'Main Menu',
       ctaButton: 'CTA Button'
+    },
+    'api::grant-page.grant-page': {
+      title: 'Page Title',
+      pathSlug: 'Path Slug',
+      description: 'Short Description',
+      programOverview: 'Program Overview',
+      primaryCta: 'Primary Call to Action',
+      ctaStrip: 'CTA Strip',
+      seo: 'SEO'
     }
   }
 
@@ -543,6 +552,12 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     'api::summit-page.summit-page': {
       pathSlug:
         'Path relative to /summit/. Examples: faq → /summit/faq; schedule → /summit/schedule. Do not include /summit/ or a leading slash.'
+    },
+    'api::grant-page.grant-page': {
+      pathSlug:
+        'Path relative to /grant/. Examples: education/on-campus → /grant/education/on-campus; overview → /grant/overview. No leading slash.',
+      description:
+        'Short description used for SEO and card text. Aim for 120–160 characters.'
     },
     'api::foundation-blog-post.foundation-blog-post': {
       pathSlug:

--- a/cms/src/utils/contentPopulate.ts
+++ b/cms/src/utils/contentPopulate.ts
@@ -45,3 +45,10 @@ export const FOUNDATION_PAGE_CONTENT_POPULATE = {
 export const BLOG_CONTENT_POPULATE = {
   on: { ...FOUNDATION_BLOG_BLOCKS }
 } as const
+
+/** Populate config for grant-page top-level component fields. */
+export const GRANT_PAGE_CONTENT_POPULATE = {
+  primaryCta: true,
+  ctaStrip: true,
+  seo: { populate: '*' }
+} as const

--- a/cms/src/utils/contentValidation.ts
+++ b/cms/src/utils/contentValidation.ts
@@ -20,6 +20,35 @@ function stripInlineCode(text: string): string {
 }
 
 /**
+ * Validate the optional primaryCta component on a grant page.
+ *
+ * When `primaryCta` is absent the CTA is simply not rendered — that is valid.
+ * When it is present both `text` and `link` are required; Strapi's partial
+ * update validator skips required-field checks on PUT, so this fills the gap.
+ *
+ * Returns a `ValidationError` on failure, `undefined` on success.
+ */
+export function validateGrantPagePrimaryCta(
+  body: unknown
+): errors.ValidationError | undefined {
+  const cta = (body as Record<string, unknown>)?.primaryCta
+  if (!cta || typeof cta !== 'object') return undefined
+
+  const { text, link } = cta as Record<string, unknown>
+  if (!text || typeof text !== 'string' || text.trim() === '') {
+    return new errors.ValidationError(
+      'Primary Call to Action: Text is required'
+    )
+  }
+  if (!link || typeof link !== 'string' || link.trim() === '') {
+    return new errors.ValidationError(
+      'Primary Call to Action: Link is required'
+    )
+  }
+  return undefined
+}
+
+/**
  * Validate that no Paragraph block contains bare JSX-like tags.
  *
  * Returns a Strapi `ValidationError` when a `<CapitalLetter...` pattern is

--- a/cms/src/utils/index.ts
+++ b/cms/src/utils/index.ts
@@ -32,7 +32,10 @@ export {
   uidToLogLabel,
   resolveFilenameSlug
 } from './mdx'
-export { validateNoNestedJsx } from './contentValidation'
+export {
+  validateNoNestedJsx,
+  validateGrantPagePrimaryCta
+} from './contentValidation'
 export {
   deleteLocaleMdxFiles,
   removeLocalizesFromLocaleFiles

--- a/cms/src/utils/index.ts
+++ b/cms/src/utils/index.ts
@@ -11,7 +11,8 @@ export {
 } from './paths'
 export {
   FOUNDATION_PAGE_CONTENT_POPULATE,
-  BLOG_CONTENT_POPULATE
+  BLOG_CONTENT_POPULATE,
+  GRANT_PAGE_CONTENT_POPULATE
 } from './contentPopulate'
 
 // MDX generation
@@ -48,6 +49,7 @@ export {
 
 // Lifecycle factories
 export {
+  type PageData,
   type PageLifecycleConfig,
   type StrapiDocumentServiceUpdateWhere,
   shouldSkipMdxExport,

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -29,7 +29,7 @@ import {
 } from './localeMdxUtils'
 import { scheduleGitSync, getTargetRepoRoot, type SyncContext } from './gitSync'
 
-interface PageData {
+export interface PageData {
   id: number
   documentId: string
   title: string
@@ -104,6 +104,19 @@ export interface PageLifecycleConfig<
   outputDir: string
   /** Strapi populate clause for fetching published content. */
   populate: Modules.Documents.Params.Populate.Any<T>
+  /**
+   * Optional MDX generation override. When provided, replaces the default
+   * `generateMDX` which assumes hero/seo/content dynamic zone fields.
+   * Receives the raw Strapi page data, preserved frontmatter fields from the
+   * existing file, and the English slug for localized entries.
+   * 
+   * We can remove this later if we standardize the hero/seo/content fields across all page content types.
+   */
+  generateMDX?: (
+    page: PageData,
+    preservedFields: Record<string, unknown>,
+    englishSlug?: string
+  ) => string
 }
 
 function normalizePathSlug(pathSlug: unknown): string {
@@ -218,7 +231,9 @@ async function writeMDXFile<T extends UID.ContentType>(
 
     // Preserve fields that exist in MDX but not in Strapi
     const preservedFields = getPreservedFields(filepath)
-    const mdxContent = generateMDX(config, page, preservedFields, englishSlug)
+    const mdxContent = config.generateMDX
+      ? config.generateMDX(page, preservedFields, englishSlug)
+      : generateMDX(config, page, preservedFields, englishSlug)
     fs.writeFileSync(filepath, await formatMdx(mdxContent), 'utf-8')
     console.log(
       `✅ Generated ${uidToLogLabel(config.contentTypeUid)} MDX: ${filepath}`

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -109,7 +109,7 @@ export interface PageLifecycleConfig<
    * `generateMDX` which assumes hero/seo/content dynamic zone fields.
    * Receives the raw Strapi page data, preserved frontmatter fields from the
    * existing file, and the English slug for localized entries.
-   * 
+   *
    * We can remove this later if we standardize the hero/seo/content fields across all page content types.
    */
   generateMDX?: (

--- a/cms/src/utils/paths.ts
+++ b/cms/src/utils/paths.ts
@@ -35,6 +35,7 @@ export const PATHS = {
     blog: 'foundation-blog-posts',
     developersBlog: 'developers-blog-posts',
     foundationPages: 'foundation-pages',
+    grantPages: 'grant-pages',
     summitPages: 'summit-pages'
   },
   /** Public asset paths. */

--- a/cms/types/generated/components.d.ts
+++ b/cms/types/generated/components.d.ts
@@ -785,6 +785,36 @@ export interface SharedHeroSection extends Struct.ComponentSchema {
   }
 }
 
+export interface SharedPrimaryCtaLink extends Struct.ComponentSchema {
+  collectionName: 'components_shared_primary_cta_links'
+  info: {
+    displayName: 'Primary CTA Link'
+  }
+  attributes: {
+    external: Schema.Attribute.Boolean &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }> &
+      Schema.Attribute.DefaultTo<false>
+    link: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    text: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+  }
+}
+
 export interface SharedRelatedArticle extends Struct.ComponentSchema {
   collectionName: 'components_shared_related_articles'
   info: {
@@ -870,6 +900,7 @@ declare module '@strapi/strapi' {
       'shared.cta-link': SharedCtaLink
       'shared.hero': SharedHero
       'shared.hero-section': SharedHeroSection
+      'shared.primary-cta-link': SharedPrimaryCtaLink
       'shared.related-article': SharedRelatedArticle
       'shared.section': SharedSection
       'shared.seo': SharedSeo

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -785,6 +785,91 @@ export interface ApiFoundationPageFoundationPage
   }
 }
 
+export interface ApiGrantPageGrantPage extends Struct.CollectionTypeSchema {
+  collectionName: 'grant-pages'
+  info: {
+    description: 'Individual grant program pages. Path slug is relative to /grant/ \u2014 e.g. education/on-campus \u2192 /grant/education/on-campus.'
+    displayName: 'Grant Page'
+    pluralName: 'grant-pages'
+    singularName: 'grant-page'
+  }
+  options: {
+    draftAndPublish: false
+  }
+  pluginOptions: {
+    i18n: {
+      localized: true
+    }
+  }
+  attributes: {
+    createdAt: Schema.Attribute.DateTime
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private
+    ctaStrip: Schema.Attribute.Component<'blocks.cta-strip', false> &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    description: Schema.Attribute.Text &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    locale: Schema.Attribute.String
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::grant-page.grant-page'
+    >
+    pathSlug: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    primaryCta: Schema.Attribute.Component<'shared.cta-link', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    programOverview: Schema.Attribute.RichText &
+      Schema.Attribute.CustomField<
+        'plugin::ckeditor5.CKEditor',
+        {
+          preset: 'defaultMarkdown'
+        }
+      > &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    publishedAt: Schema.Attribute.DateTime
+    seo: Schema.Attribute.Component<'shared.seo', false> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    updatedAt: Schema.Attribute.DateTime
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private
+  }
+}
+
 export interface ApiSummitNavigationSummitNavigation
   extends Struct.SingleTypeSchema {
   collectionName: 'summit_navigations'
@@ -1310,6 +1395,7 @@ declare module '@strapi/strapi' {
       'api::foundation-blog-post.foundation-blog-post': ApiFoundationBlogPostFoundationBlogPost
       'api::foundation-navigation.foundation-navigation': ApiFoundationNavigationFoundationNavigation
       'api::foundation-page.foundation-page': ApiFoundationPageFoundationPage
+      'api::grant-page.grant-page': ApiGrantPageGrantPage
       'api::summit-navigation.summit-navigation': ApiSummitNavigationSummitNavigation
       'api::summit-page.summit-page': ApiSummitPageSummitPage
       'plugin::content-releases.release': PluginContentReleasesRelease

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -832,7 +832,7 @@ export interface ApiGrantPageGrantPage extends Struct.CollectionTypeSchema {
           localized: true
         }
       }>
-    primaryCta: Schema.Attribute.Component<'shared.cta-link', false> &
+    primaryCta: Schema.Attribute.Component<'shared.primary-cta-link', false> &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true

--- a/src/components/pages/GrantPage.astro
+++ b/src/components/pages/GrantPage.astro
@@ -1,0 +1,92 @@
+---
+import { type Locale } from '@/utils'
+import { getCollection, render } from 'astro:content'
+import FoundationPageLayout from '@/layouts/FoundationPageLayout.astro'
+import CtaStrip from '@/components/blocks/CtaStrip.astro'
+import LinkButton from '@/components/shared/LinkButton.astro'
+import Icon from '@/components/shared/Icon.astro'
+import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
+
+interface Props {
+  slug: string
+  contentLocale: Locale
+  isFallback?: boolean
+}
+
+const { slug, contentLocale, isFallback = false } = Astro.props
+const pages = await getCollection('grant-pages')
+
+const mdxPage = pages.find(
+  (page) => page.data.pathSlug === slug && page.data.locale === contentLocale
+)
+
+if (!mdxPage) return Astro.redirect('/404')
+
+const { Content: MdxContent } = await render(mdxPage)
+const {
+  title,
+  description,
+  metaDescription,
+  metaImage,
+  canonicalUrl,
+  primaryCta,
+  ctaStrip
+} = mdxPage.data
+---
+
+<FoundationPageLayout
+  title={title}
+  description={metaDescription || description}
+  ogImageUrl={metaImage}
+  canonicalURL={canonicalUrl}
+>
+  <main class="pb-space-l">
+    <TranslationDisclaimer isVisible={isFallback} />
+
+    <section
+      class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[40vh] py-space-xl text-white flex items-center"
+    >
+      <div class="mx-auto w-full max-w-wide px-space-m">
+        <div class="max-w-narrow">
+          <h1
+            class="text-white max-w-[14em] leading-[1.2] font-semibold mb-space-xs text-[clamp(2rem,5vw,3rem)]"
+          >
+            {title}
+          </h1>
+          <p class="mb-space-m text-[1.125rem] max-w-[600px]">{description}</p>
+          {
+            primaryCta && (
+              <LinkButton
+                href={primaryCta.link}
+                variant="primary"
+                external={primaryCta.external}
+              >
+                {primaryCta.text}
+                <Icon name="arrow-right" slot="icon-right" />
+              </LinkButton>
+            )
+          }
+        </div>
+      </div>
+    </section>
+
+    <section class="py-space-xl">
+      <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
+        <div data-prose class="mx-auto max-w-narrow">
+          <MdxContent />
+        </div>
+      </div>
+    </section>
+
+    <section class="py-space-xl">
+      <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
+        <CtaStrip
+          heading={ctaStrip.heading}
+          description={ctaStrip.description}
+          primaryButtonText={ctaStrip.buttonText}
+          primaryButtonLink={ctaStrip.buttonLink}
+        />
+      </div>
+    </section>
+  </main>
+</FoundationPageLayout>

--- a/src/components/pages/GrantPage.astro
+++ b/src/components/pages/GrantPage.astro
@@ -85,6 +85,9 @@ const {
           description={ctaStrip.description}
           primaryButtonText={ctaStrip.buttonText}
           primaryButtonLink={ctaStrip.buttonLink}
+          color={ctaStrip.color}
+          secondaryButtonText={ctaStrip.secondaryButtonText}
+          secondaryButtonLink={ctaStrip.secondaryButtonLink}
         />
       </div>
     </section>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -7,6 +7,7 @@ import {
   developersBlogFrontmatterSchema,
   foundationBlogFrontmatterSchema,
   foundationPageFrontmatterSchema,
+  grantPageFrontmatterSchema,
   summitPageFrontmatterSchema
 } from './schemas/content'
 import { CONTENT, CONTENT_ROOT } from '@/utils/main/contentCollections'
@@ -25,6 +26,14 @@ const foundationPagesCollection = defineCollection({
     base: `./${CONTENT_ROOT}/${CONTENT.foundationPages}`
   }),
   schema: foundationPageFrontmatterSchema
+})
+
+const grantPagesCollection = defineCollection({
+  loader: glob({
+    pattern: '**/[^_]*.{md,mdx}',
+    base: `./${CONTENT_ROOT}/${CONTENT.grantPages}`
+  }),
+  schema: grantPageFrontmatterSchema
 })
 
 const summitPagesCollection = defineCollection({
@@ -57,6 +66,7 @@ export const collections = {
   'developers-blog': developersBlogCollection,
   'foundation-blog': foundationBlogCollection,
   'foundation-pages': foundationPagesCollection,
+  'grant-pages': grantPagesCollection,
   'summit-pages': summitPagesCollection,
   ambassadors: ambassadorCollection
 }

--- a/src/content/grant-pages/education/on-campus.mdx
+++ b/src/content/grant-pages/education/on-campus.mdx
@@ -1,0 +1,28 @@
+---
+title: 'On-Campus Financial Education Grant'
+pathSlug: 'education/on-campus'
+description: 'Funding for universities and colleges developing financial literacy curricula for students from underserved communities.'
+primaryCta:
+  text: 'Apply Now'
+  link: 'https://interledger.submittable.com/submit'
+  external: true
+ctaStrip:
+  heading: 'Ready to make an impact?'
+  description: 'Applications for the 2026 cohort are open. Submit your proposal before the deadline.'
+  buttonText: 'Start your application'
+  buttonLink: 'https://interledger.submittable.com/submit'
+  external: true
+locale: 'en'
+---
+
+The On-Campus Financial Education Grant supports universities and colleges in developing financial literacy programs for students from underserved communities. Grants of up to $50,000 are available for projects that integrate open payments standards into coursework, workshops, or student-led initiatives.
+
+## Eligibility
+
+- Accredited higher education institutions
+- Projects with a clear student-facing component
+- Commitment to open-source outputs where applicable
+
+## What we fund
+
+Research, curriculum development, faculty training, and student programme coordination that meaningfully engages with digital financial systems and the Interledger Protocol.

--- a/src/content/grant-pages/education/on-campus.mdx
+++ b/src/content/grant-pages/education/on-campus.mdx
@@ -11,7 +11,6 @@ ctaStrip:
   description: 'Applications for the 2026 cohort are open. Submit your proposal before the deadline.'
   buttonText: 'Start your application'
   buttonLink: 'https://interledger.submittable.com/submit'
-  external: true
 locale: 'en'
 ---
 

--- a/src/pages/es/grant/[...page].astro
+++ b/src/pages/es/grant/[...page].astro
@@ -1,0 +1,16 @@
+---
+import GrantPage from '@/components/pages/GrantPage.astro'
+import { getLocalizedPaths } from '@/utils'
+
+export async function getStaticPaths() {
+  return getLocalizedPaths('grant-pages', 'es', 'page')
+}
+
+const { slug, locale: contentLocale } = Astro.props
+---
+
+<GrantPage
+  slug={slug}
+  contentLocale={contentLocale}
+  isFallback={Astro.props.isFallback}
+/>

--- a/src/pages/grant/[...page].astro
+++ b/src/pages/grant/[...page].astro
@@ -1,0 +1,18 @@
+---
+import GrantPage from '@/components/pages/GrantPage.astro'
+import { getLocalizedPaths, type Locale } from '@/utils'
+
+interface Props {
+  slug: string
+  locale: Locale
+  isFallback?: boolean
+}
+
+export async function getStaticPaths() {
+  return getLocalizedPaths('grant-pages', 'en', 'page')
+}
+
+const { slug, locale: contentLocale } = Astro.props
+---
+
+<GrantPage slug={slug} contentLocale={contentLocale} />

--- a/src/pages/grant/[...page].astro
+++ b/src/pages/grant/[...page].astro
@@ -15,4 +15,8 @@ export async function getStaticPaths() {
 const { slug, locale: contentLocale } = Astro.props
 ---
 
-<GrantPage slug={slug} contentLocale={contentLocale} isFallback={Astro.props.isFallback} />
+<GrantPage
+  slug={slug}
+  contentLocale={contentLocale}
+  isFallback={Astro.props.isFallback}
+/>

--- a/src/pages/grant/[...page].astro
+++ b/src/pages/grant/[...page].astro
@@ -15,4 +15,4 @@ export async function getStaticPaths() {
 const { slug, locale: contentLocale } = Astro.props
 ---
 
-<GrantPage slug={slug} contentLocale={contentLocale} />
+<GrantPage slug={slug} contentLocale={contentLocale} isFallback={Astro.props.isFallback} />

--- a/src/schemas/content.ts
+++ b/src/schemas/content.ts
@@ -177,8 +177,7 @@ const grantCtaStripSchema = z.object({
   heading: z.string(),
   description: z.string(),
   buttonText: z.string(),
-  buttonLink: z.string(),
-  external: z.boolean().optional()
+  buttonLink: z.string()
 })
 
 export const grantPageFrontmatterSchema = z.object({

--- a/src/schemas/content.ts
+++ b/src/schemas/content.ts
@@ -173,6 +173,37 @@ export const summitPageFrontmatterSchema = z.object({
   locale: z.string().optional()
 })
 
+const grantCtaStripSchema = z.object({
+  heading: z.string(),
+  description: z.string(),
+  buttonText: z.string(),
+  buttonLink: z.string(),
+  external: z.boolean().optional()
+})
+
+export const grantPageFrontmatterSchema = z.object({
+  title: z.string().min(1, 'title is required'),
+  pathSlug: pathSlugSchema(),
+  description: z.string().min(1, 'description is required'),
+  primaryCta: z
+    .object({
+      text: z.string(),
+      link: z.string(),
+      external: z.boolean().optional()
+    })
+    .optional(),
+  ctaStrip: grantCtaStripSchema,
+  metaDescription: z.string().optional(),
+  metaImage: z.string().optional(),
+  canonicalUrl: z.string().optional(),
+  localizes: z.string().optional(),
+  locale: z.string().optional()
+})
+
+export type GrantPageFrontmatterType = z.infer<
+  typeof grantPageFrontmatterSchema
+>
+
 export const ambassadorFrontmatterSchema = z.object({
   pathSlug: pathSlugSchema(),
   name: z.string().min(1, 'name is required'),

--- a/src/schemas/content.ts
+++ b/src/schemas/content.ts
@@ -177,7 +177,10 @@ const grantCtaStripSchema = z.object({
   heading: z.string(),
   description: z.string(),
   buttonText: z.string(),
-  buttonLink: z.string()
+  buttonLink: z.string(),
+  color: z.enum(['purple', 'green']).default('purple'),
+  secondaryButtonText: z.string().optional(),
+  secondaryButtonLink: z.string().optional()
 })
 
 export const grantPageFrontmatterSchema = z.object({

--- a/src/utils/main/contentCollections.ts
+++ b/src/utils/main/contentCollections.ts
@@ -5,5 +5,6 @@ export const CONTENT = {
   blog: 'foundation-blog-posts',
   developersBlog: 'developers-blog-posts',
   foundationPages: 'foundation-pages',
+  grantPages: 'grant-pages',
   summitPages: 'summit-pages'
 } as const

--- a/src/utils/main/routes.ts
+++ b/src/utils/main/routes.ts
@@ -7,6 +7,7 @@ export const ROUTE_BASES = {
   'foundation-blog': '/blog',
   'developers-blog': '/developers/blog',
   'summit-pages': '/summit',
+  'grant-pages': '/grant',
   ambassadors: '/grant/fellowship'
 } as const
 

--- a/src/utils/main/static-paths.ts
+++ b/src/utils/main/static-paths.ts
@@ -3,6 +3,7 @@ import { defaultLocale, type Locale } from './i18'
 
 export type CollectionType =
   | 'foundation-pages'
+  | 'grant-pages'
   | 'summit-pages'
   | 'foundation-blog'
   | 'developers-blog'


### PR DESCRIPTION
## Summary
A new dedicated `grant-pages` collection to power individual grant program pages (open grants, closed grants). 

## Related Issue
Fixes INTORG-844

## Manual Test
Open the website at /grant/education/on-campus to view the initial example grant page and locally after sync we should be able to view the page in strapi and update the content

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
