### PR TITLE
fix(site): component style cleanup for hero, number tiles, and video [INTORG-1036]

### DIFF
--- a/src/components/blocks/NumberTiles.astro
+++ b/src/components/blocks/NumberTiles.astro
@@ -58,6 +58,9 @@ const LABEL_CLASS = 'text-left text-neutral-75'
         tile.prefix,
         tile.suffix
       )
+      // Full p-0: StatCard defaults to p-lg / desktop:p-xl. Zeroing only left
+      // (pl-0) left a stray right pad on every cell — flush left, inset right.
+      // Grid gap-x/y handles spacing between tiles instead.
       return (
         <StatCard
           value={parsed ?? 0}
@@ -68,7 +71,7 @@ const LABEL_CLASS = 'text-left text-neutral-75'
           label={tile.description}
           labelClass={LABEL_CLASS}
           ariaLabel={ariaLabel}
-          class="w-full items-start pt-0 pb-0 pl-0 desktop:pt-0 desktop:pb-0"
+          class="w-full items-start p-0"
         />
       )
     })

--- a/src/components/blocks/NumberTiles.astro
+++ b/src/components/blocks/NumberTiles.astro
@@ -5,10 +5,9 @@
 // digits (e.g. "1000"); we format with commas for display while the animation
 // still counts up to the parsed numeric value.
 //
-// Layout: CSS Grid instead of flexbox so the gap doesn't need subtracting out
-// of each item's width — 2 tiles per row on mobile/tablet, up to 4 per row on
-// desktop; a 5th+ tile wraps to a new row, left-aligned (grid auto-placement's
-// default behavior, no extra CSS needed).
+// Layout: CSS Grid — 2 cols mobile/tablet, 4 cols desktop. StatCard defaults
+// (p-lg, desktop:p-xl, fixed widths) are fully overridden so tiles fill each
+// track flush left; gap-x/y is the only inter-tile spacing.
 import StatCard from '@/components/shared/StatCard.astro'
 import {
   buildNumberTileAriaLabel,
@@ -36,6 +35,11 @@ const { tiles } = Astro.props
 const NUMBER_CLASS =
   'font-poppins font-semibold text-h2 tablet:text-h2-md desktop:text-h2-lg'
 const LABEL_CLASS = 'text-left text-neutral-75'
+
+// Kill StatCard padding + fixed widths at every breakpoint (bare p-0 / w-full
+// leave desktop:p-xl and desktop:w-[290px] active). All tiles stay left-aligned.
+const CARD_CLASS =
+  'w-full tablet:w-full desktop:w-full p-0 desktop:p-0 items-start'
 ---
 
 <ul
@@ -58,9 +62,6 @@ const LABEL_CLASS = 'text-left text-neutral-75'
         tile.prefix,
         tile.suffix
       )
-      // Full p-0: StatCard defaults to p-lg / desktop:p-xl. Zeroing only left
-      // (pl-0) left a stray right pad on every cell — flush left, inset right.
-      // Grid gap-x/y handles spacing between tiles instead.
       return (
         <StatCard
           value={parsed ?? 0}
@@ -71,7 +72,7 @@ const LABEL_CLASS = 'text-left text-neutral-75'
           label={tile.description}
           labelClass={LABEL_CLASS}
           ariaLabel={ariaLabel}
-          class="w-full items-start p-0"
+          class={CARD_CLASS}
         />
       )
     })

--- a/src/components/blocks/VideoEmbedBlock.astro
+++ b/src/components/blocks/VideoEmbedBlock.astro
@@ -16,4 +16,10 @@ const { url, file, externalUrl, title } = Astro.props
 const resolvedUrl = url ?? file?.url ?? externalUrl
 ---
 
-{resolvedUrl && title && <VideoEmbed url={resolvedUrl} title={title} />}
+{
+  resolvedUrl && title && (
+    <div class="mb-6xl w-full">
+      <VideoEmbed url={resolvedUrl} title={title} />
+    </div>
+  )
+}

--- a/src/components/grant/GrantFaqSection.astro
+++ b/src/components/grant/GrantFaqSection.astro
@@ -32,7 +32,7 @@ const renderedItems = await Promise.all(
 )
 ---
 
