### PR TITLE
fix(cms): shorten paragraph footnote helper text [INTORG-952]

### DIFF
--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -1146,6 +1146,10 @@ async function configureFieldLabels(strapi: StrapiInstance) {
       category: 'Option A: show profiles by category (leave profiles empty)',
       profiles: 'Option B: pick profiles manually (leave category empty)'
     },
+    'blocks.paragraph': {
+      content:
+        'Footnotes: write [^1] inline, then [^1]: Your note at the end of this block.'
+    },
     'blocks.image-block': {
       tabletImage:
         'Use if your image needs different proportions or cropping on medium-sized screens.',


### PR DESCRIPTION
## Summary
shorten helptext for paragraph ckeditor input

## Related Issue
Fixes INTORG-952

## Manual Test
open strapi - check the helptext below the ckeditor input

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)

<img width="2080" height="216" alt="image" src="https://github.com/user-attachments/assets/04c8fae9-538a-4320-bfaf-8e257a9f0cf2" />
