### PR TITLE
refactor(cms): remove CalloutText and standalone Profile from dynamic…

### DIFF
--- a/cms/src/api/foundation-page/content-types/foundation-page/schema.json
+++ b/cms/src/api/foundation-page/content-types/foundation-page/schema.json
@@ -18,47 +18,72 @@
   "attributes": {
     "title": {
       "type": "string",
-      "required": true,
-      "pluginOptions": { "i18n": { "localized": true } }
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "required": true
     },
     "pathSlug": {
       "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
       "required": true,
-      "unique": true,
-      "pluginOptions": { "i18n": { "localized": true } },
-      "description": "Path relative to the site root (/). Examples: about-us → /about-us; grant/grant-for-web → /grant/grant-for-web. No leading slash."
+      "unique": true
     },
     "pillar": {
       "type": "enumeration",
-      "enum": ["vision", "mission", "tech", "values"],
-      "pluginOptions": { "i18n": { "localized": false } },
-      "description": "Content pillar — controls page-level colour theming via data-pillar attribute"
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "enum": [
+        "vision",
+        "mission",
+        "tech",
+        "values"
+      ]
     },
     "seo": {
       "type": "component",
-      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
       "component": "shared.seo",
-      "pluginOptions": { "i18n": { "localized": true } }
+      "repeatable": false
     },
     "hero": {
       "type": "component",
-      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
       "component": "shared.hero",
-      "pluginOptions": { "i18n": { "localized": true } }
+      "repeatable": false
     },
     "content": {
       "type": "dynamiczone",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
       "components": [
         "blocks.paragraph",
-        "blocks.profile",
         "blocks.profile-grid",
         "blocks.blockquote",
-        "blocks.callout-text",
         "blocks.cta-strip",
         "blocks.pdf-embed",
         "blocks.video-embed"
-      ],
-      "pluginOptions": { "i18n": { "localized": true } }
+      ]
     }
   }
 }

--- a/cms/src/api/grant-overview-page/content-types/grant-overview-page/schema.json
+++ b/cms/src/api/grant-overview-page/content-types/grant-overview-page/schema.json
@@ -76,7 +76,6 @@
         "blocks.paragraph",
         "blocks.split-layout",
         "blocks.blockquote",
-        "blocks.callout-text",
         "blocks.video-embed",
         "blocks.image-block",
         "blocks.cta-strip",

--- a/cms/src/api/grant-page/content-types/grant-page/schema.json
+++ b/cms/src/api/grant-page/content-types/grant-page/schema.json
@@ -33,8 +33,7 @@
         }
       },
       "required": true,
-      "unique": true,
-      "description": "Path relative to /grant/. Examples: education/on-campus → /grant/education/on-campus; overview → /grant/overview. No leading slash."
+      "unique": true
     },
     "description": {
       "type": "text",
@@ -43,18 +42,17 @@
           "localized": true
         }
       },
