### PR TITLE
feat(strapi,astro): add footer notes component to templates dynamic zones

### DIFF
--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -40,6 +40,7 @@ import './imageBlockHandler'
 import './numberTilesHandler'
 import './titleCardGridHandler'
 import './ctaLinkHandler'
+import './footerNotesHandler'
 import { createRelationResolver } from './profileHandler'
 import { type ParserContext } from './mdxBlockParser'
 

--- a/cms/scripts/sync-mdx/footerNotesHandler.test.ts
+++ b/cms/scripts/sync-mdx/footerNotesHandler.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import { parseMdxToBlocks } from './mdxBlockParser'
+import { MdxParserError, ParserErrorCode } from './parserErrors'
+
+// Side-effect import: registers FooterNotes handler
+import './footerNotesHandler'
+
+// ---------------------------------------------------------------------------
+// Happy paths
+// ---------------------------------------------------------------------------
+
+describe('FooterNotes handler', () => {
+  it('parses notes with text, linkText, and linkUrl', async () => {
+    const blocks = await parseMdxToBlocks(
+      `<FooterNotes notes={[{ text: 'First note.', linkText: 'Source', linkUrl: 'https://example.com' }, { text: 'Second note.', linkText: 'https://gasfeesnow.com', linkUrl: 'https://gasfeesnow.com' }]} />`,
+      { locale: 'en' }
+    )
+
+    expect(blocks).toEqual([
+      {
+        __component: 'blocks.footer-notes',
+        notes: [
+          {
+            text: 'First note.',
+            linkText: 'Source',
+            linkUrl: 'https://example.com'
+          },
+          {
+            text: 'Second note.',
+            linkText: 'https://gasfeesnow.com',
+            linkUrl: 'https://gasfeesnow.com'
+          }
+        ]
+      }
+    ])
+  })
+
+  it('omits linkText/linkUrl when absent', async () => {
+    const blocks = await parseMdxToBlocks(
+      `<FooterNotes notes={[{ text: 'A plain citation.' }]} />`,
+      { locale: 'en' }
+    )
+
+    expect(blocks).toEqual([
+      {
+        __component: 'blocks.footer-notes',
+        notes: [{ text: 'A plain citation.' }]
+      }
+    ])
+  })
+
+  it('parses a single note', async () => {
+    const blocks = await parseMdxToBlocks(
+      `<FooterNotes notes={[{ text: 'Only note.' }]} />`,
+      { locale: 'en' }
+    )
+    if (blocks instanceof MdxParserError) throw blocks
+    expect(blocks[0]).toMatchObject({
+      __component: 'blocks.footer-notes',
+      notes: [{ text: 'Only note.' }]
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error cases
+// ---------------------------------------------------------------------------
+
+describe('FooterNotes handler — errors', () => {
+  it('returns MISSING_REQUIRED_PROP when notes is missing', async () => {
+    const result = await parseMdxToBlocks('<FooterNotes />', { locale: 'en' })
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({
+      code: ParserErrorCode.MISSING_REQUIRED_PROP
+    })
+  })
+
+  it('returns DYNAMIC_EXPRESSION when notes is a dynamic expression', async () => {
+    const result = await parseMdxToBlocks('<FooterNotes notes={someVar} />', {
+      locale: 'en'
+    })
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.DYNAMIC_EXPRESSION })
+  })
+
+  it('returns INVALID_PROP_VALUE when notes is not an array', async () => {
+    const result = await parseMdxToBlocks(
+      `<FooterNotes notes={{ text: 'Only note.' }} />`,
+      { locale: 'en' }
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
+  })
+
+  it('returns INVALID_PROP_VALUE when a note entry is missing text', async () => {
+    const result = await parseMdxToBlocks(
+      `<FooterNotes notes={[{ linkText: 'Source', linkUrl: 'https://example.com' }]} />`,
+      { locale: 'en' }
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
+  })
+
+  it('returns INVALID_PROP_VALUE when a note has linkText but no linkUrl', async () => {
+    const result = await parseMdxToBlocks(
+      `<FooterNotes notes={[{ text: 'Note.', linkText: 'Source' }]} />`,
+      { locale: 'en' }
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
+  })
+
+  it('returns INVALID_PROP_VALUE when a note has linkUrl but no linkText', async () => {
+    const result = await parseMdxToBlocks(
+      `<FooterNotes notes={[{ text: 'Note.', linkUrl: 'https://example.com' }]} />`,
+      { locale: 'en' }
+    )
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
+  })
+
+  it('returns INVALID_PROP_VALUE when fewer than 1 note is provided', async () => {
+    const result = await parseMdxToBlocks(`<FooterNotes notes={[]} />`, {
+      locale: 'en'
+    })
+    expect(result).toBeInstanceOf(MdxParserError)
+    expect(result).toMatchObject({ code: ParserErrorCode.INVALID_PROP_VALUE })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: mixed markdown + <FooterNotes> ordering
+// ---------------------------------------------------------------------------
+
+describe('FooterNotes handler — mixed content', () => {
+  it('preserves document order with surrounding markdown', async () => {
+    const mdx = [
+      'Some intro paragraph.',
+      '',
+      `<FooterNotes notes={[{ text: 'A note.' }]} />`,
+      '',
+      'More content after the notes.'
+    ].join('\n')
+
+    const blocks = await parseMdxToBlocks(mdx, { locale: 'en' })
+    if (blocks instanceof MdxParserError) throw blocks
+
+    expect(blocks).toHaveLength(3)
+    expect(blocks[0]).toMatchObject({ __component: 'blocks.paragraph' })
+    expect(blocks[1]).toEqual({
+      __component: 'blocks.footer-notes',
+      notes: [{ text: 'A note.' }]
+    })
+    expect(blocks[2]).toMatchObject({ __component: 'blocks.paragraph' })
+  })
+})

--- a/cms/scripts/sync-mdx/footerNotesHandler.ts
+++ b/cms/scripts/sync-mdx/footerNotesHandler.ts
@@ -1,0 +1,95 @@
+/**
+ * FooterNotes component handler for the MDX block parser. Handles:
+ * <FooterNotes notes={[{ text, linkText?, linkUrl? }, ...]} />
+ *
+ * `notes` isn't JSON — Prettier reformats it to JS object-literal syntax on
+ * write — so it's extracted via getStaticLiteralAttr's ESTree evaluator, not
+ * JSON.parse. No media resolution needed: every field is plain text.
+ */
+
+import type { ParsedBlock, FooterNotesBlock } from './types.blocks'
+import { getStaticLiteralAttr } from './jsxExtract'
+import { registerComponentHandler } from './mdxBlockParser'
+import type { JsxBlockNode, ParserContext } from './mdxBlockParser'
+import {
+  MdxParserError,
+  ParserErrorCode,
+  tryCatchParserError
+} from './parserErrors'
+
+const MIN_NOTES = 1
+
+interface NoteEntry {
+  text: string
+  linkText?: string
+  linkUrl?: string
+}
+
+function isNoteEntry(value: unknown): value is NoteEntry {
+  if (typeof value !== 'object' || value === null) return false
+  const record = value as Record<string, unknown>
+  const hasValidLinkText =
+    record.linkText === undefined ||
+    (typeof record.linkText === 'string' && record.linkText.trim().length > 0)
+  const hasValidLinkUrl =
+    record.linkUrl === undefined ||
+    (typeof record.linkUrl === 'string' && record.linkUrl.trim().length > 0)
+  const hasCompleteLinkPair =
+    (record.linkText === undefined) === (record.linkUrl === undefined)
+  return (
+    typeof record.text === 'string' &&
+    record.text.trim().length > 0 &&
+    hasValidLinkText &&
+    hasValidLinkUrl &&
+    hasCompleteLinkPair
+  )
+}
+
+async function handleFooterNotes(
+  node: JsxBlockNode,
+  _ctx: ParserContext
+): Promise<ParsedBlock[] | MdxParserError> {
+  return tryCatchParserError(() => {
+    const rawNotes = getStaticLiteralAttr(node, 'notes', { required: true })
+
+    if (!Array.isArray(rawNotes) || !rawNotes.every(isNoteEntry)) {
+      throw new MdxParserError({
+        code: ParserErrorCode.INVALID_PROP_VALUE,
+        message:
+          'Prop "notes" must be an array of { text, linkText?, linkUrl? } objects, with linkText/linkUrl both present or both absent.',
+        component: 'FooterNotes',
+        prop: 'notes',
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
+
+    if (rawNotes.length < MIN_NOTES) {
+      throw new MdxParserError({
+        code: ParserErrorCode.INVALID_PROP_VALUE,
+        message: `Prop "notes" requires at least ${MIN_NOTES} note.`,
+        component: 'FooterNotes',
+        prop: 'notes',
+        line: node.position?.start.line,
+        column: node.position?.start.column
+      })
+    }
+
+    const block: FooterNotesBlock = {
+      __component: 'blocks.footer-notes',
+      notes: rawNotes.map((note) => {
+        const text = note.text.trim()
+        const linkText = note.linkText?.trim()
+        const linkUrl = note.linkUrl?.trim()
+        return {
+          text,
+          ...(linkText && linkUrl ? { linkText, linkUrl } : {})
+        }
+      })
+    }
+
+    return [block]
+  })
+}
+
+registerComponentHandler('FooterNotes', handleFooterNotes)

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -804,7 +804,10 @@ export async function buildReportPayload(
 }
 
 /** Dynamic-zone components allowed in hackathon-pages MDX/Strapi content. */
-export const HACKATHON_PAGE_ALLOWED_COMPONENTS = ['blocks.paragraph'] as const
+export const HACKATHON_PAGE_ALLOWED_COMPONENTS = [
+  'blocks.paragraph',
+  'blocks.footer-notes'
+] as const
 
 /**
  * Builds a Strapi payload for a hackathon-page MDX file.

--- a/cms/scripts/sync-mdx/types.blocks.ts
+++ b/cms/scripts/sync-mdx/types.blocks.ts
@@ -206,6 +206,16 @@ export interface CtaLinkBlock extends StrapiBlockBase {
   external?: boolean
 }
 
+/**
+ * blocks.footer-notes — numbered list of source notes/citations shown at the
+ * bottom of a page. `text` is a short caption (may contain inline markdown);
+ * `linkText`/`linkUrl` are all-or-nothing. At least 1 note is required.
+ */
+export interface FooterNotesBlock extends StrapiBlockBase {
+  __component: 'blocks.footer-notes'
+  notes: { text: string; linkText?: string; linkUrl?: string }[]
+}
+
 /** blocks.title-card — entry in title-card-grid's repeatable `titleCards` field. No `__component`; it's a nested component, not a dynamic-zone block. */
 export interface TitleCard {
   heading: string
@@ -250,3 +260,4 @@ export type ParsedBlock =
   | NumberTilesBlock
   | TitleCardGridBlock
   | CtaLinkBlock
+  | FooterNotesBlock

--- a/cms/src/api/foundation-page/content-types/foundation-page/schema.json
+++ b/cms/src/api/foundation-page/content-types/foundation-page/schema.json
@@ -67,7 +67,8 @@
         "blocks.blockquote",
         "blocks.cta-strip",
         "blocks.pdf-embed",
-        "blocks.video-embed"
+        "blocks.video-embed",
+        "blocks.footer-notes"
       ]
     }
   }

--- a/cms/src/api/hackathon-page/content-types/hackathon-page/schema.json
+++ b/cms/src/api/hackathon-page/content-types/hackathon-page/schema.json
@@ -34,7 +34,7 @@
     },
     "content": {
       "type": "dynamiczone",
-      "components": ["blocks.paragraph"],
+      "components": ["blocks.paragraph", "blocks.footer-notes"],
       "pluginOptions": { "i18n": { "localized": true } }
     }
   }

--- a/cms/src/api/summit-page/content-types/summit-page/schema.json
+++ b/cms/src/api/summit-page/content-types/summit-page/schema.json
@@ -67,7 +67,8 @@
         "blocks.blockquote",
         "blocks.cta-strip",
         "blocks.pdf-embed",
-        "blocks.video-embed"
+        "blocks.video-embed",
+        "blocks.footer-notes"
       ]
     }
   }

--- a/cms/src/components/blocks/footer-note.json
+++ b/cms/src/components/blocks/footer-note.json
@@ -1,0 +1,36 @@
+{
+  "collectionName": "components_blocks_footer_notes_items",
+  "info": {
+    "displayName": "Footer Note",
+    "icon": "quote",
+    "description": "Single footnote/citation entry: caption text and an optional inline source link"
+  },
+  "options": {},
+  "attributes": {
+    "text": {
+      "type": "text",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "linkText": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "linkUrl": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    }
+  }
+}

--- a/cms/src/components/blocks/footer-notes.json
+++ b/cms/src/components/blocks/footer-notes.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_blocks_footer_notes",
+  "info": {
+    "displayName": "Footer Notes",
+    "icon": "quote",
+    "description": "Numbered list of source notes/citations, shown at the bottom of a page. At least 1 note required."
+  },
+  "options": {},
+  "attributes": {
+    "notes": {
+      "type": "component",
+      "repeatable": true,
+      "component": "blocks.footer-note",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    }
+  }
+}

--- a/cms/src/serializers/blocks/footer-notes.serializer.test.ts
+++ b/cms/src/serializers/blocks/footer-notes.serializer.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { serialize } from './footer-notes.serializer'
+
+describe('footer-notes serializer', () => {
+  it('serializes notes with text, linkText, and linkUrl', () => {
+    const result = serialize({
+      notes: [
+        {
+          text: 'Average cost to send 1 USDT on August 5, 2025 per GasFeesNow.',
+          linkText: 'https://gasfeesnow.com',
+          linkUrl: 'https://gasfeesnow.com'
+        },
+        {
+          text: 'Average price for a $200 bank initiated cross-border transfer.',
+          linkText: 'World Bank remittance prices',
+          linkUrl: 'https://remittanceprices.worldbank.org'
+        }
+      ]
+    })
+
+    expect(result).toContain(
+      'notes={[{"text":"Average cost to send 1 USDT on August 5, 2025 per GasFeesNow.","linkText":"https://gasfeesnow.com","linkUrl":"https://gasfeesnow.com"},' +
+        '{"text":"Average price for a $200 bank initiated cross-border transfer.","linkText":"World Bank remittance prices","linkUrl":"https://remittanceprices.worldbank.org"}]}'
+    )
+  })
+
+  it('omits linkText/linkUrl when absent', () => {
+    const result = serialize({
+      notes: [{ text: 'A plain citation with no source link.' }]
+    })
+
+    expect(result).toContain(
+      'notes={[{"text":"A plain citation with no source link."}]}'
+    )
+  })
+
+  it('drops a half-filled link pair (linkText without linkUrl)', () => {
+    const result = serialize({
+      notes: [{ text: 'Citation.', linkText: 'Some source' }]
+    })
+
+    expect(result).toContain('notes={[{"text":"Citation."}]}')
+  })
+
+  it('drops a half-filled link pair (linkUrl without linkText)', () => {
+    const result = serialize({
+      notes: [{ text: 'Citation.', linkUrl: 'https://example.com' }]
+    })
+
+    expect(result).toContain('notes={[{"text":"Citation."}]}')
+  })
+
+  it('throws when notes is missing', () => {
+    expect(() => serialize({})).toThrow(
+      'Footer Notes block requires at least 1 note'
+    )
+  })
+
+  it('throws when notes is empty', () => {
+    expect(() => serialize({ notes: [] })).toThrow(
+      'Footer Notes block requires at least 1 note'
+    )
+  })
+
+  it('throws when a note is missing text', () => {
+    expect(() =>
+      serialize({
+        notes: [{ text: 'First note.' }, { linkText: 'x', linkUrl: 'y' }]
+      })
+    ).toThrow('Footer Notes block: note 2 is missing text')
+  })
+})

--- a/cms/src/serializers/blocks/footer-notes.serializer.ts
+++ b/cms/src/serializers/blocks/footer-notes.serializer.ts
@@ -1,0 +1,35 @@
+export function serialize(block: {
+  notes?: {
+    text?: string
+    linkText?: string
+    linkUrl?: string
+  }[]
+}): string {
+  // Strapi's `required: true` on `notes`/`text` isn't enforced at save time
+  if (!block.notes || block.notes.length < 1) {
+    throw new Error('Footer Notes block requires at least 1 note')
+  }
+
+  const noteItems = block.notes.map((note, i) => {
+    const text = note.text?.trim()
+    if (!text) {
+      throw new Error(`Footer Notes block: note ${i + 1} is missing text`)
+    }
+
+    // Link is all-or-nothing: only emit it when both linkText and linkUrl
+    // are present, so a half-filled pair in Strapi is dropped on export
+    // (matching the import handler and how FooterNotes.astro renders it).
+    const linkText = note.linkText?.trim()
+    const linkUrl = note.linkUrl?.trim()
+    const hasLink = Boolean(linkText && linkUrl)
+
+    return {
+      text,
+      ...(hasLink ? { linkText, linkUrl } : {})
+    }
+  })
+
+  const notesAttr = ` notes={${JSON.stringify(noteItems)}}`
+
+  return `<FooterNotes${notesAttr} />`
+}

--- a/cms/src/serializers/blocks/index.ts
+++ b/cms/src/serializers/blocks/index.ts
@@ -26,6 +26,7 @@ import { serialize as splitLayout } from './split-layout.serializer'
 import { serialize as numberTiles } from './number-tiles.serializer'
 import { serialize as titleCardGrid } from './title-card-grid.serializer'
 import { serialize as ctaLink } from './cta-link.serializer'
+import { serialize as footerNotes } from './footer-notes.serializer'
 
 const SERIALIZERS: Record<string, (block: unknown) => string> = {
   'blocks.cards-grid': cardsGrid,
@@ -46,7 +47,8 @@ const SERIALIZERS: Record<string, (block: unknown) => string> = {
   'blocks.code-block': codeBlock,
   'blocks.split-layout': splitLayout,
   'blocks.title-card-grid': titleCardGrid,
-  'shared.cta-link': ctaLink
+  'shared.cta-link': ctaLink,
+  'blocks.footer-notes': footerNotes
 }
 
 /**

--- a/cms/src/utils/contentPopulate.ts
+++ b/cms/src/utils/contentPopulate.ts
@@ -60,6 +60,9 @@ const FOUNDATION_PAGE_BLOCKS = {
   },
   'blocks.video-embed': {
     populate: { file: true }
+  },
+  'blocks.footer-notes': {
+    populate: { notes: true }
   }
 } as const
 
@@ -92,10 +95,13 @@ export const REPORT_CONTENT_POPULATE = {
   }
 } as const
 
-/** Populate config for hackathon-page content field (paragraph blocks only). */
+/** Populate config for hackathon-page content field. */
 export const HACKATHON_PAGE_CONTENT_POPULATE = {
   on: {
-    'blocks.paragraph': {}
+    'blocks.paragraph': {},
+    'blocks.footer-notes': {
+      populate: { notes: true }
+    }
   }
 } as const
 

--- a/cms/types/generated/components.d.ts
+++ b/cms/types/generated/components.d.ts
@@ -394,6 +394,54 @@ export interface BlocksFaqSection extends Struct.ComponentSchema {
   }
 }
 
+export interface BlocksFooterNote extends Struct.ComponentSchema {
+  collectionName: 'components_blocks_footer_notes_items'
+  info: {
+    description: 'Single footnote/citation entry: caption text and an optional inline source link'
+    displayName: 'Footer Note'
+    icon: 'quote'
+  }
+  attributes: {
+    linkText: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    linkUrl: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    text: Schema.Attribute.Text &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+  }
+}
+
+export interface BlocksFooterNotes extends Struct.ComponentSchema {
+  collectionName: 'components_blocks_footer_notes'
+  info: {
+    description: 'Numbered list of source notes/citations, shown at the bottom of a page. At least 1 note required.'
+    displayName: 'Footer Notes'
+    icon: 'quote'
+  }
+  attributes: {
+    notes: Schema.Attribute.Component<'blocks.footer-note', true> &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+  }
+}
+
 export interface BlocksGrantFaqItem extends Struct.ComponentSchema {
   collectionName: 'components_blocks_grant_faq_items'
   info: {
@@ -1269,6 +1317,8 @@ declare module '@strapi/strapi' {
       'blocks.cta-strip': BlocksCtaStrip
       'blocks.faq-item': BlocksFaqItem
       'blocks.faq-section': BlocksFaqSection
+      'blocks.footer-note': BlocksFooterNote
+      'blocks.footer-notes': BlocksFooterNotes
       'blocks.grant-faq-item': BlocksGrantFaqItem
       'blocks.grant-faq-section': BlocksGrantFaqSection
       'blocks.image-block': BlocksImageBlock

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -742,7 +742,8 @@ export interface ApiFoundationPageFoundationPage
         'blocks.blockquote',
         'blocks.cta-strip',
         'blocks.pdf-embed',
-        'blocks.video-embed'
+        'blocks.video-embed',
+        'blocks.footer-notes'
       ]
     > &
       Schema.Attribute.SetPluginOptions<{
@@ -1024,7 +1025,9 @@ export interface ApiHackathonPageHackathonPage
     }
   }
   attributes: {
-    content: Schema.Attribute.DynamicZone<['blocks.paragraph']> &
+    content: Schema.Attribute.DynamicZone<
+      ['blocks.paragraph', 'blocks.footer-notes']
+    > &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true
@@ -1332,7 +1335,8 @@ export interface ApiSummitPageSummitPage extends Struct.CollectionTypeSchema {
         'blocks.blockquote',
         'blocks.cta-strip',
         'blocks.pdf-embed',
-        'blocks.video-embed'
+        'blocks.video-embed',
+        'blocks.footer-notes'
       ]
     > &
       Schema.Attribute.SetPluginOptions<{

--- a/src/components/blocks/DynamicZone.astro
+++ b/src/components/blocks/DynamicZone.astro
@@ -24,6 +24,7 @@ import SplitLayout from './SplitLayout.astro'
 import NumberTiles from './NumberTiles.astro'
 import TitleCardGrid from './TitleCardGrid.astro'
 import CtaLink from './CtaLink.astro'
+import FooterNotes from './FooterNotes.astro'
 
 interface Block {
   __component: string
@@ -54,7 +55,8 @@ const componentMap: Record<string, any> = {
   'blocks.split-layout': SplitLayout,
   'blocks.number-tiles': NumberTiles,
   'blocks.title-card-grid': TitleCardGrid,
-  'shared.cta-link': CtaLink
+  'shared.cta-link': CtaLink,
+  'blocks.footer-notes': FooterNotes
 }
 
 const resolvedBlocks = blocks

--- a/src/components/blocks/FooterNotes.astro
+++ b/src/components/blocks/FooterNotes.astro
@@ -2,7 +2,7 @@
 // Numbered list of source notes/citations shown at the bottom of a page
 // (foundation/summit/hackathon dynamic zones). Numbering comes from the
 // `notes` array order — no manual id field, same convention as NumberTiles.
-import { parseMarkdownInline } from '@/utils'
+import { parseMarkdownInline, getSafeExternalUrl } from '@/utils'
 
 interface FooterNote {
   text: string
@@ -27,6 +27,12 @@ const { routeLocale } = Astro.locals
           pathname: Astro.url.pathname,
           lang: routeLocale
         })
+        // Editor-supplied: normalize and restrict to http/https before use
+        // in an href, so a bare host isn't treated as a relative path and
+        // unsafe schemes (javascript:, data:, ...) can't be introduced.
+        const safeLinkUrl = note.linkUrl
+          ? getSafeExternalUrl(note.linkUrl)
+          : null
         return (
           <li class="flex flex-row gap-1.5">
             <span
@@ -37,11 +43,11 @@ const { routeLocale } = Astro.locals
             </span>
             <p class="m-0 text-[15px] leading-6 font-normal text-neutral-100 tablet:text-base tablet:leading-[26px]">
               <Fragment set:html={html} />
-              {note.linkText && note.linkUrl && (
+              {note.linkText && safeLinkUrl && (
                 <>
                   {' '}
                   <a
-                    href={note.linkUrl}
+                    href={safeLinkUrl}
                     class="text-orchid-100 underline hover:opacity-80"
                     target="_blank"
                     rel="noopener noreferrer"

--- a/src/components/blocks/FooterNotes.astro
+++ b/src/components/blocks/FooterNotes.astro
@@ -1,0 +1,59 @@
+---
+// Numbered list of source notes/citations shown at the bottom of a page
+// (foundation/summit/hackathon dynamic zones). Numbering comes from the
+// `notes` array order — no manual id field, same convention as NumberTiles.
+import { parseMarkdownInline } from '@/utils'
+
+interface FooterNote {
+  text: string
+  linkText?: string
+  linkUrl?: string
+}
+
+interface Props {
+  notes: FooterNote[]
+}
+
+const { notes } = Astro.props
+const { routeLocale } = Astro.locals
+---
+
+<section class="w-full">
+  <hr class="mb-lg border-t border-neutral-50" />
+  <ol class="m-0 flex list-none flex-col gap-lg p-0">
+    {
+      notes.map((note, index) => {
+        const html = parseMarkdownInline(note.text, {
+          pathname: Astro.url.pathname,
+          lang: routeLocale
+        })
+        return (
+          <li class="flex flex-row gap-1.5">
+            <span
+              class="shrink-0 text-[13px] leading-4 font-normal text-orchid-100"
+              aria-hidden="true"
+            >
+              {index + 1}
+            </span>
+            <p class="m-0 text-[15px] leading-6 font-normal text-neutral-100 tablet:text-base tablet:leading-[26px]">
+              <Fragment set:html={html} />
+              {note.linkText && note.linkUrl && (
+                <>
+                  {' '}
+                  <a
+                    href={note.linkUrl}
+                    class="text-orchid-100 underline hover:opacity-80"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {note.linkText}
+                  </a>
+                </>
+              )}
+            </p>
+          </li>
+        )
+      })
+    }
+  </ol>
+</section>

--- a/src/components/pages/FoundationContentPage.astro
+++ b/src/components/pages/FoundationContentPage.astro
@@ -10,6 +10,7 @@ import Paragraph from '@/components/blocks/Paragraph.astro'
 import CtaStrip from '@/components/blocks/CtaStrip.astro'
 import PdfEmbed from '@/components/shared/PdfEmbed.astro'
 import VideoEmbed from '@/components/shared/VideoEmbed.astro'
+import FooterNotes from '@/components/blocks/FooterNotes.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import Link from '@/components/shared/Link.astro'
 import OptimizedImage from '@/components/shared/OptimizedImage.astro'
@@ -103,7 +104,8 @@ if (isNotFound) return Astro.redirect('/404')
               Paragraph,
               CtaStrip,
               PdfEmbed,
-              VideoEmbed
+              VideoEmbed,
+              FooterNotes
             }}
           />
         </div>

--- a/src/components/pages/HackathonContentPage.astro
+++ b/src/components/pages/HackathonContentPage.astro
@@ -4,6 +4,7 @@ import HackathonPageLayout from '@/layouts/HackathonPageLayout.astro'
 import Breadcrumbs from '@/components/shared/Breadcrumbs.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import Paragraph from '@/components/blocks/Paragraph.astro'
+import FooterNotes from '@/components/blocks/FooterNotes.astro'
 import {
   type Locale,
   useTranslations,
@@ -58,7 +59,7 @@ const breadcrumbs = buildSectionEntryBreadcrumbs(
         data-prose
         class="mt-2xl [&_h2]:mt-3xl [&_h2]:mb-xl [&_h2]:text-[1.75rem] [&_h2]:font-semibold [&_h3]:mt-2xl [&_h3]:mb-lg [&_h3]:text-[1.25rem] [&_h3]:font-semibold [&_p]:mb-xl [&_p]:leading-[1.6] [&_ul]:mb-xl [&_ul]:ps-2xl [&_li]:mb-lg [&_a]:underline [&_a:hover]:no-underline"
       >
-        <MdxContent components={{ Paragraph }} />
+        <MdxContent components={{ Paragraph, FooterNotes }} />
       </section>
     </div>
   </main>

--- a/src/components/pages/SummitContentPage.astro
+++ b/src/components/pages/SummitContentPage.astro
@@ -10,6 +10,7 @@ import VideoEmbed from '@/components/shared/VideoEmbed.astro'
 import ProfileCard from '@/components/shared/ProfileCard.astro'
 import CalloutText from '@/components/shared/CalloutText.astro'
 import PdfEmbed from '@/components/shared/PdfEmbed.astro'
+import FooterNotes from '@/components/blocks/FooterNotes.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import Link from '@/components/shared/Link.astro'
 import OptimizedImage from '@/components/shared/OptimizedImage.astro'
@@ -106,7 +107,8 @@ const gradient =
               Paragraph,
               CtaStrip,
               PdfEmbed,
-              VideoEmbed
+              VideoEmbed,
+              FooterNotes
             }}
           />
         </div>

--- a/src/content/foundation-pages/demo-foundation-page.mdx
+++ b/src/content/foundation-pages/demo-foundation-page.mdx
@@ -1,0 +1,31 @@
+---
+pathSlug: 'demo-foundation-page'
+title: 'Foundation Page Demo'
+heroTitle: 'Foundation Page Demo'
+locale: 'en'
+description: 'Demo page for populating the foundation-page dynamic zone with sample block data.'
+---
+
+<Paragraph>
+
+The cost of sending money across borders remains far higher than sending it over the Interledger network. The figures below illustrate the gap.<sup>1</sup> Traditional remittance providers often charge a premium for cross-border transfers.<sup>2</sup> Newer fintech alternatives have narrowed that gap, but a meaningful difference remains.<sup>3</sup>
+
+</Paragraph>
+
+<FooterNotes
+  notes={[
+    {
+      text: 'Average cost to send 1 USDT (Tether, the largest stablecoin pegged to the US dollar) on August 5, 2025 per GasFeesNow.',
+      linkText: 'https://gasfeesnow.com',
+      linkUrl: 'https://gasfeesnow.com'
+    },
+    {
+      text: 'Average price for a $200 bank initiated cross-border transfer, according to the World Bank (Q3, 2024).',
+      linkText: 'World Bank Remittance Prices Worldwide',
+      linkUrl: 'https://remittanceprices.worldbank.org'
+    },
+    {
+      text: 'Average price to send $200 from the United States to Mexico using Wise for a personal account to a personal account transaction, according to the Inter-American Dialogue (2024).'
+    }
+  ]}
+/>

--- a/src/content/hackathon-pages/demo-hackathon-page.mdx
+++ b/src/content/hackathon-pages/demo-hackathon-page.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Hackathon Page Demo'
+pathSlug: 'demo-hackathon-page'
+description: 'Demo page for populating the hackathon-page dynamic zone with sample block data.'
+locale: 'en'
+---
+
+<Paragraph>
+
+Hackathon teams building on Interledger often compare their prototype's transfer costs against traditional rails.<sup>1</sup> The reference figures teams cite most often are collected below.<sup>2</sup><sup>3</sup>
+
+</Paragraph>
+
+<FooterNotes
+  notes={[
+    {
+      text: 'Average cost to send 1 USDT (Tether, the largest stablecoin pegged to the US dollar) on August 5, 2025 per GasFeesNow.',
+      linkText: 'https://gasfeesnow.com',
+      linkUrl: 'https://gasfeesnow.com'
+    },
+    {
+      text: 'Average price for a $200 bank initiated cross-border transfer, according to the World Bank (Q3, 2024).',
+      linkText: 'World Bank Remittance Prices Worldwide',
+      linkUrl: 'https://remittanceprices.worldbank.org'
+    },
+    {
+      text: 'Average price to send $200 from the United States to Mexico using Wise for a personal account to a personal account transaction, according to the Inter-American Dialogue (2024).'
+    }
+  ]}
+/>

--- a/src/content/summit-pages/demo-summit-page.mdx
+++ b/src/content/summit-pages/demo-summit-page.mdx
@@ -1,0 +1,31 @@
+---
+pathSlug: 'demo-summit-page'
+title: 'Summit Page Demo'
+heroTitle: 'Summit Page Demo'
+locale: 'en'
+description: 'Demo page for populating the summit-page dynamic zone with sample block data.'
+---
+
+<Paragraph>
+
+Sessions at the Summit referenced a number of data points on the cost of cross-border payments today.<sup>1</sup> The sources for those figures are collected below.<sup>2</sup><sup>3</sup>
+
+</Paragraph>
+
+<FooterNotes
+  notes={[
+    {
+      text: 'Average cost to send 1 USDT (Tether, the largest stablecoin pegged to the US dollar) on August 5, 2025 per GasFeesNow.',
+      linkText: 'https://gasfeesnow.com',
+      linkUrl: 'https://gasfeesnow.com'
+    },
+    {
+      text: 'Average price for a $200 bank initiated cross-border transfer, according to the World Bank (Q3, 2024).',
+      linkText: 'World Bank Remittance Prices Worldwide',
+      linkUrl: 'https://remittanceprices.worldbank.org'
+    },
+    {
+      text: 'Average price to send $200 from the United States to Mexico using Wise for a personal account to a personal account transaction, according to the Inter-American Dialogue (2024).'
+    }
+  ]}
+/>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,6 +11,7 @@ export {
   addTrailingSlash,
   ensureLeadingSlash,
   ensureAbsoluteUrl,
+  getSafeExternalUrl,
   getSocialIconName,
   FALLBACK_SOCIAL_ICON,
   type SocialIconName

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,6 +12,7 @@ export {
   ensureLeadingSlash,
   ensureAbsoluteUrl,
   getSafeExternalUrl,
+  isSafeMarkdownHref,
   getSocialIconName,
   FALLBACK_SOCIAL_ICON,
   type SocialIconName

--- a/src/utils/main/mdx.test.ts
+++ b/src/utils/main/mdx.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { createMarked } from './mdx'
+
+describe('createMarked', () => {
+  it('injects the new attribute set on inline links', () => {
+    const html = createMarked({
+      pathname: '/resources',
+      lang: 'en'
+    }).parseInline(
+      'See [Open Payments Docs](https://docs.interledger.org/) for more.'
+    ) as string
+    expect(html).toContain('data-umami-event="resources:link:docs_interledger"')
+    expect(html).toContain('data-umami-event-link-text="Open Payments Docs"')
+    expect(html).toContain('data-umami-event-lang="en"')
+  })
+
+  it('honours a label directive in the link title', () => {
+    const html = createMarked({
+      pathname: '/get-involved',
+      lang: 'en'
+    }).parseInline(
+      '[Community Forum](https://forum.interledger.org/ "label:community")'
+    ) as string
+    expect(html).toContain('data-umami-event="get_involved:link"')
+    expect(html).toContain('data-umami-event-label="community"')
+    expect(html).not.toContain('title="label:community"')
+  })
+
+  it('preserves a non-directive title', async () => {
+    const html = await createMarked({ pathname: '/' }).parse(
+      '[hi](https://example.com "real title")'
+    )
+    expect(html).toContain('title="real title"')
+    expect(html).toContain('data-umami-event="foundation_home:link:example"')
+  })
+
+  it('handles inline markdown inside link text', () => {
+    const html = createMarked({ pathname: '/' }).parseInline(
+      'Try [**bold** link](https://example.com)'
+    ) as string
+    expect(html).toContain('<strong>bold</strong>')
+    expect(html).toContain('data-umami-event="foundation_home:link:example"')
+    expect(html).toContain('data-umami-event-link-text="bold link"')
+  })
+
+  it('derives page from pathname when rendering markdown links', async () => {
+    const html = await createMarked({ pathname: '/ambassadors' }).parse(
+      '[Site](https://example.com)'
+    )
+    expect(html).toContain('data-umami-event="ambassadors:link:example"')
+    expect(html).toContain('data-umami-event-link-text="Site"')
+  })
+
+  it('defaults to foundation_home when pathname is omitted', async () => {
+    const html = (await createMarked({}).parse(
+      '[docs](https://example.com/docs)'
+    )) as string
+    expect(html).toContain('data-umami-event="foundation_home:link:example"')
+    expect(html).toContain('data-umami-event-link-text="docs"')
+    expect(html).not.toContain('undefined')
+    expect(html).not.toContain('data-umami-event=""')
+    expect(html.match(/data-umami-event="/g)).toHaveLength(1)
+  })
+
+  it('does not use a junk segment when page is explicitly undefined (optional umamiContext)', async () => {
+    const html = await createMarked({
+      page: undefined,
+      pathname: '/education',
+      lang: 'en'
+    }).parse('[Overview](/policy-and-advocacy)')
+    expect(html).toContain(
+      'data-umami-event="education:link:policy_and_advocacy"'
+    )
+    expect(html).not.toMatch(/:undefined|undefined:/)
+  })
+
+  it('escapes title attribute values and keeps umami attributes valid', async () => {
+    const html = await createMarked({ pathname: '/' }).parse(
+      '[hi](https://example.com "a title with \\"quotes\\"")'
+    )
+    expect(html).toContain('title="a title with &quot;quotes&quot;"')
+    expect(html).toContain('data-umami-event="foundation_home:link:example"')
+    expect(html).toContain('data-umami-event-link-text="hi"')
+    expect(html).not.toContain('data-umami-event=""')
+  })
+
+  it('preserves multiple links on the same line', async () => {
+    const html = await createMarked({ pathname: '/about-us' }).parse(
+      '[one](https://a.com) and [two](https://b.com)'
+    )
+    expect(html.match(/data-umami-event="/g)).toHaveLength(2)
+    expect(html).toContain('data-umami-event-link-text="one"')
+    expect(html).toContain('data-umami-event-link-text="two"')
+  })
+
+  it('drops a javascript: link, keeping only its text', () => {
+    const html = createMarked({ pathname: '/' }).parseInline(
+      '[click me](javascript:alert(1))'
+    ) as string
+    expect(html).not.toContain('<a')
+    expect(html).not.toContain('javascript:')
+    expect(html).toContain('click me')
+  })
+
+  it('drops a data: link, keeping only its text', () => {
+    const html = createMarked({ pathname: '/' }).parseInline(
+      '[click me](data:text/html,<script>alert(1)</script>)'
+    ) as string
+    expect(html).not.toContain('<a')
+    expect(html).not.toContain('data:')
+    expect(html).toContain('click me')
+  })
+
+  it('still renders a relative internal link', async () => {
+    const html = await createMarked({ pathname: '/education' }).parse(
+      '[Overview](/policy-and-advocacy)'
+    )
+    expect(html).toContain('<a href="/policy-and-advocacy"')
+  })
+})

--- a/src/utils/main/mdx.test.ts
+++ b/src/utils/main/mdx.test.ts
@@ -117,4 +117,28 @@ describe('createMarked', () => {
     )
     expect(html).toContain('<a href="/policy-and-advocacy"')
   })
+
+  it('escapes a raw <script> tag in the markdown source', () => {
+    const html = createMarked({ pathname: '/' }).parseInline(
+      'Hello <script>alert(1)</script> world'
+    ) as string
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+
+  it('escapes a raw HTML tag with an inline event handler', () => {
+    const html = createMarked({ pathname: '/' }).parseInline(
+      '<img src=x onerror=alert(1)>'
+    ) as string
+    expect(html).not.toContain('<img')
+    expect(html).toContain('&lt;img')
+  })
+
+  it('escapes a raw <a> tag with a javascript: href, bypassing the link renderer', () => {
+    const html = createMarked({ pathname: '/' }).parseInline(
+      '<a href="javascript:alert(1)">click</a>'
+    ) as string
+    expect(html).not.toContain('<a href')
+    expect(html).toContain('&lt;a href')
+  })
 })

--- a/src/utils/main/mdx.ts
+++ b/src/utils/main/mdx.ts
@@ -32,6 +32,13 @@ export function createMarked(context: UmamiContext = {}): Marked {
   if (cached) return cached
 
   const renderer: RendererObject = {
+    // Marked passes raw HTML found in the markdown source straight through
+    // unescaped by default (e.g. `<script>`, `<img onerror=...>`), independent
+    // of the href-scheme check below. Escape it instead — this is untrusted
+    // editor-supplied content rendered via `set:html`.
+    html({ text }: Tokens.HTML | Tokens.Tag) {
+      return escapeHtml(text)
+    },
     link({ href, title, tokens }: Tokens.Link) {
       const innerHtml = this.parser.parseInline(tokens)
       // Marked only HTML-escapes href, it doesn't restrict schemes — drop

--- a/src/utils/main/mdx.ts
+++ b/src/utils/main/mdx.ts
@@ -1,6 +1,63 @@
-import { createMarked, type UmamiContext } from './umami'
+import { Marked, type RendererObject, type Tokens } from 'marked'
+import { isSafeMarkdownHref } from '../shared/url'
+import {
+  type UmamiContext,
+  buildUmamiAttrs,
+  derivePage,
+  escapeHtml,
+  extractTitleLabel,
+  umamiAttrsToHtml
+} from './umami'
 import { getTableScrollAriaLabel } from './getTableScrollAriaLabel'
 import { wrapScrollableTables } from './wrapScrollableTables'
+
+const HTML_TAG = /<[^>]*>/g
+
+function stripTags(html: string): string {
+  return html.replace(HTML_TAG, '')
+}
+
+const markedCache = new Map<string, Marked>()
+
+/**
+ * Returns a Marked instance whose link renderer injects umami attributes
+ * and drops any link whose href isn't a safe scheme (see
+ * `isSafeMarkdownHref`) rather than rendering it.
+ */
+export function createMarked(context: UmamiContext = {}): Marked {
+  const page = derivePage(context)
+  const lang = context.lang?.trim() || ''
+  const cacheKey = `${page}|${lang}`
+  const cached = markedCache.get(cacheKey)
+  if (cached) return cached
+
+  const renderer: RendererObject = {
+    link({ href, title, tokens }: Tokens.Link) {
+      const innerHtml = this.parser.parseInline(tokens)
+      // Marked only HTML-escapes href, it doesn't restrict schemes — drop
+      // the link (keep the text) rather than emitting a javascript:/data:
+      // href from editor-supplied markdown.
+      if (!isSafeMarkdownHref(href ?? '')) return innerHtml
+      const { label, title: cleanedTitle } = extractTitleLabel(title)
+      const attrs = buildUmamiAttrs({
+        page,
+        lang,
+        section: 'link',
+        linkText: stripTags(innerHtml),
+        href,
+        label
+      })
+      const titleAttr = cleanedTitle
+        ? ` title="${escapeHtml(cleanedTitle)}"`
+        : ''
+      return `<a href="${escapeHtml(href ?? '')}"${titleAttr}${umamiAttrsToHtml(attrs)}>${innerHtml}</a>`
+    }
+  }
+  const instance = new Marked()
+  instance.use({ renderer })
+  markedCache.set(cacheKey, instance)
+  return instance
+}
 
 export async function parseMarkdown(
   text: string | null | undefined,

--- a/src/utils/main/umami.test.ts
+++ b/src/utils/main/umami.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildUmamiAttrs,
-  createMarked,
   deriveAction,
   deriveLabel,
   derivePage,
@@ -292,98 +291,5 @@ describe('extractTitleLabel', () => {
   it('handles missing titles', () => {
     expect(extractTitleLabel(undefined)).toEqual({})
     expect(extractTitleLabel(null)).toEqual({})
-  })
-})
-
-describe('createMarked', () => {
-  it('injects the new attribute set on inline links', () => {
-    const html = createMarked({
-      pathname: '/resources',
-      lang: 'en'
-    }).parseInline(
-      'See [Open Payments Docs](https://docs.interledger.org/) for more.'
-    ) as string
-    expect(html).toContain('data-umami-event="resources:link:docs_interledger"')
-    expect(html).toContain('data-umami-event-link-text="Open Payments Docs"')
-    expect(html).toContain('data-umami-event-lang="en"')
-  })
-
-  it('honours a label directive in the link title', () => {
-    const html = createMarked({
-      pathname: '/get-involved',
-      lang: 'en'
-    }).parseInline(
-      '[Community Forum](https://forum.interledger.org/ "label:community")'
-    ) as string
-    expect(html).toContain('data-umami-event="get_involved:link"')
-    expect(html).toContain('data-umami-event-label="community"')
-    expect(html).not.toContain('title="label:community"')
-  })
-
-  it('preserves a non-directive title', async () => {
-    const html = await createMarked({ pathname: '/' }).parse(
-      '[hi](https://example.com "real title")'
-    )
-    expect(html).toContain('title="real title"')
-    expect(html).toContain('data-umami-event="foundation_home:link:example"')
-  })
-
-  it('handles inline markdown inside link text', () => {
-    const html = createMarked({ pathname: '/' }).parseInline(
-      'Try [**bold** link](https://example.com)'
-    ) as string
-    expect(html).toContain('<strong>bold</strong>')
-    expect(html).toContain('data-umami-event="foundation_home:link:example"')
-    expect(html).toContain('data-umami-event-link-text="bold link"')
-  })
-
-  it('derives page from pathname when rendering markdown links', async () => {
-    const html = await createMarked({ pathname: '/ambassadors' }).parse(
-      '[Site](https://example.com)'
-    )
-    expect(html).toContain('data-umami-event="ambassadors:link:example"')
-    expect(html).toContain('data-umami-event-link-text="Site"')
-  })
-
-  it('defaults to foundation_home when pathname is omitted', async () => {
-    const html = (await createMarked({}).parse(
-      '[docs](https://example.com/docs)'
-    )) as string
-    expect(html).toContain('data-umami-event="foundation_home:link:example"')
-    expect(html).toContain('data-umami-event-link-text="docs"')
-    expect(html).not.toContain('undefined')
-    expect(html).not.toContain('data-umami-event=""')
-    expect(html.match(/data-umami-event="/g)).toHaveLength(1)
-  })
-
-  it('does not use a junk segment when page is explicitly undefined (optional umamiContext)', async () => {
-    const html = await createMarked({
-      page: undefined,
-      pathname: '/education',
-      lang: 'en'
-    }).parse('[Overview](/policy-and-advocacy)')
-    expect(html).toContain(
-      'data-umami-event="education:link:policy_and_advocacy"'
-    )
-    expect(html).not.toMatch(/:undefined|undefined:/)
-  })
-
-  it('escapes title attribute values and keeps umami attributes valid', async () => {
-    const html = await createMarked({ pathname: '/' }).parse(
-      '[hi](https://example.com "a title with \\"quotes\\"")'
-    )
-    expect(html).toContain('title="a title with &quot;quotes&quot;"')
-    expect(html).toContain('data-umami-event="foundation_home:link:example"')
-    expect(html).toContain('data-umami-event-link-text="hi"')
-    expect(html).not.toContain('data-umami-event=""')
-  })
-
-  it('preserves multiple links on the same line', async () => {
-    const html = await createMarked({ pathname: '/about-us' }).parse(
-      '[one](https://a.com) and [two](https://b.com)'
-    )
-    expect(html.match(/data-umami-event="/g)).toHaveLength(2)
-    expect(html).toContain('data-umami-event-link-text="one"')
-    expect(html).toContain('data-umami-event-link-text="two"')
   })
 })

--- a/src/utils/main/umami.ts
+++ b/src/utils/main/umami.ts
@@ -1,5 +1,3 @@
-import { Marked, type RendererObject, type Tokens } from 'marked'
-
 // Mirrors astro.config.mjs `i18n.locales`. Kept inline to avoid pulling the
 // astro virtual modules into the unit-test runtime.
 const LOCALE_CODES = ['en', 'es'] as const
@@ -37,7 +35,6 @@ const HTML_ESCAPE: Record<string, string> = {
   '"': '&quot;',
   "'": '&#39;'
 }
-const HTML_TAG = /<[^>]*>/g
 const MICROSITES = ['summit', 'hackathon'] as const
 const HOME_SUFFIX = '_home'
 const TITLE_LABEL_PREFIX = 'label:'
@@ -84,10 +81,6 @@ function sanitizeText(value: string): string {
 
 export function escapeHtml(value: string): string {
   return value.replace(/[&<>"']/g, (char) => HTML_ESCAPE[char])
-}
-
-function stripTags(html: string): string {
-  return html.replace(HTML_TAG, '')
 }
 
 function normaliseSegment(value: string): string {
@@ -279,38 +272,4 @@ export function extractTitleLabel(title: string | null | undefined): {
   const label = sanitizeText(trimmed.slice(TITLE_LABEL_PREFIX.length))
   if (!label) return { title }
   return { label }
-}
-
-const markedCache = new Map<string, Marked>()
-
-/** Returns a Marked instance whose link renderer injects umami attributes. */
-export function createMarked(context: UmamiContext = {}): Marked {
-  const page = derivePage(context)
-  const lang = context.lang?.trim() || ''
-  const cacheKey = `${page}|${lang}`
-  const cached = markedCache.get(cacheKey)
-  if (cached) return cached
-
-  const renderer: RendererObject = {
-    link({ href, title, tokens }: Tokens.Link) {
-      const innerHtml = this.parser.parseInline(tokens)
-      const { label, title: cleanedTitle } = extractTitleLabel(title)
-      const attrs = buildUmamiAttrs({
-        page,
-        lang,
-        section: 'link',
-        linkText: stripTags(innerHtml),
-        href,
-        label
-      })
-      const titleAttr = cleanedTitle
-        ? ` title="${escapeHtml(cleanedTitle)}"`
-        : ''
-      return `<a href="${escapeHtml(href ?? '')}"${titleAttr}${umamiAttrsToHtml(attrs)}>${innerHtml}</a>`
-    }
-  }
-  const instance = new Marked()
-  instance.use({ renderer })
-  markedCache.set(cacheKey, instance)
-  return instance
 }

--- a/src/utils/shared/url.test.ts
+++ b/src/utils/shared/url.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { ensureAbsoluteUrl, ensureLeadingSlash, getSocialIconName } from './url'
+import {
+  ensureAbsoluteUrl,
+  ensureLeadingSlash,
+  getSafeExternalUrl,
+  getSocialIconName
+} from './url'
 
 describe('ensureLeadingSlash', () => {
   it('prepends a slash when missing', () => {
@@ -60,6 +65,39 @@ describe('ensureAbsoluteUrl', () => {
 
   it('is case-insensitive about the scheme', () => {
     expect(ensureAbsoluteUrl('HTTPS://example.com')).toBe('HTTPS://example.com')
+  })
+})
+
+describe('getSafeExternalUrl', () => {
+  it('normalizes a bare host to an absolute https URL', () => {
+    expect(getSafeExternalUrl('gasfeesnow.com')).toBe('https://gasfeesnow.com')
+  })
+
+  it('leaves an absolute http/https URL untouched', () => {
+    expect(getSafeExternalUrl('https://example.com/report')).toBe(
+      'https://example.com/report'
+    )
+    expect(getSafeExternalUrl('http://example.com')).toBe('http://example.com')
+  })
+
+  it('rejects a javascript: URL', () => {
+    expect(getSafeExternalUrl('javascript:alert(1)')).toBeNull()
+  })
+
+  it('rejects a data: URL', () => {
+    expect(
+      getSafeExternalUrl('data:text/html,<script>alert(1)</script>')
+    ).toBeNull()
+  })
+
+  it('rejects other non-http(s) schemes', () => {
+    expect(getSafeExternalUrl('mailto:jane@example.com')).toBeNull()
+    expect(getSafeExternalUrl('tel:+15551234567')).toBeNull()
+  })
+
+  it('returns null for empty/whitespace-only input', () => {
+    expect(getSafeExternalUrl('')).toBeNull()
+    expect(getSafeExternalUrl('   ')).toBeNull()
   })
 })
 

--- a/src/utils/shared/url.test.ts
+++ b/src/utils/shared/url.test.ts
@@ -81,6 +81,12 @@ describe('getSafeExternalUrl', () => {
     expect(getSafeExternalUrl('http://example.com')).toBe('http://example.com')
   })
 
+  it('normalizes a protocol-relative URL to https', () => {
+    expect(getSafeExternalUrl('//cdn.example.com/a.js')).toBe(
+      'https://cdn.example.com/a.js'
+    )
+  })
+
   it('rejects a javascript: URL', () => {
     expect(getSafeExternalUrl('javascript:alert(1)')).toBeNull()
   })

--- a/src/utils/shared/url.test.ts
+++ b/src/utils/shared/url.test.ts
@@ -3,6 +3,7 @@ import {
   ensureAbsoluteUrl,
   ensureLeadingSlash,
   getSafeExternalUrl,
+  isSafeMarkdownHref,
   getSocialIconName
 } from './url'
 
@@ -98,6 +99,52 @@ describe('getSafeExternalUrl', () => {
   it('returns null for empty/whitespace-only input', () => {
     expect(getSafeExternalUrl('')).toBeNull()
     expect(getSafeExternalUrl('   ')).toBeNull()
+  })
+})
+
+describe('isSafeMarkdownHref', () => {
+  it('allows relative paths', () => {
+    expect(isSafeMarkdownHref('/policy-and-advocacy')).toBe(true)
+    expect(isSafeMarkdownHref('grants/apply')).toBe(true)
+  })
+
+  it('allows fragment-only anchors', () => {
+    expect(isSafeMarkdownHref('#section')).toBe(true)
+  })
+
+  it('allows protocol-relative hrefs', () => {
+    expect(isSafeMarkdownHref('//cdn.example.com/a.js')).toBe(true)
+  })
+
+  it('allows http/https/mailto/tel', () => {
+    expect(isSafeMarkdownHref('https://example.com')).toBe(true)
+    expect(isSafeMarkdownHref('http://example.com')).toBe(true)
+    expect(isSafeMarkdownHref('mailto:jane@example.com')).toBe(true)
+    expect(isSafeMarkdownHref('tel:+15551234567')).toBe(true)
+  })
+
+  it('rejects javascript: hrefs', () => {
+    expect(isSafeMarkdownHref('javascript:alert(1)')).toBe(false)
+  })
+
+  it('rejects data: hrefs', () => {
+    expect(isSafeMarkdownHref('data:text/html,<script>alert(1)</script>')).toBe(
+      false
+    )
+  })
+
+  it('rejects other unrecognized schemes', () => {
+    expect(isSafeMarkdownHref('vbscript:msgbox(1)')).toBe(false)
+    expect(isSafeMarkdownHref('file:///etc/passwd')).toBe(false)
+  })
+
+  it('is case-insensitive about the scheme', () => {
+    expect(isSafeMarkdownHref('JavaScript:alert(1)')).toBe(false)
+    expect(isSafeMarkdownHref('HTTPS://example.com')).toBe(true)
+  })
+
+  it('treats empty input as safe (no scheme to reject)', () => {
+    expect(isSafeMarkdownHref('')).toBe(true)
   })
 })
 

--- a/src/utils/shared/url.ts
+++ b/src/utils/shared/url.ts
@@ -87,9 +87,13 @@ export function isSafeMarkdownHref(href: string): boolean {
 export function getSafeExternalUrl(url: string): string | null {
   const absolute = ensureAbsoluteUrl(url)
   if (!absolute) return null
+  // `new URL` can't parse a protocol-relative `//host` without a base to
+  // resolve against — normalize it to https: first, matching
+  // ensureAbsoluteUrl's choice to treat `//` as already-absolute.
+  const withScheme = absolute.startsWith('//') ? `https:${absolute}` : absolute
   try {
-    const parsed = new URL(absolute)
-    return SAFE_URL_SCHEMES.has(parsed.protocol) ? absolute : null
+    const parsed = new URL(withScheme)
+    return SAFE_URL_SCHEMES.has(parsed.protocol) ? withScheme : null
   } catch {
     return null
   }

--- a/src/utils/shared/url.ts
+++ b/src/utils/shared/url.ts
@@ -49,6 +49,26 @@ const ICON_BY_HOST: Record<string, SocialIconName> = {
   'instagram.com': 'instagram'
 }
 
+const SAFE_URL_SCHEMES = new Set(['http:', 'https:'])
+
+/**
+ * Normalizes an editor-supplied external URL to absolute and returns it only
+ * if it parses to a safe `http:`/`https:` scheme. Returns `null` for
+ * unparseable input and for other schemes (`javascript:`, `data:`, etc.), so
+ * callers can skip rendering the link rather than passing it through to an
+ * `href`.
+ */
+export function getSafeExternalUrl(url: string): string | null {
+  const absolute = ensureAbsoluteUrl(url)
+  if (!absolute) return null
+  try {
+    const parsed = new URL(absolute)
+    return SAFE_URL_SCHEMES.has(parsed.protocol) ? absolute : null
+  } catch {
+    return null
+  }
+}
+
 /** The host of `url`, lowercased, or null if it can't be parsed. */
 function getHostname(url: string): string | null {
   try {

--- a/src/utils/shared/url.ts
+++ b/src/utils/shared/url.ts
@@ -51,6 +51,32 @@ const ICON_BY_HOST: Record<string, SocialIconName> = {
 
 const SAFE_URL_SCHEMES = new Set(['http:', 'https:'])
 
+// Schemes allowed in markdown/rich-text-rendered hrefs. A scheme-less href
+// (relative path, `#anchor`, protocol-relative `//host`) is always safe —
+// only an explicit, non-allowlisted scheme (`javascript:`, `data:`,
+// `vbscript:`, `file:`, ...) is rejected.
+const SAFE_MARKDOWN_HREF_SCHEMES = new Set([
+  'http:',
+  'https:',
+  'mailto:',
+  'tel:'
+])
+const HREF_SCHEME = /^([a-z][a-z\d+\-.]*):/i
+
+/**
+ * Whether an href is safe to render as a markdown/rich-text link's `href`.
+ * Used to neutralize editor-supplied markdown links (e.g. `[x](javascript:...)`)
+ * that would otherwise pass through a markdown renderer's link output
+ * untouched — renderers typically HTML-escape the href but don't restrict
+ * its scheme.
+ */
+export function isSafeMarkdownHref(href: string): boolean {
+  const trimmed = href.trim()
+  const match = HREF_SCHEME.exec(trimmed)
+  if (!match) return true
+  return SAFE_MARKDOWN_HREF_SCHEMES.has(`${match[1].toLowerCase()}:`)
+}
+
 /**
  * Normalizes an editor-supplied external URL to absolute and returns it only
  * if it parses to a safe `http:`/`https:` scheme. Returns `null` for


### PR DESCRIPTION
…and add demo pages

## Summary
Implemented the Footer Notes block (task 1 of the dynamic-zones epic) end-to-end across Strapi and Astro:

Strapi (CMS)

- New components: blocks/footer-note.json (item: text, linkText?, linkUrl?) and blocks/footer-notes.json (repeatable wrapper)
- footer-notes.serializer.ts + test — validates ≥1 note, all-or-nothing link pair, emits <FooterNotes notes={[...]} />
- Registered in serializers/blocks/index.ts and sync-mdx/types.blocks.ts
- contentPopulate.ts updated for foundation/summit (FOUNDATION_PAGE_BLOCKS) and hackathon (HACKATHON_PAGE_CONTENT_POPULATE)
- Added "blocks.footer-notes" to the content dynamiczone in all three schema.json files (foundation-page, summit-page, hackathon-page)
- sync-mdx/footerNotesHandler.ts + test for MDX→Strapi round-trip import, registered in config.ts
- Also had to extend HACKATHON_PAGE_ALLOWED_COMPONENTS in mdxTransformer.ts — a second, separate allow-list enforced only for hackathon pages — found via the dry-run sync failing with "not allowed here"

Astro

- New src/components/blocks/FooterNotes.astro — ordered list with divider, numbered notes (index-based), parseMarkdownInline for note text, optional inline link; styled with existing design tokens (orchid-100, neutral-50/100) rather than one-off hex values
- Wired into DynamicZone.astro (Strapi preview registry) and all three MDX component maps (FoundationContentPage.astro, SummitContentPage.astro, HackathonContentPage.astro)

Demo content

 - Added demo-foundation-page.mdx / demo-summit-page.mdx / demo-hackathon-page.mdx (one per template, meant to accumulate other components' demo data later) — frontmatter to generic "Page Demo" titles/slugs
- Each has a <Paragraph> intro + <FooterNotes> with 3 sample notes (no-link, matching linkText/URL, friendly linkText)

## Related Issue
Fixes INTORG-942

## Manual Test
run sync command
open any of the demo pages in strapi and astro /demo-foundation-page , /demo-summit-page or /demo-hackathon-page

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
