### PR TITLE
fix(cms): add examples to accessibility label helpers [INTORG-1020]

### DIFF
--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -1122,7 +1122,7 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     'blocks.carousel': {
       heading: 'Section Heading',
       logos: 'Logos',
-      accessibilityLabel: 'Accessible label (screen readers only)'
+      accessibilityLabel: 'Accessibility label'
     },
     'blocks.number-tiles': {
       tiles: 'Tiles'
@@ -1311,14 +1311,14 @@ async function configureFieldLabels(strapi: StrapiInstance) {
     },
     'blocks.title-card-grid': {
       ariaLabel:
-        'Used by screen readers to describe this group of cards. This text is not visible on the page.'
+        'Used by screen readers to describe this group of cards. This text is not visible on the page. Example: "Grant options" or "Ways to get involved".'
     },
     'shared.secondary-cta-link': {
       link: 'For a page on this site, start with a forward slash (e.g. /grants/apply). Only use a full URL (https://...) when External Link is checked.'
     },
     'blocks.carousel': {
       accessibilityLabel:
-        'Describes this group of logos for screen reader users. Not visible on the page.',
+        'Used by screen readers to describe this logo carousel. This text is not visible on the page. Example: "Partner logos" or "Our sponsors".',
       logos:
         'Dimensions: 240×80. Click the edit (pencil) icon on the selected image to set Alternative text.'
     },


### PR DESCRIPTION
## Summary

Editors need clearer guidance on accessibility labels. Updated Strapi helper text for every accessibility-label field so it explains purpose and includes examples.

## Related Issue

Fixes INTORG-1020

## What changed

Only two Strapi fields are accessibility labels:

| Component | Field | Helper |
|-----------|--------|--------|
| Title Card Grid | `ariaLabel` | Describes a group of cards + examples |
| Logo Carousel | `accessibilityLabel` | Describes the logo carousel + examples |

Both use: *Used by screen readers to describe this … This text is not visible on the page. Example: …*

Also aligned the carousel field label to **Accessibility label**.

## Manual Test

1. Restart Strapi so `cms/src/index.ts` field descriptions re-apply.
2. Edit a page with a Title Card Grid — confirm the accessibility label helper includes examples.
3. Edit a Logo Carousel — same.

## Checks

- [x] Searched all Strapi component schemas for `ariaLabel` / `accessibilityLabel`
- [x] Helper text updated with examples

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused