### PR TITLE
fix(styles): restore orchid prose links and orchid-150 hover [INTORG-945]

### DIFF
--- a/src/styles/README.md
+++ b/src/styles/README.md
@@ -54,7 +54,7 @@ src/styles/
 
 ## Pillar Theming System
 
-> **Currently a no-op, by design.** The legacy pillar accent colors (`--color-tech-main`, `--color-mission-main`, `--color-vision-main`, `--color-values-main`) were removed from `theme.css` as part of the new-design-system token cleanup, and the `[data-pillar='X']` override blocks in `base/variables.css` were simplified to `--color-primary: var(--color-primary)` — a self-reference that CSS treats as invalid, so the property just inherits the `:root` default (`--color-orchid-100`). The scaffolding is kept in place rather than removed: this is the mechanism that will give `foundation`, `summit`, and `hackathon` each their own theme once those mini-sites need distinct pillar colors again. Until that work happens, every pillar silently renders the same default — see "Adding a New Pillar" below for how to wire in a real color when the time comes.
+> **Currently orchid for every pillar, by design.** The legacy pillar accents (`--color-tech-main`, etc.) were removed in the design-token cleanup. Each `[data-pillar='X']` block in `base/variables.css` still sets `--color-primary`, but points at `--color-orchid-100` until distinct hues are chosen. Do **not** use `--color-primary: var(--color-primary)` — that self-reference is invalid at computed-value time and strips the primary color from the whole subtree (prose links, `text-primary`, etc.). See "Adding a New Pillar" below to wire a real hue.
 
 ### How It Works
 

--- a/src/styles/base/reset.css
+++ b/src/styles/base/reset.css
@@ -83,7 +83,7 @@
   }
 
   a:hover {
-    color: var(--color-primary);
+    color: var(--color-orchid-150);
   }
 
   /* Lenis smooth scroll — see src/scripts/smooth-scroll.ts.

--- a/src/styles/base/variables.css
+++ b/src/styles/base/variables.css
@@ -56,19 +56,21 @@
     --color-btn-txt: var(--color-white);
   }
 
-  /* Pillar overrides - set on page wrapper via data-pillar attribute
-     These override --color-primary for the entire page tree, affecting
-     all components, prose styles, and dynamic utilities that read from it. */
+  /* Pillar overrides — set on a page wrapper via data-pillar.
+     Must point at a real token (not var(--color-primary)): a self-reference
+     is invalid at computed-value time and breaks prose links / text-primary
+     for the whole subtree (e.g. profile pages with data-pillar="mission").
+     Placeholders use orchid until each pillar gets a distinct hue. */
   [data-pillar='tech'] {
-    --color-primary: var(--color-primary);
+    --color-primary: var(--color-orchid-100);
   }
   [data-pillar='mission'] {
-    --color-primary: var(--color-primary);
+    --color-primary: var(--color-orchid-100);
   }
   [data-pillar='vision'] {
-    --color-primary: var(--color-primary);
+    --color-primary: var(--color-orchid-100);
   }
   [data-pillar='values'] {
-    --color-primary: var(--color-primary);
+    --color-primary: var(--color-orchid-100);
   }
 }

--- a/src/styles/components/prose/blog.css
+++ b/src/styles/components/prose/blog.css
@@ -8,6 +8,21 @@
 
 @layer components {
   [data-prose-blog] {
+    & a {
+      color: var(--color-primary);
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
+      transition:
+        color 200ms ease-in-out,
+        text-decoration-color 200ms ease-in-out;
+    }
+
+    & a:hover {
+      color: var(--color-orchid-150);
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
+    }
+
     /* === Extended element spacing === */
     & figure {
       margin-block-end: var(--spacing-xl);

--- a/src/styles/components/prose/default.css
+++ b/src/styles/components/prose/default.css
@@ -30,10 +30,14 @@
       color: var(--color-primary);
       text-decoration-line: underline;
       text-decoration-color: currentColor;
-      transition: text-decoration-color 200ms ease-in-out;
+      transition:
+        color 200ms ease-in-out,
+        text-decoration-color 200ms ease-in-out;
     }
     a:hover {
-      text-decoration-color: transparent;
+      color: var(--color-orchid-150);
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
     }
 
     p, h2, h3, h4, h5, h6, ul, ol {

--- a/src/styles/components/prose/foundation.css
+++ b/src/styles/components/prose/foundation.css
@@ -9,10 +9,14 @@
     color: var(--color-primary);
     text-decoration-line: underline;
     text-decoration-color: currentColor;
-    transition: text-decoration-color 200ms ease-in-out;
+    transition:
+      color 200ms ease-in-out,
+      text-decoration-color 200ms ease-in-out;
   }
   [data-prose] a:hover {
-    text-decoration-color: transparent;
+    color: var(--color-orchid-150);
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
   }
   [data-prose] hr {
     border-color: var(--color-neutral-50);

--- a/src/styles/components/prose/summit.css
+++ b/src/styles/components/prose/summit.css
@@ -13,10 +13,14 @@
       color: var(--color-primary);
       text-decoration-line: underline;
       text-decoration-color: currentColor;
-      transition: text-decoration-color 200ms ease-in-out;
+      transition:
+        color 200ms ease-in-out,
+        text-decoration-color 200ms ease-in-out;
     }
     & a:hover {
-      text-decoration-color: transparent;
+      color: var(--color-orchid-150);
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
     }
   }
 }


### PR DESCRIPTION

## Summary

Profile page links were missing orchid styling because `[data-pillar]` set `--color-primary: var(--color-primary)`, which invalidates the token for the whole subtree. Pillar overrides now point at `--color-orchid-100`, so profile/prose links match blog again.

Also aligned sitewide link hover: orchid-150 with underline kept (no more underline fade-out) across default, foundation, summit, and blog prose, plus the base `a:hover` reset.

## Related Issue

Fixes [INTORG-945](https://linear.app/interledger/issue/INTORG-945/links-on-profile-pages-should-be-orchid-100)

## Manual Test

1. Open a profile with a body link (e.g. `/grant/fellowship/ayden-ferdeline`) — link should be orchid-100 + underlined
2. Hover that link — should go orchid-150 and stay underlined
3. Repeat on a blog post and a foundation prose page — same hover behavior

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)