### PR TITLE
fix(hero): render newlines in hero descriptions [INTORG-1041]

### DIFF
--- a/src/components/shared/HeroSection.astro
+++ b/src/components/shared/HeroSection.astro
@@ -44,7 +44,11 @@ const resolvedCtas = ctas.filter(
     >
       {title}
     </h1>
-    {description && <p class="mb-2xl text-[1.125rem]">{description}</p>}
+    {
+      description && (
+        <p class="mb-2xl text-[1.125rem] whitespace-pre-line">{description}</p>
+      )
+    }
     {
       resolvedCtas.length > 0 && (
         <div class="flex flex-wrap gap-xl mt-xl">

--- a/src/components/shared/PageHero.astro
+++ b/src/components/shared/PageHero.astro
@@ -87,7 +87,7 @@ const parallaxImgClass = isWideBand
 
   {
     description && (
-      <p class="text-h4 tablet:text-h4-md desktop:text-h4-lg font-normal mb-xl tablet:mb-lg">
+      <p class="text-h4 tablet:text-h4-md desktop:text-h4-lg font-normal mb-xl tablet:mb-lg whitespace-pre-line">
         {description}
       </p>
     )


### PR DESCRIPTION
## Summary

- Hero descriptions from MDX/Strapi can include `\n` (e.g. Open Payments SDK grant page), but HTML collapses them inside a plain `<p>`.
- Add `whitespace-pre-line` on the description in `PageHero` and `HeroSection` so line breaks render while normal wrapping still works.

## Related

Fixes INTORG-1041

## Test plan

1. Open a grant page whose `heroDescription` contains `\n` or `\n\n` (e.g. `/grant/innovation/sdk`).
2. Confirm the second line appears on its own line under the hero title.
3. Spot-check a foundation/summit page using `HeroSection` if it has a multi-line hero description.
4. Confirm single-line heroes are unchanged.