### PR TITLE
fix(cms): keep CKEditor list markers after an editor unmounts [INTORG-1037]

### DIFF
--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -208,6 +208,61 @@ export default {
       div:has(> div > input[name="alternativeText"]) {
         display: none !important;
       }
+
+      /* INTORG-1037: keep CKEditor content readable after an editor unmounts.
+         The plugin renders its theme through a styled-components
+         createGlobalStyle *inside every editor field*. styled-components drops
+         those global rules as soon as one instance unmounts, so collapsing a
+         repeatable component or closing an accordion strips the styling from
+         every editor still on the page. Strapi's own design-system reset then
+         wins, and lists lose their markers and their indent.
+
+         These rules duplicate the plugin theme, so the result is the same
+         whether or not the plugin's copy is currently attached. Remove this
+         block once the plugin hoists its GlobalStyle out of the field
+         component (upstream: nshenderov/strapi-plugin-ckeditor). */
+      .ck-editor__main * {
+        font: revert;
+        margin: revert;
+      }
+      .ck-editor__main blockquote,
+      .ck-editor__main ol,
+      .ck-editor__main p,
+      .ck-editor__main ul {
+        font-size: 1em;
+        line-height: 1.6em;
+        padding-top: 0.2em;
+        margin-bottom: var(--ck-spacing-large);
+      }
+      .ck-editor__main ul,
+      .ck-editor__main ol {
+        list-style: initial;
+        margin-left: 2rem;
+      }
+      .ck-editor__main ol {
+        list-style: decimal;
+      }
+      /* To-do lists draw their own checkboxes and must stay marker-free. */
+      .ck-editor__main ul.todo-list {
+        list-style: none;
+        margin: revert;
+        margin-left: 2rem;
+      }
+      /* Without the plugin theme the counter falls back to static flow and
+         lands on top of the text instead of below the editor box. */
+      .ck-editor__main + div > .ck-word-count,
+      .ck-word-count {
+        display: flex;
+        position: absolute;
+        justify-content: end;
+        gap: 0.3rem;
+        font-size: 1rem;
+        font-weight: 500;
+        text-transform: lowercase;
+        z-index: 2;
+        bottom: -2rem;
+        right: 0;
+      }
     `
     document.head.appendChild(style)
 


### PR DESCRIPTION
## Summary

Bullet and number markers vanish from CKEditor fields in the admin. The list is applied correctly (the toolbar button stays active, and the saved content is a real `<ul>`), but nothing renders. Indentation, block spacing, and the word-count widget go with it.

The trigger is editor unmount, not the content. The plugin renders its theme through a styled-components `createGlobalStyle` **inside every editor field** (`Field-C2N3FIDl.mjs:552-577`, where `MemoizedGlobalStyling` sits in the `Editor` component). styled-components does not reference-count that, so as soon as one instance unmounts it tears down those global rules for every editor still on the page.

Strapi's design-system reset then wins:

```css
/* @strapi/design-system/dist/index.mjs:3946 */
ol, ul { list-style: none; padding: unset; margin: unset }
```

This explains the intermittency editors reported. One editor on a page looks fine. Collapse a repeatable component or close an accordion, and every remaining editor loses its list styling until a full reload.

The fix mirrors the plugin theme in the admin's existing injected `<style>` block. That block is appended to `document.head` in `bootstrap()`, so React never removes it. Selectors are scoped to `.ck-editor__main` (specificity 0,1,1), which outranks the bare `ol, ul` reset (0,0,1), so they apply regardless of injection order. Values match the plugin's, so when the plugin's own copy is attached the result is unchanged.

Covered: list markers and indent, nested `ol` numbering, block spacing, the `todo-list` marker-free exception, and word-count positioning.

The real bug is upstream in the plugin. This is a local workaround, and the comment says so. Worth filing against `nshenderov/strapi-plugin-ckeditor` so the block can eventually be deleted.

## Related Issue

Fixes INTORG-1037

## Manual Test

1. Open any FAQ Page entry in the admin (`Content Manager` > `Faq Page` > create or edit).
2. In `Intro Paragraph`, type two lines and apply `Bulleted List` to the second. The marker renders.
3. Add an FAQ section, then expand one of its questions so a second editor mounts. The marker is still there.
4. Collapse that question so the second editor unmounts.
5. Before this change, the first editor loses its bullet, its indent, and its block spacing, and the word count jumps from bottom-right to unstyled top-left. After this change, all of it survives.

The same path reproduces via title cards on a Grant Overview Page, which is where the issue was first reported.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)
