### PR TITLE
fix(homepage): hero image jump fix -

### DIFF
--- a/src/components/layout/FoundationHeader.astro
+++ b/src/components/layout/FoundationHeader.astro
@@ -147,6 +147,20 @@ const headerClass = 'foundation-header sticky top-0 z-[2] px-lg desktop:px-2xl'
   </nav>
 </header>
 
+<!-- Synchronous init: set data-offscreen before first paint on desktop so the
+     browser never renders the drawer in mobile-closed state then flips it.
+     The module script below handles all interactions; this only sets the
+     initial attribute to match the viewport. -->
+<script is:inline>
+  ;(function () {
+    var w = document.getElementById('siteNavLinks')
+    if (w && window.matchMedia('(min-width: 1200px)').matches) {
+      w.dataset.offscreen = 'false'
+      w.removeAttribute('inert')
+    }
+  })()
+</script>
+
 <script>
   import './foundation-header.ts'
 </script>

--- a/src/components/layout/FoundationHeader.astro
+++ b/src/components/layout/FoundationHeader.astro
@@ -153,7 +153,7 @@ const headerClass = 'foundation-header sticky top-0 z-[2] px-lg desktop:px-2xl'
      initial attribute to match the viewport. -->
 <script is:inline>
   ;(function () {
-    var w = document.getElementById('siteNavLinks')
+    const w = document.getElementById('siteNavLinks')
     if (w && window.matchMedia('(min-width: 1200px)').matches) {
       w.dataset.offscreen = 'false'
       w.removeAttribute('inert')

--- a/src/components/pages/HomepageHero.astro
+++ b/src/components/pages/HomepageHero.astro
@@ -223,20 +223,25 @@ const heroUmami = (href: string, linkText: string) =>
 
     [data-component='HomepageHero'] .hero-stefan-wrap {
       height: 100%;
+      contain: paint;
     }
 
     [data-component='HomepageHero'] .hero-stefan-picture {
-      display: block;
+      /* Start invisible. visibility: hidden is used (not opacity/display) so it
+         cascades correctly to children while still allowing the image to load
+         eagerly as an LCP candidate. */
+      visibility: hidden;
+      opacity: 0;
       width: 100%;
-      height: 100%;
+      height: auto;
       min-height: 100%;
+      animation: hero-photo-appear 0.3s ease-in 0.1s forwards;
     }
 
     [data-component='HomepageHero'] .hero-stefan-photo {
       display: block;
       width: 100%;
       min-height: 100%;
-      height: calc(100% - var(--hero-stefan-offset-y));
       object-fit: cover;
       object-position: var(--hero-stefan-object-x) var(--hero-stefan-object-y);
       transform: translate(
@@ -244,21 +249,25 @@ const heroUmami = (href: string, linkText: string) =>
         var(--hero-stefan-offset-y)
       );
       transform-origin: top center;
-      /* Hold the image invisible until custom-property positioning is applied,
-         then fade in. Prevents a visible layout jump on slower devices. */
-      opacity: 0;
-      animation: hero-photo-appear 0.3s ease-in 0.1s forwards;
     }
   }
 
   @media (min-width: 810px) and (prefers-reduced-motion: reduce) {
-    [data-component='HomepageHero'] .hero-stefan-photo {
+    [data-component='HomepageHero'] .hero-stefan-picture {
       animation-duration: 0s;
     }
   }
 
   @keyframes hero-photo-appear {
+    /* from sets visibility: visible immediately when the active phase starts
+       (after the 100ms delay). During the delay the element's own CSS keeps
+       visibility: hidden — so no painting happens until the fade begins. */
+    from {
+      visibility: visible;
+      opacity: 0;
+    }
     to {
+      visibility: visible;
       opacity: 1;
     }
   }
@@ -276,7 +285,7 @@ const heroUmami = (href: string, linkText: string) =>
       bottom: 0;
       left: auto;
       width: var(--hero-stefan-width);
-      height: 100%;
+      height: auto;
     }
 
     [data-component='HomepageHero'] .hero-stefan-photo {
@@ -293,7 +302,7 @@ const heroUmami = (href: string, linkText: string) =>
 
   @media (min-width: 1536px) {
     [data-component='HomepageHero'] {
-      --hero-stefan-object-y: top;
+      /* --hero-stefan-object-y: top; */
     }
   }
 

--- a/src/components/pages/HomepageHero.astro
+++ b/src/components/pages/HomepageHero.astro
@@ -244,6 +244,22 @@ const heroUmami = (href: string, linkText: string) =>
         var(--hero-stefan-offset-y)
       );
       transform-origin: top center;
+      /* Hold the image invisible until custom-property positioning is applied,
+         then fade in. Prevents a visible layout jump on slower devices. */
+      opacity: 0;
+      animation: hero-photo-appear 0.3s ease-in 0.1s forwards;
+    }
+  }
+
+  @media (min-width: 810px) and (prefers-reduced-motion: reduce) {
+    [data-component='HomepageHero'] .hero-stefan-photo {
+      animation-duration: 0s;
+    }
+  }
+
+  @keyframes hero-photo-appear {
+    to {
+      opacity: 1;
     }
   }
 

