### PR TITLE
fix(cms): let sync:images seed missing media library records

### DIFF
--- a/cms/scripts/sync-images.ts
+++ b/cms/scripts/sync-images.ts
@@ -1,13 +1,13 @@
 /**
- * Check which images in public/uploads/img/original/ and public/img/ are
- * registered in Strapi's media library.
- *
- * The primary seeding mechanism lives in bootstrap (cms/src/index.ts) and runs
- * on every Strapi start. This script is for diagnostics.
+ * Sync images from public/uploads/img/original/ and public/img/ to Strapi's
+ * media library. Any image on disk that is not registered in Strapi is seeded
+ * via POST /api/seed-media, which runs seedUploadsFromDisk server-side and
+ * creates the DB record without going through Strapi's upload pipeline
+ * (preserving the git-committed filename as the URL).
  *
  * Usage:
- *   cd cms && pnpm run sync:images              # full report
- *   cd cms && pnpm run sync:images --dry-run     # same (read-only either way)
+ *   cd cms && pnpm run sync:images              # check + seed missing
+ *   cd cms && pnpm run sync:images --dry-run     # report only, no seeding
  *
  * Requires STRAPI_URL and STRAPI_API_TOKEN in ../.env
  */
@@ -22,6 +22,7 @@ config({ path: path.resolve(process.cwd(), '../.env'), quiet: true })
 
 const STRAPI_URL = process.env.STRAPI_URL ?? 'http://localhost:1337'
 const STRAPI_TOKEN = process.env.STRAPI_API_TOKEN ?? ''
