### PR TITLE
fix(hero): let description use full content width [INTORG-1008]

### DIFF
--- a/src/components/pages/FoundationContentPage.astro
+++ b/src/components/pages/FoundationContentPage.astro
@@ -69,17 +69,17 @@ if (isNotFound) return Astro.redirect('/404')
           ]}
           style={heroSectionStyle}
         >
-          <div class="mx-auto w-full max-w-wide px-2xl">
-            <div class="max-w-narrow">
-              <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
-                {mdxHeroTitle}
-              </h1>
-              {mdxHeroDescription && (
-                <p class="mb-2xl text-[1.125rem] max-w-[600px]">
-                  {mdxHeroDescription}
-                </p>
-              )}
-              {heroCtas.length > 0 && (
+          <div class="mx-auto w-full max-w-content px-2xl">
+            <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
+              {mdxHeroTitle}
+            </h1>
+            {
+              mdxHeroDescription && (
+                <p class="mb-2xl text-[1.125rem]">{mdxHeroDescription}</p>
+              )
+            }
+            {
+              heroCtas.length > 0 && (
                 <div class="flex flex-wrap gap-xl mt-xl">
                   {heroCtas.map((cta) => (
                     <Link
@@ -91,8 +91,8 @@ if (isNotFound) return Astro.redirect('/404')
                     />
                   ))}
                 </div>
-              )}
-            </div>
+              )
+            }
           </div>
         </section>
       )

--- a/src/components/pages/FoundationContentPage.astro
+++ b/src/components/pages/FoundationContentPage.astro
@@ -15,7 +15,7 @@ import VideoEmbed from '@/components/shared/VideoEmbed.astro'
 import NumberTiles from '@/components/blocks/NumberTiles.astro'
 import LogoCarousel from '@/components/blocks/LogoCarousel.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
-import Link from '@/components/shared/Link.astro'
+import HeroSection from '@/components/shared/HeroSection.astro'
 import OptimizedImage from '@/components/shared/OptimizedImage.astro'
 import TitleCardGrid from '@/components/blocks/TitleCardGrid.astro'
 import TitleCard from '@/components/shared/TitleCard.astro'
@@ -60,41 +60,12 @@ if (isNotFound) return Astro.redirect('/404')
     <TranslationDisclaimer isVisible={isFallback} />
     {
       mdxHeroTitle && (
-        <section
-          class:list={[
-            'min-h-[40vh] py-4xl text-white flex items-center',
-            heroSectionStyle
-              ? 'bg-no-repeat bg-cover bg-center'
-              : 'bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right]'
-          ]}
-          style={heroSectionStyle}
-        >
-          <div class="mx-auto w-full max-w-content px-2xl">
-            <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
-              {mdxHeroTitle}
-            </h1>
-            {
-              mdxHeroDescription && (
-                <p class="mb-2xl text-[1.125rem]">{mdxHeroDescription}</p>
-              )
-            }
-            {
-              heroCtas.length > 0 && (
-                <div class="flex flex-wrap gap-xl mt-xl">
-                  {heroCtas.map((cta) => (
-                    <Link
-                      href={cta.link}
-                      style={cta.style}
-                      variant="hero"
-                      external={cta.external}
-                      text={cta.text}
-                    />
-                  ))}
-                </div>
-              )
-            }
-          </div>
-        </section>
+        <HeroSection
+          title={mdxHeroTitle}
+          description={mdxHeroDescription}
+          ctas={heroCtas}
+          sectionStyle={heroSectionStyle}
+        />
       )
     }
     <section class="py-4xl">

--- a/src/components/pages/SummitContentPage.astro
+++ b/src/components/pages/SummitContentPage.astro
@@ -15,7 +15,7 @@ import PdfEmbed from '@/components/shared/PdfEmbed.astro'
 import NumberTiles from '@/components/blocks/NumberTiles.astro'
 import LogoCarousel from '@/components/blocks/LogoCarousel.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
-import Link from '@/components/shared/Link.astro'
+import HeroSection from '@/components/shared/HeroSection.astro'
 import OptimizedImage from '@/components/shared/OptimizedImage.astro'
 import TitleCardGrid from '@/components/blocks/TitleCardGrid.astro'
 import TitleCard from '@/components/shared/TitleCard.astro'
