### PR TITLE
fix(strapi): stop split-layout and carousel dropping from foundation, summit, hackathon MDX export [INTORG-1013]

### DIFF
--- a/cms/scripts/sync-mdx/config.test.ts
+++ b/cms/scripts/sync-mdx/config.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { buildContentTypes, type ContentTypes } from './config'
+import type { StrapiClient } from './strapiClient'
+import { createMdxFile } from './test-utils'
+
+const LOGO_URL = '/img/partner-logos/covenant.avif'
+const LOGO_UPLOAD_ID = 42
+
+/**
+ * LogoCarousel keeps each logo's name on the upload's `alternativeText`, so a
+ * content type that allows `blocks.carousel` has to hand the parser an
+ * `updateMediaAlt` callback. Content types are the only place that wiring
+ * happens, and a missing callback fails silently (the handler's call is
+ * optional), so assert it per content type.
+ */
+const CAROUSEL_PAGE_TYPES: (keyof ContentTypes)[] = [
+  'foundation-pages',
+  'summit-pages',
+  'hackathon-pages'
+]
+
+function stubStrapi() {
+  return {
+    findUploadByUrl: vi.fn().mockResolvedValue(LOGO_UPLOAD_ID),
+    findUploadByName: vi.fn().mockResolvedValue(null),
+    updateUploadAlt: vi.fn().mockResolvedValue(undefined)
+  } as unknown as StrapiClient & { updateUploadAlt: ReturnType<typeof vi.fn> }
+}
+
+function carouselMdx(pathSlug: string) {
+  return createMdxFile({
+    pathSlug,
+    frontmatter: {
+      title: 'Demo',
+      pathSlug,
+      description: 'Demo page'
+    },
+    content: `<LogoCarousel accessibilityLabel="Partner logos" logos={[{ name: 'Covenant', src: '${LOGO_URL}' }]} />`
+  })
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+describe('buildContentTypes carousel alt text wiring', () => {
+  it.each(CAROUSEL_PAGE_TYPES)(
+    'stores logo names as upload alt text for %s',
+    async (contentType) => {
+      const strapi = stubStrapi()
+      const contentTypes = buildContentTypes(
+        '/nonexistent-project-root',
+        'http://localhost:1337',
+        'token'
+      )
+
+      const payload = await contentTypes[contentType].buildPayload(
+        carouselMdx('demo'),
+        strapi,
+        null,
+        false
+      )
+
+      expect(payload).not.toBeInstanceOf(Error)
+      expect((payload as Record<string, unknown>).content).toEqual([
+        {
+          __component: 'blocks.carousel',
+          accessibilityLabel: 'Partner logos',
+          logos: [LOGO_UPLOAD_ID]
+        }
+      ])
+      expect(strapi.updateUploadAlt).toHaveBeenCalledWith(
+        LOGO_UPLOAD_ID,
+        'Covenant'
+      )
+    }
+  )
+
+  it('patches a shared logo upload once across the three page types', async () => {
+    const strapi = stubStrapi()
+    const contentTypes = buildContentTypes(
+      '/nonexistent-project-root',
+      'http://localhost:1337',
+      'token'
+    )
+
+    for (const contentType of CAROUSEL_PAGE_TYPES) {
+      await contentTypes[contentType].buildPayload(
+        carouselMdx(`demo-${contentType}`),
+        strapi,
+        null,
+        false
+      )
+    }
+
+    expect(strapi.updateUploadAlt).toHaveBeenCalledTimes(1)
+  })
+})

--- a/cms/scripts/sync-mdx/config.ts
+++ b/cms/scripts/sync-mdx/config.ts
@@ -11,6 +11,7 @@ import {
   buildFaqPayload,
   buildReportPayload,
   buildHackathonPagePayload,
+  createMediaAltUpdater,
   createMediaUploadResolver,
   type StrapiUploadContext
 } from './mdxTransformer'
@@ -110,11 +111,15 @@ function buildParsedPagePayload(
         dryRun,
         strapiUploadContext.profilePathSlugs
       ),
-      resolveMediaUpload: createMediaUploadResolver(strapi, dryRun)
+      resolveMediaUpload: createMediaUploadResolver(strapi, dryRun),
+      updateMediaAlt: createMediaAltUpdater(
+        strapi,
+        updatedAltIds,
+        mdx.pathSlug,
+        dryRun
+      )
     },