+const DRY_RUN = process.argv.includes('--dry-run')
 
 const SCAN_DIRS: ReadonlyArray<{ dir: string; urlPrefix: string }> = [
   { dir: PATHS.UPLOADS, urlPrefix: `/${PATHS.UPLOADS.replace('public/', '')}` },
@@ -43,6 +44,19 @@ const IMAGE_EXTENSIONS = new Set([
 async function strapiGet<T>(endpoint: string): Promise<T> {
   const url = `${STRAPI_URL}/api/${endpoint}`
   const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${STRAPI_TOKEN}` }
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Strapi ${res.status}: ${text}`)
+  }
+  return res.json() as Promise<T>
+}
+
+async function strapiPost<T>(endpoint: string): Promise<T> {
+  const url = `${STRAPI_URL}/api/${endpoint}`
+  const res = await fetch(url, {
+    method: 'POST',
     headers: { Authorization: `Bearer ${STRAPI_TOKEN}` }
   })
   if (!res.ok) {
@@ -92,6 +106,8 @@ async function main() {
   }
   await assertStrapiRunning(STRAPI_URL)
 
+  if (DRY_RUN) console.log('ℹ️  Dry run — no images will be seeded\n')
+
   const projectRoot = getProjectRoot()
   let totalRegistered = 0
   let totalMissing = 0
@@ -129,13 +145,13 @@ async function main() {
           totalRegistered++
         } else {
           console.log(
-            `  ❌ ${expectedUrl} (on disk, not in Strapi — restart Strapi to seed)`
+            `  ➕ ${expectedUrl} (${DRY_RUN ? 'not in Strapi — would seed' : 'not in Strapi — will seed'})`
           )
           totalMissing++
         }
       } catch (err) {
         console.error(
-          `  ⚠️  Error: ${expectedUrl}:`,
+          `  ❌ Error: ${expectedUrl}:`,
           err instanceof Error ? err.message : err
         )
         totalFailed++
@@ -143,22 +159,36 @@ async function main() {
     }
   }
 
-  console.log(
-    `\nSummary: ${totalRegistered} registered, ${totalMissing} missing, ${totalOversized} oversized, ${totalFailed} errors`
-  )
-
-  if (totalMissing > 0) {
-    console.log(
-      '\n💡 Missing files will be auto-seeded on next Strapi startup (bootstrap).'
-    )
-    console.log('   Or restart Strapi now: cd cms && pnpm run develop')
+  let totalSeeded = 0
+  if (!DRY_RUN && totalMissing > 0) {
+    console.log('\n⬆️  Seeding missing images...')
+    try {
+      const result = await strapiPost<{ seeded: number }>('seed-media')
+      totalSeeded = result.seeded
+      console.log(`✅ Seeded ${totalSeeded} image(s)`)
+    } catch (err) {
+      console.error('❌ Seeding failed:', err instanceof Error ? err.message : err)
+      totalFailed++
+    }
   }
+
+  const summaryParts = [
+    `${totalRegistered} registered`,
+    ...(!DRY_RUN && totalMissing > 0 ? [`${totalSeeded} seeded`] : []),
+    ...(DRY_RUN && totalMissing > 0 ? [`${totalMissing} would seed`] : []),
+    ...(totalOversized > 0 ? [`${totalOversized} oversized`] : []),
+    ...(totalFailed > 0 ? [`${totalFailed} errors`] : [])
+  ]
+  console.log(`\nSummary: ${summaryParts.join(', ')}`)
+
+  if (DRY_RUN && totalMissing > 0) {
+    console.log('\n💡 Run sync:images without --dry-run to seed these images.')
+  }
+
+  if (totalFailed > 0) process.exit(1)
 }
 
 main().catch((err) => {
-  console.error(
-    '❌ Fatal error:',
-    err instanceof Error ? err.message : String(err)
-  )
+  console.error('❌ Fatal error:', err instanceof Error ? err.message : String(err))
   process.exit(1)
 })

--- a/cms/scripts/sync-images.ts
+++ b/cms/scripts/sync-images.ts
@@ -1,9 +1,11 @@
 /**
- * Sync images from public/uploads/img/original/ and public/img/ to Strapi's
- * media library. Any image on disk that is not registered in Strapi is seeded
- * via POST /api/seed-media, which runs seedUploadsFromDisk server-side and
- * creates the DB record without going through Strapi's upload pipeline
- * (preserving the git-committed filename as the URL).
+ * Sync seedable media from public/uploads/img/original/ and public/img/ into
+ * Strapi's media library. Disk files not registered in Strapi are seeded via
+ * POST /api/seed-media (seedUploadsFromDisk server-side — DB records only,
+ * preserves git-committed filenames as URLs).
+ *
+ * Extension allowlist matches seedUploadsFromDisk (SEEDABLE_EXTENSIONS):
+ * images, video, and PDF.
  *
  * Usage:
  *   cd cms && pnpm run sync:images              # check + seed missing
@@ -15,7 +17,13 @@
 import fs from 'fs'
 import path from 'path'
 import { config } from 'dotenv'
-import { getProjectRoot, PATHS, validateImageFileSize } from '@/utils'
+import {
+  getProjectRoot,
+  IMAGE_EXTENSIONS,
+  PATHS,
+  SEEDABLE_EXTENSIONS,
+  validateImageFileSize
+} from '@/utils'
 import { assertStrapiRunning } from './ensureStrapiRunning'
 
 config({ path: path.resolve(process.cwd(), '../.env'), quiet: true })
@@ -29,17 +37,6 @@ const SCAN_DIRS: ReadonlyArray<{ dir: string; urlPrefix: string }> = [
   { dir: 'public/img', urlPrefix: '/img' }
 ]
 const EXCLUDED_DIR_NAMES = new Set(['optimized'])
-
-const IMAGE_EXTENSIONS = new Set([
-  '.jpg',
-  '.jpeg',
-  '.png',
-  '.gif',
-  '.svg',
-  '.webp',
-  '.avif',
-  '.tiff'
-])
 
 async function strapiGet<T>(endpoint: string): Promise<T> {
   const url = `${STRAPI_URL}/api/${endpoint}`
@@ -78,7 +75,7 @@ async function findByUrl(url: string): Promise<UploadRecord | null> {
   return files.length > 0 ? files[0] : null
 }
 
-function collectImageFiles(dir: string): string[] {
+function collectSeedableFiles(dir: string): string[] {
   if (!fs.existsSync(dir)) return []
   const results: string[] = []
 
@@ -89,7 +86,9 @@ function collectImageFiles(dir: string): string[] {
       if (entry.isDirectory()) {
         if (EXCLUDED_DIR_NAMES.has(entry.name)) continue
         walk(full)
-      } else if (IMAGE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+      } else if (
+        SEEDABLE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
+      ) {
         results.push(full)
       }
     }
@@ -106,7 +105,7 @@ async function main() {
   }
   await assertStrapiRunning(STRAPI_URL)
 
-  if (DRY_RUN) console.log('ℹ️  Dry run — no images will be seeded\n')
+  if (DRY_RUN) console.log('ℹ️  Dry run — no media will be seeded\n')
 
   const projectRoot = getProjectRoot()
   let totalRegistered = 0
@@ -118,24 +117,28 @@ async function main() {
     const absDir = path.join(projectRoot, dir)
     console.log(`\n📁 Scanning: ${absDir}`)
 
-    const files = collectImageFiles(absDir)
+    const files = collectSeedableFiles(absDir)
     if (files.length === 0) {
-      console.log('   No image files found.')
+      console.log('   No seedable media files found.')
       continue
     }
 
-    console.log(`   Found ${files.length} image file(s)\n`)
+    console.log(`   Found ${files.length} seedable file(s)\n`)
 
     for (const filePath of files) {
       const relativePath = path.relative(absDir, filePath)
       const expectedUrl = `${urlPrefix}/${relativePath.replace(/\\/g, '/')}`
+      const ext = path.extname(filePath).toLowerCase()
 
-      const sizeError = validateImageFileSize(filePath)
-      if (sizeError) {
-        console.log(`  ⚠️  Oversized: ${expectedUrl}`)
-        console.log(`      ${sizeError.message}`)
-        totalOversized++
-        continue
+      // Match seedUploadsFromDisk: only enforce the image size ceiling here.
+      if (IMAGE_EXTENSIONS.has(ext)) {
+        const sizeError = validateImageFileSize(filePath)
+        if (sizeError) {
+          console.log(`  ⚠️  Oversized: ${expectedUrl}`)
+          console.log(`      ${sizeError.message}`)
+          totalOversized++
+          continue
+        }
       }
 
       try {
@@ -161,13 +164,16 @@ async function main() {
 
   let totalSeeded = 0
   if (!DRY_RUN && totalMissing > 0) {
-    console.log('\n⬆️  Seeding missing images...')
+    console.log('\n⬆️  Seeding missing media library records...')
     try {
       const result = await strapiPost<{ seeded: number }>('seed-media')
       totalSeeded = result.seeded
-      console.log(`✅ Seeded ${totalSeeded} image(s)`)
+      console.log(`✅ Seeded ${totalSeeded} media record(s)`)
     } catch (err) {
-      console.error('❌ Seeding failed:', err instanceof Error ? err.message : err)
+      console.error(
+        '❌ Seeding failed:',
+        err instanceof Error ? err.message : err
+      )
       totalFailed++
     }
   }
@@ -182,13 +188,18 @@ async function main() {
   console.log(`\nSummary: ${summaryParts.join(', ')}`)
 
   if (DRY_RUN && totalMissing > 0) {
-    console.log('\n💡 Run sync:images without --dry-run to seed these images.')
+    console.log(
+      '\n💡 Run sync:images without --dry-run to seed these media records.'
+    )
   }
 
   if (totalFailed > 0) process.exit(1)
 }
 
 main().catch((err) => {
-  console.error('❌ Fatal error:', err instanceof Error ? err.message : String(err))
+  console.error(
+    '❌ Fatal error:',
+    err instanceof Error ? err.message : String(err)
+  )
   process.exit(1)
 })

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -39,6 +39,7 @@ import {
   IMAGE_EXTENSIONS,
   MAX_IMAGE_SIZE_LABEL
 } from './utils/uploadLimits'
+import { SEED_MIME_BY_EXT, SEEDABLE_EXTENSIONS } from './utils/seedMedia'
 import { CARD_GRID_VARIANT_DEFINITIONS } from './utils/cardGrid'
 
 const CARD_GRID_ADMIN_FIELD_LABELS = Object.fromEntries(
@@ -286,7 +287,11 @@ interface StrapiInstance {
   }
   config: { get: (key: string, defaultValue?: unknown) => unknown }
   plugin: (name: string) => StrapiPlugin | undefined
-  server: { router: { post: (path: string, handler: (ctx: KoaContext) => Promise<void>) => void } }
+  server: {
+    router: {
+      post: (path: string, handler: (ctx: KoaContext) => Promise<void>) => void
+    }
+  }
   service: (uid: string) => unknown
 }
 
@@ -617,33 +622,6 @@ async function disableImageVariants(strapi: StrapiInstance): Promise<void> {
   }
 }
 
-// Media types seeded from disk. Kept in sync with `shouldGitSyncUpload` above:
-// anything git-committed and served from the repo (images, video, PDF) must
-// also be seedable, or an MDX reference to it resolves to no media record and
-// the sync hard-fails (INTORG-876). Larger media storage is tracked in
-// INTORG-902.
-const MIME_BY_EXT: Record<string, string> = {
-  // Images
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.png': 'image/png',
-  '.gif': 'image/gif',
-  '.svg': 'image/svg+xml',
-  '.webp': 'image/webp',
-  '.avif': 'image/avif',
-  '.tiff': 'image/tiff',
-  // Video (matches the VideoEmbed externalUrl regex extensions)
-  '.mp4': 'video/mp4',
-  '.webm': 'video/webm',
-  '.ogg': 'video/ogg',
-  '.ogv': 'video/ogg',
-  '.mov': 'video/quicktime',
-  // Documents
-  '.pdf': 'application/pdf'
-}
-
-const SEEDABLE_EXTENSIONS = new Set(Object.keys(MIME_BY_EXT))
-
 /**
  * Directories under `public/` to scan for seedable media.
  * Each entry maps a disk path (relative to public/) to the URL prefix it's
@@ -692,7 +670,7 @@ async function seedUploadsFromDisk(strapi: StrapiInstance): Promise<number> {
         continue
       }
       const sizeKB = Number((stat.size / 1024).toFixed(2))
-      const mime = MIME_BY_EXT[ext] ?? 'application/octet-stream'
+      const mime = SEED_MIME_BY_EXT[ext] ?? 'application/octet-stream'
 
       await query.create({
         data: {
@@ -1957,10 +1935,9 @@ export default {
    * run jobs, or perform some special logic.
    */
   async bootstrap({ strapi }: { strapi: StrapiInstance }) {
-    // Seed-media endpoint: lets the sync-images script trigger seedUploadsFromDisk
-    // remotely without a full Strapi rebuild. Validates against STRAPI_API_TOKEN
-    // (the same token all sync scripts use) since this route bypasses Strapi's
-    // standard auth middleware.
+    // Seed-media endpoint: lets sync:images trigger seedUploadsFromDisk without
+    // restarting Strapi. Auth is STRAPI_API_TOKEN (same as other sync scripts)
+    // because this route bypasses Strapi's standard auth middleware.
     strapi.server.router.post('/api/seed-media', async (ctx) => {
       const bearer = String(ctx.request.headers['authorization'] ?? '').replace(
         'Bearer ',

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -261,6 +261,12 @@ interface DbQueryApi {
   }) => Promise<UploadFileRecord>
   count: (params: { where: Record<string, unknown> }) => Promise<number>
 }
+interface KoaContext {
+  request: { headers: Record<string, string | string[] | undefined> }
+  status: number
+  body: unknown
+}
+
 interface StrapiInstance {
   documents: ((uid: string) => StrapiDocumentService) & {
     use: (middleware: DocumentValidationMiddleware) => void
@@ -280,6 +286,7 @@ interface StrapiInstance {
   }
   config: { get: (key: string, defaultValue?: unknown) => unknown }
   plugin: (name: string) => StrapiPlugin | undefined
+  server: { router: { post: (path: string, handler: (ctx: KoaContext) => Promise<void>) => void } }
   service: (uid: string) => unknown
 }
 
@@ -649,11 +656,11 @@ const SEED_DIRS: ReadonlyArray<{ dir: string; urlPrefix: string }> = [
 ]
 const EXCLUDED_SEED_SUBDIRS = new Set(['optimized'])
 
-async function seedUploadsFromDisk(strapi: StrapiInstance): Promise<void> {
+async function seedUploadsFromDisk(strapi: StrapiInstance): Promise<number> {
   const query = strapi.db?.query('plugin::upload.file')
   if (!query) {
     strapi.log.warn('⚠️  DB query API unavailable — skipping upload seeding')
-    return
+    return 0
   }
 
   const publicDir = strapi.dirs.static.public
@@ -709,6 +716,7 @@ async function seedUploadsFromDisk(strapi: StrapiInstance): Promise<void> {
   if (seeded > 0) {
     strapi.log.info(`✅ Seeded ${seeded} upload record(s) from disk`)
   }
+  return seeded
 }
 
 interface AdminApiTokenService {
@@ -1949,6 +1957,24 @@ export default {
    * run jobs, or perform some special logic.
    */
   async bootstrap({ strapi }: { strapi: StrapiInstance }) {
+    // Seed-media endpoint: lets the sync-images script trigger seedUploadsFromDisk
+    // remotely without a full Strapi rebuild. Validates against STRAPI_API_TOKEN
+    // (the same token all sync scripts use) since this route bypasses Strapi's
+    // standard auth middleware.
+    strapi.server.router.post('/api/seed-media', async (ctx) => {
+      const bearer = String(ctx.request.headers['authorization'] ?? '').replace(
+        'Bearer ',
+        ''
+      )
+      if (!bearer || bearer !== process.env.STRAPI_API_TOKEN) {
+        ctx.status = 401
+        ctx.body = { error: 'Unauthorized' }
+        return
+      }
+      const seeded = await seedUploadsFromDisk(strapi)
+      ctx.body = { seeded }
+    })
+
     // Validate paragraph content on save — reject nested JSX before it reaches
     // the DB. Registered as a document-service middleware (see
     // registerDocumentValidation below for why) so it covers every content

--- a/cms/src/utils/index.ts
+++ b/cms/src/utils/index.ts
@@ -20,6 +20,9 @@ export {
   mediaSizeLimitError
 } from './uploadLimits'
 
+// Disk → Media Library seeding (bootstrap + sync:images)
+export { SEED_MIME_BY_EXT, SEEDABLE_EXTENSIONS } from './seedMedia'
+
 // Upload validation
 export {
   isLocalImagePath,

--- a/cms/src/utils/seedMedia.ts
+++ b/cms/src/utils/seedMedia.ts
@@ -1,0 +1,29 @@
+/**
+ * Media types seeded from disk into Strapi's Media Library (bootstrap and
+ * POST /api/seed-media). Kept in sync with `shouldGitSyncUpload` in index.ts:
+ * anything git-committed and served from the repo (images, video, PDF) must
+ * also be seedable, or an MDX reference resolves to no media record.
+ * Larger media storage is tracked in INTORG-902.
+ */
+export const SEED_MIME_BY_EXT: Record<string, string> = {
+  // Images
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+  '.tiff': 'image/tiff',
+  // Video (matches VideoEmbed externalUrl regex extensions)
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.ogg': 'video/ogg',
+  '.ogv': 'video/ogg',
+  '.mov': 'video/quicktime',
+  // Documents
+  '.pdf': 'application/pdf'
+}
+
+/** Extensions scanned by seedUploadsFromDisk and cms/scripts/sync-images.ts. */
+export const SEEDABLE_EXTENSIONS = new Set(Object.keys(SEED_MIME_BY_EXT))

--- a/cms/src/utils/uploadLimits.ts
+++ b/cms/src/utils/uploadLimits.ts
@@ -18,9 +18,9 @@ export const MAX_MEDIA_BYTES = 5 * 1024 * 1024
 export const MAX_MEDIA_SIZE_LABEL = '5 MB'
 
 /**
- * Image subset of the seedable media extensions (see MIME_BY_EXT in
- * cms/src/index.ts) — the single source of truth for "is this an image" so
- * the 2 MB limit is never applied to non-image media (PDFs, video).
+ * Image subset of seedable media (see SEED_MIME_BY_EXT in seedMedia.ts) —
+ * the source of truth for "is this an image" so the 2 MB limit is never
+ * applied to non-image media (PDFs, video).
  */
 export const IMAGE_EXTENSIONS = new Set([
   '.jpg',


### PR DESCRIPTION
## Summary

`sync:images` used to only *report* missing Media Library files and tell you to restart Strapi. Now it can **seed them** without a restart.

- Scans the same media we seed on bootstrap (images, video, PDF)
- Calls a small `POST /api/seed-media` endpoint (API token auth) that reuses the existing disk-seed logic
- `--dry-run` still just reports; a normal run seeds what’s missing

## Test plan

- [x] `cd cms && pnpm run sync:images:dry-run` — shows missing files, seeds nothing
- [x] `cd cms && pnpm run sync:images` — seeds missing files; they show up in Media Library