-<div class="mx-auto max-w-content min-w-90">
+<div class="w-full">
   <div
     class="flex flex-col gap-xl desktop:flex-row desktop:items-start desktop:gap-5xl"
   >

--- a/src/components/pages/FoundationBlogPostPage.astro
+++ b/src/components/pages/FoundationBlogPostPage.astro
@@ -13,7 +13,7 @@ import BlogPostLayout from '@/layouts/BlogPostLayout.astro'
 import Blockquote from '@/components/shared/Blockquote.astro'
 import Quote from '@/components/blocks/Quote.astro'
 import Paragraph from '@/components/blocks/Paragraph.astro'
-import VideoEmbed from '@/components/shared/VideoEmbed.astro'
+import VideoEmbedBlock from '@/components/blocks/VideoEmbedBlock.astro'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import OptimizedImage from '@/components/shared/OptimizedImage.astro'
 import ImageBlock from '@/components/blocks/ImageBlock.astro'
@@ -59,7 +59,7 @@ const relatedPosts = resolveRelatedPosts(
       Blockquote,
       Quote,
       Paragraph,
-      VideoEmbed,
+      VideoEmbed: VideoEmbedBlock,
       ImageBlock,
       CodeBlock
     }}

--- a/src/components/pages/FoundationContentPage.astro
+++ b/src/components/pages/FoundationContentPage.astro
@@ -11,7 +11,7 @@ import Paragraph from '@/components/blocks/Paragraph.astro'
 import SplitLayout from '@/components/blocks/SplitLayout.astro'
 import CtaStrip from '@/components/blocks/CtaStrip.astro'
 import PdfEmbed from '@/components/shared/PdfEmbed.astro'
-import VideoEmbed from '@/components/shared/VideoEmbed.astro'
+import VideoEmbedBlock from '@/components/blocks/VideoEmbedBlock.astro'
 import InfoCard from '@/components/shared/InfoCard.astro'
 import NumberTiles from '@/components/blocks/NumberTiles.astro'
 import LogoCarousel from '@/components/blocks/LogoCarousel.astro'
@@ -90,7 +90,7 @@ if (isNotFound) return Astro.redirect('/404')
               SplitLayout,
               CtaStrip,
               PdfEmbed,
-              VideoEmbed,
+              VideoEmbed: VideoEmbedBlock,
               InfoCard,
               TitleCard,
               CardGrid,