@@ -66,41 +66,12 @@ const noindex = isDemoPathSlug(mdxData?.pathSlug)
     <TranslationDisclaimer isVisible={isFallback} style="summit" />
     {
       mdxHeroTitle && (
-        <section
-          class:list={[
-            'min-h-[40vh] py-4xl flex items-center text-white',
-            heroSectionStyle
-              ? 'bg-no-repeat bg-cover bg-center'
-              : 'bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right]'
-          ]}
-          style={heroSectionStyle}
-        >
-          <div class="mx-auto w-full max-w-content px-2xl">
-            <h1 class="max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
-              {mdxHeroTitle}
-            </h1>
-            {
-              mdxHeroDescription && (
-                <p class="mb-2xl text-[1.125rem]">{mdxHeroDescription}</p>
-              )
-            }
-            {
-              heroCtas.length > 0 && (
-                <div class="flex flex-wrap gap-xl mt-xl">
-                  {heroCtas.map((cta) => (
-                    <Link
-                      href={cta.link}
-                      style={cta.style}
-                      variant="hero"
-                      external={cta.external}
-                      text={cta.text}
-                    />
-                  ))}
-                </div>
-              )
-            }
-          </div>
-        </section>
+        <HeroSection
+          title={mdxHeroTitle}
+          description={mdxHeroDescription}
+          ctas={heroCtas}
+          sectionStyle={heroSectionStyle}
+        />
       )
     }
     <section class="py-4xl">

--- a/src/components/pages/SummitContentPage.astro
+++ b/src/components/pages/SummitContentPage.astro
@@ -75,17 +75,17 @@ const noindex = isDemoPathSlug(mdxData?.pathSlug)
           ]}
           style={heroSectionStyle}
         >
-          <div class="mx-auto w-full max-w-wide px-2xl">
-            <div class="max-w-narrow">
-              <h1 class="max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
-                {mdxHeroTitle}
-              </h1>
-              {mdxHeroDescription && (
-                <p class="mb-2xl text-[1.125rem] max-w-[600px]">
-                  {mdxHeroDescription}
-                </p>
-              )}
-              {heroCtas.length > 0 && (
+          <div class="mx-auto w-full max-w-content px-2xl">
+            <h1 class="max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
+              {mdxHeroTitle}
+            </h1>
+            {
+              mdxHeroDescription && (
+                <p class="mb-2xl text-[1.125rem]">{mdxHeroDescription}</p>
+              )
+            }
+            {
+              heroCtas.length > 0 && (
                 <div class="flex flex-wrap gap-xl mt-xl">
                   {heroCtas.map((cta) => (
                     <Link
@@ -97,8 +97,8 @@ const noindex = isDemoPathSlug(mdxData?.pathSlug)
                     />
                   ))}
                 </div>
-              )}
-            </div>
+              )
+            }
           </div>
         </section>
       )