-      "required": true,
-      "description": "Short description used for SEO and card text. Aim for 120–160 characters."
+      "required": true
     },
     "hero": {
       "type": "component",
-      "repeatable": false,
-      "component": "shared.hero",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "component": "shared.hero",
+      "repeatable": false
     },
     "programOverview": {
       "type": "customField",
@@ -101,13 +99,13 @@
     },
     "infoCards": {
       "type": "component",
-      "repeatable": false,
-      "component": "blocks.info-cards",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "component": "blocks.info-cards",
+      "repeatable": false
     },
     "content": {
       "type": "dynamiczone",
@@ -120,7 +118,6 @@
         "blocks.paragraph",
         "blocks.split-layout",
         "blocks.blockquote",
-        "blocks.callout-text",
         "blocks.video-embed",
         "blocks.image-block",
         "blocks.cta-strip",

--- a/cms/src/api/summit-page/content-types/summit-page/schema.json
+++ b/cms/src/api/summit-page/content-types/summit-page/schema.json
@@ -18,41 +18,58 @@
   "attributes": {
     "title": {
       "type": "string",
-      "required": true,
-      "pluginOptions": { "i18n": { "localized": true } }
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "required": true
     },
     "pathSlug": {
       "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
       "required": true,
-      "unique": true,
-      "pluginOptions": { "i18n": { "localized": true } },
-      "description": "Path relative to /summit/. Examples: faq → /summit/faq; schedule → /summit/schedule. Do not include /summit/ or a leading slash."
+      "unique": true
     },
     "seo": {
       "type": "component",
-      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
       "component": "shared.seo",
-      "pluginOptions": { "i18n": { "localized": true } }
+      "repeatable": false
     },
     "hero": {
       "type": "component",
-      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
       "component": "shared.hero",
-      "pluginOptions": { "i18n": { "localized": true } }
+      "repeatable": false
     },
     "content": {
       "type": "dynamiczone",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
       "components": [
         "blocks.paragraph",
-        "blocks.profile",
         "blocks.profile-grid",
         "blocks.blockquote",
-        "blocks.callout-text",
         "blocks.cta-strip",
         "blocks.pdf-embed",
         "blocks.video-embed"
-      ],
-      "pluginOptions": { "i18n": { "localized": true } }
+      ]
     }
   }
 }

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -735,10 +735,8 @@ export interface ApiFoundationPageFoundationPage
     content: Schema.Attribute.DynamicZone<
       [
         'blocks.paragraph',
-        'blocks.profile',
         'blocks.profile-grid',
         'blocks.blockquote',
-        'blocks.callout-text',
         'blocks.cta-strip',
         'blocks.pdf-embed',
         'blocks.video-embed'
@@ -822,7 +820,6 @@ export interface ApiGrantOverviewPageGrantOverviewPage
         'blocks.paragraph',
         'blocks.split-layout',
         'blocks.blockquote',
-        'blocks.callout-text',
         'blocks.video-embed',
         'blocks.image-block',
         'blocks.cta-strip',
@@ -920,7 +917,6 @@ export interface ApiGrantPageGrantPage extends Struct.CollectionTypeSchema {
         'blocks.paragraph',
         'blocks.split-layout',
         'blocks.blockquote',
-        'blocks.callout-text',
         'blocks.video-embed',
         'blocks.image-block',
         'blocks.cta-strip',
@@ -1335,10 +1331,8 @@ export interface ApiSummitPageSummitPage extends Struct.CollectionTypeSchema {
     content: Schema.Attribute.DynamicZone<
       [
         'blocks.paragraph',
-        'blocks.profile',
         'blocks.profile-grid',
         'blocks.blockquote',
-        'blocks.callout-text',
         'blocks.cta-strip',
         'blocks.pdf-embed',
         'blocks.video-embed'

--- a/src/content/foundation-pages/developers.mdx
+++ b/src/content/foundation-pages/developers.mdx
@@ -6,7 +6,4 @@ heroDescription: 'Help shape the future of interoperable payments and enable sea
 locale: 'en'
 ---
 
-<CalloutText>
-  We welcome contributions to our open-source repositories on GitHub. If you
-  find them valuable, please give us a star. Your support makes a difference!
-</CalloutText>
+## We welcome contributions to our open-source repositories on GitHub. If you find them valuable, please give us a star. Your support makes a difference!

--- a/src/content/foundation-pages/es/grant/education.mdx
+++ b/src/content/foundation-pages/es/grant/education.mdx
@@ -6,14 +6,9 @@ locale: 'es'
 localizes: 'grant/education'
 ---
 
-<CalloutText>
-  Se encuentran disponibles subvenciones de hasta USD 50 000 para instituciones
-  de educación superior que busquen inspirar a sus estudiantes a los fines de
-  promover, favorecer e innovar en lo que respecta a soluciones para sistemas
-  financieros digitales inclusivos.
-</CalloutText>
-
 <Paragraph>
+
+## Se encuentran disponibles subvenciones de hasta USD 50 000 para instituciones de educación superior que busquen inspirar a sus estudiantes a los fines de promover, favorecer e innovar en lo que respecta a soluciones para sistemas financieros digitales inclusivos.
 
 ## Descripción general del programa
 

--- a/src/content/foundation-pages/get-involved.mdx
+++ b/src/content/foundation-pages/get-involved.mdx
@@ -5,13 +5,9 @@ heroTitle: 'Build new connec­tions'
 locale: 'en'
 ---
 
-<CalloutText>
-  Community is at the heart of everything we do. There's lots of ways you can
-  stay connected, get involved and contribute to building inclusive digital
-  financial futures.
-</CalloutText>
-
 <Paragraph>
+
+## Community is at the heart of everything we do. There's lots of ways you can stay connected, get involved and contribute to building inclusive digital financial futures.
 
 ## Connect with the community
 

--- a/src/content/foundation-pages/grant/education.mdx
+++ b/src/content/foundation-pages/grant/education.mdx
@@ -5,13 +5,9 @@ heroTitle: 'Inspire future leaders'
 locale: 'en'
 ---
 
-<CalloutText>
-  Grants of up to $50,000 USD are available to higher education institutions
-  that seek to inspire their students to advocate, champion and innovate
-  solutions for inclusive digital financial systems.
-</CalloutText>
-
 <Paragraph>
+
+## Grants of up to $50,000 USD are available to higher education institutions that seek to inspire their students to advocate, champion and innovate solutions for inclusive digital financial systems.
 
 ## Program Overview
 

--- a/src/content/foundation-pages/interledger.mdx
+++ b/src/content/foundation-pages/interledger.mdx
@@ -5,12 +5,9 @@ heroTitle: 'The modern way to send payments™'
 locale: 'en'
 ---
 
-<CalloutText>
-  Interledger is the global payments network for inclusive financial service
-  providers.
-</CalloutText>
-
 <Paragraph>
+
+## Interledger is the global payments network for inclusive financial service providers.
 
 The Interledger network connects financial services that have implemented the Interledger Protocol (ILP) and helps make payments easier, faster and cheaper.
 

--- a/src/content/foundation-pages/media.mdx
+++ b/src/content/foundation-pages/media.mdx
@@ -5,12 +5,9 @@ heroTitle: 'Insights and updates'
 locale: 'en'
 ---
 
-<CalloutText>
-  We are passionate about sharing stories around open-source, digital financial
-  inclusion, and how we are revolutionizing digital payments.
-</CalloutText>
-
 <Paragraph>
+
+## We are passionate about sharing stories around open-source, digital financial inclusion, and how we are revolutionizing digital payments.
 
 At the Interledger Foundation, we’re committed to amplifying stories that reflect the transformative power of open-source innovation and digital financial inclusion.
 

--- a/src/content/foundation-pages/open-payments.mdx
+++ b/src/content/foundation-pages/open-payments.mdx
@@ -6,12 +6,9 @@ heroDescription: 'Payments made easy'
 locale: 'en'
 ---
 
-<CalloutText>
-  Sending a payment should be as easy as sending an email. The Open Payments
-  standard brings this vision to life.
-</CalloutText>
-
 <Paragraph>
+
+## Sending a payment should be as easy as sending an email. The Open Payments standard brings this vision to life.
 
 Open Payments enables applications to interact directly with users' accounts. It simplifies online payments for e-commerce purchases, subscription fees, donations, and more.
 

--- a/src/content/foundation-pages/open-standards.mdx
+++ b/src/content/foundation-pages/open-standards.mdx
@@ -5,12 +5,9 @@ heroTitle: "Open for every\uFEFFone"
 locale: 'en'
 ---
 
-<CalloutText>
-  Our technology is always open, accessible, and shared with the global
-  community.
-</CalloutText>
-
 <Paragraph>
+
+## Our technology is always open, accessible, and shared with the global community.
 
 We believe that payment networks should be interoperable to remove barriers to participating in the global financial ecosystem. The open standards we steward are governed and developed in collaboration with participating financial services providers, community members and the relevant standard bodies like the World Wide Web Consortium (W3C).
 

--- a/src/content/foundation-pages/policy-and-advocacy.mdx
+++ b/src/content/foundation-pages/policy-and-advocacy.mdx
@@ -5,12 +5,9 @@ heroTitle: 'Policy and Advocacy'
 locale: 'en'
 ---
 
-<CalloutText>
-  $21 million awarded in grants | 271 projects supported to date | 42 countries
-  represented globally
-</CalloutText>
-
 <Paragraph>
+
+## $21 million awarded in grants | 271 projects supported to date | 42 countries represented globally
 
 The Interledger Foundation seeks to foster inclusive financial systems that ensure equitable access to digital financial infrastructure, empowering individuals and communities to participate fully in the global economy. Our public policy engagement emphasizes transparency, accountability, and collaboration to address global challenges in digital financial inclusion, advance economic opportunity, and build trust and dignity in financial technologies.
 

--- a/src/content/foundation-pages/web-monetization.mdx
+++ b/src/content/foundation-pages/web-monetization.mdx
@@ -6,12 +6,9 @@ locale: 'en'
 pillar: 'tech'
 ---
 
-<CalloutText>
-  Web Monetization allows websites to automatically and passively receive
-  payments from visitors.
-</CalloutText>
-
 <Paragraph>
+
+## Web Monetization allows websites to automatically and passively receive payments from visitors.
 
 The web as we know it today is dominated by intrusive ads, invasive tracking, and prohibitively expensive subscriptions. This broken business model compromises accessibility, user experience, and privacy. Since Web Monetization was designed with the web in mind, it opens the door to some revolutionary new opportunities.
 


### PR DESCRIPTION
… zones

## Summary
- Remove `blocks.callout-text` from the dynamic zone options on foundation-page, grant-page, grant-overview-page, and summit-page - CalloutText is being retired
- Remove `blocks.profile` from the dynamic zone options on foundation-page and summit-page — only `blocks.profile-grid` remains selectable there going forward.
- Rewrite the 10 MDX pages that used `<CalloutText>` to use a plain `##` heading instead, since the block can no longer be added to new content.

## Why
We're intentionally *not* deleting the component definitions, serializers, sync-mdx handlers, their tests, etc. 
Only the dynamic zone allow-lists change, so editors can't attach new instances of either block.

## Related Issue
Fixes INTORG-933

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
