### PR TITLE
feat(scroll): roll out global smooth scroll + add scroll resistance

### DIFF
--- a/src/components/pages/ContactPage.astro
+++ b/src/components/pages/ContactPage.astro
@@ -118,6 +118,7 @@ const t = useTranslations(routeLocale)
               id="recaptcha-error"
               class="hidden text-red-600 text-sm"
               role="alert"
+              tabindex="-1"
             >
               {t('contact.error.captcha')}
             </p>
@@ -128,6 +129,7 @@ const t = useTranslations(routeLocale)
               id="submit-error"
               class="hidden text-red-600 text-sm"
               role="alert"
+              tabindex="-1"
             >
               {t('contact.error.submit')}
             </p>
@@ -176,6 +178,7 @@ const t = useTranslations(routeLocale)
       )?.value?.trim()
       if (!recaptchaDone) {
         recaptchaError?.classList.remove('hidden')
+        recaptchaError?.focus()
         recaptchaError?.scrollIntoView({ behavior: 'smooth', block: 'center' })
         return
       }
@@ -194,6 +197,7 @@ const t = useTranslations(routeLocale)
       } catch (err) {
         console.error(err)
         submitError?.classList.remove('hidden')
+        submitError?.focus()
         submitError?.scrollIntoView({ behavior: 'smooth', block: 'center' })
       }
     })

