### PR TITLE
style(prose): style GFM footnotes for blog and reports [INTORG-839]

### DIFF
--- a/src/content/reports/policy-and-advocacy-role-stablecoins-facilitating-low-value-low-cost-transactions.mdx
+++ b/src/content/reports/policy-and-advocacy-role-stablecoins-facilitating-low-value-low-cost-transactions.mdx
@@ -4,7 +4,7 @@ pathSlug: 'policy-and-advocacy/role-stablecoins-facilitating-low-value-low-cost-
 section: 'foundation'
 heading: 'The Role of Stablecoins in Facilitating Low-Value, Low-Cost Transactions'
 description: 'How stablecoins can lower the cost of small-value payments, and what policymakers and payment providers should weigh before adopting them at scale.'
-introParagraph: "A stablecoin is a type of digital currency that aims to maintain a steady value by being pegged to a specific fiat currency. For example, if a stablecoin is pegged to the US dollar, that means one unit of the coin is designed to remain equal in value to one US dollar. Stablecoins have now matured beyond their speculative origins and offer serious potential as infrastructure-grade tools for cross-border settlement. For the Interledger Foundation, as stewards of an open, nonprofit payment network that connects disparate financial ecosystems, regulated stablecoins offer an increasingly viable solution to the long-standing settlement gap in our technology stack.\_\n\nHowever, the utility of stablecoins is not uniform. The cost-effectiveness, accessibility, and regulatory risks of stablecoins vary dramatically by geography, network, and transaction type. This policy brief outlines when and how stablecoins align with our mission to foster inclusive digital financial systems and sets clear boundaries around the types of cryptocurrencies we believe should play a role in achieving that vision."
+introParagraph: "A stablecoin is a type of digital currency that aims to maintain a steady value by being pegged to a specific fiat currency. For example, if a stablecoin is pegged to the US dollar, that means one unit of the coin is designed to remain equal in value to one US dollar. Stablecoins have now matured beyond their speculative origins and offer serious potential as infrastructure-grade tools for cross-border settlement. For the Interledger Foundation, as stewards of an open, nonprofit payment network that connects disparate financial ecosystems, regulated stablecoins offer an increasingly viable solution to the long-standing settlement gap in our technology stack.\n\nHowever, the utility of stablecoins is not uniform. The cost-effectiveness, accessibility, and regulatory risks of stablecoins vary dramatically by geography, network, and transaction type. This policy brief outlines when and how stablecoins align with our mission to foster inclusive digital financial systems and sets clear boundaries around the types of cryptocurrencies we believe should play a role in achieving that vision."
 date:
   publishDate: '2026-06-15'
   lastUpdated: '2026-07-13'
@@ -16,5 +16,26 @@ locale: 'en'
 Cross-border remittances and micropayments have long been underserved by traditional payment rails, where fixed fees make small transfers disproportionately expensive. Stablecoins, by settling on open networks with minimal intermediation, have been put forward as a way to close that gap.
 
 Realizing that potential depends on more than the technology itself. Consumer protection, reserve transparency, and interoperability with existing financial infrastructure all shape whether stablecoin-based payments can be trusted for everyday, low-value use.