-    strapiUploadContext,
-    updatedAltIds,
-    dryRun
+    strapiUploadContext
   )
 }
 
@@ -123,8 +128,11 @@ export function buildContentTypes(
   strapiUrl: string,
   strapiToken: string
 ): ContentTypes {
-  // One Map per content type per sync run — guards against updating the same
-  // upload file's alt text multiple times with potentially different values.
+  // Alt-text maps guard against updating the same upload file's alt text
+  // multiple times per sync run with potentially different values. Foundation,
+  // summit and hackathon pages share one: they allow the same blocks and draw
+  // on the same partner-logo uploads, so a name that differs between them is a
+  // conflict worth warning about, not a silent overwrite.
   const blogAltIds = new Map<number, string | null>()
   const pageAltIds = new Map<number, string | null>()
   const grantPageAltIds = new Map<number, string | null>()
@@ -194,7 +202,13 @@ export function buildContentTypes(
               dryRun,
               profilePathSlugs
             ),
-            resolveMediaUpload: createMediaUploadResolver(strapi, dryRun)
+            resolveMediaUpload: createMediaUploadResolver(strapi, dryRun),
+            updateMediaAlt: createMediaAltUpdater(
+              strapi,
+              pageAltIds,
+              mdx.pathSlug,
+              dryRun
+            )
           }
         )
       }

--- a/cms/scripts/sync-mdx/mdxTransformer.test.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import { fileURLToPath } from 'node:url'
 
 const mockProjectRootHolder = vi.hoisted(() => ({ current: '' }))
 
