### PR TITLE
fix: give blog thumnails aspect-ratio for consistent heights

### DIFF
--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -49,12 +49,12 @@ const cardImageClasses = twMerge(
   'object-cover rounded-3xl',
   featured
     ? 'w-full max-h-[220px] aspect-2/1'
-    : 'max-w-[220px] max-h-[140px] tablet:max-h-[160px] desktop:max-w-[260px]'
+    : 'aspect-240/140 max-w-[220px] tablet:max-w-full'
 )
 ---
 
 <li class={cardClasses}>
-  <div class="flex flex-col gap-lg">
+  <div class="flex flex-col gap-lg tablet:basis-[70%]">
     <h3 class="m-0">
       <a
         href={postPath}
@@ -82,7 +82,7 @@ const cardImageClasses = twMerge(
       bylineClasses={featured ? 'flex-row' : ''}
     />
   </div>
-  <div>
+  <div class="tablet:basis-[30%]">
     {
       thumbnail && (
         <OptimizedImage


### PR DESCRIPTION
## Summary 
Non-featured blog card thumbnails previously used `max-w`/`max-h` constraints, which let images render at inconsistent heights depending on their natural aspect ratio. Replaced with `aspect-240/140` so all thumbnails in a grid render at a uniform height.

Note:  Design specified an aspect ratio of `216/144`, but that ratio cropped text on some of the existing thumbnail images. I adjusted to `240/140`, which fits the current image set better.

<img width="1294" height="1035" alt="image" src="https://github.com/user-attachments/assets/08ba7dbb-fe84-4d10-b35b-c0eff55c38de" />


## Related Issue
Fixes INTORG-882 

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)