--- a/src/components/pages/HomePage.astro
+++ b/src/components/pages/HomePage.astro
@@ -8,7 +8,6 @@ import StatsSection, {
 import TextMediaSection from '@/components/shared/TextMediaSection.astro'
 import LinkButton from '@/components/shared/LinkButton.astro'
 import OptimizedImage from '@/components/shared/OptimizedImage.astro'
-import SmoothScroll from '@/components/shared/SmoothScroll.astro'
 import { useTranslations, type Locale } from '@/utils'
 import PillarsSection from '@/components/shared/PillarsSection.astro'
 import LogoCarousel from '@/components/blocks/LogoCarousel.astro'
@@ -56,7 +55,6 @@ const stats: StatItem[] = [
   bodyClass="flex flex-col min-h-full min-w-[360px] overflow-x-clip bg-black"
   headerTheme="dark"
 >
-  <SmoothScroll />
   <main class="bg-black" data-umami-component="foundation-home-page">
     <HomepageHero pageLang={pageLang} pathname={Astro.url.pathname} />
     <AnimatedNetwork />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@
  */
 import '../styles/tailwind.css'
 import SeoHead from '@/components/shared/SeoHead.astro'
+import SmoothScroll from '@/components/shared/SmoothScroll.astro'
 import { useTranslations, buildCanonicalMeta } from '@/utils'
 
 interface Props {
@@ -86,6 +87,7 @@ const {
   </head>
 
   <body class={bodyClass} style={bodyStyle}>
+    <SmoothScroll />
     <slot name="header" />
     <slot />
     <slot name="footer" />

--- a/src/scripts/smooth-scroll.ts
+++ b/src/scripts/smooth-scroll.ts
@@ -1,7 +1,8 @@
 import Lenis from 'lenis'
 
-// duration in seconds. Mirrors the Framer prototype's Smooth Scroll
-// component (intensity: 9 → duration: 9/10).
+// Seconds for the easing animation to catch up after a scroll impulse.
+// Mirrors the Framer prototype's Smooth Scroll component (intensity: 9 →
+// duration: 9/10). Doesn't affect scroll resistance — that's wheelMultiplier.
 const DURATION_SECONDS = 0.9
 
 const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
@@ -63,6 +64,7 @@ function start(): void {
   refreshHeaderOffset()
   lenis = new Lenis({
     duration: DURATION_SECONDS,
+    wheelMultiplier: 0.8, // lower = more resistance per wheel tick; native = 1
     autoRaf: true
     // autoResize (default true) recomputes Lenis's scroll limit on reflow
     // (zoom, late-loading media). Without it the limit goes stale and

--- a/src/scripts/smooth-scroll.ts
+++ b/src/scripts/smooth-scroll.ts
@@ -5,6 +5,9 @@ import Lenis from 'lenis'
 // duration: 9/10). Doesn't affect scroll resistance — that's wheelMultiplier.
 const DURATION_SECONDS = 0.9
 
+// Lower = more resistance per wheel tick; native = 1.
+const WHEEL_MULTIPLIER = 0.8
+
 const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
 
 let lenis: Lenis | null = null
@@ -13,7 +16,7 @@ function start(): void {
   if (lenis) return
   lenis = new Lenis({
     duration: DURATION_SECONDS,
-    wheelMultiplier: 0.8, // lower = more resistance per wheel tick; native = 1
+    wheelMultiplier: WHEEL_MULTIPLIER,
     autoRaf: true
     // autoResize (default true) recomputes Lenis's scroll limit on reflow
     // (zoom, late-loading media). Without it the limit goes stale and

--- a/src/scripts/smooth-scroll.ts
+++ b/src/scripts/smooth-scroll.ts
@@ -8,60 +8,9 @@ const DURATION_SECONDS = 0.9
 const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
 
 let lenis: Lenis | null = null
-let cachedHeaderOffset = 0
-
-function refreshHeaderOffset(): void {
-  const header = document.querySelector('.foundation-header')
-  cachedHeaderOffset = header instanceof HTMLElement ? header.offsetHeight : 0
-}
-
-function findAnchorTarget(hash: string): HTMLElement | null {
-  try {
-    const el = document.querySelector(decodeURIComponent(hash))
-    return el instanceof HTMLElement ? el : null
-  } catch {
-    return null
-  }
-}
-
-function onAnchorClick(event: MouseEvent): void {
-  if (!lenis) return
-  if (
-    event.defaultPrevented ||
-    event.button !== 0 ||
-    event.metaKey ||
-    event.ctrlKey ||
-    event.shiftKey ||
-    event.altKey
-  ) {
-    return
-  }
-
-  const target = event.target
-  if (!(target instanceof Element)) return
-
-  const anchor = target.closest('a[href]')
-  if (!(anchor instanceof HTMLAnchorElement)) return
-
-  if (anchor.origin !== window.location.origin) return
-  if (anchor.pathname !== window.location.pathname) return
-
-  const hash = anchor.hash
-  if (!hash || hash === '#') return
-
-  const destination = findAnchorTarget(hash)
-  if (!destination) return
-
-  event.preventDefault()
-  const scrollMarginTop =
-    parseFloat(getComputedStyle(destination).scrollMarginTop) || 0
-  const offset = scrollMarginTop || cachedHeaderOffset
-  lenis.scrollTo(destination, { offset: -offset })
-}
 
 function start(): void {
   if (lenis) return
-  refreshHeaderOffset()
   lenis = new Lenis({
     duration: DURATION_SECONDS,
     wheelMultiplier: 0.8, // lower = more resistance per wheel tick; native = 1
@@ -70,15 +19,10 @@ function start(): void {
     // (zoom, late-loading media). Without it the limit goes stale and
     // wheel/key scrolling can't reach the bottom of a taller page.
   })
-
-  window.addEventListener('resize', refreshHeaderOffset, { passive: true })
-  document.addEventListener('click', onAnchorClick)
 }
 
 function stop(): void {
   if (!lenis) return
-  document.removeEventListener('click', onAnchorClick)
-  window.removeEventListener('resize', refreshHeaderOffset)
   lenis.destroy()
   lenis = null
 }

--- a/src/styles/base/reset.css
+++ b/src/styles/base/reset.css
@@ -63,10 +63,24 @@
     height: 100%;
     overflow-x: clip;
     color-scheme: light;
+    scroll-behavior: smooth;
+    overscroll-behavior: none;
   }
 
   html[data-theme='dark'] {
     color-scheme: dark;
+  }
+
+  /* Offsets anchor-jump targets clear of the fixed header, read by native
+     fragment scrolling (scroll-behavior: smooth, above). */
+  :target {
+    scroll-margin-top: var(--site-header-height);
+  }
+
+  @media (min-width: 1200px) {
+    :target {
+      scroll-margin-top: var(--site-header-height-desktop);
+    }
   }
 
   body {
@@ -109,10 +123,8 @@
     height: auto;
   }
 
-  .lenis.lenis-smooth {
-    scroll-behavior: auto !important;
-  }
-
+  /* Deliberately no scroll-behavior override: anchor jumps keep using
+     native scroll-behavior: smooth (above) even while Lenis is active. */
   .lenis.lenis-smooth [data-lenis-prevent] {
     overscroll-behavior: contain;
   }

--- a/src/styles/base/reset.css
+++ b/src/styles/base/reset.css
@@ -125,10 +125,14 @@
     height: auto;
   }
 
-  /* Deliberately no scroll-behavior override: anchor jumps keep using
-     native scroll-behavior: smooth (above) even while Lenis is active. */
   .lenis.lenis-smooth [data-lenis-prevent] {
     overscroll-behavior: contain;
+  }
+
+  /* table-scroll: horizontal-only prevent, kept separate from the
+     blanket rule above so vertical scroll still goes through Lenis. */
+  .lenis.lenis-smooth [data-lenis-prevent-horizontal] {
+    overscroll-behavior: auto;
   }
 
   .lenis.lenis-stopped {

--- a/src/styles/base/reset.css
+++ b/src/styles/base/reset.css
@@ -63,7 +63,6 @@
     height: 100%;
     overflow-x: clip;
     color-scheme: light;
-    overscroll-behavior: none;
     @media (prefers-reduced-motion: no-preference) {
       scroll-behavior: smooth;
     }
@@ -73,14 +72,12 @@
     color-scheme: dark;
   }
 
-  /* Offsets anchor-jump targets clear of the fixed header, read by native
-     fragment scrolling (scroll-behavior: smooth, above). */
-  :target {
+  /* Clears the fixed header on fragment jumps, tab-focus, and focused
+     scrollIntoView() targets (e.g. ContactPage's form errors). */
+  :where(:target, :is(h1, h2, h3, h4, h5, h6)[id], [id]:focus-visible)
+  {
     scroll-margin-top: var(--site-header-height);
-  }
-
-  @media (min-width: 1200px) {
-    :target {
+    @variant desktop {
       scroll-margin-top: var(--site-header-height-desktop);
     }
   }
@@ -115,24 +112,23 @@
       --spacing-hr: var(--spacing-3xl);
     }
     @variant dark {
-      --color-hr: var(--color-neutral-75)
+      --color-hr: var(--color-neutral-75);
     }
   }
   /* Lenis smooth scroll — see src/scripts/smooth-scroll.ts.
      Classes are added/removed by Lenis at runtime. Rules are inert when
-     the script is not loaded on a page. */
+     the script is not loaded on a page.
+
+     [data-lenis-prevent-horizontal] (set on .table-scroll by
+     wrapScrollableTables.ts) has no rule here on purpose — an `auto`
+     override would reopen the vertical axis too, clobbering
+     overscroll-behavior-x: contain from prose/blog.css. */
   html.lenis {
     height: auto;
   }
 
   .lenis.lenis-smooth [data-lenis-prevent] {
     overscroll-behavior: contain;
-  }
-
-  /* table-scroll: horizontal-only prevent, kept separate from the
-     blanket rule above so vertical scroll still goes through Lenis. */
-  .lenis.lenis-smooth [data-lenis-prevent-horizontal] {
-    overscroll-behavior: auto;
   }
 
   .lenis.lenis-stopped {

--- a/src/styles/base/reset.css
+++ b/src/styles/base/reset.css
@@ -63,8 +63,10 @@
     height: 100%;
     overflow-x: clip;
     color-scheme: light;
-    scroll-behavior: smooth;
     overscroll-behavior: none;
+    @media (prefers-reduced-motion: no-preference) {
+      scroll-behavior: smooth;
+    }
   }
 
   html[data-theme='dark'] {

--- a/src/styles/base/typography.css
+++ b/src/styles/base/typography.css
@@ -8,7 +8,7 @@
   src: url('/fonts/poppins-regular.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
 }
 
 @font-face {
@@ -16,7 +16,7 @@
   src: url('/fonts/poppins-medium.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
 }
 
 @font-face {
@@ -24,5 +24,5 @@
   src: url('/fonts/poppins-semibold.woff2') format('woff2');
   font-weight: 600;
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
 }

--- a/src/styles/base/typography.css
+++ b/src/styles/base/typography.css
@@ -8,7 +8,7 @@
   src: url('/fonts/poppins-regular.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
-  font-display: swap;
+  font-display: optional;
 }
 
 @font-face {
@@ -16,7 +16,7 @@
   src: url('/fonts/poppins-medium.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;
-  font-display: swap;
+  font-display: optional;
 }
 
 @font-face {
@@ -24,5 +24,5 @@
   src: url('/fonts/poppins-semibold.woff2') format('woff2');
   font-weight: 600;
   font-style: normal;
-  font-display: swap;
+  font-display: optional;
 }

--- a/src/utils/main/rehypeWrapScrollableTables.test.ts
+++ b/src/utils/main/rehypeWrapScrollableTables.test.ts
@@ -43,7 +43,7 @@ describe('rehypeWrapScrollableTables', () => {
     expect(out).toContain('class="table-scroll"')
     expect(out).toContain('role="region"')
     expect(out).toContain('tabindex="0"')
-    expect(out).toContain('data-lenis-prevent')
+    expect(out).toContain('data-lenis-prevent-horizontal')
     expect(out).toContain('<table>')
   })
 

--- a/src/utils/main/rehypeWrapScrollableTables.ts
+++ b/src/utils/main/rehypeWrapScrollableTables.ts
@@ -25,7 +25,8 @@ function createTableScrollWrapper(table: Element, ariaLabel: string): Element {
       role: 'region',
       ariaLabel,
       tabIndex: 0,
-      dataLenisPrevent: ''
+      // See wrapScrollableTables.ts for why this is the horizontal-only variant.
+      dataLenisPreventHorizontal: ''
     },
     children: [table]
   }

--- a/src/utils/main/wrapScrollableTables.test.ts
+++ b/src/utils/main/wrapScrollableTables.test.ts
@@ -18,7 +18,7 @@ describe('wrapScrollableTables', () => {
     expect(out).toContain('role="region"')
     expect(out).toContain('aria-label="Scrollable table"')
     expect(out).toContain('tabindex="0"')
-    expect(out).toContain('data-lenis-prevent')
+    expect(out).toContain('data-lenis-prevent-horizontal')
     expect(out).toContain('<table>')
   })
 

--- a/src/utils/main/wrapScrollableTables.ts
+++ b/src/utils/main/wrapScrollableTables.ts
@@ -22,8 +22,10 @@ export function wrapScrollableTables(html: string, ariaLabel: string): string {
   if (tables.length === 0) return html
 
   for (const table of tables) {
+    // Horizontal-only prevent: this region only scrolls sideways, so vertical
+    // wheel/touch gestures should keep scrolling the page via Lenis.
     const wrapper = parse(
-      `<div class="${TABLE_SCROLL_CLASS}" role="region" aria-label="${escapeAttr(ariaLabel)}" tabindex="0" data-lenis-prevent></div>`,
+      `<div class="${TABLE_SCROLL_CLASS}" role="region" aria-label="${escapeAttr(ariaLabel)}" tabindex="0" data-lenis-prevent-horizontal></div>`,
       { lowerCaseTagName: false }
     ).querySelector('div')
     if (!wrapper) continue


### PR DESCRIPTION
## Summary
- adds wheelMultiplier: 0.8 in Lenis settings, for **scroll resistance** 
- anchor-jump handling moves from a custom JS click handler to native `scroll-behavior: smooth` + scroll-margin-top, which now respects prefers-reduced-motion automatically.
- mounts Lenis smooth scroll site-wide via BaseLayout instead of just the homepage
- fixes table scroll-chaining prevention (data-lenis-prevent) to only block horizontal gestures, so vertical wheel/touch scrolling over a table still hands off to Lenis instead of getting stuck.

## Related Issue
Fixes INTORG-978

## Manual Test
<!-- Reviewer steps (only if needed) -->
 - [ ] Homepage: confirm the AnimatedNetwork section still keeps its slowed-down scroll animation at the end
 - [ ] All pages: scroll should feel "buttery" — scroll resistance applied consistently, not just on homepage
- [ ] overscroll-behavior: none + scroll-behavior: verify the scroll is smooth
  - [ ] /grant/faq — in-page link jump
  - [ ] /blog/web-monetization-open-payments-part-3-sending-money — jump to footnotes
  - [ ] general tab-key scroll behavior 
- [ ] prefers-reduced-motion: reduce — smooth scroll and anchor jumps should fall back to instant/no animation

⚠️  anchor jumps correctly account for the fixed header offset on localhost, but not on deployed environments. Not a quick fix - tracked separately in [INTOG-1005].

## Checks

- [x] `pnpm run format`
- [ ] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
