### PR TITLE
fix(cms): parse pasted markdown into real content in the CKEditor

### DIFF
--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -4,6 +4,7 @@ import {
 } from '@_sh/strapi-plugin-ckeditor'
 import type { PluginConfig, Preset } from '@_sh/strapi-plugin-ckeditor'
 import type { HeadingOption } from '@ckeditor/ckeditor5-heading'
+import { PasteFromMarkdownExperimental } from '@ckeditor/ckeditor5-markdown-gfm'
 import type { Editor } from 'ckeditor5'
 import { formatSplitLayoutPanelTitle } from '../plugins/split-layout-type-picker/admin/layoutTypeLabels'
 
@@ -62,6 +63,12 @@ const markdownPresetNoH1: Preset = {
     ...defaultMarkdownPreset.editorConfig,
     heading: { options: headingOptionsWithoutH1 },
     extraPlugins: [
+      // Autoformat only converts "- "/"1. " into a list when typed, not when
+      // pasted, so a pasted hyphenated list stays literal text; clicking the
+      // toolbar's list button then wraps that literal "- " text in <li> tags
+      // instead of producing real list items. This plugin parses pasted
+      // plain-text/markdown content into real CKEditor content on paste.
+      PasteFromMarkdownExperimental,
       function cleanGoogleDocsOnPaste(editor: Editor) {
         const clipboardPlugin = editor.plugins.get('ClipboardPipeline')
 


### PR DESCRIPTION
## Summary

Pasting a hyphenated list (`- a`, `- b`, `- c`) into a CKEditor rich-text field and then clicking the bulleted-list toolbar button did not produce a real list. Autoformat only converts `- ` / `1. ` into a list when those characters are *typed*, not when text already containing them is pasted, so the pasted lines stayed as literal paragraph text (`- a`, `- b`, `- c`). Clicking the toolbar's list button afterward just wrapped that literal text in `<li>` tags instead of producing clean list items, leaving stray `-` characters behind (or losing items if the surrounding markup broke, as tracked separately in INTORG-1025's other root cause, already fixed on `playground`).

Adds `PasteFromMarkdownExperimental` (from `@ckeditor/ckeditor5-markdown-gfm`, already an installed peer dependency of the CKEditor plugin, matching how `cms/src/admin/app.tsx` already imports `@ckeditor/ckeditor5-heading` and `ckeditor5` directly) to the shared markdown preset's `extraPlugins`. It intercepts the clipboard pipeline and parses pasted plain-text/markdown content into real editor content, so a pasted list becomes an actual list immediately, no toolbar click needed.

## Related Issue

INTORG-1025

## Manual Test

1. Open any field using the "Basic Markdown" or "Default Markdown" CKEditor preset (e.g. a Title Card description).
2. Paste a plain-text hyphenated list, e.g.:
   ```
   - one
   - two
   - three
   ```
3. Confirm it renders as a real bulleted list immediately after pasting, with no leftover `-` characters and no toolbar click required.
4. Confirm typing `- ` still autoformats into a list as before (unchanged behavior).
5. Confirm pasting rich HTML (e.g. from a Google Doc) is unaffected.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)