### PR TITLE
fix(cms): keep locale and localizes on Spanish blog MDX export [INTORG-1035]

### DIFF
--- a/cms/src/utils/blogLifecycle.test.ts
+++ b/cms/src/utils/blogLifecycle.test.ts
@@ -153,7 +153,7 @@ describe('resolveBlogMdxFilename — write/delete path parity', () => {
 describe('generateBlogMDX — locale and localizes', () => {
   it('always writes locale for English posts', () => {
     const mdx = generateBlogMDX(makePost({ locale: 'en' }))
-    expect(mdx).toMatch(/^locale:\s*'en'/m)
+    expect(mdx).toMatch(/^locale:\s*en$/m)
     expect(mdx).not.toMatch(/^localizes:/m)
   })
 
@@ -165,8 +165,9 @@ describe('generateBlogMDX — locale and localizes', () => {
         localizations: [{ pathSlug: 'test-post', locale: 'en' }]
       })
     )
-    expect(mdx).toMatch(/^locale:\s*'es'/m)
-    expect(mdx).toMatch(/^localizes:\s*'test-post'/m)
+    // Bare YAML (no quotes) — matches checked-in blog MDX / pathSlug style.
+    expect(mdx).toMatch(/^locale:\s*es$/m)
+    expect(mdx).toMatch(/^localizes:\s*test-post$/m)
   })
 
   it('places locale and localizes after featured, before images', () => {
@@ -199,8 +200,8 @@ describe('generateBlogMDX — locale and localizes', () => {
         localizations: []
       })
     )
-    expect(mdx).toMatch(/^locale:\s*'es'/m)
-    expect(mdx).toMatch(/^localizes:\s*'test-post'/m)
+    expect(mdx).toMatch(/^locale:\s*es$/m)
+    expect(mdx).toMatch(/^localizes:\s*test-post$/m)
   })
 
   it('uses the explicit englishSlug option for localizes', () => {
@@ -212,7 +213,7 @@ describe('generateBlogMDX — locale and localizes', () => {
       }),
       { englishSlug: 'english-path' }
     )
-    expect(mdx).toMatch(/^localizes:\s*'english-path'/m)
+    expect(mdx).toMatch(/^localizes:\s*english-path$/m)
   })
 
   it('writes locale and localizes after stamping a missing document locale as es', () => {
@@ -227,8 +228,8 @@ describe('generateBlogMDX — locale and localizes', () => {
     const mdx = generateBlogMDX({ ...postFromStrapi, locale })
 
     expect(locale).toBe('es')
-    expect(mdx).toMatch(/^locale:\s*'es'/m)
-    expect(mdx).toMatch(/^localizes:\s*'test-post'/m)
+    expect(mdx).toMatch(/^locale:\s*es$/m)
+    expect(mdx).toMatch(/^localizes:\s*test-post$/m)
   })
 })
 

--- a/cms/src/utils/blogLifecycle.test.ts
+++ b/cms/src/utils/blogLifecycle.test.ts
@@ -79,12 +79,25 @@ describe('resolveBlogEnglishSlug', () => {
     ).toBe('english-slug')
   })
 
-  it('falls back to the post pathSlug when localizations are empty', () => {
+  it('returns undefined when no EN counterpart is known', () => {
+    // Must not invent localizes from the ES pathSlug alone.
     expect(
       resolveBlogEnglishSlug(
-        makePost({ locale: 'es', pathSlug: 'shared-slug', localizations: [] })
+        makePost({ locale: 'es', pathSlug: 'es-only-slug', localizations: [] })
       )
-    ).toBe('shared-slug')
+    ).toBeUndefined()
+  })
+
+  it('ignores non-en localization entries (not a real EN counterpart)', () => {
+    expect(
+      resolveBlogEnglishSlug(
+        makePost({
+          locale: 'es',
+          pathSlug: 'es-slug',
+          localizations: [{ pathSlug: 'fr-slug', locale: 'fr' }]
+        })
+      )
+    ).toBeUndefined()
   })
 })
 
