### PR TITLE
fix: podcast was using outdated CTA strip schema

### DIFF
--- a/cms/scripts/sync-mdx/mdxTransformer.ts
+++ b/cms/scripts/sync-mdx/mdxTransformer.ts
@@ -872,14 +872,7 @@ export async function buildPodcastPagePayload(
       heading: ctaStripFm.heading,
       description: ctaStripFm.description,
       primaryButtonText: ctaStripFm.buttonText,
-      primaryButtonLink: ctaStripFm.buttonLink,
-      color: ctaStripFm.color,
-      ...(ctaStripFm.secondaryButtonText
-        ? { secondaryButtonText: ctaStripFm.secondaryButtonText }
-        : {}),
-      ...(ctaStripFm.secondaryButtonLink
-        ? { secondaryButtonLink: ctaStripFm.secondaryButtonLink }
-        : {})
+      primaryButtonLink: ctaStripFm.buttonLink
     }
 
     return {

--- a/cms/src/utils/podcastPageMdx.test.ts
+++ b/cms/src/utils/podcastPageMdx.test.ts
@@ -76,19 +76,18 @@ describe('generatePodcastPageMdx', () => {
     expect(podcasts[0]?.series).toBe('Future Money')
   })
 
-  it('flattens ctaStrip with a default purple color', () => {
+  it('flattens ctaStrip', () => {
     const { data } = matter(generatePodcastPageMdx(makePage()))
     const ctaStrip = data.ctaStrip as {
       heading: string
       buttonText: string
       buttonLink: string
-      color: string
     }
 
     expect(ctaStrip.heading).toBe('Listen now')
     expect(ctaStrip.buttonText).toBe('Listen')
     expect(ctaStrip.buttonLink).toBe('/podcast')
-    expect(ctaStrip.color).toBe('purple')
+    expect(ctaStrip).not.toHaveProperty('color')
   })
 
   it('adds localizes for a non-default locale, using the English slug', () => {

--- a/cms/src/utils/podcastPageMdx.ts
+++ b/cms/src/utils/podcastPageMdx.ts
@@ -23,9 +23,6 @@ export interface PodcastPageCtaStrip {
   description?: string
   primaryButtonText?: string
   primaryButtonLink?: string
-  secondaryButtonText?: string
-  secondaryButtonLink?: string
-  color?: 'purple' | 'green'
 }
 
 export interface PodcastPageTitleCard {
@@ -81,14 +78,7 @@ function ctaStripFrontmatter(ctaStrip: PodcastPageCtaStrip) {
     heading: ctaStrip.heading ?? '',
     description: ctaStrip.description ?? '',
     buttonText: ctaStrip.primaryButtonText ?? '',
-    buttonLink: ctaStrip.primaryButtonLink ?? '',
-    color: ctaStrip.color ?? 'purple',
-    ...(ctaStrip.secondaryButtonText
-      ? { secondaryButtonText: ctaStrip.secondaryButtonText }
-      : {}),
-    ...(ctaStrip.secondaryButtonLink
-      ? { secondaryButtonLink: ctaStrip.secondaryButtonLink }
-      : {})
+    buttonLink: ctaStrip.primaryButtonLink ?? ''
   }
 }
 

--- a/src/content/podcast-pages/podcast.mdx
+++ b/src/content/podcast-pages/podcast.mdx
@@ -143,6 +143,5 @@ ctaStrip:
   description: 'Get the latest episodes and updates from the F|M Podcast delivered straight to your inbox.'
   buttonText: 'Subscribe'
   buttonLink: '/subscribe'
-  color: 'purple'
 locale: 'en'
 ---

--- a/src/schemas/content.ts
+++ b/src/schemas/content.ts
@@ -286,10 +286,7 @@ const podcastCtaStripSchema = z.object({
   heading: z.string(),
   description: z.string(),
   buttonText: z.string(),
-  buttonLink: z.string(),
-  color: z.enum(['purple', 'green']).default('purple'),
-  secondaryButtonText: z.string().optional(),
-  secondaryButtonLink: z.string().optional()
+  buttonLink: z.string()
 })
 
 const podcastTitleCardSchema = z.object({


### PR DESCRIPTION
## Summary
<!-- What changed and why -->
Build and sync workflow is breaking
"📁 Syncing foundation-blog-posts...
   Found 152 MDX files (0 invalid skipped)
   🔄 Updated: grant/grantmaking-faq (en)
   🔄 Updated: policy-and-advocacy/role-stablecoins-facilitating-low-value-low-cost-transactions (en)
   🔄 Updated: simplifying-interledger-the-graveyard-of-possible-protocol-features (en)
   🔄 Updated: 2022 (en)
   🔄 Updated: about-us (en)
      📌 Matched via localizes: about-us: about-us (es)
   ❌ Error processing podcast (en): Strapi API error (400): {"data":null,"error":{"status":400,"name":"ValidationError","message":"Invalid key color at ctaStrip","details":{"key":"color","path":"ctaStrip","source":"body"}}}"

This fixes the legacy CTA strip schema the podcast page brought in

## Related Issue
<!-- Fixes INTORG-123 -->

## Manual Test
<!-- Reviewer steps (only if needed) -->

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [ ] Linked issue included
- [ ] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
