### PR TITLE
fix(profiles): Strapi validation, helper text, and breadcrumb truncate [INTORG-863]

### DIFF
--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -13,168 +13,6 @@ vi.mock('@/utils', async (importOriginal) => {
   }
 })
 
-vi.mock('./siteSchemas', async () => {
-  const { z } = await import('zod')
-  const sectionSchema = z.object({
-    title: z.string(),
-    content: z.string(),
-    ctas: z
-      .array(
-        z.object({
-          label: z.string(),
-          href: z.string()
-        })
-      )
-      .optional()
-  })
-  const pageSchema = z.object({
-    title: z.string().min(1, 'title is required'),
-    pathSlug: z.string().min(1, 'slug is required'),
-    description: z.string().optional(),
-    heroTitle: z.string().optional(),
-    heroDescription: z.string().optional(),
-    heroImage: z.string().optional(),
-    sections: z.array(sectionSchema).optional(),
-    localizes: z.string().optional(),
-    locale: z.string().optional()
-  })
-  const grantCtaStripSchema = z.object({
-    heading: z.string(),
-    description: z.string(),
-    buttonText: z.string(),
-    buttonLink: z.string(),
-    color: z.enum(['purple', 'green']).default('purple'),
-    secondaryButtonText: z.string().optional(),
-    secondaryButtonLink: z.string().optional()
-  })
-  const grantFaqItemSchema = z.object({
-    question: z.string(),
-    answer: z.string()
-  })
-  const grantFaqSectionSchema = z.object({
-    title: z.string(),
-    subtitle: z.string(),
-    description: z.string(),
-    ctaText: z.string(),
-    ctaLink: z.string(),
-    items: z.array(grantFaqItemSchema).min(2)
-  })
-  const grantInfoCardSchema = z.object({
-    heading: z.string().min(1, 'card heading is required'),
-    body: z.string().min(1, 'card body is required')
-  })
-  const grantInfoCardsSchema = z.object({
-    heading: z.string().optional(),
-    cards: z.tuple([
-      grantInfoCardSchema,
-      grantInfoCardSchema,
-      grantInfoCardSchema
-    ])
-  })
-  const grantPageSchema = z.object({
-    title: z.string().min(1, 'title is required'),
-    pathSlug: z.string().min(1, 'pathSlug is required'),
-    description: z.string().min(1, 'description is required'),
-    programOverview: z.string().optional(),
-    primaryCta: z
-      .object({
-        text: z.string(),
-        link: z.string(),
-        external: z.boolean().optional()
-      })
-      .optional(),
-    infoCards: grantInfoCardsSchema.optional(),
-    ctaStrip: grantCtaStripSchema,
-    faqSection: grantFaqSectionSchema.optional(),
-    metaImage: z.string().optional(),
-    canonicalUrl: z.string().optional(),
-    localizes: z.string().optional(),
-    locale: z.string().optional()
-  })
-  const grantOverviewPageSchema = z.object({
-    title: z.string().min(1, 'title is required'),
-    pathSlug: z.string().min(1, 'pathSlug is required'),
-    description: z.string().min(1, 'description is required'),
-    heroTitle: z.string().optional(),
-    heroDescription: z.string().optional(),
-    heroImage: z.string().optional(),
-    heroImageAlt: z.string().nullable().optional(),
-    heroImageMobile: z.string().optional(),
-    heroImageMobileAlt: z.string().nullable().optional(),
-    heroCtas: z
-      .array(
-        z.object({
-          text: z.string(),
-          link: z.string(),
-          style: z.enum(['primary', 'secondary']).optional(),
-          external: z.boolean().optional()
-        })
-      )
-      .max(1)
-      .optional(),
-    ctaStrip: grantCtaStripSchema,
-    metaImage: z.string().optional(),
-    canonicalUrl: z.string().optional(),
-    localizes: z.string().optional(),
-    locale: z.string().optional()
-  })
-  const faqSchema = z.object({
-    title: z.string().min(1, 'title is required'),
-    pathSlug: z.string().min(1, 'pathSlug is required'),
-    section: z.enum(['summit', 'hackathon', 'foundation']),
-    heading: z.string().min(1, 'heading is required'),
-    description: z.string().min(1, 'description is required'),
-    introParagraph: z.string().nullable().optional(),
-    locale: z.string().optional(),
-    localizes: z.string().optional()
-  })
-  const reportDateSchema = z.object({
-    publishDate: z.coerce.date(),
-    lastUpdated: z.coerce.date().optional()
-  })
-  const reportSchema = z.object({
-    title: z.string().min(1, 'title is required'),
-    pathSlug: z.string().min(1, 'pathSlug is required'),
-    section: z.enum(['summit', 'hackathon', 'foundation']),
-    heading: z.string().min(1, 'heading is required'),
-    description: z.string().min(1, 'description is required'),
-    introParagraph: z.string().nullable().optional(),
-    date: reportDateSchema.optional(),
-    locale: z.string(),
-    localizes: z.string().optional()
-  })
-  const profileSchema = z.object({
-    pathSlug: z.string().min(1, 'pathSlug is required'),
-    name: z.string().min(1, 'name is required'),
-    section: z.enum(['summit', 'hackathon', 'foundation']),
-    photo: z.string().nullable(),
-    photoAlt: z.string().nullable().optional(),
-    category: z.string().nullable().optional(),
-    tagline: z.string().nullable().optional(),
-    description: z.string().nullable().optional(),
-    role: z.string().nullable().optional(),
-    cta: z
-      .object({
-        text: z.string().optional(),
-        link: z.string().optional(),
-        style: z.enum(['primary', 'secondary']).optional(),
-        external: z.boolean().optional()
-      })
-      .optional(),
-    locale: z.string(),
-    localizes: z.string().optional()
-  })
-  return {
-    foundationPageFrontmatterSchema: pageSchema,
-    summitPageFrontmatterSchema: pageSchema,
-    grantPageFrontmatterSchema: grantPageSchema,
-    grantOverviewPageFrontmatterSchema: grantOverviewPageSchema,
-    faqFrontmatterSchema: faqSchema,
-    reportFrontmatterSchema: reportSchema,
-    profileFrontmatterSchema: profileSchema
-  }
-})
-
 import {
   getEntryField,
   buildPagePayload,
@@ -2100,7 +1938,8 @@ const baseFaqFrontmatter = {
   title: 'Frequently Asked Questions',
   section: 'foundation' as const,
   heading: 'Frequently Asked Questions',
-  description: 'Answers to common questions, 120 to 160 characters.'
+  description: 'Answers to common questions, 120 to 160 characters.',
+  locale: 'en'
 }
 
 // Maps faq MDX frontmatter to the Strapi faq payload shape.
@@ -2523,8 +2362,8 @@ describe('buildProfilePayload', () => {
       )
 
       expect(payload).toBeInstanceOf(Error)
-      expect((payload as Error).message).toContain('team/jane-doe')
       expect((payload as Error).message).toContain('cta')
+      expect((payload as Error).message).toContain('link')
     })
 
     it('returns Error when link is present but text is missing', async () => {
@@ -2543,6 +2382,8 @@ describe('buildProfilePayload', () => {
       )
 
       expect(payload).toBeInstanceOf(Error)
+      expect((payload as Error).message).toContain('cta')
+      expect((payload as Error).message).toContain('text')
     })
   })
 })

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -2289,9 +2289,7 @@ describe('createMediaUploadResolver', () => {
   })
 })
 
