### PR TITLE
fix(blog): move CTA strip below pagination [INTORG-994]

### DIFF
--- a/src/components/pages/FoundationBlogListingPage.astro
+++ b/src/components/pages/FoundationBlogListingPage.astro
@@ -104,14 +104,8 @@ const featuredPosts = showFeatured
       >
         {
           featuredPosts.length > 0 && (
-            <div class="flex flex-col gap-4xl desktop:gap-5xl" slot="featured">
+            <div slot="featured">
               <FeaturedPosts posts={featuredPosts} />
-              <CtaStrip
-                heading={t('blog.cta.heading')}
-                description={t('blog.cta.description')}
-                primaryButtonText={t('blog.cta.link_text')}
-                primaryButtonLink={subscribePath}
-              />
             </div>
           )
         }
@@ -125,6 +119,14 @@ const featuredPosts = showFeatured
         label={title}
         class="mt-3xl tablet:mt-4xl desktop:mt-5xl"
       />
+      <div class="mt-4xl desktop:mt-5xl">
+        <CtaStrip
+          heading={t('blog.cta.heading')}
+          description={t('blog.cta.description')}
+          primaryButtonText={t('blog.cta.link_text')}
+          primaryButtonLink={subscribePath}
+        />
+      </div>
     </div>
   </main>
 </FoundationPageLayout>


### PR DESCRIPTION
## Summary
Moved the blog list CTA strip below pagination so it no longer sits in the featured section.

## Related Issue
Fixes INTORG-994

## Manual Test
- [ ] `/blog` — CTA appears below pagination
- [ ] Filtered/paginated blog pages — CTA still present

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [x] Screenshots for UI changes (if applicable)

<img width="3122" height="998" alt="image-e3bc19cf-3599-4354-a000-a7fcb3dcb548" src="https://github.com/user-attachments/assets/fd281ad4-b3ec-4a93-ad80-5ff3264aaa0e" />


<img width="956" height="814" alt="image" src="https://github.com/user-attachments/assets/d58fd523-7b16-47a6-a5f9-bce334be2a59" />
