### PR TITLE
fix(cta): tie an in-body CTA to the paragraph above it [INTORG-1045]

### DIFF
--- a/src/components/blocks/CtaLink.astro
+++ b/src/components/blocks/CtaLink.astro
@@ -10,9 +10,24 @@ interface Props {
 }
 
 const { text, link, style = 'primary', external = false } = Astro.props
+
+// Spacing (Radu, 2026-08-12): a CTA belongs to the paragraph above it, so that
+// gap is tight (24px, 32px from desktop) and the gap below is the full block
+// gap of 120px. `Paragraph` tightens its own bottom margin when it sees
+// `.cta-link` next to it, and the 120px below comes from here. Before this the
+// CTA had no margin at all, so the following heading sat flush against it
+// (INTORG-1045).
+//
+// `cta-link` is the hook `Paragraph` matches on. Keep the two in step.
+const spacingClass = 'cta-link mb-6xl'
 ---
 
-<LinkButton href={link} variant={style} external={external}>
+<LinkButton
+  href={link}
+  variant={style}
+  external={external}
+  class={spacingClass}
+>
   {text}
   {external && <Icon name="arrow-right" slot="icon-right" />}
 </LinkButton>

--- a/src/components/blocks/Paragraph.astro
+++ b/src/components/blocks/Paragraph.astro
@@ -17,8 +17,27 @@ const alignmentClass =
       ? 'text-right'
       : ''
 
+// A CTA that directly follows a paragraph belongs to that paragraph, so the
+// two sit closer together than two independent blocks do: 24px up to desktop
+// and 32px from there (Radu, 2026-08-12). The gap under the CTA stays the
+// standard 120px, which CtaLink supplies itself.
+//
+// `:has(+ .cta-link)` lets the paragraph react to what follows it, so neither
+// the editor nor the MDX author has to mark the pair up. Written as a literal
+// string because the Tailwind v4 scanner reads the source text.
+//
+// The last-child rule is load-bearing, not tidying. This wrapper has no
+// padding or border, so the bottom margin of its final paragraph collapses
+// out of it and the larger of the two margins wins. That inner margin is 32px,
+// which silently swallowed the 24px below desktop. Zero it and the wrapper's
+// own margin decides the gap.
+const CTA_PAIR_SPACING =
+  '[&:has(+.cta-link)]:mb-xl desktop:[&:has(+.cta-link)]:mb-2xl [&:has(+.cta-link)>*:last-child]:mb-0'
+
 const hasContent = content != null && content !== ''
-const className = [alignmentClass, 'mb-6xl'].filter(Boolean).join(' ')
+const className = [alignmentClass, 'mb-6xl', CTA_PAIR_SPACING]
+  .filter(Boolean)
+  .join(' ')
 const htmlContent = hasContent
   ? await parseMarkdown(content, {
       page: umamiContext,


### PR DESCRIPTION
## Summary

On the Grant for the Web page the CTA had 120px above it and 0px below, so the
"Our Grantees" heading sat flush against the button.

Two things combined. `Paragraph` carries a bottom margin only, so it pushes the
CTA down but nothing pushes the next block away from it. `CtaLink` had no margin
at all, so it took whatever its neighbours gave it, and underneath that was
nothing.

Radu settled the rule: a CTA belongs to the paragraph above it. So
it sits 24px under that paragraph, 32px from `desktop`, and the block that
follows takes the normal 120px.

`Paragraph` now tightens its own bottom margin when a CTA follows it, matched
with `:has(+ .cta-link)`. `CtaLink` carries `mb-6xl` and the `cta-link` hook
class that `Paragraph` looks for. Neither an editor nor an MDX author marks the
pair up, and no page structure changes.

**Worth a look in review:** the class list also carries
`[&:has(+.cta-link)>*:last-child]:mb-0`. That rule is load-bearing, not tidying.
The `Paragraph` wrapper has no padding or border, so the bottom margin of its
final `<p>` collapses out of it, and the larger of the two margins wins. That
inner margin is 32px, which silently swallowed the 24px below `desktop`. The
first version of this fix measured 32px at every width and looked correct at
desktop purely by coincidence, because 32px is also the desktop value. If you
change these numbers, measure all three widths. Two of them agreeing proves
nothing here.

## Related Issue

Fixes INTORG-1045

## Manual Test

Open `/grant/innovation/grant-web/` and find the "Learn about Web Monetization"
button.

| | Above the button | Below the button |
| --- | --- | --- |
| Before | 120px | 0px, heading flush against it |
| After, under 1200px | 24px | 120px |
| After, from 1200px | 32px | 120px |

Measured on a built page at 390px, 900px and 1280px.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [ ] Screenshots for UI changes (if applicable)

