### PR TITLE
fix(blog): fall back to EN for untranslated related articles [INTORG-964]

### DIFF
--- a/src/components/pages/FoundationBlogPostPage.astro
+++ b/src/components/pages/FoundationBlogPostPage.astro
@@ -1,7 +1,11 @@
 ---
-import { useTranslations, type Locale } from '@/utils'
+import {
+  useTranslations,
+  resolveRelatedPosts,
+  defaultLocale,
+  type Locale
+} from '@/utils'
 import { getCollection, render } from 'astro:content'
-import type { CollectionEntry } from 'astro:content'
 import CommunityLinksFoundation from '@/components/blog/CommunityLinksFoundation.astro'
 import ArticleBio from '@/components/blog/ArticleBio.astro'
 import RelatedArticles from '@/components/blog/RelatedArticles.astro'
@@ -34,16 +38,14 @@ if (!mdxPost) return Astro.redirect('/404')
 const { Content: MdxContent } = await render(mdxPost)
 const mdxData = mdxPost.data
 
-// Resolve related-article slugs to posts in the same locale; skip any that
-// don't exist so a stale slug never breaks the build.
-const relatedPosts = (mdxData.relatedArticles ?? [])
-  .map((relatedSlug) =>
-    posts.find(
-      (post) =>
-        post.data.pathSlug === relatedSlug && post.data.locale === contentLocale
-    )
-  )
-  .filter((post): post is CollectionEntry<'foundation-blog'> => Boolean(post))
+// Resolve related-article slugs to posts, falling back to the EN post when no
+// translation exists in the current locale (see resolveRelatedPosts).
+const relatedPosts = resolveRelatedPosts(
+  posts,
+  mdxData.relatedArticles,
+  contentLocale,
+  defaultLocale
+)
 ---
 
 <BlogPostLayout frontmatter={mdxData}>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -94,7 +94,8 @@ export {
   TECH_BLOG_FALLBACK_THUMBNAIL,
   getFeaturedPosts,
   getBlogThumbnail,
-  getReadingTime
+  getReadingTime,
+  resolveRelatedPosts
 } from './main/blog'
 
 // Main site: Text

--- a/src/utils/main/blog.test.ts
+++ b/src/utils/main/blog.test.ts
@@ -3,6 +3,7 @@ import type { CollectionEntry } from 'astro:content'
 import {
   getFeaturedPosts,
   getBlogThumbnail,
+  resolveRelatedPosts,
   TECH_BLOG_FALLBACK_THUMBNAIL
 } from './blog'
 
@@ -15,6 +16,7 @@ interface FakePost {
   thumbnailImage?: string
   featureImage?: string
   legacy?: boolean
+  locale?: string
 }
 
 // Minimal stand-in for a content collection entry; only the fields the helpers
@@ -28,7 +30,8 @@ function makePost(post: FakePost): Entry {
       featured: post.featured ?? false,
       thumbnailImage: post.thumbnailImage,
       featureImage: post.featureImage,
-      legacy: post.legacy ?? false
+      legacy: post.legacy ?? false,
+      locale: post.locale ?? 'en'
     }
   } as unknown as Entry
 }
@@ -100,5 +103,59 @@ describe('getBlogThumbnail', () => {
     const post = makePost({ slug: 'a', date: '2025-01-01' })
 
     expect(getBlogThumbnail(post)).toBeNull()
+  })
+})
+
+describe('resolveRelatedPosts', () => {
+  it('returns an empty array when there are no slugs', () => {
+    const posts = [makePost({ slug: 'a', date: '2025-01-01' })]
+
+    expect(resolveRelatedPosts(posts, undefined, 'en', 'en')).toEqual([])
+    expect(resolveRelatedPosts(posts, [], 'en', 'en')).toEqual([])
+  })
+
+  it('resolves slugs to posts in the requested locale', () => {
+    const posts = [
+      makePost({ slug: 'x', date: '2025-01-01', locale: 'es' }),
+      makePost({ slug: 'x', date: '2025-01-01', locale: 'en' })
+    ]
+
+    const result = resolveRelatedPosts(posts, ['x'], 'es', 'en')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].data.locale).toBe('es')
+  })
+
+  it('falls back to the EN post when no translation exists in the locale', () => {
+    // Regression for INTORG-964: an ES page whose related post is EN-only used
+    // to drop the post, hiding the whole section. It should show the EN post.
+    const posts = [
+      makePost({ slug: 'en-only', date: '2025-01-01', locale: 'en' })
+    ]
+
+    const result = resolveRelatedPosts(posts, ['en-only'], 'es', 'en')
+
+    expect(result).toHaveLength(1)
+    expect(result[0].data.locale).toBe('en')
+  })
+
+  it('skips slugs that resolve to no post in any locale', () => {
+    const posts = [makePost({ slug: 'real', date: '2025-01-01', locale: 'en' })]
+
+    const result = resolveRelatedPosts(posts, ['real', 'ghost'], 'es', 'en')
+
+    expect(result.map((p) => p.data.pathSlug)).toEqual(['real'])
+  })
+
+  it('preserves the order of the requested slugs', () => {
+    const posts = [
+      makePost({ slug: 'a', date: '2025-01-01', locale: 'en' }),
+      makePost({ slug: 'b', date: '2025-01-01', locale: 'en' }),
+      makePost({ slug: 'c', date: '2025-01-01', locale: 'en' })
+    ]
+
+    const result = resolveRelatedPosts(posts, ['c', 'a', 'b'], 'en', 'en')
+
+    expect(result.map((p) => p.data.pathSlug)).toEqual(['c', 'a', 'b'])
   })
 })

