### PR TITLE
fix(uploads): explain the image size limit instead of crashing [INTORG-1000]

### DIFF
--- a/cms/config/plugins.ts
+++ b/cms/config/plugins.ts
@@ -1,3 +1,5 @@
+import { MAX_MEDIA_BYTES } from '../src/utils/uploadLimits'
+
 export default () => ({
   ckeditor: {
     enabled: true
@@ -18,10 +20,11 @@ export default () => ({
       provider: 'local',
       breakpoints: {},
       // 5 MB cap (INTORG-876): uploaded media is git-committed into the repo, so
-      // large files are rejected in the admin with a "file too large" error.
-      // Editors use YouTube for big videos. Alternative storage for large media
-      // is tracked post-launch in INTORG-902.
-      sizeLimit: 5 * 1024 * 1024
+      // large files are rejected in the admin. Editors use YouTube for big
+      // videos. Alternative storage for large media is tracked post-launch in
+      // INTORG-902. The bootstrap upload override enforces the same ceiling with
+      // a friendlier message, plus a tighter 2 MB one for images.
+      sizeLimit: MAX_MEDIA_BYTES
     }
   }
 })

--- a/cms/src/index.test.ts
+++ b/cms/src/index.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import { errors } from '@strapi/utils'
-import { registerDocumentValidation } from './index'
+import {
+  assertUploadWithinLimit,
+  createCheckFileSize,
+  registerDocumentValidation
+} from './index'
 
 function getRegisteredMiddleware(
   uid: string,
@@ -154,5 +158,110 @@ describe('registerDocumentValidation', () => {
     }
     await middleware(fromPublicApi, next)
     expect(next).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('assertUploadWithinLimit', () => {
+  // Strapi hands the provider a size in kilobytes, not bytes.
+  const kb = (bytes: number) => bytes / 1000
+
+  it('rejects an image over 2 MB, naming its real size', () => {
+    const file = {
+      hash: 'h',
+      ext: '.jpg',
+      mime: 'image/jpeg',
+      name: 'hero.jpg'
+    }
+
+    expect(() =>
+      assertUploadWithinLimit(
+        { ...file, size: kb(3 * 1024 * 1024) },
+        'hero.jpg'
+      )
+    ).toThrow(/hero\.jpg.*3\.00 MB.*2 MB/s)
+  })
+
+  it('accepts an image under 2 MB', () => {
+    const file = {
+      hash: 'h',
+      ext: '.jpg',
+      mime: 'image/jpeg',
+      size: kb(1.5 * 1024 * 1024)
+    }
+
+    expect(() => assertUploadWithinLimit(file, 'hero.jpg')).not.toThrow()
+  })
+
+  it('holds non-image media to the 5 MB limit instead of the image one', () => {
+    const clip = { hash: 'h', ext: '.mp4', mime: 'video/mp4' }
+
+    expect(() =>
+      assertUploadWithinLimit(
+        { ...clip, size: kb(4 * 1024 * 1024) },
+        'clip.mp4'
+      )
+    ).not.toThrow()
+    expect(() =>
+      assertUploadWithinLimit(
+        { ...clip, size: kb(6 * 1024 * 1024) },
+        'clip.mp4'
+      )
+    ).toThrow(/clip\.mp4.*6\.00 MB.*5 MB/s)
+  })
+
+  it('falls back to the buffer length, which is already in bytes', () => {
+    const file = {
+      hash: 'h',
+      ext: '.png',
+      mime: 'image/png',
+      buffer: Buffer.alloc(3 * 1024 * 1024)
+    }
+
+    expect(() => assertUploadWithinLimit(file, 'hero.png')).toThrow(/3\.00 MB/)
+  })
+
+  it('defers to the mid-stream check when the size is unknown', () => {
+    const file = { hash: 'h', ext: '.png', mime: 'image/png' }
+
+    expect(() => assertUploadWithinLimit(file, 'hero.png')).not.toThrow()
+  })
+})
+
+describe('createCheckFileSize', () => {
+  const oversized = {
+    hash: 'h',
+    ext: '.jpg',
+    mime: 'image/jpeg',
+    name: 'hero.jpg',
+    size: 3 * 1024
+  }
+
+  it('awaits the wrapped check so its rejection propagates', async () => {
+    // Regression guard: dropping this promise surfaced as an unhandled
+    // rejection that killed the Strapi process (INTORG-1000).
+    const original = vi.fn(() =>
+      Promise.reject(new errors.PayloadTooLargeError('too big'))
+    )
+    const checkFileSize = createCheckFileSize(original)
+    const withinOurLimits = {
+      hash: 'h',
+      ext: '.mp4',
+      mime: 'video/mp4',
+      size: 1
+    }
+
+    await expect(checkFileSize(withinOurLimits)).rejects.toThrow('too big')
+  })
+
+  it('reports our limit before deferring to the wrapped check', async () => {
+    const original = vi.fn(() => Promise.resolve())
+    const checkFileSize = createCheckFileSize(original)
+
+    await expect(checkFileSize(oversized)).rejects.toThrow(/2 MB limit/)
+    expect(original).not.toHaveBeenCalled()
+  })
+
+  it('works when the provider has no size check of its own', async () => {
+    await expect(createCheckFileSize()(oversized)).rejects.toThrow(/2 MB limit/)
   })
 })

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -24,9 +24,12 @@ import {
 import { validateContentBlocks } from './serializers/blocks'
 import { errors } from '@strapi/utils'
 import {
-  formatImageSize,
+  formatFileSize,
+  imageOverSizeLimitError,
   imageSizeLimitError,
   isImageOverSizeLimit,
+  isMediaOverSizeLimit,
+  mediaSizeLimitError,
   IMAGE_EXTENSIONS,
   MAX_IMAGE_SIZE_LABEL
 } from './utils/uploadLimits'
@@ -179,10 +182,10 @@ interface UploadProvider {
   upload: (file: UploadFile) => Promise<void>
   uploadStream: (file: UploadFile) => Promise<void>
   delete: (file: UploadFile) => Promise<void>
-  checkFileSize: (file: UploadFile, options?: unknown) => void
+  checkFileSize: (file: UploadFile, options?: unknown) => Promise<void>
 }
 
-interface UploadFile {
+export interface UploadFile {
   hash: string
   ext: string
   url?: string
@@ -366,10 +369,22 @@ async function ensureLocales(strapi: StrapiInstance) {
 const UPLOAD_SUBDIR = 'img/original'
 const UPLOAD_URL_PREFIX = `/uploads/${UPLOAD_SUBDIR}`
 
+/**
+ * Strapi normalizes `file.size` to kilobytes (`bytesToKbytes` in @strapi/utils,
+ * which divides by 1000) before the provider ever sees the file. Comparing it
+ * against a byte limit directly silently disables the check.
+ */
+const BYTES_PER_STRAPI_KBYTE = 1000
+
 function getUploadFileSizeBytes(file: UploadFile): number {
-  if (typeof file.size === 'number') return file.size
+  if (typeof file.size === 'number') return file.size * BYTES_PER_STRAPI_KBYTE
   if (file.buffer) return file.buffer.length
   return 0
+}
+
+function getUploadLabel(file: UploadFile): string {
+  if (typeof file.name === 'string') return file.name
+  return `${file.hash ?? 'upload'}${file.ext ?? ''}`
 }
 
 function normalizeUploadExt(ext: string): string {
@@ -391,23 +406,60 @@ function isImageUpload(file: UploadFile): boolean {
   return IMAGE_EXTENSIONS.has(normalizeUploadExt(rawExt))
 }
 
-function assertImageWithinUploadLimit(file: UploadFile, label: string): void {
-  if (!isImageUpload(file)) return
-
+/**
+ * Enforces both upload ceilings — 2 MB for images, 5 MB for everything else —
+ * with a message that names the actual size and tells the editor what to do
+ * about it (INTORG-1000).
+ */
+export function assertUploadWithinLimit(file: UploadFile, label: string): void {
   const sizeBytes = getUploadFileSizeBytes(file)
   // size/buffer unknown (0) — stream uploads are enforced mid-pipe instead.
-  if (sizeBytes > 0 && isImageOverSizeLimit(sizeBytes)) {
-    throw new errors.ApplicationError(imageSizeLimitError(label, sizeBytes))
+  if (sizeBytes === 0) return
+
+  if (isImageUpload(file)) {
+    if (isImageOverSizeLimit(sizeBytes)) {
+      throw new errors.PayloadTooLargeError(
+        imageSizeLimitError(label, sizeBytes)
+      )
+    }
+    return
+  }
+
+  if (isMediaOverSizeLimit(sizeBytes)) {
+    throw new errors.PayloadTooLargeError(mediaSizeLimitError(label, sizeBytes))
   }
 }
 
-function assertWrittenImageWithinLimit(file: UploadFile, dest: string): void {
+/**
+ * Wraps the provider's own size check so ours runs first — an oversized file
+ * then gets our actionable message instead of the provider's bare "exceeds size
+ * limit of 5 MB".
+ *
+ * The wrapped check is async, so its result has to be awaited. Calling it and
+ * dropping the promise turned a rejection into an unhandled rejection, which
+ * killed the Strapi process and left the editor staring at a network error
+ * instead of an explanation (INTORG-1000).
+ */
+export function createCheckFileSize(
+  originalCheckFileSize?: (file: UploadFile, options?: unknown) => Promise<void>
+) {
+  return async (file: UploadFile, options?: unknown): Promise<void> => {
+    assertUploadWithinLimit(file, getUploadLabel(file))
+    await originalCheckFileSize?.(file, options)
+  }
+}
+
+function assertWrittenImageWithinLimit(
+  file: UploadFile,
+  dest: string,
+  label: string
+): void {
   if (!isImageUpload(file)) return
 
   const { size } = fs.statSync(dest)
   if (isImageOverSizeLimit(size)) {
     fs.unlinkSync(dest)
-    throw new errors.ApplicationError(imageSizeLimitError(dest, size))
+    throw new errors.PayloadTooLargeError(imageSizeLimitError(label, size))
   }
 }
 
@@ -415,6 +467,7 @@ function assertWrittenImageWithinLimit(file: UploadFile, dest: string): void {
  * Counts bytes while piping an image upload so we can abort as soon as the
  * stream exceeds the 2 MB image limit, instead of writing a huge file and
  * unlinking it in the post-write check (when `file.size` / `buffer` were absent).
+ * The real size is unknown at that point, so the message omits it.
  */
 function createImageSizeLimitTransform(label: string): Transform {
   let bytesSeen = 0
@@ -423,7 +476,7 @@ function createImageSizeLimitTransform(label: string): Transform {
       bytesSeen += chunk.length
       if (isImageOverSizeLimit(bytesSeen)) {
         callback(
-          new errors.ApplicationError(imageSizeLimitError(label, bytesSeen))
+          new errors.PayloadTooLargeError(imageOverSizeLimitError(label))
         )
         return
       }
@@ -452,21 +505,13 @@ function overrideUploadProvider(strapi: StrapiInstance): void {
   const provider = uploadPlugin.provider
   const originalCheckFileSize = provider.checkFileSize?.bind(provider)
 
-  provider.checkFileSize = (file: UploadFile, options?: unknown) => {
-    originalCheckFileSize?.(file, options)
-    const label =
-      typeof file.name === 'string'
-        ? file.name
-        : `${file.hash ?? 'upload'}${file.ext ?? ''}`
-    assertImageWithinUploadLimit(file, label)
-  }
+  provider.checkFileSize = createCheckFileSize(originalCheckFileSize)
 
   provider.uploadStream = async (file: UploadFile) => {
     const stream = file.stream ?? file.getStream?.()
     if (!stream) throw new Error('Missing file stream')
-    const label =
-      typeof file.name === 'string' ? file.name : `${file.hash}${file.ext}`
-    assertImageWithinUploadLimit(file, label)
+    const label = getUploadLabel(file)
+    assertUploadWithinLimit(file, label)
     const dest = path.join(uploadPath, `${file.hash}${file.ext}`)
     try {
       if (isImageUpload(file)) {
@@ -482,18 +527,17 @@ function overrideUploadProvider(strapi: StrapiInstance): void {
       if (fs.existsSync(dest)) fs.unlinkSync(dest)
       throw err
     }
-    assertWrittenImageWithinLimit(file, dest)
+    assertWrittenImageWithinLimit(file, dest, label)
     file.url = `${UPLOAD_URL_PREFIX}/${file.hash}${file.ext}`
   }
 
   provider.upload = async (file: UploadFile) => {
     if (!file.buffer) throw new Error('Missing file buffer')
-    const label =
-      typeof file.name === 'string' ? file.name : `${file.hash}${file.ext}`
-    assertImageWithinUploadLimit(file, label)
+    const label = getUploadLabel(file)
+    assertUploadWithinLimit(file, label)
     const dest = path.join(uploadPath, `${file.hash}${file.ext}`)
     fs.writeFileSync(dest, file.buffer)
-    assertWrittenImageWithinLimit(file, dest)
+    assertWrittenImageWithinLimit(file, dest, label)
     file.url = `${UPLOAD_URL_PREFIX}/${file.hash}${file.ext}`
   }
 
@@ -618,7 +662,7 @@ async function seedUploadsFromDisk(strapi: StrapiInstance): Promise<void> {
       const stat = fs.statSync(filePath)
       if (IMAGE_EXTENSIONS.has(ext) && isImageOverSizeLimit(stat.size)) {
         strapi.log.warn(
-          `⚠️  Skipping seed for oversized image (${formatImageSize(stat.size)}): ${url}`
+          `⚠️  Skipping seed for oversized image (${formatFileSize(stat.size)}): ${url}`
         )
         continue
       }

--- a/cms/src/utils/index.ts
+++ b/cms/src/utils/index.ts
@@ -4,15 +4,20 @@ export { tryCatchAsync } from './tryCatch'
 // Code block
 export { CODE_BLOCK_LANGUAGES, type CodeBlockLanguage } from './codeBlock'
 
-// Upload limits (mirrored in src/utils/shared/uploadLimits.ts)
+// Upload limits (image half mirrored in src/utils/shared/uploadLimits.ts)
 export {
   MAX_IMAGE_BYTES,
   MAX_IMAGE_SIZE_LABEL,
+  MAX_MEDIA_BYTES,
+  MAX_MEDIA_SIZE_LABEL,
   IMAGE_EXTENSIONS,
-  formatImageSize,
+  formatFileSize,
+  imageOverSizeLimitError,
   imageSizeLimitError,
   isImageOverSizeLimit,
-  isImagePath
+  isImagePath,
+  isMediaOverSizeLimit,
+  mediaSizeLimitError
 } from './uploadLimits'
 
 // Upload validation

--- a/cms/src/utils/uploadLimits.ts
+++ b/cms/src/utils/uploadLimits.ts
@@ -1,9 +1,21 @@
 import path from 'path'
 
-/** Maximum allowed image upload size (2 MB). Keep in sync with src/utils/shared/uploadLimits.ts */
+/**
+ * Upload ceilings. Media uploaded through the admin is git-committed into the
+ * site repo (INTORG-876), so both limits are deliberately tight.
+ *
+ * The image half of this module is mirrored in src/utils/shared/uploadLimits.ts
+ * for the Astro side; the media half is CMS-only, since only Strapi accepts
+ * non-image uploads.
+ */
 export const MAX_IMAGE_BYTES = 2 * 1024 * 1024
 
 export const MAX_IMAGE_SIZE_LABEL = '2 MB'
+
+/** Ceiling for non-image media (video, PDF). Mirrored in cms/config/plugins.ts. */
+export const MAX_MEDIA_BYTES = 5 * 1024 * 1024
+
+export const MAX_MEDIA_SIZE_LABEL = '5 MB'
 
 /**
  * Image subset of the seedable media extensions (see MIME_BY_EXT in
@@ -29,13 +41,33 @@ export function isImageOverSizeLimit(bytes: number): boolean {
   return bytes > MAX_IMAGE_BYTES
 }
 
-export function formatImageSize(bytes: number): string {
+export function isMediaOverSizeLimit(bytes: number): boolean {
+  return bytes > MAX_MEDIA_BYTES
+}
+
+export function formatFileSize(bytes: number): string {
   if (bytes >= 1024 * 1024) {
     return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
   }
   return `${(bytes / 1024).toFixed(1)} KB`
 }
 
+/** What an editor should do about an oversized image, in one sentence. */
+const IMAGE_SIZE_REMEDY =
+  'Resize or compress it, or save it as WebP or AVIF, then upload again.'
+
 export function imageSizeLimitError(fileLabel: string, bytes: number): string {
-  return `Image "${fileLabel}" is ${formatImageSize(bytes)} — maximum allowed size is ${MAX_IMAGE_SIZE_LABEL}.`
+  return `"${fileLabel}" is ${formatFileSize(bytes)}, over the ${MAX_IMAGE_SIZE_LABEL} limit for images. ${IMAGE_SIZE_REMEDY}`
+}
+
+/**
+ * Variant for the streaming upload path, which aborts as soon as the limit is
+ * passed and so never learns the real file size.
+ */
+export function imageOverSizeLimitError(fileLabel: string): string {
+  return `"${fileLabel}" is over the ${MAX_IMAGE_SIZE_LABEL} limit for images. ${IMAGE_SIZE_REMEDY}`
+}
+
+export function mediaSizeLimitError(fileLabel: string, bytes: number): string {
+  return `"${fileLabel}" is ${formatFileSize(bytes)}, over the ${MAX_MEDIA_SIZE_LABEL} limit for videos and documents. For a longer video, upload it to YouTube and paste the link instead.`
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,7 +23,8 @@ export { parseStatNumber, formatStatNumber } from './shared/parseStatNumber'
 export {
   MAX_IMAGE_BYTES,
   MAX_IMAGE_SIZE_LABEL,
-  formatImageSize,
+  formatFileSize,
+  imageOverSizeLimitError,
   imageSizeLimitError,
   isImageOverSizeLimit
 } from './shared/uploadLimits'

--- a/src/utils/shared/uploadLimits.test.ts
+++ b/src/utils/shared/uploadLimits.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   MAX_IMAGE_BYTES,
-  formatImageSize,
+  formatFileSize,
+  imageOverSizeLimitError,
   imageSizeLimitError,
   isImageOverSizeLimit
 } from './uploadLimits'
@@ -10,6 +11,7 @@ describe('uploadLimits', () => {
   it('allows images at or below 2 MB', () => {
     expect(isImageOverSizeLimit(MAX_IMAGE_BYTES)).toBe(false)
     expect(isImageOverSizeLimit(MAX_IMAGE_BYTES - 1)).toBe(false)
+    expect(isImageOverSizeLimit(0)).toBe(false)
   })
 
   it('rejects images over 2 MB', () => {
@@ -17,13 +19,24 @@ describe('uploadLimits', () => {
   })
 
   it('formats sizes for error messages', () => {
-    expect(formatImageSize(512)).toBe('0.5 KB')
-    expect(formatImageSize(2 * 1024 * 1024)).toBe('2.00 MB')
+    expect(formatFileSize(512)).toBe('0.5 KB')
+    expect(formatFileSize(2 * 1024 * 1024)).toBe('2.00 MB')
   })
 
-  it('builds a human-readable limit error', () => {
-    expect(imageSizeLimitError('/img/hero.png', MAX_IMAGE_BYTES + 1)).toContain(
-      '2 MB'
-    )
+  it('names the actual size, the limit, and a remedy', () => {
+    const message = imageSizeLimitError('hero.png', 3 * 1024 * 1024)
+
+    expect(message).toContain('hero.png')
+    expect(message).toContain('3.00 MB')
+    expect(message).toContain('2 MB')
+    expect(message).toMatch(/resize or compress/i)
+  })
+
+  it('omits the size when only "over the limit" is known', () => {
+    const message = imageOverSizeLimitError('hero.png')
+
+    expect(message).toContain('hero.png')
+    expect(message).toContain('2 MB')
+    expect(message).not.toMatch(/\d+\.\d+ MB/)
   })
 })

--- a/src/utils/shared/uploadLimits.ts
+++ b/src/utils/shared/uploadLimits.ts
@@ -1,4 +1,8 @@
-/** Maximum allowed image upload size (2 MB). Keep in sync with cms/src/utils/uploadLimits.ts */
+/**
+ * Maximum allowed image upload size (2 MB). Keep in sync with the image half of
+ * cms/src/utils/uploadLimits.ts (that file also carries a CMS-only ceiling for
+ * non-image media).
+ */
 export const MAX_IMAGE_BYTES = 2 * 1024 * 1024
 
 export const MAX_IMAGE_SIZE_LABEL = '2 MB'
@@ -7,13 +11,21 @@ export function isImageOverSizeLimit(bytes: number): boolean {
   return bytes > MAX_IMAGE_BYTES
 }
 
-export function formatImageSize(bytes: number): string {
+export function formatFileSize(bytes: number): string {
   if (bytes >= 1024 * 1024) {
     return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
   }
   return `${(bytes / 1024).toFixed(1)} KB`
 }
 
+/** What an editor should do about an oversized image, in one sentence. */
+const IMAGE_SIZE_REMEDY =
+  'Resize or compress it, or save it as WebP or AVIF, then upload again.'
+
 export function imageSizeLimitError(fileLabel: string, bytes: number): string {
-  return `Image "${fileLabel}" is ${formatImageSize(bytes)} — maximum allowed size is ${MAX_IMAGE_SIZE_LABEL}.`
+  return `"${fileLabel}" is ${formatFileSize(bytes)}, over the ${MAX_IMAGE_SIZE_LABEL} limit for images. ${IMAGE_SIZE_REMEDY}`
+}
+
+export function imageOverSizeLimitError(fileLabel: string): string {
+  return `"${fileLabel}" is over the ${MAX_IMAGE_SIZE_LABEL} limit for images. ${IMAGE_SIZE_REMEDY}`
 }


### PR DESCRIPTION
## Summary

Uploading an oversized image gave editors either a misleading number or a raw `Unexpected token '<', "<html> <h"... is not valid JSON`. Reproducing it against a local Strapi turned up three separate causes:

**The 2 MB check never actually ran.** `getUploadFileSizeBytes` read `file.size` as bytes, but Strapi normalizes it to kilobytes (`bytesToKbytes`, which divides by 1000) before the provider ever sees the file. A 3 MB image reported `3131` and sailed past the `> 2097152` comparison. Every rejection therefore fell through to the mid-stream backstop, which aborts the instant it crosses the line, so the message always said "is 2.06 MB" no matter how large the file really was.

**Files over the 5 MB provider cap crashed the Strapi process.** The `checkFileSize` override called the wrapped provider check without awaiting it. That check is async, so its `PayloadTooLargeError` became an unhandled rejection and killed Node mid-request. That is where the non-JSON response in the ticket comes from: the admin's `response.json()` has nothing valid to parse.

**The message offered no remedy.** Even when the number was right, it stated a limit and stopped there.

Messages now name the real size, the limit that applies, and what to do about it. Images and other media get separate ceilings and separate wording, and the 5 MB value is shared with the upload plugin config instead of being written in two places.

Worth a reviewer's attention:

- `PayloadTooLargeError` (413) replaces `ApplicationError` (400). Same JSON body shape, so the admin renders it identically.
- Our limits now run **before** the provider's own check, so an oversized file gets our wording rather than the provider's bare "exceeds size limit of 5 MB".
- `formatImageSize` is renamed `formatFileSize` since it now formats non-images too. Both barrels updated.
- Boundary behaviour: Strapi's KB rounding is lossy by a few bytes, so a file within ~5 bytes of the limit passes the up-front check and is then caught exactly by the post-write `fs.statSync` check. No false rejections, no false accepts.

## Related Issue

Fixes INTORG-1000

## Manual Test

Media Library, Add new assets:

1. An image between 2 and 5 MB is rejected with its real size and a remedy.
2. An image over 5 MB gets the same message, and the CMS stays up. On staging this kills the process and the dialog shows `Failed to fetch` or the JSON parse error from the ticket.
3. A video or PDF over 5 MB is rejected with the YouTube suggestion instead of the image wording.
4. An image under 2 MB still uploads (201) and lands in `public/uploads/img/original/`.

Before and after, same 3 MB file:

> `Image "big.jpg" is 2.06 MB — maximum allowed size is 2 MB.`

> `"big.jpg" is 3.06 MB, over the 2 MB limit for images. Resize or compress it, or save it as WebP or AVIF, then upload again.`

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

Also `tsc --noEmit` on the CMS, 835 CMS tests and 219 root tests passing. Eight new tests cover the KB conversion, the image/media split, and a regression guard on the dropped promise.

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable) - n/a, the UI change is error copy, quoted before/after under Manual Test
