### PR TITLE
feat(blocks): enable title card grid on foundation, summit, and hackathon pages [INTORG-887]

### DIFF
--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -826,7 +826,10 @@ export async function buildReportPayload(
 }
 
 /** Dynamic-zone components allowed in hackathon-pages MDX/Strapi content. */
-export const HACKATHON_PAGE_ALLOWED_COMPONENTS = ['blocks.paragraph'] as const
+export const HACKATHON_PAGE_ALLOWED_COMPONENTS = [
+  'blocks.paragraph',
+  'blocks.title-card-grid'
+] as const
 
 /**
  * Builds a Strapi payload for a hackathon-page MDX file.

--- a/cms/src/api/foundation-page/content-types/foundation-page/schema.json
+++ b/cms/src/api/foundation-page/content-types/foundation-page/schema.json
@@ -67,7 +67,8 @@
         "blocks.blockquote",
         "blocks.cta-strip",
         "blocks.pdf-embed",
-        "blocks.video-embed"
+        "blocks.video-embed",
+        "blocks.title-card-grid"
       ]
     }
   }

--- a/cms/src/api/hackathon-page/content-types/hackathon-page/schema.json
+++ b/cms/src/api/hackathon-page/content-types/hackathon-page/schema.json
@@ -34,7 +34,7 @@
     },
     "content": {
       "type": "dynamiczone",
-      "components": ["blocks.paragraph"],
+      "components": ["blocks.paragraph", "blocks.title-card-grid"],
       "pluginOptions": { "i18n": { "localized": true } }
     }
   }

--- a/cms/src/api/summit-page/content-types/summit-page/schema.json
+++ b/cms/src/api/summit-page/content-types/summit-page/schema.json
@@ -67,7 +67,8 @@
         "blocks.blockquote",
         "blocks.cta-strip",
         "blocks.pdf-embed",
-        "blocks.video-embed"
+        "blocks.video-embed",
+        "blocks.title-card-grid"
       ]
     }
   }

--- a/cms/src/utils/contentPopulate.ts
+++ b/cms/src/utils/contentPopulate.ts
@@ -7,6 +7,7 @@
  * Keep these in sync with the component lists in the content-type schemas:
  * - foundation-page/schema.json
  * - summit-page/schema.json
+ * - hackathon-page/schema.json
  * - foundation-blog-post/schema.json
  */
 
@@ -54,6 +55,9 @@ const FOUNDATION_PAGE_BLOCKS = {
   },
   'blocks.video-embed': {
     populate: { file: true }
+  },
+  'blocks.title-card-grid': {
+    populate: { titleCards: { populate: { secondaryCta: true } } }
   }
 } as const
 
@@ -82,10 +86,13 @@ export const REPORT_CONTENT_POPULATE = {
   }
 } as const
 
-/** Populate config for hackathon-page content field (paragraph blocks only). */
+/** Populate config for hackathon-page content field. */
 export const HACKATHON_PAGE_CONTENT_POPULATE = {
   on: {
-    'blocks.paragraph': {}
+    'blocks.paragraph': {},
+    'blocks.title-card-grid': {
+      populate: { titleCards: { populate: { secondaryCta: true } } }
+    }
   }
 } as const
 

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -739,7 +739,8 @@ export interface ApiFoundationPageFoundationPage
         'blocks.blockquote',
         'blocks.cta-strip',
         'blocks.pdf-embed',
