### PR TITLE
fix(cms): deleting a translated page didn't delete its MDX file [INTORG-869]

### DIFF
--- a/cms/src/utils/flatContentLifecycle.ts
+++ b/cms/src/utils/flatContentLifecycle.ts
@@ -264,10 +264,7 @@ export function createFlatLocaleMdxLifecycle<
           (loc) => getBaseDir(loc),
           label
         )
-        deleteLocaleMdxFiles(
-          (loc) => getFilePath(loc, result.pathSlug),
-          label
-        )
+        deleteLocaleMdxFiles((loc) => getFilePath(loc, result.pathSlug), label)
       } else {
         // Non-English files are named after the English slug, not their own.
         const enEntry = await fetchPublished(result.documentId, defaultLang)

--- a/cms/src/utils/flatContentLifecycle.ts
+++ b/cms/src/utils/flatContentLifecycle.ts
@@ -252,19 +252,34 @@ export function createFlatLocaleMdxLifecycle<
       if (shouldSkipMdxExport()) return
       if (!result?.documentId) return
 
-      console.log(
-        `🗑️  Deleting ${label} MDX for all locales: ${result.pathSlug}`
-      )
+      const locale = result.locale || defaultLang
 
-      removeLocalizesFromLocaleFiles(
-        result.pathSlug,
-        (locale) => getBaseDir(locale),
-        label
-      )
-      deleteLocaleMdxFiles(
-        (locale) => getFilePath(locale, result.pathSlug),
-        label
-      )
+      if (locale === defaultLang) {
+        // Non-English files are named after the English slug, so this cascades to them too.
+        console.log(
+          `🗑️  Deleting ${label} MDX for all locales: ${result.pathSlug}`
+        )
+        removeLocalizesFromLocaleFiles(
+          result.pathSlug,
+          (loc) => getBaseDir(loc),
+          label
+        )
+        deleteLocaleMdxFiles(
+          (loc) => getFilePath(loc, result.pathSlug),
+          label
+        )
+      } else {
+        // Non-English files are named after the English slug, not their own.
+        const enEntry = await fetchPublished(result.documentId, defaultLang)
+        const filenameSlug = resolveFileSlug(
+          locale,
+          result.pathSlug,
+          enEntry?.pathSlug
+        )
+        const filepath = path.join(getBaseDir(locale), `${filenameSlug}.mdx`)
+        console.log(`🗑️  Deleting ${label} MDX (${locale}): ${filenameSlug}`)
+        deleteMdxIfExists(filepath, locale)
+      }
 
       const ctx: SyncContext = {
         slug: result.pathSlug,

--- a/cms/src/utils/flatContentLifecycle.ts
+++ b/cms/src/utils/flatContentLifecycle.ts
@@ -274,8 +274,17 @@ export function createFlatLocaleMdxLifecycle<
           enEntry?.pathSlug
         )
         const filepath = path.join(getBaseDir(locale), `${filenameSlug}.mdx`)
-        console.log(`🗑️  Deleting ${label} MDX (${locale}): ${filenameSlug}`)
-        deleteMdxIfExists(filepath, locale)
+        if (fs.existsSync(filepath)) {
+          try {
+            fs.unlinkSync(filepath)
+            console.log(`🗑️  Deleted ${locale} ${label} MDX: ${filepath}`)
+          } catch (error) {
+            console.error(
+              `Failed to delete ${locale} ${label} MDX: ${filepath}`,
+              error
+            )
+          }
+        }
       }
 
       const ctx: SyncContext = {

--- a/cms/src/utils/mdx.test.ts
+++ b/cms/src/utils/mdx.test.ts
@@ -3,9 +3,9 @@ import { formatMdx, pathSlugToMdxFilename, resolveFilenameSlug } from './mdx'
 
 describe('resolveFilenameSlug', () => {
   it('uses the English slug for a non-English locale when provided', () => {
-    expect(resolveFilenameSlug('es', 'subvenciones/beca', 'grant/fellowship')).toBe(
-      'grant/fellowship'
-    )
+    expect(
+      resolveFilenameSlug('es', 'subvenciones/beca', 'grant/fellowship')
+    ).toBe('grant/fellowship')
   })
 
   it('falls back to its own slug for a non-English locale with no English sibling', () => {
@@ -15,9 +15,9 @@ describe('resolveFilenameSlug', () => {
   })
 
   it('always uses its own slug for the English locale, ignoring englishSlug', () => {
-    expect(resolveFilenameSlug('en', 'grant/fellowship', 'grant/fellowship')).toBe(
-      'grant/fellowship'
-    )
+    expect(
+      resolveFilenameSlug('en', 'grant/fellowship', 'grant/fellowship')
+    ).toBe('grant/fellowship')
   })
 })
 

--- a/cms/src/utils/mdx.test.ts
+++ b/cms/src/utils/mdx.test.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect } from 'vitest'
-import { formatMdx, pathSlugToMdxFilename } from './mdx'
+import { formatMdx, pathSlugToMdxFilename, resolveFilenameSlug } from './mdx'
+
+describe('resolveFilenameSlug', () => {
+  it('uses the English slug for a non-English locale when provided', () => {
+    expect(resolveFilenameSlug('es', 'subvenciones/beca', 'grant/fellowship')).toBe(
+      'grant/fellowship'
+    )
+  })
+
+  it('falls back to its own slug for a non-English locale with no English sibling', () => {
+    expect(resolveFilenameSlug('es', 'subvenciones/beca', undefined)).toBe(
+      'subvenciones/beca'
+    )
+  })
+
+  it('always uses its own slug for the English locale, ignoring englishSlug', () => {
+    expect(resolveFilenameSlug('en', 'grant/fellowship', 'grant/fellowship')).toBe(
+      'grant/fellowship'
+    )
+  })
+})
 
 describe('pathSlugToMdxFilename', () => {
   it('flattens nested path slugs to hyphenated filename stems', () => {

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -565,18 +565,44 @@ export function createPageLifecycle<T extends UID.ContentType>(
         return
       }
 
-      console.log(`🗑️  Deleting ${label} MDX for all locales: ${slug}`)
-
+      const locale = result.locale || defaultLang
       const outputDir = getOutputDir(config)
-      removeLocalizesFromLocaleFiles(
-        slug,
-        (locale) => path.join(outputDir, locale),
-        label
-      )
-      deleteLocaleMdxFiles(
-        (locale) => resolvePageFilepath(outputDir, result, locale),
-        label
-      )
+
+      if (locale === defaultLang) {
+        // Non-English files are named after the English slug, so this cascades to them too.
+        console.log(`🗑️  Deleting ${label} MDX for all locales: ${slug}`)
+        removeLocalizesFromLocaleFiles(
+          slug,
+          (loc) => path.join(outputDir, loc),
+          label
+        )
+        deleteLocaleMdxFiles(
+          (loc) => resolvePageFilepath(outputDir, result, loc),
+          label
+        )
+      } else {
+        // Non-English files are named after the English slug, not their own.
+        const englishResult = await fetchPublished(
+          config,
+          result.documentId,
+          defaultLang
+        )
+        if (englishResult instanceof Error) {
+          console.error(`⚠️  ${englishResult.message}`)
+        }
+        const englishSlug =
+          englishResult instanceof Error
+            ? undefined
+            : (englishResult?.pathSlug ?? undefined)
+
+        const filenameSlug = resolveFilenameSlug(locale, slug, englishSlug)
+        console.log(`🗑️  Deleting ${label} MDX (${locale}): ${filenameSlug}`)
+        deleteMdxIfExists(
+          resolvePageFilepath(outputDir, { pathSlug: filenameSlug }, locale),
+          locale,
+          label
+        )
+      }
 
       scheduleGitSync(label, { slug, action: 'delete', author })
     }


### PR DESCRIPTION
## Summary

Deleting a Spanish (non-English) entry in Strapi left its MDX file on disk. Both lifecycle delete hooks computed the file path from the deleted entry's own `pathSlug`, but non-English MDX files are actually named after the English sibling's slug — so whenever the two diverged, the path never matched and the delete silently no-opped. English deletes worked by coincidence since both locales share that same slug.

Fixed by resolving the English sibling's slug before computing the delete path for non-English entries, and deleting only that one locale's file (leaving the English source untouched).

## Related Issue
Fixes INTORG-869

## Manual Test
- Create an EN page + ES translation with a different `pathSlug`, publish both, delete only the ES entry in Strapi — confirm the ES `.mdx` file is removed and the EN file/entry are untouched.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)