### PR TITLE
fix(styles): update styles on hr

### DIFF
--- a/src/styles/base/reset.css
+++ b/src/styles/base/reset.css
@@ -86,17 +86,17 @@
     color: var(--color-orchid-150);
   }
 
-   hr {
+  hr {
     color: var(--color-neutral-50);
     border-top-width:2px;
-    --spacing-hr: var(--spacing-md); 
+    --spacing-hr: var(--spacing-xl); 
     margin-top: var(--spacing-hr);
     padding-bottom: var(--spacing-hr);
     @variant tablet {
-      --spacing-hr: var(--spacing-lg);
+      --spacing-hr: var(--spacing-2xl);
     }
     @variant desktop {
-      --spacing-hr: var(--spacing-xl);
+      --spacing-hr: var(--spacing-3xl);
     }
     @variant dark {
       color: var(--color-neutral-75)

--- a/src/styles/base/reset.css
+++ b/src/styles/base/reset.css
@@ -86,6 +86,22 @@
     color: var(--color-orchid-150);
   }
 
+   hr {
+    color: var(--color-neutral-50);
+    border-top-width:2px;
+    --spacing-hr: var(--spacing-md); 
+    margin-top: var(--spacing-hr);
+    padding-bottom: var(--spacing-hr);
+    @variant tablet {
+      --spacing-hr: var(--spacing-lg);
+    }
+    @variant desktop {
+      --spacing-hr: var(--spacing-xl);
+    }
+    @variant dark {
+      color: var(--color-neutral-75)
+    }
+  }
   /* Lenis smooth scroll — see src/scripts/smooth-scroll.ts.
      Classes are added/removed by Lenis at runtime. Rules are inert when
      the script is not loaded on a page. */


### PR DESCRIPTION
## Summary

Adds the `hr` styling (color, top border, responsive spacing via `--spacing-hr`, dark mode color) into the global base reset (`reset.css`) as a plain element rule.

<img width="1019" height="247" alt="image" src="https://github.com/user-attachments/assets/db3def7f-631e-4dda-af22-3205f3364d35" />

<img width="1018" height="235" alt="image" src="https://github.com/user-attachments/assets/4a2b36d1-f938-4d0d-8e80-556d7fc75422" />


## Related Issue
Fixes INTORG-899

## Manual Test
Go on https://deploy-preview-406--interledger-org-v5.netlify.app/blog/wallet-work-week/ and check the styles for the `<hr>`

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)
