### PR TITLE
ci: cache key will now be based on content hash instead of run id

### DIFF
--- a/.github/actions/cache-optimized-images/action.yml
+++ b/.github/actions/cache-optimized-images/action.yml
@@ -1,0 +1,44 @@
+name: Cache optimized images
+description: >
+  Restores and saves public/img/optimized, keyed by the content of the image
+  sources and of the encoder itself.
+
+# Why this is a shared action rather than an inline `actions/cache` step:
+# pr-checks.yml and merge.yml must produce a byte-identical key, otherwise a PR
+# never matches the cache warmed on its base branch and silently pays a full
+# cold encode (~17 min) instead of restoring. Duplicating the hashFiles()
+# expression across two files makes that failure both easy to cause and
+# invisible when it happens.
+#
+# The key covers two kinds of input:
+#
+#   public/img/**, public/uploads/img/original/**
+#     The sources. Deliberately broad rather than a list of raster extensions:
+#     `**` also matches uppercase extensions (the encoder lowercases before
+#     testing, so IMAGE.JPG is processed) and cannot silently miss a new format.
+#     It over-invalidates on SVG-only changes, which costs one extra cache save
+#     and never costs correctness.
+#
+#   scripts/optimize-images.ts, src/utils/main/imagePaths.ts
+#     The encoder. Required, not cosmetic: cache keys are immutable, so a save
+#     to an existing key is silently skipped. Without these, changing
+#     AVIF_QUALITY would bump PIPELINE_ID and force a full re-encode whose
+#     output could never be saved (the images-only key already exists), leaving
+#     every subsequent run to re-encode from scratch.
+#
+# Placement: keep this before any step that builds. The key is evaluated when
+# the step starts, and public/img/optimized is gitignored, so on a fresh
+# checkout the directory does not exist yet and cannot pollute its own key.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v4
+      with:
+        path: public/img/optimized
+        key: optimized-images-${{ hashFiles('public/img/**', 'public/uploads/img/original/**', 'scripts/optimize-images.ts', 'src/utils/main/imagePaths.ts') }}
+        # Prefix fallback when the image set has changed: restores the newest
+        # snapshot in scope so the encoder only pays for the delta. The script
+        # hashes each source individually, so a stale snapshot is still correct.
+        restore-keys: |
+          optimized-images-

--- a/.github/actions/cache-optimized-images/action.yml
+++ b/.github/actions/cache-optimized-images/action.yml
@@ -3,6 +3,10 @@ description: >
   Restores and saves public/img/optimized, keyed by the content of the image
   sources and of the encoder itself.
 
+outputs:
+  cache-hit:
+    description: Whether the cache key was an exact hit (not a restore-keys fallback).
+    value: ${{ steps.cache.outputs.cache-hit }}
 # Why this is a shared action rather than an inline `actions/cache` step:
 # pr-checks.yml and merge.yml must produce a byte-identical key, otherwise a PR
 # never matches the cache warmed on its base branch and silently pays a full

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -33,9 +33,9 @@ jobs:
   # new PR a full cold encode (~17 min, ~88% of that job). This job writes into
   # refs/heads/staging (or playground), which those PRs can read.
   #
-  # Deliberately unconditional and dependency-free:
-  #   - When nothing changed it is an exact key hit, so the post-job save is
-  #     skipped and the whole job finishes in well under a minute.
+  # Deliberately unconditional:
+  #   - When nothing changed it is an exact key hit, so the post-job cache save is skipped.
+  #   - If `pnpm install` + `optimize:images` are gated on cache-hit, the job can finish in well under a minute.
   #   - The restore refreshes the entry's last-accessed time, which is what
   #     GitHub's cache eviction is based on. Gating this on "images changed"
   #     would let the branch's entry go stale and be evicted precisely when the

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -3,6 +3,7 @@ name: Build and Sync
 # Conditionally rebuilds the Strapi CMS on the self-hosted runner if cms/ changed,
 # and/or syncs to Strapi when src/content changes (.md/.mdx), navigation JSON changes,
 # or static media under public/img/, public/uploads/, or public/documents/ changes.
+# Also warms the optimized-image cache for this branch so PRs targeting it can restore it.
 # Does NOT trigger an Astro build — Astro is built and deployed separately via Netlify.
 
 on:
