### PR TITLE
fix(cms): close TitleCard at column 0 so lists do not break MDX

### DIFF
--- a/cms/src/serializers/blocks/title-card-grid.serializer.test.ts
+++ b/cms/src/serializers/blocks/title-card-grid.serializer.test.ts
@@ -94,6 +94,28 @@ describe('title-card-grid serializer', () => {
     expect(result).toContain('heading="C &gt; D"')
   })
 
+  it('closes TitleCard at column 0 after a list so MDX does not swallow the tag', () => {
+    const result = serialize({
+      columns: 'Two',
+      ariaLabel: 'Education grants',
+      titleCards: [
+        {
+          ...validCard,
+          description:
+            'Supports universities.\n\n- Curriculum development\n- Interdisciplinary research'
+        }
+      ]
+    })
+
+    // Closing tag must not be indented (would continue the list item in MDX).
+    expect(result).toMatch(/\n<\/TitleCard>/)
+    expect(result).not.toMatch(/[ \t]<\/TitleCard>/)
+    // Blank line after description terminates the list before the close tag.
+    expect(result).toContain(
+      'Interdisciplinary research\n\n</TitleCard>'
+    )
+  })
+
   it('escapes MDX braces in description', () => {
     const result = serialize({
       columns: 'Three',

--- a/cms/src/serializers/blocks/title-card-grid.serializer.test.ts
+++ b/cms/src/serializers/blocks/title-card-grid.serializer.test.ts
@@ -111,9 +111,7 @@ describe('title-card-grid serializer', () => {
     expect(result).toMatch(/\n<\/TitleCard>/)
     expect(result).not.toMatch(/[ \t]<\/TitleCard>/)
     // Blank line after description terminates the list before the close tag.
-    expect(result).toContain(
-      'Interdisciplinary research\n\n</TitleCard>'
-    )
+    expect(result).toContain('Interdisciplinary research\n\n</TitleCard>')
   })
 
   it('escapes MDX braces in description', () => {

--- a/cms/src/serializers/blocks/title-card-grid.serializer.ts
+++ b/cms/src/serializers/blocks/title-card-grid.serializer.ts
@@ -121,10 +121,15 @@ export function serialize(block: {
       : ''
     const ctaAttrs = ` buttonUrl="${esc(card.secondaryCta.link)}" buttonText="${esc(card.secondaryCta.text)}" buttonExternal={${card.secondaryCta.external ?? false}}`
 
-    const description = escMdxBraces(card.description)
+    const description = escMdxBraces(card.description.trim())
 
-    return `<TitleCard${headingAttr}${subheadingAttr}${ctaAttrs}>\n${description}\n  </TitleCard>`
+    // Blank lines around the description, closing tag at column 0. A body that
+    // ends in a list needs both: MDX treats an indented line after a list item
+    // as a continuation of that item, so `\n  </TitleCard>` is swallowed into
+    // the list and the next sync fails with "Expected the closing tag
+    // </TitleCard> ... after the end of listItem". Same fix as blocks.faq.
+    return `<TitleCard${headingAttr}${subheadingAttr}${ctaAttrs}>\n\n${description}\n\n</TitleCard>`
   })
 
-  return `<TitleCardGrid${gridAttrs}>\n  ${cards.join('\n  ')}\n</TitleCardGrid>`
+  return `<TitleCardGrid${gridAttrs}>\n\n${cards.join('\n\n')}\n\n</TitleCardGrid>`
 }

--- a/cms/src/serializers/blocks/title-card-grid.serializer.ts
+++ b/cms/src/serializers/blocks/title-card-grid.serializer.ts
@@ -121,7 +121,7 @@ export function serialize(block: {
       : ''
     const ctaAttrs = ` buttonUrl="${esc(card.secondaryCta.link)}" buttonText="${esc(card.secondaryCta.text)}" buttonExternal={${card.secondaryCta.external ?? false}}`
 
-    const description = escMdxBraces(card.description.trim())
+    const description = escMdxBraces(card.description)
 
     // Blank lines around the description, closing tag at column 0. A body that
     // ends in a list needs both: MDX treats an indented line after a list item


### PR DESCRIPTION
quick fix that resolves staging issue 

<img width="586" height="952" alt="image" src="https://github.com/user-attachments/assets/bd9a9d64-f3b9-45e7-94f2-2ca81aa87246" />