@@ -175,7 +188,7 @@ describe('generateBlogMDX — locale and localizes', () => {
       makePost({
         locale: 'es',
         pathSlug: 'test-post',
-        localizations: [],
+        localizations: [{ pathSlug: 'test-post', locale: 'en' }],
         featureMedia: {
           image: { name: 'banner.jpg', url: '/img/banner.jpg' },
           alternativeText: 'Banner'
@@ -192,16 +205,18 @@ describe('generateBlogMDX — locale and localizes', () => {
     expect(featureImageAt).toBeGreaterThan(localizesAt)
   })
 
-  it('falls back to pathSlug for localizes when localizations lack pathSlug', () => {
+  it('omits localizes when no EN counterpart is known', () => {
+    // ES-only post: enPost null, empty localizations. Writing localizes:
+    // <es-pathSlug> would be a lie and make sync-mdx/translationMap invent EN.
     const mdx = generateBlogMDX(
       makePost({
         locale: 'es',
-        pathSlug: 'test-post',
+        pathSlug: 'es-only-slug',
         localizations: []
       })
     )
     expect(mdx).toMatch(/^locale:\s*es$/m)
-    expect(mdx).toMatch(/^localizes:\s*test-post$/m)
+    expect(mdx).not.toMatch(/^localizes:/m)
   })
 
   it('uses the explicit englishSlug option for localizes', () => {
@@ -216,9 +231,26 @@ describe('generateBlogMDX — locale and localizes', () => {
     expect(mdx).toMatch(/^localizes:\s*english-path$/m)
   })
 
-  it('writes locale and localizes after stamping a missing document locale as es', () => {
+  it('defaults missing locale to en; callers must stamp locale for localized exports', () => {
+    // Simulates Strapi omitting locale on the document payload.
+    // generateBlogMDX itself defaults missing locale to en — no localizes.
+    // Callers (fetchBlogPost / writeMDXFile) must stamp the requested locale
+    // before generating ES frontmatter.
+    const mdx = generateBlogMDX(
+      makePost({
+        locale: undefined,
+        pathSlug: 'test-post',
+        localizations: []
+      } as Record<string, unknown>)
+    )
+    expect(mdx).toMatch(/^locale:\s*en$/m)
+    expect(mdx).not.toMatch(/^localizes:/m)
+  })
+
+  it('writes locale after stamping a missing document locale as es', () => {
     // Strapi omitted locale on the document; fetchBlogPost stamps the
-    // requested locale before generateBlogMDX runs.
+    // requested locale before generateBlogMDX runs. Without an EN counterpart
+    // we still write locale, but not a fabricated localizes.
     const postFromStrapi = makePost({
       locale: undefined,
       pathSlug: 'test-post',
@@ -229,7 +261,23 @@ describe('generateBlogMDX — locale and localizes', () => {
 
     expect(locale).toBe('es')
     expect(mdx).toMatch(/^locale:\s*es$/m)
-    expect(mdx).toMatch(/^localizes:\s*test-post$/m)
+    expect(mdx).not.toMatch(/^localizes:/m)
+  })
+
+  it('writes localizes when EN is known only via the englishSlug option', () => {
+    const postFromStrapi = makePost({
+      locale: undefined,
+      pathSlug: 'es-slug',
+      localizations: []
+    } as Record<string, unknown>)
+    const locale = stampBlogLocale(postFromStrapi, 'es')
+    const mdx = generateBlogMDX(
+      { ...postFromStrapi, locale },
+      { englishSlug: 'en-slug' }
+    )
+
+    expect(mdx).toMatch(/^locale:\s*es$/m)
+    expect(mdx).toMatch(/^localizes:\s*en-slug$/m)
   })
 })
 

--- a/cms/src/utils/blogLifecycle.test.ts
+++ b/cms/src/utils/blogLifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { generateBlogMDX } from '@/utils'
+import { generateBlogMDX, resolveBlogEnglishSlug } from '@/utils'
 
 // Minimal BlogResult factory — only the fields generateBlogMDX reads matter.
 // Cast through unknown because the test deliberately omits Strapi-only fields.
@@ -21,6 +21,137 @@ function makePost(overrides: Record<string, unknown> = {}) {
     ...overrides
   } as unknown as Parameters<typeof generateBlogMDX>[0]
 }
+
+describe('resolveBlogEnglishSlug', () => {
+  it('prefers an explicit englishSlug argument', () => {
+    expect(
+      resolveBlogEnglishSlug(
+        makePost({
+          locale: 'es',
+          pathSlug: 'es-slug',
+          localizations: [{ pathSlug: 'other', locale: 'en' }]
+        }),
+        'explicit-en'
+      )
+    ).toBe('explicit-en')
+  })
+
+  it('prefers the en localization entry over others', () => {
+    expect(
+      resolveBlogEnglishSlug(
+        makePost({
+          locale: 'es',
+          pathSlug: 'shared-slug',
+          localizations: [
+            { pathSlug: 'wrong', locale: 'fr' },
+            { pathSlug: 'english-slug', locale: 'en' }
+          ]
+        })
+      )
+    ).toBe('english-slug')
+  })
+
+  it('falls back to the post pathSlug when localizations are empty', () => {
+    expect(
+      resolveBlogEnglishSlug(
+        makePost({ locale: 'es', pathSlug: 'shared-slug', localizations: [] })
+      )
+    ).toBe('shared-slug')
+  })
+})
+
+describe('generateBlogMDX — locale and localizes', () => {
+  it('always writes locale for English posts', () => {
+    const mdx = generateBlogMDX(makePost({ locale: 'en' }))
+    expect(mdx).toMatch(/^locale:\s*'en'/m)
+    expect(mdx).not.toMatch(/^localizes:/m)
+  })
+
+  it('writes locale and localizes for Spanish posts', () => {
+    const mdx = generateBlogMDX(
+      makePost({
+        locale: 'es',
+        pathSlug: 'test-post',
+        localizations: [{ pathSlug: 'test-post', locale: 'en' }]
+      })
+    )
+    expect(mdx).toMatch(/^locale:\s*'es'/m)
+    expect(mdx).toMatch(/^localizes:\s*'test-post'/m)
+  })
+
+  it('places locale and localizes after featured, before images', () => {
+    const mdx = generateBlogMDX(
+      makePost({
+        locale: 'es',
+        pathSlug: 'test-post',
+        localizations: [],
+        featureMedia: {
+          image: { name: 'banner.jpg', url: '/img/banner.jpg' },
+          alternativeText: 'Banner'
+        }
+      })
+    )
+    const featuredAt = mdx.indexOf('featured:')
+    const localeAt = mdx.indexOf('locale:')
+    const localizesAt = mdx.indexOf('localizes:')
+    const featureImageAt = mdx.indexOf('featureImage:')
+    expect(featuredAt).toBeGreaterThan(-1)
+    expect(localeAt).toBeGreaterThan(featuredAt)
+    expect(localizesAt).toBeGreaterThan(localeAt)
+    expect(featureImageAt).toBeGreaterThan(localizesAt)
+  })
+
+  it('falls back to pathSlug for localizes when localizations lack pathSlug', () => {
+    const mdx = generateBlogMDX(
+      makePost({
+        locale: 'es',
+        pathSlug: 'test-post',
+        localizations: []
+      })
+    )
+    expect(mdx).toMatch(/^locale:\s*'es'/m)
+    expect(mdx).toMatch(/^localizes:\s*'test-post'/m)
+  })
+
+  it('uses the explicit englishSlug option for localizes', () => {
+    const mdx = generateBlogMDX(
+      makePost({
+        locale: 'es',
+        pathSlug: 'es-only-slug',
+        localizations: []
+      }),
+      { englishSlug: 'english-path' }
+    )
+    expect(mdx).toMatch(/^localizes:\s*'english-path'/m)
+  })
+
+  it('still writes locale and localizes when locale was missing on the post', () => {
+    // Simulates Strapi omiting locale on the document payload.
+    const mdx = generateBlogMDX(
+      makePost({
+        locale: 'es',
+        pathSlug: 'test-post',
+        localizations: []
+      })
+    )
+    // After writeMDXFile stamps locale; generateBlogMDX itself defaults missing
+    // locale to en — callers must pass locale. Stamp it as writeMDXFile does.
+    const stamped = generateBlogMDX(
+      makePost({
+        locale: undefined,
+        pathSlug: 'test-post',
+        localizations: []
+      } as Record<string, unknown>)
+    )
+    // Missing locale defaults to en — no localizes (by design for EN).
+    expect(stamped).toMatch(/^locale:\s*'en'/m)
+    expect(stamped).not.toMatch(/^localizes:/m)
+
+    // With locale stamped (as writeMDXFile / fetchBlogPost do):
+    expect(mdx).toMatch(/^locale:\s*'es'/m)
+    expect(mdx).toMatch(/^localizes:\s*'test-post'/m)
+  })
+})
 
 describe('generateBlogMDX — article bios', () => {
   it('throws when a bio has a null author', () => {

--- a/cms/src/utils/blogLifecycle.test.ts
+++ b/cms/src/utils/blogLifecycle.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { generateBlogMDX, resolveBlogEnglishSlug } from '@/utils'
+import {
+  generateBlogMDX,
+  resolveBlogEnglishSlug,
+  stampBlogLocale
+} from '@/utils'
 
 // Minimal BlogResult factory — only the fields generateBlogMDX reads matter.
 // Cast through unknown because the test deliberately omits Strapi-only fields.
@@ -21,6 +25,24 @@ function makePost(overrides: Record<string, unknown> = {}) {
     ...overrides
   } as unknown as Parameters<typeof generateBlogMDX>[0]
 }
+
+describe('stampBlogLocale', () => {
+  it('keeps a present locale from the document', () => {
+    expect(stampBlogLocale({ locale: 'es' }, 'en')).toBe('es')
+  })
+
+  it('uses the requested locale when the document omits locale', () => {
+    // Regression: Strapi sometimes returns ES documents without locale set.
+    // Without this stamp, export defaulted to en and dropped localizes.
+    expect(stampBlogLocale({ locale: undefined }, 'es')).toBe('es')
+    expect(stampBlogLocale({ locale: null }, 'es')).toBe('es')
+    expect(stampBlogLocale({ locale: '   ' }, 'es')).toBe('es')
+  })
+
+  it('falls back to defaultLang when both are empty', () => {
+    expect(stampBlogLocale({ locale: undefined }, '')).toBe('en')
+  })
+})
 
 describe('resolveBlogEnglishSlug', () => {
   it('prefers an explicit englishSlug argument', () => {
@@ -125,29 +147,18 @@ describe('generateBlogMDX — locale and localizes', () => {
     expect(mdx).toMatch(/^localizes:\s*'english-path'/m)
   })
 
-  it('still writes locale and localizes when locale was missing on the post', () => {
-    // Simulates Strapi omiting locale on the document payload.
-    const mdx = generateBlogMDX(
-      makePost({
-        locale: 'es',
-        pathSlug: 'test-post',
-        localizations: []
-      })
-    )
-    // After writeMDXFile stamps locale; generateBlogMDX itself defaults missing
-    // locale to en — callers must pass locale. Stamp it as writeMDXFile does.
-    const stamped = generateBlogMDX(
-      makePost({
-        locale: undefined,
-        pathSlug: 'test-post',
-        localizations: []
-      } as Record<string, unknown>)
-    )
-    // Missing locale defaults to en — no localizes (by design for EN).
-    expect(stamped).toMatch(/^locale:\s*'en'/m)
-    expect(stamped).not.toMatch(/^localizes:/m)
+  it('writes locale and localizes after stamping a missing document locale as es', () => {
+    // Strapi omitted locale on the document; fetchBlogPost stamps the
+    // requested locale before generateBlogMDX runs.
+    const postFromStrapi = makePost({
+      locale: undefined,
+      pathSlug: 'test-post',
+      localizations: []
+    } as Record<string, unknown>)
+    const locale = stampBlogLocale(postFromStrapi, 'es')
+    const mdx = generateBlogMDX({ ...postFromStrapi, locale })
 
-    // With locale stamped (as writeMDXFile / fetchBlogPost do):
+    expect(locale).toBe('es')
     expect(mdx).toMatch(/^locale:\s*'es'/m)
     expect(mdx).toMatch(/^localizes:\s*'test-post'/m)
   })

--- a/cms/src/utils/blogLifecycle.test.ts
+++ b/cms/src/utils/blogLifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   generateBlogMDX,
   resolveBlogEnglishSlug,
+  resolveBlogMdxFilename,
   stampBlogLocale
 } from '@/utils'
 
@@ -37,6 +38,11 @@ describe('stampBlogLocale', () => {
     expect(stampBlogLocale({ locale: undefined }, 'es')).toBe('es')
     expect(stampBlogLocale({ locale: null }, 'es')).toBe('es')
     expect(stampBlogLocale({ locale: '   ' }, 'es')).toBe('es')
+  })
+
+  it('trusts a reported locale that differs from the request (no overwrite)', () => {
+    // e.g. asked for es but i18n fell back to the EN document
+    expect(stampBlogLocale({ locale: 'en' }, 'es')).toBe('en')
   })
 
   it('falls back to defaultLang when both are empty', () => {
@@ -79,6 +85,68 @@ describe('resolveBlogEnglishSlug', () => {
         makePost({ locale: 'es', pathSlug: 'shared-slug', localizations: [] })
       )
     ).toBe('shared-slug')
+  })
+})
+
+describe('resolveBlogMdxFilename — write/delete path parity', () => {
+  it('uses the English slug for Spanish filenames when pathSlugs differ', () => {
+    // Mirrors the afterDelete bug: lifecycle result has no localizations, so
+    // the englishSlug must come from a separate EN fetch (passed explicitly).
+    expect(
+      resolveBlogMdxFilename(
+        {
+          locale: 'es',
+          pathSlug: 'es-slug',
+          date: '2026-06-10',
+          localizations: []
+        },
+        'en-slug'
+      )
+    ).toBe('2026-06-10-en-slug.mdx')
+  })
+
+  it('does not fall back to localizations[0] when that entry is not EN', () => {
+    // Old delete path used localizations[0]?.pathSlug, which can be wrong.
+    expect(
+      resolveBlogMdxFilename(
+        {
+          locale: 'es',
+          pathSlug: 'es-slug',
+          date: '2026-06-10',
+          localizations: [{ pathSlug: 'wrong-first', locale: 'fr' }]
+        },
+        'en-slug'
+      )
+    ).toBe('2026-06-10-en-slug.mdx')
+  })
+
+  it('defaults missing locale to en so delete does not aim at the wrong tree', () => {
+    // getOutputPath(undefined) hits the EN root; filename must still use own slug.
+    expect(
+      resolveBlogMdxFilename(
+        {
+          locale: undefined,
+          pathSlug: 'en-slug',
+          date: '2026-06-10',
+          localizations: []
+        },
+        undefined
+      )
+    ).toBe('2026-06-10-en-slug.mdx')
+  })
+
+  it('uses own pathSlug for English filenames', () => {
+    expect(
+      resolveBlogMdxFilename(
+        {
+          locale: 'en',
+          pathSlug: 'en-slug',
+          date: '2026-06-10',
+          localizations: []
+        },
+        'ignored-for-en'
+      )
+    ).toBe('2026-06-10-en-slug.mdx')
   })
 })
 

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -133,13 +133,19 @@ function generateFilename({
   return `${prefix}${pathSlug}.mdx`
 }
 
+/** Fields needed to resolve the English pathSlug used in blog filenames. */
+export type BlogSlugSource = {
+  pathSlug?: string | null
+  localizations?: { pathSlug?: string; locale?: string }[] | null
+}
+
 /**
  * Resolve the English pathSlug for a non-en blog export.
  * Prefer an explicit englishSlug, then the en localization entry, then any
  * localization pathSlug, then the post's own pathSlug (blogs share pathSlug).
  */
 export function resolveBlogEnglishSlug(
-  post: BlogResult,
+  post: BlogSlugSource,
   englishSlug?: string | null
 ): string {
   const fromArg = englishSlug?.trim()
@@ -158,6 +164,26 @@ export function resolveBlogEnglishSlug(
   if (fromAny) return fromAny
 
   return (post.pathSlug || '').trim()
+}
+
+/**
+ * Filename used for blog MDX write and delete.
+ * Non-default locales use the English pathSlug so paths stay locale-independent.
+ */
+export function resolveBlogMdxFilename(
+  post: BlogSlugSource & { date?: string | null; locale?: string | null },
+  englishSlug?: string | null
+): string {
+  const locale = (post.locale || defaultLang).trim() || defaultLang
+  const resolvedEnglishSlug = resolveBlogEnglishSlug(post, englishSlug)
+  return generateFilename({
+    date: post.date ?? '',
+    pathSlug: resolveFilenameSlug(
+      locale,
+      (post.pathSlug || '').trim(),
+      resolvedEnglishSlug
+    )
+  })
 }
 
 export function generateBlogMDX(
@@ -270,10 +296,10 @@ async function writeMDXFile({
 }): Promise<string> {
   const locale = (post.locale || defaultLang).trim() || defaultLang
   const resolvedEnglishSlug = resolveBlogEnglishSlug(post, englishSlug)
-  const filename = generateFilename({
-    date: post.date,
-    pathSlug: resolveFilenameSlug(locale, post.pathSlug, resolvedEnglishSlug)
-  })
+  const filename = resolveBlogMdxFilename(
+    { ...post, locale },
+    resolvedEnglishSlug
+  )
   const filepath = path.join(outputPath, filename)
   const mdxContent = generateBlogMDX(
     { ...post, locale },
@@ -289,19 +315,18 @@ async function writeMDXFile({
 
 async function deleteMDXFile({
   outputPath,
-  post
+  post,
+  englishSlug
 }: {
   outputPath: string
   post: BlogResult
+  englishSlug?: string | null
 }): Promise<string | null> {
-  const filename = generateFilename({
-    date: post.date,
-    pathSlug: resolveFilenameSlug(
-      post.locale,
-      post.pathSlug,
-      post.localizations?.[0]?.pathSlug
-    )
-  })
+  const locale = (post.locale || defaultLang).trim() || defaultLang
+  const filename = resolveBlogMdxFilename(
+    { ...post, locale },
+    englishSlug
+  )
   const filepath = path.join(outputPath, filename)
 
   try {
@@ -366,9 +391,10 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
         continue
       }
       try {
+        // Trust post.locale from fetchBlogPost (stamped only when omitted).
         const filepath = await writeMDXFile({
-          outputPath: getOutputPath(locale),
-          post: { ...post, locale },
+          outputPath: getOutputPath(post.locale),
+          post,
           englishSlug
         })
         filepaths.push(filepath)
@@ -387,19 +413,20 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
     async afterCreate(event: BlogEvent) {
       const { result } = event
       if (!result || !result.publishedAt) return
-      const locale = result.locale || defaultLang
-      const post = await fetchBlogPost(result.documentId, locale)
+      const requestedLocale = result.locale || defaultLang
+      const post = await fetchBlogPost(result.documentId, requestedLocale)
       if (shouldSkipMdxExport()) return
       if (!post) return
       const label = event.model.singularName
       console.log(`📝 Creating ${label} MDX for: ${post.pathSlug}`)
       const enPost =
-        locale === defaultLang
+        post.locale === defaultLang
           ? post
           : await fetchBlogPost(result.documentId, defaultLang)
+      // Trust post.locale from fetchBlogPost (stamped only when omitted).
       await writeMDXFile({
-        outputPath: getOutputPath(locale),
-        post: { ...post, locale },
+        outputPath: getOutputPath(post.locale),
+        post,
         englishSlug: enPost?.pathSlug
       })
       const ctx: SyncContext = {
@@ -433,8 +460,11 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
       const { result } = event
       if (!result || !result.publishedAt) return
 
-      const locale = result.locale || defaultLang
-      const currentLocalePost = await fetchBlogPost(result.documentId, locale)
+      const requestedLocale = result.locale || defaultLang
+      const currentLocalePost = await fetchBlogPost(
+        result.documentId,
+        requestedLocale
+      )
       if (shouldSkipMdxExport()) return
 
       const label = event.model.singularName
@@ -462,9 +492,10 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
         if (!post) return
         console.log(`📝 Updating ${label} MDX for: ${post.pathSlug}`)
         try {
+          // Trust post.locale from fetchBlogPost (stamped only when omitted).
           await writeMDXFile({
-            outputPath: getOutputPath(locale),
-            post: { ...post, locale },
+            outputPath: getOutputPath(post.locale),
+            post,
             englishSlug: enPost?.pathSlug
           })
         } catch (error) {
@@ -484,10 +515,24 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
       const { result } = event
       if (!result || !result.publishedAt) return
       const label = event.model.singularName
+      // Lifecycle results often omit `locale` and never populate `localizations`.
+      // Stamp locale and resolve the English pathSlug the same way write does so
+      // we unlink the real on-disk filename (en slug for all locales).
+      // The deleted locale can no longer be re-fetched; EN still can when we
+      // deleted a non-en translation.
+      const locale = stampBlogLocale(result, defaultLang)
+      const enPost =
+        locale === defaultLang
+          ? null
+          : await fetchBlogPost(result.documentId, defaultLang)
+      const englishSlug =
+        locale === defaultLang ? result.pathSlug : enPost?.pathSlug
+
       console.log(`📝 Deleting ${label} MDX for: ${result.pathSlug}`)
       await deleteMDXFile({
-        outputPath: getOutputPath(result.locale),
-        post: result
+        outputPath: getOutputPath(locale),
+        post: { ...result, locale },
+        englishSlug
       })
       const ctx: SyncContext = {
         slug: result.pathSlug,

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -77,12 +77,25 @@ interface BlogEvent {
  * Prefer the document's own locale when present; otherwise use the locale we
  * requested from Strapi. Document payloads sometimes omit `locale`, which used
  * to make ES exports drop both `locale: es` and `localizes`.
+ *
+ * When the document reports a locale that differs from the request (e.g. i18n
+ * fell back to EN), trust the reported value — never overwrite it.
  */
 export function stampBlogLocale(
   post: { locale?: string | null },
   requestedLocale: string
 ): string {
-  return post.locale?.trim() || requestedLocale.trim() || defaultLang
+  const requested = requestedLocale.trim()
+  const reported = post.locale?.trim()
+  if (reported) {
+    if (requested && reported !== requested) {
+      console.warn(
+        `⚠️  Blog fetch requested locale "${requested}" but document reports "${reported}"; trusting document locale`
+      )
+    }
+    return reported
+  }
+  return requested || defaultLang
 }
 
 /**
@@ -140,14 +153,19 @@ export type BlogSlugSource = {
 }
 
 /**
- * Resolve the English pathSlug for a non-en blog export.
- * Prefer an explicit englishSlug, then the en localization entry, then any
- * localization pathSlug, then the post's own pathSlug (blogs share pathSlug).
+ * Resolve a real English pathSlug for a non-en blog export.
+ * Prefer an explicit englishSlug (from an EN fetch), then the en localization
+ * entry. Returns undefined when no EN counterpart is known — callers must not
+ * invent one from the post's own pathSlug (that writes a false `localizes`
+ * line and breaks sync-mdx / translationMap).
+ *
+ * Filenames still work without an EN slug: resolveFilenameSlug falls back to
+ * the locale's own pathSlug when englishSlug is missing.
  */
 export function resolveBlogEnglishSlug(
   post: BlogSlugSource,
   englishSlug?: string | null
-): string {
+): string | undefined {
   const fromArg = englishSlug?.trim()
   if (fromArg) return fromArg
 
@@ -158,12 +176,7 @@ export function resolveBlogEnglishSlug(
   const fromEn = enEntry?.pathSlug?.trim()
   if (fromEn) return fromEn
 
-  const fromAny = localizations
-    .find((entry) => entry.pathSlug?.trim())
-    ?.pathSlug?.trim()
-  if (fromAny) return fromAny
-
-  return (post.pathSlug || '').trim()
+  return undefined
 }
 
 /**
@@ -235,8 +248,8 @@ export function generateBlogMDX(
     // Bare scalars (not yqs) to match checked-in blog MDX and pathSlug above —
     // Prettier leaves YAML quoting alone, so quoting here would churn every save.
     `locale: ${locale}`,
-    // Locale files must keep `localizes` pointing at the English pathSlug so
-    // sync-mdx can match translations.
+    // Only when we resolved a real EN counterpart — never the ES pathSlug as
+    // a stand-in (that advertises a non-existent EN route and confuses sync).
     isLocalized && englishSlug ? `localizes: ${englishSlug}` : null,
     post.featureMedia?.image?.url
       ? `featureImage: ${yqs(post.featureMedia.image.url)}`
@@ -287,6 +300,15 @@ export function generateBlogMDX(
   return `---\n${frontmatter}\n---\n\n${content}\n`
 }
 
+/**
+ * Normalize empty locale for path + frontmatter only (does not override a real
+ * reported locale). Write and delete share this so filenames stay aligned.
+ */
+function withNormalizedLocale(post: BlogResult): BlogResult {
+  const locale = (post.locale || defaultLang).trim() || defaultLang
+  return { ...post, locale }
+}
+
 async function writeMDXFile({
   outputPath,
   post,
@@ -296,17 +318,11 @@ async function writeMDXFile({
   post: BlogResult
   englishSlug?: string | null
 }): Promise<string> {
-  const locale = (post.locale || defaultLang).trim() || defaultLang
-  const resolvedEnglishSlug = resolveBlogEnglishSlug(post, englishSlug)
-  const filename = resolveBlogMdxFilename(
-    { ...post, locale },
-    resolvedEnglishSlug
-  )
+  // Same path resolution as deleteMDXFile (resolveBlogMdxFilename + englishSlug).
+  const normalized = withNormalizedLocale(post)
+  const filename = resolveBlogMdxFilename(normalized, englishSlug)
   const filepath = path.join(outputPath, filename)
-  const mdxContent = generateBlogMDX(
-    { ...post, locale },
-    { englishSlug: resolvedEnglishSlug }
-  )
+  const mdxContent = generateBlogMDX(normalized, { englishSlug })
 
   await fs.promises.mkdir(outputPath, { recursive: true })
   await fs.promises.writeFile(filepath, await formatMdx(mdxContent), 'utf-8')
@@ -324,11 +340,9 @@ async function deleteMDXFile({
   post: BlogResult
   englishSlug?: string | null
 }): Promise<string | null> {
-  const locale = (post.locale || defaultLang).trim() || defaultLang
-  const filename = resolveBlogMdxFilename(
-    { ...post, locale },
-    englishSlug
-  )
+  // Same path resolution as writeMDXFile (resolveBlogMdxFilename + englishSlug).
+  const normalized = withNormalizedLocale(post)
+  const filename = resolveBlogMdxFilename(normalized, englishSlug)
   const filepath = path.join(outputPath, filename)
 
   try {
@@ -415,9 +429,10 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
     async afterCreate(event: BlogEvent) {
       const { result } = event
       if (!result || !result.publishedAt) return
+      // Skip before any documents() fetch (sync-mdx sets this header).
+      if (shouldSkipMdxExport()) return
       const requestedLocale = result.locale || defaultLang
       const post = await fetchBlogPost(result.documentId, requestedLocale)
-      if (shouldSkipMdxExport()) return
       if (!post) return
       const label = event.model.singularName
       console.log(`📝 Creating ${label} MDX for: ${post.pathSlug}`)
@@ -461,13 +476,14 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
     async afterUpdate(event: BlogEvent) {
       const { result } = event
       if (!result || !result.publishedAt) return
+      // Skip before any documents() fetch (sync-mdx sets this header).
+      if (shouldSkipMdxExport()) return
 
       const requestedLocale = result.locale || defaultLang
       const currentLocalePost = await fetchBlogPost(
         result.documentId,
         requestedLocale
       )
-      if (shouldSkipMdxExport()) return
 
       const label = event.model.singularName
       const { oldPathSlug, oldDate } = event.state
@@ -518,11 +534,13 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
       if (!result || !result.publishedAt) return
       const label = event.model.singularName
       // Lifecycle results often omit `locale` and never populate `localizations`.
-      // Stamp locale and resolve the English pathSlug the same way write does so
-      // we unlink the real on-disk filename (en slug for all locales).
-      // The deleted locale can no longer be re-fetched; EN still can when we
-      // deleted a non-en translation.
-      const locale = stampBlogLocale(result, defaultLang)
+      // Prefer the deleted document's locale; only fall back when fully omitted.
+      // Resolve englishSlug via an EN fetch (not localizations[0]) so the
+      // filename matches writeMDXFile / resolveBlogMdxFilename.
+      const locale = stampBlogLocale(
+        result,
+        result.locale?.trim() || defaultLang
+      )
       const enPost =
         locale === defaultLang
           ? null

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -74,6 +74,18 @@ interface BlogEvent {
 }
 
 /**
+ * Prefer the document's own locale when present; otherwise use the locale we
+ * requested from Strapi. Document payloads sometimes omit `locale`, which used
+ * to make ES exports drop both `locale: es` and `localizes`.
+ */
+export function stampBlogLocale(
+  post: { locale?: string | null },
+  requestedLocale: string
+): string {
+  return post.locale?.trim() || requestedLocale.trim() || defaultLang
+}
+
+/**
  * Re-fetch blog post with full populate for dynamiczone content.
  * Lifecycle event.result doesn't populate dynamiczone `on` params —
  * same pattern as pageLifecycle.ts fetchPublished().
@@ -99,12 +111,10 @@ async function fetchBlogPost(
       }
     })
     if (!post) return null
-    // Strapi document responses sometimes omit `locale`; stamp the locale we
-    // requested so ES exports always write `locale: es` + `localizes`.
+    const stamped = post as unknown as BlogResult
     return {
-      ...(post as unknown as BlogResult),
-      locale:
-        (post as { locale?: string }).locale?.trim() || locale || defaultLang
+      ...stamped,
+      locale: stampBlogLocale(stamped, locale)
     }
   } catch (error) {
     console.error(`Failed to fetch blog post ${documentId} (${locale}):`, error)

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -232,10 +232,12 @@ export function generateBlogMDX(
     `pathSlug: ${post.pathSlug}`,
     `featured: ${post.featured ?? false}`,
     // Always write locale so ES files never lose `locale: es` on re-export.
-    `locale: ${yqs(locale)}`,
+    // Bare scalars (not yqs) to match checked-in blog MDX and pathSlug above —
+    // Prettier leaves YAML quoting alone, so quoting here would churn every save.
+    `locale: ${locale}`,
     // Locale files must keep `localizes` pointing at the English pathSlug so
     // sync-mdx can match translations.
-    isLocalized && englishSlug ? `localizes: ${yqs(englishSlug)}` : null,
+    isLocalized && englishSlug ? `localizes: ${englishSlug}` : null,
     post.featureMedia?.image?.url
       ? `featureImage: ${yqs(post.featureMedia.image.url)}`
       : null,

--- a/cms/src/utils/blogLifecycle.ts
+++ b/cms/src/utils/blogLifecycle.ts
@@ -64,7 +64,7 @@ interface BlogResult {
   }[]
   categories?: { categoryValue: string }[]
   relatedArticles?: { slug: string }[]
-  localizations: { pathSlug: string }[]
+  localizations: { pathSlug?: string; locale?: string }[]
 }
 
 interface BlogEvent {
@@ -98,7 +98,14 @@ async function fetchBlogPost(
         content: BLOG_CONTENT_POPULATE
       }
     })
-    return post as unknown as BlogResult | null
+    if (!post) return null
+    // Strapi document responses sometimes omit `locale`; stamp the locale we
+    // requested so ES exports always write `locale: es` + `localizes`.
+    return {
+      ...(post as unknown as BlogResult),
+      locale:
+        (post as { locale?: string }).locale?.trim() || locale || defaultLang
+    }
   } catch (error) {
     console.error(`Failed to fetch blog post ${documentId} (${locale}):`, error)
     return null
@@ -116,8 +123,44 @@ function generateFilename({
   return `${prefix}${pathSlug}.mdx`
 }
 
-export function generateBlogMDX(post: BlogResult) {
+/**
+ * Resolve the English pathSlug for a non-en blog export.
+ * Prefer an explicit englishSlug, then the en localization entry, then any
+ * localization pathSlug, then the post's own pathSlug (blogs share pathSlug).
+ */
+export function resolveBlogEnglishSlug(
+  post: BlogResult,
+  englishSlug?: string | null
+): string {
+  const fromArg = englishSlug?.trim()
+  if (fromArg) return fromArg
+
+  const localizations = post.localizations ?? []
+  const enEntry = localizations.find(
+    (entry) => (entry.locale || '').trim() === defaultLang
+  )
+  const fromEn = enEntry?.pathSlug?.trim()
+  if (fromEn) return fromEn
+
+  const fromAny = localizations
+    .find((entry) => entry.pathSlug?.trim())
+    ?.pathSlug?.trim()
+  if (fromAny) return fromAny
+
+  return (post.pathSlug || '').trim()
+}
+
+export function generateBlogMDX(
+  post: BlogResult,
+  options: { englishSlug?: string | null } = {}
+) {
   const yqs = yamlSingleQuoteScalar
+  const locale = (post.locale || defaultLang).trim() || defaultLang
+  const isLocalized = locale !== defaultLang
+  const englishSlug = isLocalized
+    ? resolveBlogEnglishSlug(post, options.englishSlug)
+    : undefined
+
   const articleBios =
     post.articleBio?.length > 0
       ? `articleBios:${post.articleBio
@@ -144,6 +187,7 @@ export function generateBlogMDX(post: BlogResult) {
           .join('')}`
       : null
 
+  // Stable order matching existing blog MDX (locale/localizes before images).
   const frontmatterLines = [
     `title: ${yqs(post.title)}`,
     `description: ${yqs(post.description)}`,
@@ -151,6 +195,11 @@ export function generateBlogMDX(post: BlogResult) {
     post.lastUpdated ? `lastUpdated: ${post.lastUpdated}` : null,
     `pathSlug: ${post.pathSlug}`,
     `featured: ${post.featured ?? false}`,
+    // Always write locale so ES files never lose `locale: es` on re-export.
+    `locale: ${yqs(locale)}`,
+    // Locale files must keep `localizes` pointing at the English pathSlug so
+    // sync-mdx can match translations.
+    isLocalized && englishSlug ? `localizes: ${yqs(englishSlug)}` : null,
     post.featureMedia?.image?.url
       ? `featureImage: ${yqs(post.featureMedia.image.url)}`
       : null,
@@ -189,11 +238,7 @@ export function generateBlogMDX(post: BlogResult) {
           })
           .join('')}`
       : null,
-    post.legacy ? `legacy: true` : null,
-    post.locale ? `locale: ${yqs(post.locale)}` : null,
-    post.localizations?.[0]?.pathSlug
-      ? `localizes: ${post.localizations[0].pathSlug}`
-      : null
+    post.legacy ? `legacy: true` : null
   ].filter(Boolean) as string[]
 
   const frontmatter = frontmatterLines.join('\n')
@@ -206,21 +251,24 @@ export function generateBlogMDX(post: BlogResult) {
 
 async function writeMDXFile({
   outputPath,
-  post
+  post,
+  englishSlug
 }: {
   outputPath: string
   post: BlogResult
+  englishSlug?: string | null
 }): Promise<string> {
+  const locale = (post.locale || defaultLang).trim() || defaultLang
+  const resolvedEnglishSlug = resolveBlogEnglishSlug(post, englishSlug)
   const filename = generateFilename({
     date: post.date,
-    pathSlug: resolveFilenameSlug(
-      post.locale,
-      post.pathSlug,
-      post.localizations?.[0]?.pathSlug
-    )
+    pathSlug: resolveFilenameSlug(locale, post.pathSlug, resolvedEnglishSlug)
   })
   const filepath = path.join(outputPath, filename)
-  const mdxContent = generateBlogMDX(post)
+  const mdxContent = generateBlogMDX(
+    { ...post, locale },
+    { englishSlug: resolvedEnglishSlug }
+  )
 
   await fs.promises.mkdir(outputPath, { recursive: true })
   await fs.promises.writeFile(filepath, await formatMdx(mdxContent), 'utf-8')
@@ -296,6 +344,7 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
   async function exportAllBlogLocales(documentId: string): Promise<string[]> {
     const filepaths: string[] = []
     const enPost = await fetchBlogPost(documentId, defaultLang)
+    const englishSlug = enPost?.pathSlug
 
     for (const locale of LOCALES) {
       const post =
@@ -308,8 +357,9 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
       }
       try {
         const filepath = await writeMDXFile({
-          outputPath: getOutputPath(post.locale),
-          post
+          outputPath: getOutputPath(locale),
+          post: { ...post, locale },
+          englishSlug
         })
         filepaths.push(filepath)
       } catch (error) {
@@ -327,12 +377,21 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
     async afterCreate(event: BlogEvent) {
       const { result } = event
       if (!result || !result.publishedAt) return
-      const post = await fetchBlogPost(result.documentId, result.locale)
+      const locale = result.locale || defaultLang
+      const post = await fetchBlogPost(result.documentId, locale)
       if (shouldSkipMdxExport()) return
       if (!post) return
       const label = event.model.singularName
       console.log(`📝 Creating ${label} MDX for: ${post.pathSlug}`)
-      await writeMDXFile({ outputPath: getOutputPath(post.locale), post })
+      const enPost =
+        locale === defaultLang
+          ? post
+          : await fetchBlogPost(result.documentId, defaultLang)
+      await writeMDXFile({
+        outputPath: getOutputPath(locale),
+        post: { ...post, locale },
+        englishSlug: enPost?.pathSlug
+      })
       const ctx: SyncContext = {
         slug: post.pathSlug,
         action: 'create',
@@ -364,10 +423,8 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
       const { result } = event
       if (!result || !result.publishedAt) return
 
-      const currentLocalePost = await fetchBlogPost(
-        result.documentId,
-        result.locale
-      )
+      const locale = result.locale || defaultLang
+      const currentLocalePost = await fetchBlogPost(result.documentId, locale)
       if (shouldSkipMdxExport()) return
 
       const label = event.model.singularName
@@ -395,7 +452,11 @@ export function createBlogLifecycle({ outputDir }: { outputDir: string }) {
         if (!post) return
         console.log(`📝 Updating ${label} MDX for: ${post.pathSlug}`)
         try {
-          await writeMDXFile({ outputPath: getOutputPath(post.locale), post })
+          await writeMDXFile({
+            outputPath: getOutputPath(locale),
+            post: { ...post, locale },
+            englishSlug: enPost?.pathSlug
+          })
         } catch (error) {
           throw toValidationError(error)
         }

--- a/cms/src/utils/index.ts
+++ b/cms/src/utils/index.ts
@@ -141,6 +141,7 @@ export {
   createBlogLifecycle,
   generateBlogMDX,
   resolveBlogEnglishSlug,
+  resolveBlogMdxFilename,
   stampBlogLocale
 } from './blogLifecycle'
 export {

--- a/cms/src/utils/index.ts
+++ b/cms/src/utils/index.ts
@@ -140,7 +140,8 @@ export {
 export {
   createBlogLifecycle,
   generateBlogMDX,
-  resolveBlogEnglishSlug
+  resolveBlogEnglishSlug,
+  stampBlogLocale
 } from './blogLifecycle'
 export {
   type ProfileMdxCta,

--- a/cms/src/utils/index.ts
+++ b/cms/src/utils/index.ts
@@ -137,7 +137,11 @@ export {
   createPageLifecycle,
   readLocaleFromUpdateEvent
 } from './pageLifecycle'
-export { createBlogLifecycle, generateBlogMDX } from './blogLifecycle'
+export {
+  createBlogLifecycle,
+  generateBlogMDX,
+  resolveBlogEnglishSlug
+} from './blogLifecycle'
 export {
   type ProfileMdxCta,
   type ProfileMdxInput,


### PR DESCRIPTION
## Summary

Saving a Spanish foundation blog post in Strapi re-exported MDX without `locale: es` and `localizes`, which broke EN/ES pairing for sync and language switching.

The export path now stamps the requested locale on re-fetch, always writes `locale`, resolves the English pathSlug for `localizes` (with a shared pathSlug fallback when localizations lack pathSlug), and places `locale` / `localizes` after `featured` to match existing blog MDX field order.

## Related Issue

Fixes INTORG-1035

## Manual Test

1. Restart Strapi so the blog lifecycle reloads.
2. Open an existing Spanish blog post (e.g. Call for Papers ES), make a small edit, publish/save.
3. Confirm the MDX under `src/content/foundation-blog-posts/es/` still has:
   - `locale: 'es'` (or `locale: es`)
   - `localizes: '<english-path-slug>'`
   - both fields after `featured`, before `featureImage`
4. Confirm language switch / sync still matches EN and ES via `localizes`.

## Checks

- [x] Unit tests: `cms` `blogLifecycle.test.ts` (12 passing)
- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits
- [x] Linked issue included
- [x] Scope is focused
- [ ] Screenshots for UI changes (if applicable)