### PR TITLE
fix(blog): fit tables to the blog width and wrap on tablet+ [INTORG-968]

### DIFF
--- a/src/styles/components/prose/blog.css
+++ b/src/styles/components/prose/blog.css
@@ -37,7 +37,7 @@
       border-inline: 2px solid var(--color-raspberry-100);
       padding-inline: var(--spacing-md);
       margin-block: var(--spacing-2xl);
-      
+
       @variant tablet {
         padding-inline: var(--spacing-lg);
       }
@@ -78,6 +78,11 @@
       outline-offset: 2px;
     }
 
+    /* Mobile keeps the natural (max-content) width so genuinely wide tables can
+       scroll inside .table-scroll — cramming every column into ~340px is worse
+       than a horizontal scroll. From tablet up there's room to fit the table to
+       the blog column, which makes long cells wrap instead of the table
+       scrolling (auto layout then distributes the columns to fit). */
     & table {
       width: max-content;
       min-width: 100%;
@@ -86,6 +91,10 @@
       border-radius: var(--radius-2xl);
       overflow: hidden;
       background-color: var(--color-neutral-0);
+
+      @variant tablet {
+        width: 100%;
+      }
     }
 
     & th,
@@ -170,7 +179,7 @@
     .video-embed {
       border-radius: var(--radius-3xl);
       overflow: hidden;
-      margin-block-end: var(--spacing-2xl)
+      margin-block-end: var(--spacing-2xl);
     }
   }
 }

--- a/src/styles/components/prose/blog.css
+++ b/src/styles/components/prose/blog.css
@@ -78,11 +78,8 @@
       outline-offset: 2px;
     }
 
-    /* Mobile keeps the natural (max-content) width so genuinely wide tables can
-       scroll inside .table-scroll — cramming every column into ~340px is worse
-       than a horizontal scroll. From tablet up there's room to fit the table to
-       the blog column, which makes long cells wrap instead of the table
-       scrolling (auto layout then distributes the columns to fit). */
+    /* Mobile: max-content so wide tables scroll rather than cram columns into
+       ~340px. Tablet+ has room to fit the column, so cells wrap instead. */
     & table {
       width: max-content;
       min-width: 100%;


### PR DESCRIPTION
## Summary

Wide blog tables (e.g. the "Glossary of Terms" table on `/blog/ilf-and-hsms/`) used `width: max-content` and scrolled horizontally at every breakpoint. Per design feedback from Sarah, a table like that should fit the blog content column and wrap its cell text on desktop/tablet, and only fall back to horizontal scroll on mobile (where fitting every column would crush them).

Change: from the `tablet` breakpoint the table is set to `width: 100%`, so auto table layout distributes the columns to fit the blog width and long cells wrap. Mobile keeps `width: max-content` inside `.table-scroll` for the scroll fallback.

Note on the "max column width ~3/4" idea from Sarah: a percentage `max-width` on a `<td>` is not honored by browsers under auto table layout. `width: 100%` already keeps the whole table within the blog column, and auto layout distributes the columns sensibly on its own, so no per-column cap is needed. A hard cap would require `table-layout: fixed` with explicit column widths, which does not fit arbitrary CMS-authored tables. Happy to revisit if a stricter split is wanted.

## Related Issue

Fixes INTORG-968

## Manual Test

Open `/blog/ilf-and-hsms/` and scroll to "Glossary of Terms":
1. Desktop and tablet: the table fits within the blog column and the Description cells wrap to multiple lines. No horizontal scrollbar.
2. Mobile (narrow width): the table keeps its natural width and scrolls horizontally inside its container; the page itself does not overflow.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)