--- a/src/components/shared/HeroSection.astro
+++ b/src/components/shared/HeroSection.astro
@@ -44,11 +44,7 @@ const resolvedCtas = ctas.filter(
     >
       {title}
     </h1>
-    {
-      description && (
-        <p class="mb-2xl text-[1.125rem]">{description}</p>
-      )
-    }
+    {description && <p class="mb-2xl text-[1.125rem]">{description}</p>}
     {
       resolvedCtas.length > 0 && (
         <div class="flex flex-wrap gap-xl mt-xl">

--- a/src/components/shared/HeroSection.astro
+++ b/src/components/shared/HeroSection.astro
@@ -1,50 +1,68 @@
 ---
+/**
+ * Gradient/cover hero for foundation, summit, and page-preview routes.
+ * Description spans the full max-w-content column; title keeps a line-length cap.
+ * (Grant-style white/parallax heroes use PageHero instead.)
+ */
 import Link from './Link.astro'
 
-interface CtaLink {
-  link: string
-  text: string
+export interface HeroSectionCta {
+  text?: string
+  link?: string
   style?: string
   external?: boolean
 }
 
 interface Props {
-  title?: string
-  content?: string
-  ctas?: CtaLink[]
+  title: string
+  description?: string | null
+  ctas?: HeroSectionCta[]
+  /** From getHeroSectionStyle — cover image when set, else primary gradient. */
+  sectionStyle?: Record<string, string>
 }
 
-const { title, content, ctas } = Astro.props
+const { title, description, ctas = [], sectionStyle } = Astro.props
+
+const resolvedCtas = ctas.filter(
+  (cta): cta is HeroSectionCta & { text: string; link: string } =>
+    Boolean(cta.text?.trim() && cta.link?.trim())
+)
 ---
 
 <section
-  class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[30vh] md:min-h-[50vh] py-2xl text-white flex items-center"
+  class:list={[
+    'min-h-[40vh] py-4xl text-white flex items-center',
+    sectionStyle
+      ? 'bg-no-repeat bg-cover bg-center'
+      : 'bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right]'
+  ]}
+  style={sectionStyle}
 >
-  <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
-    <div>
-      <h1
-        class="text-white max-w-[15em] leading-tight font-semibold mb-lg text-h3-md tablet:text-h3-lg"
-      >
-        {title ?? ''}
-      </h1>
-      <p class="max-w-[50em] text-[1.125rem] leading-relaxed mb-lg">
-        {content ?? ''}
-      </p>
-      {
-        ctas && ctas.length > 0 && (
-          <div class="flex flex-wrap gap-xl mt-xl">
-            {ctas.map((link) => (
-              <Link
-                href={link.link}
-                style={link.style}
-                variant="hero"
-                external={link.external}
-                text={link.text}
-              />
-            ))}
-          </div>
-        )
-      }
-    </div>
+  <div class="mx-auto w-full max-w-content px-2xl">
+    <h1
+      class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]"
+    >
+      {title}
+    </h1>
+    {
+      description && (
+        <p class="mb-2xl text-[1.125rem]">{description}</p>
+      )
+    }
+    {
+      resolvedCtas.length > 0 && (
+        <div class="flex flex-wrap gap-xl mt-xl">
+          {resolvedCtas.map((cta) => (
+            <Link
+              href={cta.link}
+              style={cta.style}
+              variant="hero"
+              external={cta.external}
+              text={cta.text}
+            />
+          ))}
+        </div>
+      )
+    }
   </div>
 </section>

--- a/src/components/shared/PageHero.astro
+++ b/src/components/shared/PageHero.astro
@@ -85,7 +85,7 @@ const parallaxImgClass = isWideBand
 
     {
       description && (
-        <p class="text-h4 tablet:text-h4-md desktop:text-h4-lg font-normal max-w-[42em] mb-xl tablet:mb-lg">
+        <p class="text-h4 tablet:text-h4-md desktop:text-h4-lg font-normal mb-xl tablet:mb-lg">
           {description}
         </p>
       )

--- a/src/components/shared/PageHero.astro
+++ b/src/components/shared/PageHero.astro
@@ -61,49 +61,50 @@ const parallaxImgClass = isWideBand
   : 'parallax-img absolute inset-x-0 top-[-40%] h-[180%] w-full object-cover'
 ---
 
-<!-- White content section -->
+<!--
+  Content column is max-w-content (1440px) with no horizontal padding so title
+  and description span the full content width.
+-->
 <div
-  class="mx-auto bg-white px-lg pt-[calc(var(--spacing-6xl)-var(--site-header-height))] pb-3xl tablet:px-xl tablet:pt-[calc(var(--spacing-6xl)-var(--site-header-height))] tablet:pb-5xl desktop:pt-[calc(var(--spacing-6xl)-var(--site-header-height-desktop))] desktop:max-w-content"
+  class="mx-auto w-full max-w-content bg-white pt-[calc(var(--spacing-6xl)-var(--site-header-height))] pb-3xl tablet:pt-[calc(var(--spacing-6xl)-var(--site-header-height))] tablet:pb-5xl desktop:pt-[calc(var(--spacing-6xl)-var(--site-header-height-desktop))]"
 >
-  <div class="mx-auto max-w-content">
-    {
-      breadcrumbs && breadcrumbs.length > 0 && (
-        <div class="mb-xl tablet:mb-2xl">
-          <Breadcrumbs
-            breadcrumbs={breadcrumbs}
-            class="[&_a]:text-body-sm-standard"
-          />
-        </div>
-      )
-    }
+  {
+    breadcrumbs && breadcrumbs.length > 0 && (
+      <div class="mb-xl tablet:mb-2xl">
+        <Breadcrumbs
+          breadcrumbs={breadcrumbs}
+          class="[&_a]:text-body-sm-standard"
+        />
+      </div>
+    )
+  }
 
-    <h1
-      class="text-h1 tablet:text-h1-md desktop:text-h1-lg text-neutral-900 mb-2xl tablet:mb-3xl desktop:max-w-content"
-    >
-      {title}
-    </h1>
+  <h1
+    class="text-h1 tablet:text-h1-md desktop:text-h1-lg text-neutral-900 mb-2xl tablet:mb-3xl"
+  >
+    {title}
+  </h1>
 
-    {
-      description && (
-        <p class="text-h4 tablet:text-h4-md desktop:text-h4-lg font-normal mb-xl tablet:mb-lg">
-          {description}
-        </p>
-      )
-    }
-    {
-      cta && (
-        <LinkButton
-          href={cta.link}
-          variant={cta.style === 'secondary' ? 'secondary' : 'primary'}
-          external={cta.external}
-          class="w-full tablet:w-auto"
-        >
-          {cta.text}
-          <Icon name="arrow-right" slot="icon-right" />
-        </LinkButton>
-      )
-    }
-  </div>
+  {
+    description && (
+      <p class="text-h4 tablet:text-h4-md desktop:text-h4-lg font-normal mb-xl tablet:mb-lg">
+        {description}
+      </p>
+    )
+  }
+  {
+    cta && (
+      <LinkButton
+        href={cta.link}
+        variant={cta.style === 'secondary' ? 'secondary' : 'primary'}
+        external={cta.external}
+        class="w-full tablet:w-auto"
+      >
+        {cta.text}
+        <Icon name="arrow-right" slot="icon-right" />
+      </LinkButton>
+    )
+  }
 </div>
 
 <!-- Parallax image: image is taller than the frame so we can pan as you scroll -->

--- a/src/pages/page-preview.astro
+++ b/src/pages/page-preview.astro
@@ -86,17 +86,17 @@ const content = page.content || []
     {
       heroTitle && (
         <section class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[40vh] py-4xl text-white flex items-center">
-          <div class="mx-auto w-full max-w-wide px-2xl">
-            <div class="max-w-narrow">
-              <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
-                {heroTitle}
-              </h1>
-              {heroDescription && (
-                <p class="mb-2xl text-[1.125rem] max-w-[600px]">
-                  {heroDescription}
-                </p>
-              )}
-              {heroCtas.length > 0 && (
+          <div class="mx-auto w-full max-w-content px-2xl">
+            <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
+              {heroTitle}
+            </h1>
+            {
+              heroDescription && (
+                <p class="mb-2xl text-[1.125rem]">{heroDescription}</p>
+              )
+            }
+            {
+              heroCtas.length > 0 && (
                 <div class="flex flex-wrap gap-xl mt-xl">
                   {heroCtas.map((cta) => (
                     <Link
@@ -108,8 +108,8 @@ const content = page.content || []
                     />
                   ))}
                 </div>
-              )}
-            </div>
+              )
+            }
           </div>
         </section>
       )

--- a/src/pages/page-preview.astro
+++ b/src/pages/page-preview.astro
@@ -7,7 +7,7 @@
 import BaseLayout from '@/layouts/BaseLayout.astro'
 import DynamicZone from '@/components/blocks/DynamicZone.astro'
 import TableScrollSupport from '@/components/shared/TableScrollSupport.astro'
-import Link from '@/components/shared/Link.astro'
+import HeroSection from '@/components/shared/HeroSection.astro'
 import { applyPreviewNoStore, fetchStrapi } from '@/utils'
 
 interface HeroCta {
@@ -85,33 +85,11 @@ const content = page.content || []
 
     {
       heroTitle && (
-        <section class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[40vh] py-4xl text-white flex items-center">
-          <div class="mx-auto w-full max-w-content px-2xl">
-            <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
-              {heroTitle}
-            </h1>
-            {
-              heroDescription && (
-                <p class="mb-2xl text-[1.125rem]">{heroDescription}</p>
-              )
-            }
-            {
-              heroCtas.length > 0 && (
-                <div class="flex flex-wrap gap-xl mt-xl">
-                  {heroCtas.map((cta) => (
-                    <Link
-                      href={cta.link}
-                      style={cta.style}
-                      variant="hero"
-                      external={cta.external}
-                      text={cta.text}
-                    />
-                  ))}
-                </div>
-              )
-            }
-          </div>
-        </section>
+        <HeroSection
+          title={heroTitle}
+          description={heroDescription}
+          ctas={heroCtas}
+        />
       )
     }
 

--- a/src/pages/preview/page-preview.astro
+++ b/src/pages/preview/page-preview.astro
@@ -88,17 +88,17 @@ const content = page.content || []
     {
       heroTitle && (
         <section class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[40vh] py-4xl text-white flex items-center">
-          <div class="mx-auto w-full max-w-wide px-2xl">
-            <div class="max-w-narrow">
-              <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
-                {heroTitle}
-              </h1>
-              {heroDescription && (
-                <p class="mb-2xl text-[1.125rem] max-w-[600px]">
-                  {heroDescription}
-                </p>
-              )}
-              {heroCtas.length > 0 && (
+          <div class="mx-auto w-full max-w-content px-2xl">
+            <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
+              {heroTitle}
+            </h1>
+            {
+              heroDescription && (
+                <p class="mb-2xl text-[1.125rem]">{heroDescription}</p>
+              )
+            }
+            {
+              heroCtas.length > 0 && (
                 <div class="flex flex-wrap gap-xl mt-xl">
                   {heroCtas.map((cta) => (
                     <Link
@@ -110,8 +110,8 @@ const content = page.content || []
                     />
                   ))}
                 </div>
-              )}
-            </div>
+              )
+            }
           </div>
         </section>
       )

--- a/src/pages/preview/page-preview.astro
+++ b/src/pages/preview/page-preview.astro
@@ -7,7 +7,7 @@
 import BaseLayout from '@/layouts/BaseLayout.astro'
 import DynamicZone from '@/components/blocks/DynamicZone.astro'
 import TableScrollSupport from '@/components/shared/TableScrollSupport.astro'
-import Link from '@/components/shared/Link.astro'
+import HeroSection from '@/components/shared/HeroSection.astro'
 import { applyPreviewNoStore, fetchStrapi } from '@/utils'
 
 interface HeroCta {
@@ -87,33 +87,11 @@ const content = page.content || []
 
     {
       heroTitle && (
-        <section class="bg-gradient-primary bg-no-repeat bg-cover bg-[position:bottom_right] min-h-[40vh] py-4xl text-white flex items-center">
-          <div class="mx-auto w-full max-w-content px-2xl">
-            <h1 class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]">
-              {heroTitle}
-            </h1>
-            {
-              heroDescription && (
-                <p class="mb-2xl text-[1.125rem]">{heroDescription}</p>
-              )
-            }
-            {
-              heroCtas.length > 0 && (
-                <div class="flex flex-wrap gap-xl mt-xl">
-                  {heroCtas.map((cta) => (
-                    <Link
-                      href={cta.link}
-                      style={cta.style}
-                      variant="hero"
-                      external={cta.external}
-                      text={cta.text}
-                    />
-                  ))}
-                </div>
-              )
-            }
-          </div>
-        </section>
+        <HeroSection
+          title={heroTitle}
+          description={heroDescription}
+          ctas={heroCtas}
+        />
       )
     }
 


### PR DESCRIPTION
## Summary

Hero descriptions were capped by a narrow column (`max-w-narrow` / `max-w-[600px]`). They now use the full content shell (`max-w-content`, 1440px). Titles keep their own line-length limit.

## Related Issue

Fixes INTORG-1008

## Manual Test

1. Open a foundation or summit page with a long hero description.
2. Confirm the description stretches to the content width (not a short ~600px column).
3. Check grant/overview heroes (PageHero) and Strapi page preview.

## Checks

- [x] Foundation + summit content page heroes
- [x] Page preview heroes
- [x] PageHero (grant-style)

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused

<img width="2056" height="687" alt="image" src="https://github.com/user-attachments/assets/20a4e5ae-6d83-4cf0-9961-33aaa752d6da" />