-// Maps profile MDX frontmatter to the Strapi profile-page payload shape.
-// Key risk: a half-filled `cta` (text without link, or vice versa) must
-// surface as an Error rather than silently dropping the CTA (see #359).
+// Incomplete CTA (text without link, or vice versa) must throw, not be dropped.
 describe('buildProfilePayload', () => {
   function stubStrapi(): StrapiClient {
     return {

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -143,13 +143,35 @@ vi.mock('./siteSchemas', async () => {
     locale: z.string(),
     localizes: z.string().optional()
   })
+  const profileSchema = z.object({
+    pathSlug: z.string().min(1, 'pathSlug is required'),
+    name: z.string().min(1, 'name is required'),
+    section: z.enum(['summit', 'hackathon', 'foundation']),
+    photo: z.string().nullable(),
+    photoAlt: z.string().nullable().optional(),
+    category: z.string().nullable().optional(),
+    tagline: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    role: z.string().nullable().optional(),
+    cta: z
+      .object({
+        text: z.string().optional(),
+        link: z.string().optional(),
+        style: z.enum(['primary', 'secondary']).optional(),
+        external: z.boolean().optional()
+      })
+      .optional(),
+    locale: z.string(),
+    localizes: z.string().optional()
+  })
   return {
     foundationPageFrontmatterSchema: pageSchema,
     summitPageFrontmatterSchema: pageSchema,
     grantPageFrontmatterSchema: grantPageSchema,
     grantOverviewPageFrontmatterSchema: grantOverviewPageSchema,
     faqFrontmatterSchema: faqSchema,
-    reportFrontmatterSchema: reportSchema
+    reportFrontmatterSchema: reportSchema,
+    profileFrontmatterSchema: profileSchema
   }
 })
 
@@ -160,7 +182,8 @@ import {
   buildGrantOverviewPagePayload,
   buildFaqPayload,
   buildReportPayload,
-  createMediaUploadResolver
+  createMediaUploadResolver,
+  buildProfilePayload
 } from './mdxTransformer'
 import {
   foundationPageFrontmatterSchema,
@@ -168,7 +191,8 @@ import {
   grantPageFrontmatterSchema,
   grantOverviewPageFrontmatterSchema,
   faqFrontmatterSchema,
-  reportFrontmatterSchema
+  reportFrontmatterSchema,
+  profileFrontmatterSchema
 } from './siteSchemas'
 import type { StrapiEntry } from './strapiClient'
 import type { StrapiUploadContext } from './mdxTransformer'
@@ -2423,5 +2447,102 @@ describe('createMediaUploadResolver', () => {
     ).rejects.toThrow(
       'Upload "https://example.com/not-a-local-asset.png" could not be resolved to a Strapi file ID.'
     )
+  })
+})
+
+// Maps profile MDX frontmatter to the Strapi profile-page payload shape.
+// Key risk: a half-filled `cta` (text without link, or vice versa) must
+// surface as an Error rather than silently dropping the CTA (see #359).
+describe('buildProfilePayload', () => {
+  function stubStrapi(): StrapiClient {
+    return {
+      findUploadByUrl: async () => null,
+      updateUploadAlt: async () => undefined
+    } as unknown as StrapiClient
+  }
+
+  const baseProfileFrontmatter = {
+    name: 'Jane Doe',
+    section: 'foundation',
+    photo: null,
+    locale: 'en'
+  }
+
+  describe('cta', () => {
+    it('is null in payload when absent from frontmatter', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'team/jane-doe',
+        frontmatter: baseProfileFrontmatter
+      })
+
+      const payload = await buildProfilePayload(
+        profileFrontmatterSchema,
+        mdx,
+        stubStrapi()
+      )
+
+      expect((payload as Record<string, unknown>).cta).toBeNull()
+    })
+
+    it('is included in payload when both text and link are present', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'team/jane-doe',
+        frontmatter: {
+          ...baseProfileFrontmatter,
+          cta: { text: 'Read more', link: 'https://example.com' }
+        }
+      })
+
+      const payload = await buildProfilePayload(
+        profileFrontmatterSchema,
+        mdx,
+        stubStrapi()
+      )
+
+      expect((payload as Record<string, unknown>).cta).toEqual({
+        text: 'Read more',
+        link: 'https://example.com',
+        style: 'primary',
+        external: false
+      })
+    })
+
+    it('returns Error when text is present but link is missing', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'team/jane-doe',
+        frontmatter: {
+          ...baseProfileFrontmatter,
+          cta: { text: 'Read more' }
+        }
+      })
+
+      const payload = await buildProfilePayload(
+        profileFrontmatterSchema,
+        mdx,
+        stubStrapi()
+      )
+
+      expect(payload).toBeInstanceOf(Error)
+      expect((payload as Error).message).toContain('team/jane-doe')
+      expect((payload as Error).message).toContain('cta')
+    })
+
+    it('returns Error when link is present but text is missing', async () => {
+      const mdx = createMdxFile({
+        pathSlug: 'team/jane-doe',
+        frontmatter: {
+          ...baseProfileFrontmatter,
+          cta: { link: 'https://example.com' }
+        }
+      })
+
+      const payload = await buildProfilePayload(
+        profileFrontmatterSchema,
+        mdx,
+        stubStrapi()
+      )
+
+      expect(payload).toBeInstanceOf(Error)
+    })
   })
 })

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -402,11 +402,25 @@ interface ProfileCtaFrontmatter {
   external?: boolean
 }
 