@@ -23,7 +24,8 @@ import {
   buildHackathonPagePayload,
   createMediaUploadResolver,
   buildProfilePayload,
-  buildBlogPayload
+  buildBlogPayload,
+  HACKATHON_PAGE_ALLOWED_COMPONENTS
 } from './mdxTransformer'
 import {
   foundationPageFrontmatterSchema,
@@ -2330,6 +2332,23 @@ const baseHackathonPageFrontmatter = {
 }
 
 describe('buildHackathonPagePayload', () => {
+  // The allow-list is a hand-maintained copy of the zone's component list, so
+  // a block added to the schema but not here fails the sync as "unsupported".
+  it('allows exactly the components the hackathon-page zone declares', () => {
+    const schemaPath = fileURLToPath(
+      new URL(
+        '../../src/api/hackathon-page/content-types/hackathon-page/schema.json',
+        import.meta.url
+      )
+    )
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'))
+    const declared: string[] = schema.attributes.content.components
+
+    expect([...HACKATHON_PAGE_ALLOWED_COMPONENTS].sort()).toEqual(
+      [...declared].sort()
+    )
+  })
+
   describe('error handling', () => {
     it('returns Error when title is missing', async () => {
       const mdx = createMdxFile({

--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -422,6 +422,27 @@ async function updateUploadAltOnce(
   updatedAltIds.set(id, alt)
 }
 
+/**
+ * Builds an `updateMediaAlt` callback for the MDX block parser. LogoCarousel
+ * stores each logo's name as the upload's `alternativeText` (uploads are the
+ * only place a carousel logo can carry alt text), so any content type whose
+ * dynamic zone allows `blocks.carousel` must supply this — without it the
+ * handler's optional call is a no-op and logo names are silently dropped.
+ *
+ * Share one `updatedAltIds` map across content types that draw on the same
+ * uploads so conflicting names get warned about rather than last-write-wins.
+ */
+export function createMediaAltUpdater(
+  strapi: StrapiClient,
+  updatedAltIds: Map<number, string | null>,
+  pathSlug: string,
+  dryRun: boolean
+): (id: number, alt: string | null) => Promise<void> {
+  return async (id: number, alt: string | null) => {
+    await updateUploadAltOnce(strapi, id, alt, updatedAltIds, pathSlug, dryRun)
+  }
+}
+
 interface ProfileCtaFrontmatter {
   text?: string
   link?: string
@@ -604,16 +625,12 @@ export async function buildGrantPagePayload(
             strapiUploadContext?.profilePathSlugs
           ),
           resolveMediaUpload: createMediaUploadResolver(strapi, dryRun),
-          updateMediaAlt: async (id: number, alt: string | null) => {
-            await updateUploadAltOnce(
-              strapi,
-              id,
-              alt,
-              updatedAltIds,
-              mdx.pathSlug,
-              dryRun
-            )
-          }
+          updateMediaAlt: createMediaAltUpdater(
+            strapi,
+            updatedAltIds,
+            mdx.pathSlug,
+            dryRun
+          )
         }
       : undefined
 
@@ -688,16 +705,12 @@ export async function buildGrantOverviewPagePayload(
             strapiUploadContext?.profilePathSlugs
           ),
           resolveMediaUpload: createMediaUploadResolver(strapi, dryRun),
-          updateMediaAlt: async (id: number, alt: string | null) => {
-            await updateUploadAltOnce(
-              strapi,
-              id,
-              alt,
-              updatedAltIds,
-              mdx.pathSlug,
-              dryRun
-            )
-          }
+          updateMediaAlt: createMediaAltUpdater(
+            strapi,
+            updatedAltIds,
+            mdx.pathSlug,
+            dryRun
+          )
         }
       : undefined
 

--- a/cms/src/utils/contentPopulate.test.ts
+++ b/cms/src/utils/contentPopulate.test.ts
@@ -1,0 +1,100 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { describe, it, expect } from 'vitest'
+import {
+  BLOG_CONTENT_POPULATE,
+  FOUNDATION_PAGE_CONTENT_POPULATE,
+  GRANT_OVERVIEW_PAGE_CONTENT_POPULATE,
+  GRANT_PAGE_CONTENT_POPULATE,
+  HACKATHON_PAGE_CONTENT_POPULATE,
+  PROFILE_PAGE_CONTENT_POPULATE,
+  REPORT_CONTENT_POPULATE
+} from './contentPopulate'
+
+const API_DIR = fileURLToPath(new URL('../api', import.meta.url))
+
+/**
+ * Populate config each content type's lifecycle uses to read its dynamic zone
+ * back out of Strapi for the MDX export, keyed by API directory name.
+ *
+ * Grant configs nest the zone under a `content` key because they also populate
+ * top-level component fields; the rest are the zone config itself.
+ */
+const ZONE_POPULATE_BY_CONTENT_TYPE: Record<string, { on: object }> = {
+  'foundation-page': FOUNDATION_PAGE_CONTENT_POPULATE,
+  'summit-page': FOUNDATION_PAGE_CONTENT_POPULATE,
+  'hackathon-page': HACKATHON_PAGE_CONTENT_POPULATE,
+  'foundation-blog-post': BLOG_CONTENT_POPULATE,
+  'profile-page': PROFILE_PAGE_CONTENT_POPULATE,
+  report: REPORT_CONTENT_POPULATE,
+  'grant-page': GRANT_PAGE_CONTENT_POPULATE.content,
+  'grant-overview-page': GRANT_OVERVIEW_PAGE_CONTENT_POPULATE.content
+}
+
+type DynamicZone = { field: string; components: string[] }
+
+/** Dynamic zones declared by a content type's schema, in schema order. */
+function readDynamicZones(contentType: string): DynamicZone[] {
+  const schemaPath = path.join(
+    API_DIR,
+    contentType,
+    'content-types',
+    contentType,
+    'schema.json'
+  )
+  const schema = JSON.parse(readFileSync(schemaPath, 'utf8'))
+  const attributes: Record<string, { type: string; components?: string[] }> =
+    schema.attributes ?? {}
+
+  return Object.entries(attributes)
+    .filter(([, attribute]) => attribute.type === 'dynamiczone')
+    .map(([field, attribute]) => ({
+      field,
+      components: attribute.components ?? []
+    }))
+}
+
+/** API directory names that declare at least one dynamic zone. */
+function contentTypesWithDynamicZones(): string[] {
+  return readdirSync(API_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((contentType) => readDynamicZones(contentType).length > 0)
+    .sort()
+}
+
+describe('dynamic zone populate configs', () => {
+  const contentTypes = contentTypesWithDynamicZones()
+
+  it('covers every content type that declares a dynamic zone', () => {
+    expect(contentTypes).toEqual(
+      Object.keys(ZONE_POPULATE_BY_CONTENT_TYPE).sort()
+    )
+  })
+
+  it.each(contentTypes)('populates every block %s allows', (contentType) => {
+    const populate = ZONE_POPULATE_BY_CONTENT_TYPE[contentType]
+    expect(
+      populate,
+      `no populate config mapped for ${contentType}`
+    ).toBeDefined()
+
+    const populated = Object.keys(populate.on)
+    const zones = readDynamicZones(contentType)
+    expect(
+      zones,
+      `${contentType} declares more than one dynamic zone; ` +
+        'ZONE_POPULATE_BY_CONTENT_TYPE maps one config per content type'
+    ).toHaveLength(1)
+
+    const missing = zones[0].components.filter(
+      (component) => !populated.includes(component)
+    )
+    expect(
+      missing,
+      `${contentType}.${zones[0].field} allows components missing from its populate map, ` +
+        `so they would be dropped from the MDX export: ${missing.join(', ')}`
+    ).toEqual([])
+  })
+})

--- a/cms/src/utils/contentPopulate.ts
+++ b/cms/src/utils/contentPopulate.ts
@@ -4,11 +4,12 @@
  * Used by page and blog lifecycles to ensure all block types
  * and their nested relations are fully populated when fetching from Strapi.
  *
- * Keep these in sync with the component lists in the content-type schemas:
- * - foundation-page/schema.json
- * - summit-page/schema.json
- * - hackathon-page/schema.json
- * - foundation-blog-post/schema.json
+ * A dynamic-zone query only returns components listed in its `on` map, so a
+ * component a schema allows but this file omits is silently dropped from the
+ * MDX export. `contentPopulate.test.ts` walks the schemas and fails on any gap.
+ *
+ * Listing a component a zone no longer allows is harmless (Strapi ignores it),
+ * so the test only checks the schema-to-populate direction.
  */
 
 /** Blocks available in grant page dynamic zones. */
@@ -162,9 +163,6 @@ export const GRANT_PAGE_CONTENT_POPULATE = {
   content: {
     on: {
       ...GRANT_BLOCKS,
-      'blocks.carousel': {
-        populate: { logos: true }
-      },
       'blocks.profile-grid': {
         populate: { profiles: true }
       }


### PR DESCRIPTION
## Summary

`contentPopulate.ts` builds the populate map for Strapi's dynamic-zone queries, but foundation, summit, and hackathon pages were missing `blocks.split-layout` and `blocks.carousel` in that map. A dynamic-zone query only returns components listed there, so those blocks got silently dropped from the MDX export on every Publish, even though they stayed fully visible in the admin form the whole time.

PR #455 (agenda component) added those same entries as a side effect while this branch was in flight, so most of that part of the diff here is now just a doc-comment update and a duplicate-entry cleanup in `GRANT_PAGE_CONTENT_POPULATE`.

The part still needed: once the blocks stop being dropped, LogoCarousel names came back empty, because `updateMediaAlt` (which saves each logo's name as the upload's alt text on import) was only wired up for grant pages. Added `createMediaAltUpdater` in `mdxTransformer.ts` and wired it into the foundation/summit/hackathon import paths in `config.ts`.

Also added `contentPopulate.test.ts`, which walks each content type's schema and checks that every allowed component is in its populate map, so this doesn't get missed a third time.

## Related Issue

Fixes INTORG-1013

## Manual Test

Verified against a local Strapi instance for all three page types:

- Reimported the demo pages with `sync:mdx --force`; partner-logo uploads now carry alt text.
- Edited an unrelated field on each demo page in the admin and clicked Publish.
- Confirmed the exported MDX kept every block and that carousel names round-tripped correctly.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused (6 files)
- [ ] Screenshots for UI changes (N/A, no UI changes)