--- a/src/components/pages/GrantPage.astro
+++ b/src/components/pages/GrantPage.astro
@@ -103,7 +103,7 @@ const breadcrumbs = [
     {
       programOverviewHtml && (
         <section class="pt-4xl">
-          <div class="mx-auto max-w-content px-4 min-w-90 tablet:px-xl desktop:max-w-content">
+          <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
             <div data-prose set:html={programOverviewHtml} />
           </div>
         </section>
@@ -113,7 +113,7 @@ const breadcrumbs = [
     {
       primaryCta && (
         <section class="">
-          <div class="mx-auto max-w-content px-4 min-w-90 tablet:px-xl desktop:max-w-content">
+          <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
             <LinkButton
               href={primaryCta.link}
               variant="primary"
@@ -136,9 +136,7 @@ const breadcrumbs = [
     }
 
     <section class="tablet:py-4xl">
-      <div
-        class="mx-auto max-w-content px-4 min-w-90 tablet:px-xl desktop:max-w-content"
-      >
+      <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
         <div data-prose>
           <MdxContent
             components={{
@@ -163,16 +161,16 @@ const breadcrumbs = [
 
     {
       faqSection && (
-        <section class="pt-0 pb-4xl px-lg tablet:py-4xl tablet:px-xl">
-          <GrantFaqSection {...faqSection} />
+        <section class="pt-0 pb-4xl tablet:py-4xl">
+          <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
+            <GrantFaqSection {...faqSection} />
+          </div>
         </section>
       )
     }
 
     <section class="tablet:py-4xl">
-      <div
-        class="mx-auto px-lg max-w-content min-w-90 tablet:px-xl desktop:px-0 desktop:max-w-content"
-      >
+      <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
         <CtaStrip
           heading={ctaStrip.heading}
           description={ctaStrip.description}

--- a/src/components/pages/PodcastPage.astro
+++ b/src/components/pages/PodcastPage.astro
@@ -66,7 +66,7 @@ const breadcrumbs = [
 
     <section class="py-4xl">
       <div
-        class="mx-auto max-w-content px-lg min-w-90 tablet:px-xl desktop:max-w-content"
+        class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]"
       >
         <CardGrid
           ariaLabel={titleCards.ariaLabel}
@@ -79,7 +79,7 @@ const breadcrumbs = [
 
     <section class="py-4xl">
       <div
-        class="mx-auto max-w-content px-lg min-w-90 tablet:px-xl desktop:max-w-content"
+        class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]"
       >
         <PodcastList podcasts={podcasts} />
       </div>
@@ -87,7 +87,7 @@ const breadcrumbs = [
 
     <section class="tablet:py-4xl">
       <div
-        class="mx-auto max-w-content px-lg min-w-90 tablet:px-xl desktop:max-w-content"
+        class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]"
       >
         <CtaStrip
           heading={ctaStrip.heading}

--- a/src/components/pages/PodcastPage.astro
+++ b/src/components/pages/PodcastPage.astro
@@ -65,9 +65,7 @@ const breadcrumbs = [
     />
 
     <section class="py-4xl">
-      <div
-        class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]"
-      >
+      <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
         <CardGrid
           ariaLabel={titleCards.ariaLabel}
           columns={titleCards.columns}
@@ -78,17 +76,13 @@ const breadcrumbs = [
     </section>
 
     <section class="py-4xl">
-      <div
-        class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]"
-      >
+      <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
         <PodcastList podcasts={podcasts} />
       </div>
     </section>
 
     <section class="tablet:py-4xl">
-      <div
-        class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]"
-      >
+      <div class="mx-auto max-w-content min-w-[360px] max-[1324px]:px-[5%]">
         <CtaStrip
           heading={ctaStrip.heading}
           description={ctaStrip.description}

--- a/src/components/pages/SummitContentPage.astro
+++ b/src/components/pages/SummitContentPage.astro
@@ -8,7 +8,7 @@ import Quote from '@/components/blocks/Quote.astro'
 import Paragraph from '@/components/blocks/Paragraph.astro'
 import SplitLayout from '@/components/blocks/SplitLayout.astro'
 import CtaStrip from '@/components/blocks/CtaStrip.astro'
-import VideoEmbed from '@/components/shared/VideoEmbed.astro'
+import VideoEmbedBlock from '@/components/blocks/VideoEmbedBlock.astro'
 import ProfileCard from '@/components/shared/ProfileCard.astro'
 import CalloutText from '@/components/shared/CalloutText.astro'
 import PdfEmbed from '@/components/shared/PdfEmbed.astro'
@@ -106,7 +106,7 @@ const noindex = isDemoPathSlug(mdxData?.pathSlug)
               SplitLayout,
               CtaStrip,
               PdfEmbed,
-              VideoEmbed,
+              VideoEmbed: VideoEmbedBlock,
               InfoCard,
               TitleCard,
               CardGrid,

--- a/src/components/shared/HeroSection.astro
+++ b/src/components/shared/HeroSection.astro
@@ -38,7 +38,7 @@ const resolvedCtas = ctas.filter(
   ]}
   style={sectionStyle}
 >
-  <div class="mx-auto w-full max-w-content max-[1460px]:px-[5%]">
+  <div class="mx-auto w-full max-w-content min-w-[360px] max-[1324px]:px-[5%]">
     <h1
       class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]"
     >

--- a/src/components/shared/HeroSection.astro
+++ b/src/components/shared/HeroSection.astro
@@ -44,7 +44,11 @@ const resolvedCtas = ctas.filter(
     >
       {title}
     </h1>
-    {description && <p class="mb-2xl text-[1.125rem]">{description}</p>}
+    {
+      description && (
+        <p class="mb-2xl text-[1.125rem] text-white">{description}</p>
+      )
+    }
     {
       resolvedCtas.length > 0 && (
         <div class="flex flex-wrap gap-xl mt-xl">

--- a/src/components/shared/HeroSection.astro
+++ b/src/components/shared/HeroSection.astro
@@ -38,7 +38,7 @@ const resolvedCtas = ctas.filter(
   ]}
   style={sectionStyle}
 >
-  <div class="mx-auto w-full max-w-content px-2xl">
+  <div class="mx-auto w-full max-w-content max-[1460px]:px-[5%]">
     <h1
       class="text-white max-w-[14em] leading-[1.2] font-semibold mb-lg text-[clamp(2rem,5vw,3rem)]"
     >

--- a/src/components/shared/PageHero.astro
+++ b/src/components/shared/PageHero.astro
@@ -61,12 +61,8 @@ const parallaxImgClass = isWideBand
   : 'parallax-img absolute inset-x-0 top-[-40%] h-[180%] w-full object-cover'
 ---
 
-<!--
-  Content column is max-w-content (1440px) with no horizontal padding so title
-  and description span the full content width.
--->
 <div
-  class="mx-auto w-full max-w-content bg-white pt-[calc(var(--spacing-6xl)-var(--site-header-height))] pb-3xl tablet:pt-[calc(var(--spacing-6xl)-var(--site-header-height))] tablet:pb-5xl desktop:pt-[calc(var(--spacing-6xl)-var(--site-header-height-desktop))]"
+  class="mx-auto w-full max-w-content max-[1460px]:px-[5%] bg-white pt-[calc(var(--spacing-6xl)-var(--site-header-height))] pb-3xl tablet:pt-[calc(var(--spacing-6xl)-var(--site-header-height))] tablet:pb-5xl desktop:pt-[calc(var(--spacing-6xl)-var(--site-header-height-desktop))]"
 >
   {
     breadcrumbs && breadcrumbs.length > 0 && (

--- a/src/components/shared/PageHero.astro
+++ b/src/components/shared/PageHero.astro
@@ -62,7 +62,7 @@ const parallaxImgClass = isWideBand
 ---
 
 <div
-  class="mx-auto w-full max-w-content max-[1460px]:px-[5%] bg-white pt-[calc(var(--spacing-6xl)-var(--site-header-height))] pb-3xl tablet:pt-[calc(var(--spacing-6xl)-var(--site-header-height))] tablet:pb-5xl desktop:pt-[calc(var(--spacing-6xl)-var(--site-header-height-desktop))]"
+  class="mx-auto w-full max-w-content min-w-[360px] max-[1324px]:px-[5%] bg-white pt-[calc(var(--spacing-6xl)-var(--site-header-height))] pb-3xl tablet:pt-[calc(var(--spacing-6xl)-var(--site-header-height))] tablet:pb-5xl desktop:pt-[calc(var(--spacing-6xl)-var(--site-header-height-desktop))]"
 >
   {
     breadcrumbs && breadcrumbs.length > 0 && (


### PR DESCRIPTION
WIP


<img width="1156" height="860" alt="image" src="https://github.com/user-attachments/assets/d4cefeb9-c010-4aa7-9a06-4fd180318548" />


## Summary

Small visual spacing/alignment fixes across shared page components:

- **HeroSection / PageHero** — match content horizontal padding (`max-[1460px]:px-[5%]`) so hero text lines up with the page content column; force white description text on `HeroSection` so it stays readable on dark/branded hero backgrounds.
- **NumberTiles** — fully override StatCard’s default `p-lg` / `desktop:p-xl` and fixed per-breakpoint widths (`w-full` + `p-0` at every breakpoint). Partial overrides left a stray right pad / fixed width so the row looked inset; tiles now fill the grid track flush left with only grid gap between them.
- **VideoEmbedBlock** — wrap embeds in `mb-6xl` and route foundation/summit/blog MDX `VideoEmbed` through `VideoEmbedBlock` so spacing after videos matches other page blocks.

## Related Issue

Fixes INTORG-1036

## Manual Test

1. Open a foundation/summit/hackathon page with a hero description — text is white and horizontally aligned with body content.
2. Open a page with `NumberTiles` (e.g. grantmaking / demo pages) — tile numbers are left-aligned, no extra left/right pad inside cells; gap between tiles only.
3. Open a page with a video embed in MDX — consistent bottom margin after the embed before the next block.

## Checks

- [ ] `pnpm run format`
- [ ] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)