-/** Normalize the frontmatter CTA into a Strapi component payload, or null. */
-function ctaPayload(value: unknown): ProfileCtaFrontmatter | null {
+/**
+ * Normalize the frontmatter CTA into a Strapi component payload, or null.
+ *
+ * Throws if a `cta` object is present but missing required `text`/`link` —
+ * silently dropping it would let an editor's half-filled CTA vanish without
+ * any signal (see #359). Absent `cta` is valid (no CTA renders) and returns
+ * null.
+ */
+function ctaPayload(
+  value: unknown,
+  pathSlug: string
+): ProfileCtaFrontmatter | null {
   if (!value || typeof value !== 'object') return null
   const cta = value as ProfileCtaFrontmatter
-  if (!cta.text || !cta.link) return null
+  if (!cta.text || !cta.link) {
+    throw new Error(
+      `[${pathSlug}] Profile "cta" is missing required "text" and/or "link" — both are required when a cta is provided.`
+    )
+  }
   return {
     text: cta.text,
     link: cta.link,
@@ -466,7 +480,7 @@ export async function buildProfilePayload(
       }
     }
 
-    const cta = ctaPayload(mdx.frontmatter.cta)
+    const cta = ctaPayload(mdx.frontmatter.cta, mdx.pathSlug)
     const content = await buildContentFromMdxBody(mdx, existingEntry, parserCtx)
 
     return {

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -404,11 +404,7 @@ interface ProfileCtaFrontmatter {
 
 /**
  * Normalize the frontmatter CTA into a Strapi component payload, or null.
- *
- * Throws if a `cta` object is present but missing required `text`/`link` —
- * silently dropping it would let an editor's half-filled CTA vanish without
- * any signal (see #359). Absent `cta` is valid (no CTA renders) and returns
- * null.
+ * Throws if `cta` is present but missing `text`/`link`. Absent `cta` is fine.
  */
 function ctaPayload(
   value: unknown,

--- a/cms/src/api/profile-page/content-types/profile-page/schema.json
+++ b/cms/src/api/profile-page/content-types/profile-page/schema.json
@@ -34,8 +34,7 @@
         "i18n": {
           "localized": true
         }
-      },
-      "description": "Full path from the site root, no leading slash. Determines the public URL only. Examples: hackathon/2025/judges/jane-doe; summit/2025/speakers/jane-doe; grant/fellowship/jane-doe."
+      }
     },
     "section": {
       "type": "enumeration",
@@ -45,8 +44,7 @@
         "i18n": {
           "localized": false
         }
-      },
-      "description": "Site section for routing and breadcrumbs. Does not affect MDX file location."
+      }
     },
     "tagline": {
       "type": "string",
@@ -62,8 +60,7 @@
         "i18n": {
           "localized": true
         }
-      },
-      "description": "Short optional description or bio blurb shown on profile cards and detail pages."
+      }
     },
     "cta": {
       "type": "component",
@@ -78,7 +75,6 @@
     },
     "role": {
       "type": "string",
-      "description": "Job title or role shown under the profile name on the detail page (e.g. 'Open Web Advocate & Open Source Contributor').",
       "pluginOptions": {
         "i18n": {
           "localized": true
@@ -87,7 +83,6 @@
     },
     "photo": {
       "type": "media",
-      "description": "Image alt text comes from the media Alternative text field when set; otherwise MDX export uses the profile name as photoAlt.",
       "multiple": false,
       "required": false,
       "allowedTypes": ["images"],
@@ -100,7 +95,6 @@
     "category": {
       "type": "string",
       "required": true,
-      "description": "Groups profiles for summary views (e.g. '2025 Hackathon Judges', 'Leadership Team', 'Fellows 2026').",
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -684,13 +684,19 @@ async function configureFieldLabels(strapi: StrapiInstance) {
 
   const contentTypeDescriptions: Record<string, Record<string, string>> = {
     'api::profile-page.profile-page': {
+      tagline:
+        'Used on profile grids below the avatar and name. Not shown on the profile page.',
+      category:
+        'Groups related profiles so a Profile Grid can list everyone who shares this label (e.g. "Fellows 2026", "2025 Hackathon Judges").',
       photo:
-        'Click the edit (pencil) icon on the selected image to set Alternative text. Leave it empty for decorative images (renders alt="").',
-      role: "Job title or role shown under the profile name on the detail page (e.g. 'Open Web Advocate & Open Source Contributor').",
+        'The photo is cropped to a circle on the site — upload an image that works in that shape, with the face centred and clear of the edges. Click the edit (pencil) icon to set Alternative text; leave it empty for decorative images.',
+      pathSlug:
+        'This should include the category and the person’s name, e.g. 2025/judges/jane-doe. No leading slash. Determines the public URL.',
+      role: "Job title or role shown under the profile name on the profile page (e.g. 'Open Web Advocate & Open Source Contributor').",
       section:
         'Site section for routing and breadcrumbs. Use foundation for profiles at the site root or under a full pathSlug (e.g. grant/fellowship/jane-doe); summit or hackathon when the profile lives under that microsite prefix.',
       description:
-        'Short intro blurb shown on the profile detail page, above the CTA and biography sections.'
+        'Short intro blurb shown on the profile page, above the CTA and biography sections.'
     },
     'api::foundation-page.foundation-page': {
       pathSlug:

--- a/src/components/blog/BlogPostHeader.astro
+++ b/src/components/blog/BlogPostHeader.astro
@@ -45,7 +45,7 @@ const blogPath = translatePath(
 <div class="flex flex-col gap-2xl desktop:gap-3xl">
   <h1
     itemprop="headline"
-    class="text-neutral-900 text-h2 tablet:text-h2-md desktop:text-h2-lg"
+    class="text-neutral-900 text-h2 tablet:text-h2-md desktop:text-h2-lg break-words"
   >
     {frontmatter.title}
   </h1>

--- a/src/components/shared/Breadcrumbs.astro
+++ b/src/components/shared/Breadcrumbs.astro
@@ -24,7 +24,7 @@ const { routeLocale } = Astro.locals
 const currentPath = stripTrailingSlash(Astro.url.pathname)
 const t = useTranslations(routeLocale)
 const breadcrumbClasses = twMerge(
-  'flex flex-nowrap items-center overflow-hidden list-none m-0 p-0 [&_a]:no-underline text-neutral-75 [&_a]:text-neutral-75 [&_a[aria-current="page"]]:text-orchid-100 [&_svg]:text-current',
+  'flex min-w-0 w-full flex-nowrap items-center overflow-hidden list-none m-0 p-0 [&_a]:no-underline text-neutral-75 [&_a]:text-neutral-75 [&_a[aria-current="page"]]:text-orchid-100 [&_svg]:text-current',
   breakBeforeLastItem ? 'gap-x-xs tablet:gap-xs' : 'gap-xs',
   className
 )
@@ -41,22 +41,22 @@ function getItemClasses(isLast: boolean): string {
 }
 
 function getLinkClasses(isLast: boolean): string {
-  const base = `inline-block ${linkPaddingClass} text-body-lg-standard rounded-lg border border-transparent focus-visible:outline-none focus-visible:border-orchid-100 hover:text-neutral-900`
+  const base = `${linkPaddingClass} text-body-lg-standard rounded-lg border border-transparent focus-visible:outline-none focus-visible:border-orchid-100 hover:text-neutral-900`
   if (isLast) {
-    return `${base} min-w-0 max-w-full overflow-hidden`
+    return `${base} block min-w-0 flex-1 truncate`
   }
-  return base
+  return `inline-block ${base}`
 }
 
 function getNameClasses(isLast: boolean): string {
   if (isLast) {
-    return 'block min-w-0 truncate'
+    return 'block truncate'
   }
   return 'whitespace-nowrap'
 }
 ---
 
-<nav aria-label={t('nav.breadcrumb')}>
+<nav aria-label={t('nav.breadcrumb')} class="min-w-0 max-w-full">
   <ol
     class={breadcrumbClasses}
     itemscope

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -64,13 +64,13 @@ const breadcrumbs = [
   >
     <TableScrollSupport />
     <slot name="disclaimer" />
-    <div class="max-w-narrow m-auto">
+    <div class="max-w-narrow m-auto min-w-0 w-full">
       <Breadcrumbs breadcrumbs={breadcrumbs} class="mb-2xl desktop:mb-3xl" />
       <article
         data-prose-blog
         itemscope
         itemtype="http://schema.org/Article"
-        class="mb-5xl min-w-0 tablet:mb-4xl desktop:mb-5xl"
+        class="mb-5xl min-w-0 overflow-x-clip tablet:mb-4xl desktop:mb-5xl"
       >
         <BlogPostHeader frontmatter={frontmatter} />
         <slot />

--- a/src/schemas/tsconfig.json
+++ b/src/schemas/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  // Standalone config so CMS vitest (CI installs only cms/) can transform these
+  // Zod schemas via @site without resolving the repo-root Astro tsconfig.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "isolatedModules": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/src/styles/components/prose/blog.css
+++ b/src/styles/components/prose/blog.css
@@ -48,9 +48,15 @@
 
     img {
       display: block;
+      max-width: 100%;
+      height: auto;
       margin-inline: auto;
       border-radius: var(--radius-3xl);
     }
+
+    /* Long URLs / unbroken strings should wrap instead of forcing page overflow */
+    overflow-wrap: anywhere;
+    word-break: break-word;
 
     /* === Table styles === */
     & .table-scroll {


### PR DESCRIPTION
## Summary

Addresses review feedback on the profile template PR:

- **Strapi validation / incomplete components** — required profile fields are enforced (`section`, `pathSlug`, `category`, etc.); empty photo and biography are handled explicitly instead of silently dropping incomplete data on export/sync
- **Breadcrumbs overflow** — restores a proper flex truncate chain (replacing the broken `line-clamp-2` revert) so long last crumbs (e.g. blog post titles) ellipsize instead of overflowing the page
- **Strapi helper text** — Tag line, Category, Photo, and URL Slug descriptions are set via bootstrap `contentTypeDescriptions` (visible across environments); “detail page” wording updated to “profile page”

## Related Issue

Fixes INTORG-863

## Manual Test

1. **Validation** — try saving a profile without required fields; confirm Strapi rejects with a clear error
2. **Photo / biography** — save with no photo and empty biography; confirm export/sync does not silently strip related fields, and the profile page still renders (fallback avatar where expected)
3. **Breadcrumbs** — open a long-title blog post on mobile (e.g. banking-without-banks); last crumb should truncate with an ellipsis, no horizontal scroll
4. **Helper text** — open a Profile Page in Strapi admin and confirm Tag line, Category, Photo, and URL Slug helpers match the PR comments

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)