### PR TITLE
fix(homepage): fix dark section gap on homepage top nav bar

### DIFF
--- a/src/components/layout/foundation-header.ts
+++ b/src/components/layout/foundation-header.ts
@@ -12,6 +12,12 @@ if (headerRoot) {
 const header = document.querySelector<HTMLElement>('.foundation-header')
 const darkSections = [
   document.querySelector('[data-component="HomepageHero"]'),
+  // Spans the entire hero-to-problem-section scroll range (art + copy), so
+  // watching it closes the gap between the hero and the next data-nav-dark
+  // section — at wide viewports the network art's width-driven height can
+  // outgrow the vh-based overlap connecting them, leaving a moment where
+  // neither neighbor intersects the viewport.
+  document.querySelector('[data-component="AnimatedNetwork"]'),
   ...Array.from(document.querySelectorAll('[data-nav-dark]'))
 ].filter(Boolean) as Element[]
 


### PR DESCRIPTION
## Summary
- fixed the gap of dark screens to include the animated network section, so we have a dark theme for the header top nav bar

## Related Issue
Fixes INTORG-906

## Manual Test
- open the homepage in desktop mode and navigate from top to the problem we're solving section. Top bar nav menu should stay in dark theme/mode.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
