### PR TITLE
fix(profile): no color ring under avatar photos [INTORG-1023]

### DIFF
--- a/src/components/pages/ProfileDetailPage.astro
+++ b/src/components/pages/ProfileDetailPage.astro
@@ -110,7 +110,7 @@ const Layout = getSectionPageLayout(entry.data.section)
               loading="eager"
               fetchpriority="high"
               decoding="sync"
-              class="absolute inset-0 h-full w-full object-cover object-center"
+              class="absolute inset-0 h-full w-full scale-[0.94] object-cover object-[center_18%] translate-y-[4%]"
             />
           ) : (
             <div class="absolute inset-0">

--- a/src/components/pages/ProfileDetailPage.astro
+++ b/src/components/pages/ProfileDetailPage.astro
@@ -110,7 +110,7 @@ const Layout = getSectionPageLayout(entry.data.section)
               loading="eager"
               fetchpriority="high"
               decoding="sync"
-              class="absolute inset-0 h-full w-full object-contain object-bottom"
+              class="absolute inset-0 h-full w-full object-cover object-center"
             />
           ) : (
             <div class="absolute inset-0">

--- a/src/components/shared/ProfileCard.astro
+++ b/src/components/shared/ProfileCard.astro
@@ -63,7 +63,7 @@ const umamiBase = {
             height={240}
             loading="lazy"
             sizes="150px"
-            class="h-full w-full object-contain object-bottom"
+            class="h-full w-full object-cover object-center"
           />
         ) : (
           <ProfileAvatarFallback />

--- a/src/components/shared/ProfileCard.astro
+++ b/src/components/shared/ProfileCard.astro
@@ -63,7 +63,7 @@ const umamiBase = {
             height={240}
             loading="lazy"
             sizes="150px"
-            class="h-full w-full object-cover object-center"
+            class="h-full w-full scale-[0.94] object-cover object-[center_18%] translate-y-[4%]"
           />
         ) : (
           <ProfileAvatarFallback />


### PR DESCRIPTION
## Summary

Profile photos were sitting in a colored circle with `object-contain`, so you could see a color ring under/around the image.

Switched to `object-cover` so the photo fills the circle edge-to-edge (cards + profile detail page).

## Related Issue

Fixes INTORG-1023

## Checks

- [x] Small, focused change
- [x] Screenshots if helpful

<img width="1492" height="772" alt="image" src="https://github.com/user-attachments/assets/8747c616-5c09-402a-b84c-966edb95064d" />
