### PR TITLE
feat(hackathon): FoundationFooter uses hackathon navigation [INTORG-1046]

### DIFF
--- a/src/components/layout/FoundationFooter.astro
+++ b/src/components/layout/FoundationFooter.astro
@@ -7,15 +7,20 @@ import {
   localizeRoute,
   type UiKey
 } from '@/utils'
-import type { MenuGroup } from '@/types/navigation'
+import type { MenuGroup, NavigationSite } from '@/types/navigation'
 import Icon from '@/components/shared/Icon.astro'
 import LinkButton from '@/components/shared/LinkButton.astro'
 import InterledgerIcon from '@/components/logos/InterledgerIcon.astro'
 
+interface Props {
+  site?: NavigationSite
+}
+
+const { site = 'foundation' } = Astro.props
 const { routeLocale } = Astro.locals
 const t = useTranslations(routeLocale)
 
-const { mainMenu } = getNavigation('foundation', routeLocale)
+const { mainMenu } = getNavigation(site, routeLocale)
 
 const resourcesColumn: MenuGroup = {
   label: 'Resources',

--- a/src/config/hackathon-navigation.es.json
+++ b/src/config/hackathon-navigation.es.json
@@ -6,8 +6,24 @@
         {
           "label": "Descripción general",
           "href": "/es/hackathon/overview"
+        },
+        {
+          "label": "Preguntas frecuentes",
+          "href": "/es/hackathon/faqs"
         }
       ]
+    },
+    {
+      "label": "Recursos",
+      "href": "/es/hackathon/resources"
+    },
+    {
+      "label": "Requisitos de participación",
+      "href": "/es/hackathon/participation"
+    },
+    {
+      "label": "Código de conducta",
+      "href": "/es/hackathon/code-conduct"
     }
   ],
   "ctaButton": {

--- a/src/config/hackathon-navigation.es.json
+++ b/src/config/hackathon-navigation.es.json
@@ -15,15 +15,16 @@
     },
     {
       "label": "Recursos",
-      "href": "/es/hackathon/resources"
-    },
-    {
-      "label": "Requisitos de participación",
-      "href": "/es/hackathon/participation"
-    },
-    {
-      "label": "Código de conducta",
-      "href": "/es/hackathon/code-conduct"
+      "items": [
+        {
+          "label": "Requisitos de participación",
+          "href": "/es/hackathon/participation"
+        },
+        {
+          "label": "Código de conducta",
+          "href": "/es/hackathon/code-conduct"
+        }
+      ]
     }
   ],
   "ctaButton": {

--- a/src/config/hackathon-navigation.json
+++ b/src/config/hackathon-navigation.json
@@ -15,15 +15,16 @@
     },
     {
       "label": "Resources",
-      "href": "/hackathon/resources"
-    },
-    {
-      "label": "Participation requirements",
-      "href": "/hackathon/participation"
-    },
-    {
-      "label": "Code of conduct",
-      "href": "/hackathon/code-conduct"
+      "items": [
+        {
+          "label": "Participation requirements",
+          "href": "/hackathon/participation"
+        },
+        {
+          "label": "Code of conduct",
+          "href": "/hackathon/code-conduct"
+        }
+      ]
     }
   ],
   "ctaButton": {

--- a/src/config/hackathon-navigation.json
+++ b/src/config/hackathon-navigation.json
@@ -6,8 +6,24 @@
         {
           "label": "Overview",
           "href": "/hackathon/overview"
+        },
+        {
+          "label": "FAQ",
+          "href": "/hackathon/faqs"
         }
       ]
+    },
+    {
+      "label": "Resources",
+      "href": "/hackathon/resources"
+    },
+    {
+      "label": "Participation requirements",
+      "href": "/hackathon/participation"
+    },
+    {
+      "label": "Code of conduct",
+      "href": "/hackathon/code-conduct"
     }
   ],
   "ctaButton": {

--- a/src/layouts/HackathonPageLayout.astro
+++ b/src/layouts/HackathonPageLayout.astro
@@ -7,7 +7,7 @@
  */
 import { useTranslations } from '@/utils'
 import BaseLayout from './BaseLayout.astro'
-import MicrositeFooter from '@/components/layout/MicrositeFooter.astro'
+import FoundationFooter from '@/components/layout/FoundationFooter.astro'
 import MicrositeHeader from '@/components/layout/MicrositeHeader.astro'
 import TableScrollSupport from '@/components/shared/TableScrollSupport.astro'
 
@@ -52,5 +52,5 @@ const {
   >
     <slot />
   </div>
-  <MicrositeFooter slot="footer" />
+  <FoundationFooter site="hackathon" slot="footer" />
 </BaseLayout>


### PR DESCRIPTION
## Summary

- Wire `HackathonPageLayout` to `FoundationFooter` with `site="hackathon"` so the hackathon chrome uses the same footer component as foundation, driven by the hackathon nav config.
- Teach `FoundationFooter` an optional `site` prop (default `foundation`) that selects the navigation source via `getNavigation`.
- Populate EN/ES `hackathon-navigation` with Overview, FAQ, and a Resources group (participation requirements, code of conduct).


## Test plan

1. Open a hackathon page (e.g. `/hackathon/overview`).
2. Confirm the footer shows Hackathon (Overview, FAQ) and Resources (Participation requirements, Code of conduct) columns, plus the usual legal Resources column if still appended.
3. Switch locale to ES and confirm Spanish labels and `/es/hackathon/...` hrefs.
4. Confirm foundation pages still use the foundation menu (default `site`).

## Related

Fixes INTORG-1046