### PR TITLE
feat(number-tiles): format animated stats with commas [INTORG-940]

### DIFF
--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -1025,7 +1025,7 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     },
     'blocks.number-tile': {
       number:
-        'Plain text — commas can be typed manually, e.g. "1,000". Do not include the suffix here.',
+        'Enter digits only (e.g. "1000") — the site formats thousands with commas. Do not include the suffix here.',
       suffix: 'Optional suffix shown after the number, e.g. "M+" or "+".'
     }
   }

--- a/src/components/blocks/NumberTiles.astro
+++ b/src/components/blocks/NumberTiles.astro
@@ -1,15 +1,16 @@
 ---
 // Row of stat tiles for the grant-overview-page dynamic zone (INTORG-854).
 // Reuses the homepage's StatCard/AnimatedNumber trio rather than duplicating
-// the count-up + accessibility pattern — see `display` prop on both for why
-// (the `number` field here is free text, e.g. "1,000", not a clean number).
+// the count-up + accessibility pattern. Strapi stores plain digits (e.g.
+// "1000"); we format with commas for display while the animation still
+// counts up to the parsed numeric value.
 //
 // Layout: CSS Grid instead of flexbox so the gap doesn't need subtracting out
 // of each item's width — 2 tiles per row on mobile/tablet, up to 4 per row on
 // desktop; a 5th+ tile wraps to a new row, left-aligned (grid auto-placement's
 // default behavior, no extra CSS needed).
 import StatCard from '@/components/shared/StatCard.astro'
-import { parseStatNumber } from '@/utils'
+import { formatStatNumber, parseStatNumber } from '@/utils'
 
 interface Tile {
   number: string
@@ -39,10 +40,14 @@ const LABEL_CLASS = 'text-left text-neutral-75'
   {
     tiles.map((tile) => {
       const parsed = parseStatNumber(tile.number)
+      // Strapi stores plain digits (e.g. "1000"); format for display with
+      // commas. Non-numeric free text falls back to the raw field value.
+      const display =
+        parsed !== null ? formatStatNumber(parsed) : tile.number
       return (
         <StatCard
           value={parsed ?? 0}
-          display={tile.number}
+          display={display}
           suffix={tile.suffix}
           numberClass={NUMBER_CLASS}
           label={tile.description}

--- a/src/components/blocks/NumberTiles.astro
+++ b/src/components/blocks/NumberTiles.astro
@@ -42,8 +42,7 @@ const LABEL_CLASS = 'text-left text-neutral-75'
       const parsed = parseStatNumber(tile.number)
       // Strapi stores plain digits (e.g. "1000"); format for display with
       // commas. Non-numeric free text falls back to the raw field value.
-      const display =
-        parsed !== null ? formatStatNumber(parsed) : tile.number
+      const display = parsed !== null ? formatStatNumber(parsed) : tile.number
       return (
         <StatCard
           value={parsed ?? 0}

--- a/src/components/shared/AnimatedNumber.astro
+++ b/src/components/shared/AnimatedNumber.astro
@@ -93,12 +93,13 @@ const formatted = display ?? String(value)
       // the DOM quiet either way.
       let lastValue = -Infinity
       let startTs: number | null = null
+      const format = (n: number) => n.toLocaleString('en-US')
       const step = (ts: number) => {
         if (startTs === null) startTs = ts
         const progress = Math.min((ts - startTs) / duration, 1)
         const current = Math.floor(progress * target)
         if (current !== lastValue) {
-          display.textContent = String(current)
+          display.textContent = format(current)
           lastValue = current
         }
         if (progress < 1) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,7 +18,7 @@ export {
 export { tryCatchAsync } from './shared/tryCatch'
 export { twMerge } from './shared/twMerge'
 export { getVisiblePages } from './shared/pagination'
-export { parseStatNumber } from './shared/parseStatNumber'
+export { parseStatNumber, formatStatNumber } from './shared/parseStatNumber'
 
 // Main site: URL & routing
 export {

--- a/src/utils/shared/parseStatNumber.test.ts
+++ b/src/utils/shared/parseStatNumber.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseStatNumber } from './parseStatNumber'
+import { formatStatNumber, parseStatNumber } from './parseStatNumber'
 
 describe('parseStatNumber', () => {
   it('parses plain digits', () => {
@@ -21,5 +21,17 @@ describe('parseStatNumber', () => {
 
   it('returns null for a whitespace-only string', () => {
     expect(parseStatNumber('   ')).toBeNull()
+  })
+})
+
+describe('formatStatNumber', () => {
+  it('adds grouping commas', () => {
+    expect(formatStatNumber(1000)).toBe('1,000')
+    expect(formatStatNumber(21000000)).toBe('21,000,000')
+  })
+
+  it('leaves small numbers ungrouped', () => {
+    expect(formatStatNumber(21)).toBe('21')
+    expect(formatStatNumber(0)).toBe('0')
   })
 })

--- a/src/utils/shared/parseStatNumber.ts
+++ b/src/utils/shared/parseStatNumber.ts
@@ -1,9 +1,16 @@
-/** Parses a stat tile's free-text number field (e.g. "1,000") into a plain
- * number for driving a count-up animation. Returns null when the text isn't
- * a parseable number (e.g. it's non-numeric), so callers can fall back to a
- * static, non-animated render instead. */
+/** Parses a stat tile's free-text number field (e.g. "1,000" or "1000") into a
+ * plain number for driving a count-up animation. Returns null when the text
+ * isn't a parseable number (e.g. it's non-numeric), so callers can fall back
+ * to a static, non-animated render instead. */
 export function parseStatNumber(text: string): number | null {
   const stripped = text.replace(/,/g, '')
   const n = Number(stripped)
   return Number.isFinite(n) && stripped.trim() !== '' ? n : null
+}
+
+/** Formats a number with grouping commas for display (e.g. 1000 → "1,000").
+ * Uses en-US so Strapi editors can enter plain digits and the site always
+ * shows a consistent thousands separator. */
+export function formatStatNumber(value: number): string {
+  return value.toLocaleString('en-US')
 }


### PR DESCRIPTION

## Summary

Number tiles now show thousands separators (e.g. `1,000`) while keeping the count-up animation. Strapi can store plain digits (`1000`); the site formats for display and mid-animation frames.

- Adds `formatStatNumber()` and uses it in `NumberTiles`
- `AnimatedNumber` formats intermediate values with commas
- Updates Strapi helper text: enter digits only; commas are added on the site

## Related Issue

Fixes INTORG-940

## Manual Test

1. Set a number tile to `1000` in Strapi (no comma)
2. View the grant overview page — resting value should read `1,000`
3. Reload and scroll the tiles into view — animation should count up with commas and land on `1,000`
4. Confirm small numbers (e.g. `21`) still render without a comma

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)