### PR TITLE
feat(cms): preserve markdown footnotes through the CKEditor round-trip [INTORG-838]

### DIFF
--- a/cms/scripts/sync-mdx/footnote-roundtrip.test.ts
+++ b/cms/scripts/sync-mdx/footnote-roundtrip.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { parseMdxToBlocks, type ParserContext } from './mdxBlockParser'
+import { serialize as serializeParagraph } from '../../src/serializers/blocks/paragraph.serializer'
+
+// Side-effect import: registers the Paragraph handler.
+import './paragraphHandler'
+
+// A blog body using GFM footnotes: inline references ([^1]) plus their
+// definitions. Astro's GFM renders these as linked, auto-numbered footnotes.
+const FOOTNOTE_BODY = `This claim needs a note[^1] and here is another[^2].
+
+[^1]: First footnote definition.
+[^2]: Second footnote definition.`
+
+// The real sync always passes sourceText so the parser slices the raw source
+// (byte-for-byte) instead of re-serializing the AST, which would escape the
+// footnote brackets (\\[^1]). Mirror that here.
+const ctx = (mdx: string): ParserContext => ({ locale: 'en', sourceText: mdx })
+
+const contentOf = (block: unknown) => (block as { content: string }).content
+
+describe('Footnote round-trip through the sync pipeline (INTORG-838)', () => {
+  it('import preserves footnote refs and definitions verbatim (flat markdown)', async () => {
+    const blocks = await parseMdxToBlocks(FOOTNOTE_BODY, ctx(FOOTNOTE_BODY))
+
+    expect(blocks).toHaveLength(1)
+    const content = contentOf(blocks[0])
+    expect(content).toContain('[^1]')
+    expect(content).toContain('[^2]')
+    expect(content).toContain('[^1]: First footnote definition.')
+    // Must not be escaped or converted to plain links.
+    expect(content).not.toContain('\\[^')
+    expect(content).not.toContain('user-content-fn')
+  })
+
+  it('import preserves footnotes when wrapped in <Paragraph> (the exported form)', async () => {
+    const exported = serializeParagraph({ content: FOOTNOTE_BODY })
+    const blocks = await parseMdxToBlocks(exported, ctx(exported))
+
+    expect(blocks).toHaveLength(1)
+    const content = contentOf(blocks[0])
+    expect(content).toContain('[^1]')
+    expect(content).toContain('[^1]: First footnote definition.')
+    expect(content).not.toContain('\\[^')
+  })
+
+  it('export wraps footnote content verbatim in <Paragraph>', () => {
+    const mdx = serializeParagraph({ content: FOOTNOTE_BODY })
+
+    expect(mdx).toContain('<Paragraph>')
+    expect(mdx).toContain('[^1]')
+    expect(mdx).toContain('[^1]: First footnote definition.')
+  })
+
+  it('is idempotent across export → import → export', async () => {
+    const once = serializeParagraph({ content: FOOTNOTE_BODY })
+    const blocks = await parseMdxToBlocks(once, ctx(once))
+    const twice = serializeParagraph({ content: contentOf(blocks[0]) })
+
+    expect(twice).toBe(once)
+  })
+})

--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -119,6 +119,46 @@ const markdownPresetNoH1: Preset = {
           },
           { priority: 'high' }
         )
+      },
+      // Preserve markdown footnotes ([^1] refs and [^1]: definitions) through
+      // the editor's markdown round-trip. The GFM processor otherwise turns
+      // them into plain links + an ordered list, which serialize back as dead
+      // anchors and destroy the footnotes on save. We swap footnote markers for
+      // private-use placeholders before md->view (so the processor treats them
+      // as literal text) and restore them after view->md. Footnotes stay
+      // verbatim in Strapi and are rendered by Astro's GFM at build time.
+      function preserveFootnotes(editor: CKEditor) {
+        const processor = editor.data.processor as unknown as {
+          toView: (markdown: string) => unknown
+          toData: (view: unknown) => string
+        }
+        if (!processor || typeof processor.toView !== 'function') return
+
+        // CKEditor's GFM markdown processor breaks footnotes two ways:
+        //  - on load (md -> view) it interprets [^1] into links + an ordered
+        //    list, so they no longer round-trip as footnotes;
+        //  - on save (view -> md) its writer escapes the bracket ([^1] ->
+        //    \[^1]), which renders as literal text instead of a footnote.
+        // Fix both edges: escape footnote markers before md->view so the
+        // processor leaves them as literal text (shown verbatim in the editor),
+        // then strip that escaping after view->md so they persist as real GFM
+        // footnotes. Authors write raw markdown; Astro's GFM renders them.
+        const FOOTNOTE_MARKER = /\[\^[^\]]+\]/g
+        const ESCAPED_FOOTNOTE = /\\(?=\[\^[^\]]+\])/g
+        // The writer also escapes the scheme colon of bare URLs inside footnote
+        // definitions (https:// -> https\://), which would break the autolink.
+        const ESCAPED_URL_SCHEME = /\\(?=:\/\/)/g
+
+        const originalToView = processor.toView.bind(processor)
+        const originalToData = processor.toData.bind(processor)
+
+        processor.toView = (markdown: string) =>
+          originalToView(markdown.replace(FOOTNOTE_MARKER, (m) => `\\${m}`))
+
+        processor.toData = (view: unknown) =>
+          originalToData(view)
+            .replace(ESCAPED_FOOTNOTE, '')
+            .replace(ESCAPED_URL_SCHEME, '')
       }
     ]
   }