--- a/src/utils/main/blog.ts
+++ b/src/utils/main/blog.ts
@@ -60,11 +60,11 @@ export function getBlogThumbnail(post: FoundationBlogEntry): string | null {
 /**
  * Resolves related-article slugs to posts for display.
  *
- * Prefers the post in `contentLocale`, then falls back to the canonical
- * `defaultLocale` (EN) post when no translation exists — matching the site's
- * EN-fallback rule so an untranslated related post still shows (in EN) instead
- * of the whole section silently vanishing. Slugs that resolve to nothing (e.g.
- * a stale slug) are skipped so the build never breaks.
+ * Prefers the post in `contentLocale`, then falls back to `fallbackLocale`
+ * when no translation exists. Callers pass the site's default locale (EN),
+ * matching the site's EN-fallback rule so an untranslated related post still
+ * shows (in EN) instead of the whole section silently vanishing. Slugs that
+ * resolve to nothing (e.g. a stale slug) are skipped so the build never breaks.
  *
  * `posts` should be the full collection across locales, since a related post
  * may only exist in the default locale.

--- a/src/utils/main/blog.ts
+++ b/src/utils/main/blog.ts
@@ -1,4 +1,5 @@
 import type { CollectionEntry } from 'astro:content'
+import type { Locale } from './locales'
 
 type FoundationBlogEntry = CollectionEntry<'foundation-blog'>
 
@@ -54,6 +55,37 @@ export function getBlogThumbnail(post: FoundationBlogEntry): string | null {
   if (featureImage) return featureImage
   if (legacy) return TECH_BLOG_FALLBACK_THUMBNAIL
   return null
+}
+
+/**
+ * Resolves related-article slugs to posts for display.
+ *
+ * Prefers the post in `contentLocale`, then falls back to the canonical
+ * `defaultLocale` (EN) post when no translation exists — matching the site's
+ * EN-fallback rule so an untranslated related post still shows (in EN) instead
+ * of the whole section silently vanishing. Slugs that resolve to nothing (e.g.
+ * a stale slug) are skipped so the build never breaks.
+ *
+ * `posts` should be the full collection across locales, since a related post
+ * may only exist in the default locale.
+ */
+export function resolveRelatedPosts(
+  posts: FoundationBlogEntry[],
+  slugs: readonly string[] | undefined,
+  contentLocale: Locale,
+  fallbackLocale: Locale
+): FoundationBlogEntry[] {
+  const findBySlug = (slug: string, locale: Locale) =>
+    posts.find(
+      (post) => post.data.pathSlug === slug && post.data.locale === locale
+    )
+
+  return (slugs ?? [])
+    .map(
+      (slug) =>
+        findBySlug(slug, contentLocale) ?? findBySlug(slug, fallbackLocale)
+    )
+    .filter((post): post is FoundationBlogEntry => Boolean(post))
 }
 
 export function getReadingTime(text: string | undefined): number {


### PR DESCRIPTION
## Summary

The "Other relevant articles" section did not display on former-developers blog posts (in Spanish). Related-article slugs were resolved strictly in the current locale, so an ES page whose related articles are EN-only (typical for legacy developer posts, which mostly aren't translated) dropped every slug and hid the whole section. Foundation posts' related articles have ES translations, so they still rendered, which is why the two post types looked different.

The resolver now prefers the current locale and falls back to the canonical EN post when no translation exists, matching the site's existing EN-fallback rule (`getLocalizedPaths`). The fallback card links to the EN post, which is the same content an ES visitor would see for that post anyway.

Refactored the logic out of the `.astro` frontmatter into a pure, unit-tested `resolveRelatedPosts` helper.

## Related Issue

Fixes INTORG-964

## Manual Test

1. Set (or sync) one or more `relatedArticles` on a legacy post whose targets are EN-only (e.g. `interledger-universe`).
2. Visit `/es/blog/<slug>` for that post.
3. Before: no "Other relevant articles" section. After: the section renders, showing the EN related posts (linking to their EN routes).
4. Confirm EN routes and ES posts whose related articles have ES translations are unaffected.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)