@@ -23,6 +24,45 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+
+  # Keeps this branch's cache scope populated so PRs targeting it have something
+  # to restore. GitHub scopes caches by ref: a run may read its own ref, its PR
+  # base branch, and the default branch. pr-checks.yml only runs on
+  # pull_request, so every entry it wrote landed in refs/pull/N/merge and the
+  # staging/playground scopes stayed empty — which made the first run of every
+  # new PR a full cold encode (~17 min, ~88% of that job). This job writes into
+  # refs/heads/staging (or playground), which those PRs can read.
+  #
+  # Deliberately unconditional and dependency-free:
+  #   - When nothing changed it is an exact key hit, so the post-job save is
+  #     skipped and the whole job finishes in well under a minute.
+  #   - The restore refreshes the entry's last-accessed time, which is what
+  #     GitHub's cache eviction is based on. Gating this on "images changed"
+  #     would let the branch's entry go stale and be evicted precisely when the
+  #     repo is near its 10 GB cache cap.
+  #   - It must not be blocked by a Strapi rebuild or sync failure, and must not
+  #     block them either.
+  warm-image-cache:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Cache optimized images
+        uses: ./.github/actions/cache-optimized-images
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Optimize images
+        run: pnpm run optimize:images
 
   # Inspects the current push event and the changes that were made in it, then decides which outputs to set.
   # Depending on the changes, the following flags may be set:
@@ -340,7 +380,9 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [detect-changes, rebuild-strapi, sync-to-strapi]
+    # warm-image-cache is included so a silent warming failure is visible —
+    # otherwise PR builds quietly regress to a full cold encode.
+    needs: [detect-changes, rebuild-strapi, sync-to-strapi, warm-image-cache]
     if: ${{ always() && failure() }}
     steps:
       - name: Notify Slack on failure

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,13 +57,13 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      # Content-addressed, so an unchanged image set is an exact key hit and the
+      # post-job save is skipped entirely. The previous key used github.run_id,
+      # which can never match, so every run restored via the prefix fallback and
+      # then wrote another ~148 MB entry — filling the 10 GB repo cache and
+      # evicting the very entries it depended on.
       - name: Cache optimized images
-        uses: actions/cache@v4
-        with:
-          path: public/img/optimized
-          key: optimized-images-${{ github.run_id }}
-          restore-keys: |
-            optimized-images-
+        uses: ./.github/actions/cache-optimized-images
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary
In previous iterations the pipeline would store the new set of optimised images into the cache using a key based on the run id of the pipeline. This PR changes this mechanism to rather store the newly generated set of optimised images into the cache against a key based on the hash of the content used during optimisation.

This change should not only improve warmup times but would also allow us to better utilise the github cache.

However, this change should be viewed as an intermediate step and is not going to solve the growing problem of image optimisation taking longer and longer, and having to be repeated each time a single image was added. This will be addressed in an upcoming PR.

- Introduces a new workflow so that we can run the image optimisation manually
- Moved the optimisation calling to a centralised github action for less duplication
- Added cache warming

<img width="1729" height="483" alt="image" src="https://github.com/user-attachments/assets/502e3191-ac2c-4c80-bd7d-d3e70cc1a974" />


## Manual Test
A reviewer can see the actions runs associated with this PR.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)


---

## AI description
This pull request introduces a content-addressed caching system for optimized images in the GitHub Actions workflows, significantly improving CI performance and reliability. It does this by adding a reusable composite action for caching optimized images and updating the workflows to use this action. Additionally, a new job is added to pre-warm the cache on branch builds, ensuring that pull requests can restore optimized images efficiently and avoid long cold-encode times.

**Optimized image caching improvements:**

* Added a new composite action `.github/actions/cache-optimized-images` that restores and saves `public/img/optimized` using a content-based cache key, ensuring exact cache hits when the image sources or encoder change. This avoids unnecessary cache misses and redundant encodes.
* Updated the `pr-checks.yml` workflow to use the new `cache-optimized-images` action, replacing the previous run-id-based cache key with a content-addressed key for more efficient and reliable caching.

**Workflow enhancements:**

* Added a new unconditional `warm-image-cache` job to `merge.yml` that pre-populates the cache for the current branch, so pull requests targeting this branch can restore the cache and avoid expensive cold encodes. This job is deliberately unconditional to keep cache entries fresh and prevent eviction.
* Updated documentation and comments in `merge.yml` to explain the cache warming strategy and its benefits for PR builds.
* Added `warm-image-cache` as a dependency of the `notify-slack` job in `merge.yml` to ensure cache warming failures are surfaced and not silently ignored.