--- a/src/components/pages/HomepageHero.astro
+++ b/src/components/pages/HomepageHero.astro
@@ -291,12 +291,6 @@ const heroUmami = (href: string, linkText: string) =>
     }
   }
 
-  @media (min-width: 1280px) {
-    [data-component='HomepageHero'] {
-      --hero-stefan-object-y: 30%;
-    }
-  }
-
   @media (min-width: 1880px) {
     [data-component='HomepageHero'] {
       --hero-stefan-object-x: 80%;

--- a/src/components/pages/HomepageHero.astro
+++ b/src/components/pages/HomepageHero.astro
@@ -199,12 +199,10 @@ const heroUmami = (href: string, linkText: string) =>
     inset-inline: 0;
     bottom: 0;
     height: 40%;
-    background-color: var(--hero-fade-fill);
+    background: linear-gradient(to top, var(--hero-fade-fill), transparent);
     pointer-events: none;
     display: none;
     z-index: 0;
-    -webkit-mask: linear-gradient(180deg, #0000 0%, #000 100%);
-    mask: linear-gradient(180deg, #0000 0%, #000 100%);
   }
 
   @media (min-width: 810px) {
@@ -295,14 +293,7 @@ const heroUmami = (href: string, linkText: string) =>
 
   @media (min-width: 1280px) {
     [data-component='HomepageHero'] {
-      --hero-stefan-object-y: 15%;
-      --hero-stefan-offset-y: -10vh;
-    }
-  }
-
-  @media (min-width: 1536px) {
-    [data-component='HomepageHero'] {
-      /* --hero-stefan-object-y: top; */
+      --hero-stefan-object-y: 30%;
     }
   }
 


### PR DESCRIPTION
## Summary
On slower devices or weak connectivity there is jump of the hero image on the home page.
The jump happens because the image renders on page before the CSS custom properties (the transform/object-position) are calculated and applied. 
 - Repair the hero keyframe
 - Add paint containment to the hero wrap
 - refix positioning and bottom mask position

Secondary fix:
 - Eliminate nav CLS via synchronous inline script 
Here is what happens: HTML renders with data-offscreen="true". The external header-nav.ts module runs after the browser has already painted at least one frame. On desktop, the script immediately sets data-offscreen="false", triggering a CSS repaint. Total CLS is 0.0042 (well within "good"), but it contributes to the paint instability window.
- The fix: Add a small synchronous inline <script> block at the bottom of FoundationHeader.astro, placed after the nav wrapper element in the DOM. A synchronous script pauses HTML parsing and modifies the attribute before the browser paints that section, so the browser never paints the wrong state.

## Related Issue
INTORG-852

## Manual Test
Refresh the homepage, the hero image might have a slight delay to appear but should have the correct final position.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
