### PR TITLE
refactor(cms): drop hackathon-page custom generateMDX override [INTORG-987]

### DIFF
--- a/cms/src/api/hackathon-page/content-types/hackathon-page/lifecycles.ts
+++ b/cms/src/api/hackathon-page/content-types/hackathon-page/lifecycles.ts
@@ -1,52 +1,10 @@
-import matter from 'gray-matter'
 import { createPageLifecycle, PATHS } from '../../../utils'
-import type { PageData } from '../../../../utils/pageLifecycle'
-import {
-  defaultLang,
-  MATTER_STRINGIFY_OPTIONS,
-  serializeContent
-} from '../../../../utils'
 import { HACKATHON_PAGE_CONTENT_POPULATE } from '../../../../utils/contentPopulate'
-
-/**
- * Duplicates the default `generateMDX` in pageLifecycle.ts, which now
- * handles a missing hero and a bare `description` field too. Kept only
- * because it predates that support; safe to remove in favor of the default.
- */
-function generateHackathonPageMDX(
-  page: PageData,
-  preservedFields: Record<string, unknown>,
-  englishSlug?: string
-): string {
-  const locale = page.locale || defaultLang
-  const isLocalized = locale !== defaultLang
-  const { localizes, ...restPreserved } = preservedFields
-  const localizesValue =
-    (isLocalized && englishSlug ? englishSlug : undefined) || localizes
-
-  const frontmatterData: Record<string, unknown> = {
-    ...restPreserved,
-    pathSlug: page.pathSlug,
-    title: page.title,
-    description: page.description,
-    ...(localizesValue ? { localizes: localizesValue } : {}),
-    locale
-  }
-
-  const content = serializeContent(page.content)
-
-  return matter.stringify(
-    content ? `\n${content}\n` : '',
-    frontmatterData,
-    MATTER_STRINGIFY_OPTIONS
-  )
-}
 
 export default createPageLifecycle({
   contentTypeUid: 'api::hackathon-page.hackathon-page',
   outputDir: `${PATHS.CONTENT_ROOT}/${PATHS.CONTENT.hackathonPages}`,
   populate: {
     content: HACKATHON_PAGE_CONTENT_POPULATE
-  },
-  generateMDX: generateHackathonPageMDX
+  }
 })

--- a/cms/src/utils/pageLifecycle.test.ts
+++ b/cms/src/utils/pageLifecycle.test.ts
@@ -113,6 +113,28 @@ describe('generateMDX — required field validation', () => {
       })
     ).toThrow('Hero CTA is missing required link')
   })
+
+  it('writes title/description/locale without hero fields when hero is absent', () => {
+    const result = generateMDX(testConfig, base)
+
+    expect(result).toContain("title: 'Test Page'")
+    expect(result).toContain("description: 'Test description'")
+    expect(result).toContain("locale: 'en'")
+    expect(result).not.toContain('heroTitle')
+    expect(result).not.toContain('heroImage')
+  })
+
+  it('clears stale hero fields preserved from MDX when the page has no hero', () => {
+    const result = generateMDX(testConfig, base, {
+      heroTitle: 'Stale',
+      heroImage: '/old.jpg',
+      heroCtas: [{ text: 'Go', link: '/' }]
+    })
+
+    expect(result).not.toContain('heroTitle')
+    expect(result).not.toContain('heroImage')
+    expect(result).not.toContain('heroCtas')
+  })
 })
 
 describe('resolvePageFilepath', () => {

--- a/cms/src/utils/pageLifecycle.test.ts
+++ b/cms/src/utils/pageLifecycle.test.ts
@@ -128,11 +128,13 @@ describe('generateMDX — required field validation', () => {
     const result = generateMDX(testConfig, base, {
       heroTitle: 'Stale',
       heroImage: '/old.jpg',
+      heroImageMobile: '/old-mobile.jpg',
       heroCtas: [{ text: 'Go', link: '/' }]
     })
 
     expect(result).not.toContain('heroTitle')
     expect(result).not.toContain('heroImage')
+    expect(result).not.toContain('heroImageMobile')
     expect(result).not.toContain('heroCtas')
   })
 })

--- a/cms/src/utils/pageLifecycle.ts
+++ b/cms/src/utils/pageLifecycle.ts
@@ -200,6 +200,7 @@ export function generateMDX<T extends UID.ContentType = UID.ContentType>(
     'heroDescription',
     'heroImage',
     'heroImageAlt',
+    'heroImageMobile',
     'heroCtas'
   ] as const
   for (const key of heroManagedKeys) {


### PR DESCRIPTION
## Summary
Remove hackathon-page's custom `generateMDX` — the shared default now handles pages with no hero and a bare description field.

## Related Issue
Fixes INTORG-987

## Manual Test
- [ ] Save a hackathon page in Strapi and confirm MDX export still looks correct

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)