### PR TITLE
chore(netlify): fix missing using  env param used to clear cache 

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,17 +765,23 @@ The page also tags its response with `Netlify-Cache-ID: roadmap`. After each wri
 
 This is Netlify _Durable Cache_ (confirmed by the `cache-status: "Netlify Durable"` response header), which persists across deploys by design. The data sync above purges on **data** changes, but a pure **code** change — e.g. editing the inline styles in `RoadmapBoard.astro` — would otherwise deploy successfully and keep serving the old cached HTML for up to 12h, because nothing tied to the deploy calls `purgeCache`. (Symptom: the fix works in `pnpm start` but the deploy preview looks stale.)
 
-The `netlify/plugins/purge-roadmap` build plugin closes that gap. Its `onSuccess` hook calls `purgeCache({ tags: ['roadmap'] })` on every successful deploy, so code/CSS changes show up immediately. It runs in the build context (auto-authenticated, no token) and is scoped to the deploy (preview purges preview, prod purges prod). It is registered as a second `[[plugins]]` entry in `netlify.toml`, separate from `cache-images` (which is a build-time _image_ cache, unrelated to this CDN cache).
+The `netlify/plugins/purge-roadmap` build plugin closes that gap. Its `onSuccess` hook calls `purgeCache({ tags: ['roadmap'], token })` on every successful deploy, so code/CSS changes show up immediately, and is scoped to the deploy (preview purges preview, prod purges prod). It is registered as a second `[[plugins]]` entry in `netlify.toml`, separate from `cache-images` (which is a build-time _image_ cache, unrelated to this CDN cache).
+
+Unlike the sync functions' token-free `purgeCache()` call, the build plugin runs in the build context, which does not always have a purge-capable token auto-injected. It reads `NETLIFY_API_TOKEN` from the environment and passes it explicitly; if the variable isn't set, the plugin logs a warning and skips the purge rather than failing the build. In practice this means:
+
+- **Production**: set `NETLIFY_API_TOKEN` (a personal access token, see "Environment variables" below) so post-deploy purges actually run.
+- **Deploy previews**: if the token isn't scoped/available for preview contexts, the plugin no-ops — code changes on a preview may keep serving stale cached HTML until the 12h cache expires. Check the deploy log for `[purge-roadmap]` to confirm whether the purge ran or was skipped.
 
 ### Environment variables
 
-| Variable                | Required   | Notes                                                                                 |
-| ----------------------- | ---------- | ------------------------------------------------------------------------------------- |
-| `LINEAR_API_KEY`        | Production | Read-only Linear API key used by the sync functions.                                  |
-| `API_SECRET`            | Production | Bearer token gating `POST /api/roadmap-sync`.                                         |
-| `LINEAR_CUSTOM_VIEW_ID` | No         | Defaults to the public roadmap view, baked into `src/linear/env.ts`. Set to override. |
+| Variable                | Required   | Notes                                                                                                                                                                                                                                       |
+| ----------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LINEAR_API_KEY`        | Production | Read-only Linear API key used by the sync functions.                                                                                                                                                                                        |
+| `API_SECRET`            | Production | Bearer token gating `POST /api/roadmap-sync`.                                                                                                                                                                                               |
+| `LINEAR_CUSTOM_VIEW_ID` | No         | Defaults to the public roadmap view, baked into `src/linear/env.ts`. Set to override.                                                                                                                                                       |
+| `NETLIFY_API_TOKEN`     | No         | Personal access token used by the `purge-roadmap` build plugin to purge the CDN cache post-deploy. Missing it just skips the post-deploy purge (see "CDN caching" above) — it does not affect the sync functions' own `purgeCache()` calls. |
 
-Only the sync functions read these; the page does not. A missing `LINEAR_API_KEY` fails the sync (logged in Netlify's function logs) without breaking the page.
+Only the sync functions read `LINEAR_API_KEY` / `API_SECRET` / `LINEAR_CUSTOM_VIEW_ID`; the page does not. A missing `LINEAR_API_KEY` fails the sync (logged in Netlify's function logs) without breaking the page.
 
 ### Local development
 

--- a/netlify/plugins/purge-roadmap/index.js
+++ b/netlify/plugins/purge-roadmap/index.js
@@ -12,7 +12,7 @@ export const onSuccess = async () => {
 
   if (!token) {
     console.warn(
-      '[purge-roadmap] NETLIFY_API_TOKEN not set — skipping roadmap CDN cache purge',
+      '[purge-roadmap] NETLIFY_API_TOKEN not set — skipping roadmap CDN cache purge'
     )
     return
   }

--- a/netlify/plugins/purge-roadmap/index.js
+++ b/netlify/plugins/purge-roadmap/index.js
@@ -5,9 +5,18 @@ import { purgeCache } from '@netlify/functions'
 // only other purge trigger is a data sync — so a code/CSS-only change would keep
 // serving stale HTML until the cache expires. This invalidates the `roadmap`
 // tag on every successful deploy so code changes show up immediately. Scoped to
-// the deploy context (preview purges preview, prod purges prod) and auto-
-// authenticated in the build runtime, so it needs no token.
+// the deploy context (preview purges preview, prod purges prod) via the token,
+// since the build runtime doesn't always auto-inject one.
 export const onSuccess = async () => {
-  await purgeCache({ tags: ['roadmap'] })
+  const token = process.env.NETLIFY_API_TOKEN
+
+  if (!token) {
+    console.warn(
+      '[purge-roadmap] NETLIFY_API_TOKEN not set — skipping roadmap CDN cache purge',
+    )
+    return
+  }
+
+  await purgeCache({ tags: ['roadmap'], token })
   console.log('[purge-roadmap] purged roadmap CDN cache after deploy')
 }

--- a/netlify/plugins/purge-roadmap/index.js
+++ b/netlify/plugins/purge-roadmap/index.js
@@ -12,7 +12,7 @@ export const onSuccess = async () => {
 
   if (!token) {
     console.warn(
-      '[purge-roadmap] NETLIFY_API_TOKEN not set — skipping roadmap CDN cache purge'
+      '[purge-roadmap] NETLIFY_API_TOKEN not set — skipping roadmap CDN cache purge (configure NETLIFY_API_TOKEN in Netlify site environment variables)'
     )
     return
   }

--- a/src/linear/env.ts
+++ b/src/linear/env.ts
@@ -30,6 +30,10 @@ export const LINEAR_CUSTOM_VIEW_ID =
 // from here via build-snapshot) does not fail at cold start when API_SECRET is
 // unset, since it never uses it.
 
-// Note: CDN cache purging uses Netlify's token-free purgeCache() from the
-// function runtime (see netlify/functions/utils/purge-roadmap-cache.mts), so no
-// NETLIFY_API_TOKEN / NETLIFY_SITE_ID is needed.
+// Note: the sync functions' CDN cache purging uses Netlify's token-free
+// purgeCache() from the function runtime (see
+// netlify/functions/utils/purge-roadmap-cache.mts), so no NETLIFY_API_TOKEN /
+// NETLIFY_SITE_ID is needed there. The separate netlify/plugins/purge-roadmap
+// build plugin runs in the build context instead, where a purge-capable token
+// isn't always auto-injected — it requires NETLIFY_API_TOKEN to be set
+// (see README "CDN caching") and skips its post-deploy purge without it.


### PR DESCRIPTION
## Summary
- fix clearing netlify roadmap data cache after deploy

## Related Issue
Fixes INTORG-905

## Manual Test
fix can be seen on the netlify on the project deploys page

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
