### PR TITLE
chore(strapi,astro): add split-layout component to dynamic zones

### DIFF
--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -805,6 +805,7 @@ export async function buildReportPayload(
 /** Dynamic-zone components allowed in hackathon-pages MDX/Strapi content. */
 export const HACKATHON_PAGE_ALLOWED_COMPONENTS = [
   'blocks.paragraph',
+  'blocks.split-layout',
   'blocks.profile-grid',
   'blocks.title-card-grid',
   'blocks.carousel'

--- a/cms/src/api/foundation-page/content-types/foundation-page/schema.json
+++ b/cms/src/api/foundation-page/content-types/foundation-page/schema.json
@@ -63,6 +63,7 @@
       },
       "components": [
         "blocks.paragraph",
+        "blocks.split-layout",
         "blocks.profile-grid",
         "blocks.blockquote",
         "blocks.cta-strip",

--- a/cms/src/api/hackathon-page/content-types/hackathon-page/schema.json
+++ b/cms/src/api/hackathon-page/content-types/hackathon-page/schema.json
@@ -36,6 +36,7 @@
       "type": "dynamiczone",
       "components": [
         "blocks.paragraph",
+        "blocks.split-layout",
         "blocks.profile-grid",
         "blocks.title-card-grid",
         "blocks.carousel"

--- a/cms/src/api/summit-page/content-types/summit-page/schema.json
+++ b/cms/src/api/summit-page/content-types/summit-page/schema.json
@@ -63,6 +63,7 @@
       },
       "components": [
         "blocks.paragraph",
+        "blocks.split-layout",
         "blocks.profile-grid",
         "blocks.blockquote",
         "blocks.cta-strip",

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -738,6 +738,7 @@ export interface ApiFoundationPageFoundationPage
     content: Schema.Attribute.DynamicZone<
       [
         'blocks.paragraph',
+        'blocks.split-layout',
         'blocks.profile-grid',
         'blocks.blockquote',
         'blocks.cta-strip',
@@ -1074,6 +1075,7 @@ export interface ApiHackathonPageHackathonPage
     content: Schema.Attribute.DynamicZone<
       [
         'blocks.paragraph',
+        'blocks.split-layout',
         'blocks.profile-grid',
         'blocks.title-card-grid',
         'blocks.carousel',
@@ -1383,6 +1385,7 @@ export interface ApiSummitPageSummitPage extends Struct.CollectionTypeSchema {
     content: Schema.Attribute.DynamicZone<
       [
         'blocks.paragraph',
+        'blocks.split-layout',
         'blocks.profile-grid',
         'blocks.blockquote',
         'blocks.cta-strip',

--- a/src/components/pages/FoundationContentPage.astro
+++ b/src/components/pages/FoundationContentPage.astro
@@ -7,6 +7,7 @@ import ProfileGrid from '@/components/shared/ProfileGrid.astro'
 import Blockquote from '@/components/shared/Blockquote.astro'
 import CalloutText from '@/components/shared/CalloutText.astro'
 import Paragraph from '@/components/blocks/Paragraph.astro'
+import SplitLayout from '@/components/blocks/SplitLayout.astro'
 import CtaStrip from '@/components/blocks/CtaStrip.astro'
 import PdfEmbed from '@/components/shared/PdfEmbed.astro'
 import VideoEmbed from '@/components/shared/VideoEmbed.astro'
@@ -101,6 +102,7 @@ if (isNotFound) return Astro.redirect('/404')
               Blockquote,
               CalloutText,
               Paragraph,
+              SplitLayout,
               CtaStrip,
               PdfEmbed,
               VideoEmbed,

--- a/src/components/pages/HackathonContentPage.astro
+++ b/src/components/pages/HackathonContentPage.astro
@@ -4,6 +4,7 @@ import HackathonPageLayout from '@/layouts/HackathonPageLayout.astro'
 import Breadcrumbs from '@/components/shared/Breadcrumbs.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import Paragraph from '@/components/blocks/Paragraph.astro'
+import SplitLayout from '@/components/blocks/SplitLayout.astro'
 import TitleCardGrid from '@/components/blocks/TitleCardGrid.astro'
 import TitleCard from '@/components/shared/TitleCard.astro'
 import ProfileGrid from '@/components/shared/ProfileGrid.astro'
@@ -67,6 +68,7 @@ const breadcrumbs = buildSectionEntryBreadcrumbs(
         <MdxContent
           components={{
             Paragraph,
+            SplitLayout,
             TitleCardGrid,
             TitleCard,
             ProfileGrid,

--- a/src/components/pages/SummitContentPage.astro
+++ b/src/components/pages/SummitContentPage.astro
@@ -5,6 +5,7 @@ import SummitPageLayout from '@/layouts/SummitPageLayout.astro'
 import ProfileGrid from '@/components/shared/ProfileGrid.astro'
 import Blockquote from '@/components/shared/Blockquote.astro'
 import Paragraph from '@/components/blocks/Paragraph.astro'
+import SplitLayout from '@/components/blocks/SplitLayout.astro'
 import CtaStrip from '@/components/blocks/CtaStrip.astro'
 import VideoEmbed from '@/components/shared/VideoEmbed.astro'
 import ProfileCard from '@/components/shared/ProfileCard.astro'
@@ -105,6 +106,7 @@ const gradient =
               Blockquote,
               CalloutText,
               Paragraph,
+              SplitLayout,
               CtaStrip,
               PdfEmbed,
               VideoEmbed,

--- a/src/content/foundation-pages/demo-foundation-page.mdx
+++ b/src/content/foundation-pages/demo-foundation-page.mdx
@@ -18,6 +18,16 @@ The cost of sending money across borders remains far higher than sending it over
 
 </Paragraph>
 
+<SplitLayout
+  layoutType="image-text"
+  imageSrc="/img/foundation-blog/education-grant.jpg"
+  imageAlt="Bowie State students and their professor"
+>
+
+Interledger-funded programs pair open payment infrastructure with hands-on fellowships, giving participants practical experience that carries directly into fintech, open banking, and digital inclusion careers.
+
+</SplitLayout>
+
 <ProfileGrid
   heading="Featured Profiles"
   pathSlugs={[

--- a/src/content/hackathon-pages/demo-hackathon-page.mdx
+++ b/src/content/hackathon-pages/demo-hackathon-page.mdx
@@ -17,6 +17,12 @@ Hackathon teams building on Interledger often compare their prototype's transfer
 
 </Paragraph>
 
+<SplitLayout layoutType="video-text" videoUrl="https://www.youtube.com/watch?v=oJNFsO3k7LM">
+
+Interledger is designed to help systems operate as a network, and fund those working to make financial access open and fair at a global scale.
+
+</SplitLayout>
+
 <ProfileGrid
   heading="Featured Profiles"
   pathSlugs={[

--- a/src/content/summit-pages/demo-summit-page.mdx
+++ b/src/content/summit-pages/demo-summit-page.mdx
@@ -18,6 +18,15 @@ Sessions at the Summit referenced a number of data points on the cost of cross-b
 
 </Paragraph>
 
+<SplitLayout
+  layoutType="image-quote"
+  imagePosition="left"
+  imageSrc="/uploads/img/original/erica.png"
+  imageAlt="Erica"
+  quote="At Interledger, we envision a world where sending value across the internet is as seamless as sending an email. Our work is dedicated to making this vision a reality, fostering a more connected and inclusive global economy."
+  quoteSource="Erica"
+/>
+
 <ProfileGrid
   heading="Featured Profiles"
   pathSlugs={[


### PR DESCRIPTION
## Summary

- Strapi schemas — added `blocks.split-layout` to the `content` dynamiczone in `foundation-page`, `summit-page`, and `hackathon-page` schema.json files.

- Sync pipeline — added `blocks.split-layout `to `HACKATHON_PAGE_ALLOWED_COMPONENTS` in mdxTransformer.ts (Hackathon's extra client-side allowlist).

- Astro templates — registered `SplitLayout` (import + MDX components map) in `FoundationContentPage.astro`, `SummitContentPage.astro`, and `HackathonContentPage.astro`, matching the existing `GrantPage.astro` pattern.

- Demo content — added a `<SplitLayout>` example to each demo MDX page: `image-text` on Foundation, `image-quote` (left-positioned) on Summit, `video-text` on Hackathon.

## Related Issue
Fixes INTORG-894

## Manual Test
- run sync command
- open any of the demo pages in strapi and astro /demo-foundation-page , /demo-summit-page or /demo-hackathon-page

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
