### PR TITLE
docs(hero): recommend upload dimensions for the parallax background image

### DIFF
--- a/cms/src/components/shared/hero.json
+++ b/cms/src/components/shared/hero.json
@@ -28,7 +28,6 @@
       "type": "media",
       "multiple": false,
       "allowedTypes": ["images"],
-      "description": "Desktop hero image, used in a scrolling parallax panel — upload larger than the display size so it can pan without pixelating. Recommended: ~4000×2500px, under 2MB, AVIF format.",
       "pluginOptions": {
         "i18n": {
           "localized": true
@@ -39,7 +38,6 @@
       "type": "media",
       "multiple": false,
       "allowedTypes": ["images"],
-      "description": "Optional mobile hero image. Recommended size: 768×480px. Falls back to desktop image when absent.",
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/cms/src/components/shared/hero.json
+++ b/cms/src/components/shared/hero.json
@@ -28,7 +28,7 @@
       "type": "media",
       "multiple": false,
       "allowedTypes": ["images"],
-      "description": "Desktop hero image. Recommended size: 1440×600px.",
+      "description": "Desktop hero image, used in a scrolling parallax panel — upload larger than the display size so it can pan without pixelating. Recommended: ~4000×2500px, under 2MB, AVIF format.",
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -885,6 +885,12 @@ async function configureFieldLabels(strapi: StrapiInstance) {
       categoryValue:
         'You can select multiple categories — click "+ Add an entry" for each category'
     },
+    'shared.hero': {
+      backgroundImage:
+        'Desktop hero image, used in a scrolling parallax panel — upload larger than the display size so it can pan without pixelating. Recommended: ~4000×2500px, under 2MB, AVIF format.',
+      backgroundImageMobile:
+        'Optional mobile hero image. Recommended size: 768×480px. Falls back to desktop image when absent.'
+    },
     'shared.report-date': {
       lastUpdated:
         'Only fill in when the report has had a meaningful editorial update (revised text, new sections, or corrected facts).'

--- a/src/components/shared/PageHero.astro
+++ b/src/components/shared/PageHero.astro
@@ -19,7 +19,7 @@ interface BreadcrumbItem {
 interface Props {
   title: string
   description?: string | null
-  /** Desktop hero image. Recommended: 1440×600px. */
+  /** Desktop hero image URL, used in a scrolling parallax panel — upload larger than the display size so it can pan without pixelating. Recommended: ~4000×2500px, under 2MB, AVIF format. */
   image?: string | null
   imageAlt?: string | null
   /** Optional mobile image. Recommended: 768×480px. */


### PR DESCRIPTION
## Summary
The hero's background image is rendered inside a scrolling parallax panel and needs to be uploaded larger than its display size to pan without pixelating — the old "1440×600px" guidance was sized for a static, non-parallax image and no longer reflects what editors should actually upload. Updated the helper text in both the Strapi admin (component schema description) and the Astro prop's JSDoc to recommend ~4000×2500px, under 2MB, AVIF format.

## Related Issue
Fixes INTORG-897

## Manual Test
- Open the Hero component's "Desktop hero image" field in Strapi admin (any content type using `shared.hero`: foundation-page, summit-page, grant-overview-page) and confirm the new helper text shows under the upload field.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
