### PR TITLE
fix(pillarSection): fix styles

### DIFF
--- a/src/components/shared/PillarCard.astro
+++ b/src/components/shared/PillarCard.astro
@@ -28,7 +28,7 @@ const articleClasses = twMerge(
 )
 const textContentClasses = `
 flex flex-col gap-lg 
-[&>p]:text-body-lg-standard tablet:[&>p]:text-body-lg-standard-md
+[&>p]:text-h5 tablet:[&>p]:text-h5-md desktop:[&>p]:text-h5-lg
 `
 const doubleRowHeader = `flex flex-row
 [&>h3]:text-h2 tablet:[&>h3]:text-h3-md desktop:[&>h3]:text-h3-lg desktop:[&>h3]:h-[2lh]

--- a/src/components/shared/PillarsSection.astro
+++ b/src/components/shared/PillarsSection.astro
@@ -130,7 +130,8 @@ const threePillars = [
     }
     .pillars-heading {
       animation: shrink linear forwards;
-      animation-timeline: scroll();
+      animation-timeline: view();
+      animation-range-start: 30%;
     }
   }
 
@@ -156,7 +157,7 @@ const threePillars = [
 
   @keyframes shrink {
     from {
-      scale: 1.1;
+      scale: 1;
     }
     to {
       scale: 0.6;

--- a/src/components/shared/PillarsSection.astro
+++ b/src/components/shared/PillarsSection.astro
@@ -32,8 +32,8 @@ const sectionContainerClasses = `
   `
 const headingClasses = `
   pillars-heading
-  text-h3
-  tablet:text-h3-md tablet:pt-[20vh] tablet:animate-rise-in-view
+  text-h2
+  tablet:text-h2-md tablet:pt-[20vh] tablet:animate-rise-in-view
   desktop:text-h2-lg
   desktop:z-0 desktop:sticky desktop:top-0 
   `
@@ -105,11 +105,12 @@ const threePillars = [
 
 <style>
   .pillar-card {
-    /* Equal-height floor for the cards: the staggered top margins below would
-       otherwise make flex-stretch give them uneven heights. Anchors are the
-       tallest natural content measured per viewport width — 434.4px at
-       1200px, 420px at 2000px. Re-measure if card copy or layout changes. */
-    --card-min-h: clamp(420px, calc(528px - 7.8vw), 434.4px);
+    /* Equal-height floor for the cards: staggered top margins break normal
+       flex-stretch. Real content height steps down as text re-wraps —
+       492px at 1200-1279px, 462px at 1280-1480px, 432px at 1481px+ — so this
+       line is anchored to each step's last width (1280px→492px, 1481px→462px)
+       to never undershoot. Re-measure if card copy or layout changes. */
+    --card-min-h: clamp(432px, calc(683px - 14.9vw), 492px);
   }
 
   @media (min-width: 1200px) {


### PR DESCRIPTION
## Summary
- Bumped pillar card description text to the `h5` scale and recalculated the equal-height floor (`--card-min-h`) so all three cards stay the same height at every viewport width instead of drifting apart once the bigger text re-wraps.
- Fixed the "We see a world..." heading's shrink animation starting too early: switched animation-timeline from `scroll()` (whole-page scroll) to `view()` (the heading's own viewport entry), so it now holds at rest until the heading is 30% into view before shrinking.
## Related Issue
Fixes INTORG-1003

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