+
+## The Advantages of Stablecoins for Settlement
+
+### Lower Transaction Costs
+
+Stablecoins offer only marginal efficiency gains for same-currency domestic payments in high-income markets with instant payment systems or account-to-account systems. A FedNow transaction for a domestic payment in the United States costs $0.045 (which, while low, is still too high for micropayments). The equation changes significantly with regards to cross-border payments, particularly between payment corridors with fragmented infrastructure.
+
+A native stablecoin transfer can settle a $1 transaction for
+
+- $0.0001 on Aptos
+- $0.0002 on Polygon
+- $0.0006 on Avalanche.[^1]
+
+By contrast:
+
+- International wire transfers can absorb 13.32% of the principal through fees and FX spreads.[^2]
+- Cross-border fintechs like Wise average 1.89% for the same payment.[^3]
+
+[^1]: Average cost to send 1 USDT (Tether, the largest stablecoin pegged to the US dollar) on August 5, 2025 per GasFeesNow. [https://gasfeesnow.com](https://gasfeesnow.com)
+[^2]: Average price for a $200 bank initiated cross-border transfer, according to the World Bank (Q3, 2024). [https://remittanceprices.worldbank.org/sites/default/files/rpw_main_report_and_annex_q324.pdf](https://remittanceprices.worldbank.org/sites/default/files/rpw_main_report_and_annex_q324.pdf)
+[^3]: Average price to send $200 from the United States to Mexico using Wise for a personal account to a personal account transaction, according to the Inter-American Dialogue (2024). [https://thedialogue.org/wp-content/uploads/2024/03/Transaction-Costs-and-Money-Transfer-Operators-A-Review-of-Costs-by-MTO-Receiving-Countries.pdf](https://thedialogue.org/wp-content/uploads/2024/03/Transaction-Costs-and-Money-Transfer-Operators-A-Review-of-Costs-by-MTO-Receiving-Countries.pdf)
 
 </Paragraph>

--- a/src/content/reports/policy-and-advocacy-role-stablecoins-facilitating-low-value-low-cost-transactions.mdx
+++ b/src/content/reports/policy-and-advocacy-role-stablecoins-facilitating-low-value-low-cost-transactions.mdx
@@ -35,7 +35,9 @@ By contrast:
 - Cross-border fintechs like Wise average 1.89% for the same payment.[^3]
 
 [^1]: Average cost to send 1 USDT (Tether, the largest stablecoin pegged to the US dollar) on August 5, 2025 per GasFeesNow. [https://gasfeesnow.com](https://gasfeesnow.com)
+
 [^2]: Average price for a $200 bank initiated cross-border transfer, according to the World Bank (Q3, 2024). [https://remittanceprices.worldbank.org/sites/default/files/rpw_main_report_and_annex_q324.pdf](https://remittanceprices.worldbank.org/sites/default/files/rpw_main_report_and_annex_q324.pdf)
+
 [^3]: Average price to send $200 from the United States to Mexico using Wise for a personal account to a personal account transaction, according to the Inter-American Dialogue (2024). [https://thedialogue.org/wp-content/uploads/2024/03/Transaction-Costs-and-Money-Transfer-Operators-A-Review-of-Costs-by-MTO-Receiving-Countries.pdf](https://thedialogue.org/wp-content/uploads/2024/03/Transaction-Costs-and-Money-Transfer-Operators-A-Review-of-Costs-by-MTO-Receiving-Countries.pdf)
 
 </Paragraph>

--- a/src/styles/README.md
+++ b/src/styles/README.md
@@ -25,7 +25,8 @@ src/styles/
 │       ├── base-typography.css  # Common h2, h3, p, lists
 │       ├── foundation.css   # [data-prose] specific
 │       ├── blog.css        # [data-prose-blog] specific
-│       └── summit.css      # [data-prose-summit] specific
+│       ├── summit.css      # [data-prose-summit] specific
+│       └── footnotes.css   # GFM footnotes under [data-prose] / [data-prose-blog]
 └── utilities/              # Utilities layer - custom @utility definitions
     └── animations.css       # Scroll-driven animation utilities (animate-rise-in-view, etc.)
 ```

--- a/src/styles/components/prose/footnotes.css
+++ b/src/styles/components/prose/footnotes.css
@@ -2,15 +2,15 @@
  * GFM footnote styles (micromark `class="footnotes"` / `data-footnotes`).
  * Shared by foundation prose (reports) and blog articles.
  *
- * Design: orchid-100 superscript markers at caption size (13px / 0.8125rem);
- * body copy stays neutral; links use primary (orchid) with underline.
+ * Design: primary-colored superscript markers at caption size (13px / 0.8125rem);
+ * body copy stays neutral; links use primary with underline.
  */
 
 @layer components {
   :is([data-prose], [data-prose-blog]) {
-    /* Inline citation markers — 13px orchid-100 */
+    /* Inline citation markers — 13px primary */
     a[data-footnote-ref] {
-      color: var(--color-orchid-100);
+      color: var(--color-primary);
       font-size: var(--text-caption);
       font-weight: 400;
       line-height: 1;
@@ -72,14 +72,14 @@
       margin-block-end: 0;
     }
 
-    /* List markers — 13px orchid-100 superscripts */
+    /* List markers — 13px primary superscripts */
     .footnotes li::before,
     [data-footnotes] li::before {
       content: counter(footnote);
       position: absolute;
       inset-inline-start: 0;
       top: 0;
-      color: var(--color-orchid-100);
+      color: var(--color-primary);
       font-size: var(--text-caption);
       font-weight: 400;
       line-height: 1.2;
@@ -96,7 +96,7 @@
 
     .footnotes a,
     [data-footnotes] a {
-      color: var(--color-orchid-100);
+      color: var(--color-primary);
       font-weight: 400;
       text-decoration-line: underline;
       text-decoration-color: currentColor;

--- a/src/styles/components/prose/footnotes.css
+++ b/src/styles/components/prose/footnotes.css
@@ -36,18 +36,8 @@
       font-weight: var(--text-body-sm-standard--font-weight);
     }
 
-    .footnotes > :is(h2, h3)#footnote-label,
-    [data-footnotes] > :is(h2, h3)#footnote-label {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
+    /* GFM emits `<h2 id="footnote-label" class="sr-only">`; Tailwind's
+       sr-only utility hides it for sighted users — no duplicate rules here. */
 
     .footnotes ol,
     [data-footnotes] ol {

--- a/src/styles/components/prose/footnotes.css
+++ b/src/styles/components/prose/footnotes.css
@@ -12,7 +12,7 @@
     a[data-footnote-ref] {
       color: var(--color-primary);
       font-size: var(--text-caption);
-      font-weight: 400;
+      font-weight: var(--text-caption--font-weight);
       line-height: 1;
       text-decoration-line: none;
       vertical-align: super;
@@ -51,7 +51,7 @@
     [data-footnotes] li {
       position: relative;
       counter-increment: footnote;
-      padding-inline-start: 1.25rem;
+      padding-inline-start: var(--spacing-lg);
       margin-block-end: var(--spacing-md);
       font-size: inherit;
       line-height: inherit;
@@ -71,7 +71,7 @@
       top: 0;
       color: var(--color-primary);
       font-size: var(--text-caption);
-      font-weight: 400;
+      font-weight: var(--text-caption--font-weight);
       line-height: 1.2;
       vertical-align: super;
     }
@@ -87,7 +87,7 @@
     .footnotes a,
     [data-footnotes] a {
       color: var(--color-primary);
-      font-weight: 400;
+      font-weight: var(--text-body-sm-standard--font-weight);
       text-decoration-line: underline;
       text-decoration-color: currentColor;
       overflow-wrap: anywhere;

--- a/src/styles/components/prose/footnotes.css
+++ b/src/styles/components/prose/footnotes.css
@@ -1,0 +1,126 @@
+/**
+ * GFM footnote styles (micromark `class="footnotes"` / `data-footnotes`).
+ * Shared by foundation prose (reports) and blog articles.
+ *
+ * Design: orchid-100 superscript markers at caption size (13px / 0.8125rem);
+ * body copy stays neutral; links use primary (orchid) with underline.
+ */
+
+@layer components {
+  :is([data-prose], [data-prose-blog]) {
+    /* Inline citation markers — 13px orchid-100 */
+    a[data-footnote-ref] {
+      color: var(--color-orchid-100);
+      font-size: var(--text-caption);
+      font-weight: 400;
+      line-height: 1;
+      text-decoration-line: none;
+      vertical-align: super;
+    }
+
+    a[data-footnote-ref]:hover {
+      color: var(--color-orchid-150);
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
+    }
+
+    /* Footnote list at end of article */
+    .footnotes,
+    [data-footnotes] {
+      margin-block-start: var(--spacing-3xl);
+      padding-block-start: var(--spacing-2xl);
+      border-block-start: 2px solid var(--color-neutral-50);
+      color: var(--color-neutral-100);
+      font-size: var(--text-body-sm-standard);
+      line-height: var(--text-body-sm-standard--line-height);
+      font-weight: var(--text-body-sm-standard--font-weight);
+    }
+
+    .footnotes > :is(h2, h3)#footnote-label,
+    [data-footnotes] > :is(h2, h3)#footnote-label {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .footnotes ol,
+    [data-footnotes] ol {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      counter-reset: footnote;
+    }
+
+    .footnotes li,
+    [data-footnotes] li {
+      position: relative;
+      counter-increment: footnote;
+      padding-inline-start: 1.25rem;
+      margin-block-end: var(--spacing-md);
+      font-size: inherit;
+      line-height: inherit;
+    }
+
+    .footnotes li:last-child,
+    [data-footnotes] li:last-child {
+      margin-block-end: 0;
+    }
+
+    /* List markers — 13px orchid-100 superscripts */
+    .footnotes li::before,
+    [data-footnotes] li::before {
+      content: counter(footnote);
+      position: absolute;
+      inset-inline-start: 0;
+      top: 0;
+      color: var(--color-orchid-100);
+      font-size: var(--text-caption);
+      font-weight: 400;
+      line-height: 1.2;
+      vertical-align: super;
+    }
+
+    .footnotes li p,
+    [data-footnotes] li p {
+      margin-block: 0;
+      font-size: inherit;
+      line-height: inherit;
+      color: var(--color-neutral-100);
+    }
+
+    .footnotes a,
+    [data-footnotes] a {
+      color: var(--color-orchid-100);
+      font-weight: 400;
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
+      overflow-wrap: anywhere;
+    }
+
+    .footnotes a:hover,
+    [data-footnotes] a:hover {
+      color: var(--color-orchid-150);
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
+    }
+
+    .footnotes a.data-footnote-backref,
+    [data-footnotes] a.data-footnote-backref {
+      font-size: var(--text-caption);
+      margin-inline-start: var(--spacing-xs);
+      text-decoration-line: none;
+    }
+
+    .footnotes a.data-footnote-backref:hover,
+    [data-footnotes] a.data-footnote-backref:hover {
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
+    }
+  }
+}

--- a/src/styles/components/prose/footnotes.css
+++ b/src/styles/components/prose/footnotes.css
@@ -28,7 +28,7 @@
     .footnotes,
     [data-footnotes] {
       margin-block-start: var(--spacing-3xl);
-      padding-block-start: var(--spacing-2xl);
+      padding-block-start: var(--spacing-3xl);
       border-block-start: 2px solid var(--color-neutral-50);
       color: var(--color-neutral-100);
       font-size: var(--text-body-sm-standard);

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -56,6 +56,7 @@
 @import './components/prose/foundation.css';
 @import './components/prose/blog.css';
 @import './components/prose/summit.css';
+@import './components/prose/footnotes.css';
 @import './components/navigation.css';
 
 /* Utilities layer - custom @utility definitions */


### PR DESCRIPTION
## Summary
Style footnotes according to figma

## Related Issue
Fixes INTORG-839

## Manual Test
1. Open http://localhost:1103/policy-and-advocacy/role-stablecoins-facilitating-low-value-low-cost-transactions
2. Confirm inline `[^n]` markers are 13px orchid-100 superscripts
3. Scroll to the notes block: 2px `neutral-50` top border, space below the border, orchid link styling
4. Spot-check http://localhost:1103/blog/web-monetization-open-payments-part-3-sending-money for the same footnote treatment

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`) — suggest `style(prose): style GFM footnotes for blog and reports [INTORG-839]`
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)

<img width="1710" height="1432" alt="image" src="https://github.com/user-attachments/assets/a14d50fb-c3de-48f5-af96-fe2781585600" />