-        'blocks.video-embed'
+        'blocks.video-embed',
+        'blocks.title-card-grid'
       ]
     > &
       Schema.Attribute.SetPluginOptions<{
@@ -1021,7 +1022,9 @@ export interface ApiHackathonPageHackathonPage
     }
   }
   attributes: {
-    content: Schema.Attribute.DynamicZone<['blocks.paragraph']> &
+    content: Schema.Attribute.DynamicZone<
+      ['blocks.paragraph', 'blocks.title-card-grid']
+    > &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true
@@ -1329,7 +1332,8 @@ export interface ApiSummitPageSummitPage extends Struct.CollectionTypeSchema {
         'blocks.blockquote',
         'blocks.cta-strip',
         'blocks.pdf-embed',
-        'blocks.video-embed'
+        'blocks.video-embed',
+        'blocks.title-card-grid'
       ]
     > &
       Schema.Attribute.SetPluginOptions<{

--- a/src/components/pages/FoundationContentPage.astro
+++ b/src/components/pages/FoundationContentPage.astro
@@ -13,6 +13,8 @@ import VideoEmbed from '@/components/shared/VideoEmbed.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import Link from '@/components/shared/Link.astro'
 import OptimizedImage from '@/components/shared/OptimizedImage.astro'
+import TitleCardGrid from '@/components/blocks/TitleCardGrid.astro'
+import TitleCard from '@/components/shared/TitleCard.astro'
 
 interface Props {
   slug: string
@@ -103,7 +105,9 @@ if (isNotFound) return Astro.redirect('/404')
               Paragraph,
               CtaStrip,
               PdfEmbed,
-              VideoEmbed
+              VideoEmbed,
+              TitleCardGrid,
+              TitleCard
             }}
           />
         </div>

--- a/src/components/pages/HackathonContentPage.astro
+++ b/src/components/pages/HackathonContentPage.astro
@@ -4,6 +4,8 @@ import HackathonPageLayout from '@/layouts/HackathonPageLayout.astro'
 import Breadcrumbs from '@/components/shared/Breadcrumbs.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import Paragraph from '@/components/blocks/Paragraph.astro'
+import TitleCardGrid from '@/components/blocks/TitleCardGrid.astro'
+import TitleCard from '@/components/shared/TitleCard.astro'
 import {
   type Locale,
   useTranslations,
@@ -58,7 +60,7 @@ const breadcrumbs = buildSectionEntryBreadcrumbs(
         data-prose
         class="mt-2xl [&_h2]:mt-3xl [&_h2]:mb-xl [&_h2]:text-[1.75rem] [&_h2]:font-semibold [&_h3]:mt-2xl [&_h3]:mb-lg [&_h3]:text-[1.25rem] [&_h3]:font-semibold [&_p]:mb-xl [&_p]:leading-[1.6] [&_ul]:mb-xl [&_ul]:ps-2xl [&_li]:mb-lg [&_a]:underline [&_a:hover]:no-underline"
       >
-        <MdxContent components={{ Paragraph }} />
+        <MdxContent components={{ Paragraph, TitleCardGrid, TitleCard }} />
       </section>
     </div>
   </main>

--- a/src/components/pages/SummitContentPage.astro
+++ b/src/components/pages/SummitContentPage.astro
@@ -13,6 +13,8 @@ import PdfEmbed from '@/components/shared/PdfEmbed.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import Link from '@/components/shared/Link.astro'
 import OptimizedImage from '@/components/shared/OptimizedImage.astro'
+import TitleCardGrid from '@/components/blocks/TitleCardGrid.astro'
+import TitleCard from '@/components/shared/TitleCard.astro'
 
 interface Props {
   slug: string
@@ -106,7 +108,9 @@ const gradient =
               Paragraph,
               CtaStrip,
               PdfEmbed,
-              VideoEmbed
+              VideoEmbed,
+              TitleCardGrid,
+              TitleCard
             }}
           />
         </div>


### PR DESCRIPTION
## Summary

Wires the existing Title Cards block (`blocks.title-card-grid` / `blocks.title-card`) into the Foundation, Summit, and Hackathon page types. 

## Related Issue

Fixes INTORG-887

## Manual Test

1. In Strapi admin, open a Foundation, Summit, or Hackathon page and confirm "Title Card Grid" is now selectable in the dynamic zone.
2. Add a 2-column and a 3-column Title Card Grid with a couple of cards (heading, sub-heading, description, secondary CTA — try both internal and external links).
3. Publish and confirm the MDX exports correctly and the page renders the cards with correct column count and the hover color change.
4. Verified locally: rendered a temporary `<TitleCardGrid>` block on one live MDX page per collection (`about-us.mdx`, `summit-pages/home.mdx`, `hackathon-pages/overview.mdx`) against a throwaway dev server — confirmed 2-col and 3-col grid classes and hover styling appeared correctly in the rendered HTML, then reverted the test content.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable) — no new UI; existing Title Card component visuals are unchanged


<img width="3184" height="2002" alt="image" src="https://github.com/user-attachments/assets/1b786d0f-7fb8-4517-a71f-2a75560af263" />