--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -145,9 +145,12 @@ const markdownPresetNoH1: Preset = {
         // footnotes. Authors write raw markdown; Astro's GFM renders them.
         const FOOTNOTE_MARKER = /\[\^[^\]]+\]/g
         const ESCAPED_FOOTNOTE = /\\(?=\[\^[^\]]+\])/g
-        // The writer also escapes the scheme colon of bare URLs inside footnote
-        // definitions (https:// -> https\://), which would break the autolink.
-        const ESCAPED_URL_SCHEME = /\\(?=:\/\/)/g
+        // The writer also escapes markdown punctuation throughout a bare
+        // (autolinked) URL — the scheme colon (https:// -> https\://) and host
+        // dots (example.com -> example\.com) — which corrupts the rendered
+        // link. Match each bare URL and strip the escapes back out. Markdown
+        // links ([text](url)) round-trip fine; only plain-text URLs need this.
+        const BARE_URL = /https?\\?:\/\/\S+/g
 
         const originalToView = processor.toView.bind(processor)
         const originalToData = processor.toData.bind(processor)
@@ -158,7 +161,7 @@ const markdownPresetNoH1: Preset = {
         processor.toData = (view: unknown) =>
           originalToData(view)
             .replace(ESCAPED_FOOTNOTE, '')
-            .replace(ESCAPED_URL_SCHEME, '')
+            .replace(BARE_URL, (url) => url.replace(/\\/g, ''))
       }
     ]
   }


### PR DESCRIPTION
## Summary

Astro's GFM already renders footnotes correctly. The problem was **Strapi's CKEditor**, which mangled footnote markdown two ways:
- on **load** it interpreted `[^1]` into plain links + an ordered list;
- on **save** its markdown writer escaped the bracket (`[^1]` -> `\[^1]`, which renders as literal text) and the URL scheme inside definitions (`https://` -> `https\://`).

This PR adds a small `preserveFootnotes` CKEditor plugin (via the existing `extraPlugins` mechanism in the markdown preset) that fixes **both edges** of the round-trip:
- before md to view: escape footnote markers so the processor leaves them as literal text (shown verbatim in the editor) instead of interpreting them;
- after view to md: strip the writer's escaping of footnote markers and URL schemes so they persist as real GFM footnotes.

<img width="1804" height="1618" alt="image" src="https://github.com/user-attachments/assets/32f61897-108e-4fff-b914-098ebb25b354" />
<img width="1578" height="828" alt="image" src="https://github.com/user-attachments/assets/50764719-3439-4eda-b1db-ecf4ee28441b" />


## Related Issue

Closes INTORG-838. Unblocks INTORG-691 (blog merge). Styling of the rendered footnotes is INTORG-839.

## Manual Test

1. Start the CMS (`pnpm --dir cms develop`) and the site (`pnpm start`).
2. In Strapi, open a Blog post, add a Paragraph block, and type/paste markdown with a footnote, e.g.:
   ```
   Sending money across borders still costs too much[^1].

   [^1]: Average price for a $200 bank transfer, per the World Bank (2024). https://remittanceprices.worldbank.org
   ```
3. Save & Publish. Re-open the post: the content still shows `[^1]` and `[^1]: ...` 
4. On the site, open the post: `[^1]` renders as a superscript link to an auto-numbered footnote at the bottom, with a back-link, and the URL inside the definition is a working link. 
5. Round-trip: the export lifecycle and `pnpm --dir cms sync:mdx` keep the footnote markdown intact both directions.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused 
- [x] Screenshots / video for UI behavior 

