### PR TITLE
fix: sessionize speaker images must also be optimized

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,9 +808,11 @@ pnpm run optimize:images
 
 **How it works:**
 
-- Images are sourced from two locations:
+- Images are sourced from three locations:
   - `public/img/` — static assets committed to the repo
   - `public/uploads/img/original/` — images uploaded via Strapi
+  - `public/sessionize-speakers/img/` — summit speaker photos pulled by `pnpm run sync:sessionize` (output goes to `public/img/optimized/sessionize-speakers/`)
+- The 2 MB image size limit fails the build for the first two locations; for Sessionize photos it only warns, since speakers upload those to a third party and nobody here can re-cut them
 - Each image produces variants at widths ≤ its original width, avoiding upscaling
 - Outputs are cached: a variant is skipped if it already exists and is newer than the source
 - The `public/img/optimized/` directory is gitignored — variants are generated at build time

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -40,8 +40,14 @@ export default defineConfig({
     // variants catalog under src/generated/ (no runtime fs against public/),
     // but keep these exclusions so a future filesystem probe cannot pull image
     // binaries into the SSR function and breach AWS Lambda's unzipped size
-    // limit (INTORG-946 / ADR-008).
-    excludeFiles: ['./public/img/**/*', './public/uploads/**/*']
+    // limit (INTORG-946 / ADR-008). public/sessionize-speakers is the same
+    // shape: ~22MB of speaker photos, growing by a summit's worth each year,
+    // served by the CDN and never read at Lambda runtime.
+    excludeFiles: [
+      './public/img/**/*',
+      './public/uploads/**/*',
+      './public/sessionize-speakers/**/*'
+    ]
   }),
   markdown: {
     rehypePlugins: [rehypeUmamiLinks, rehypeWrapScrollableTables]

--- a/netlify.toml
+++ b/netlify.toml
@@ -91,6 +91,16 @@
   [headers.values]
     Cache-Control = "public, max-age=86400, stale-while-revalidate=604800"
 
+# Sessionize speaker photos. Needed on its own because they live outside /img
+# and would otherwise keep the catch-all's max-age=0. That matters twice over:
+# the originals are the <img> fallback, and per the note above, Image CDN
+# transforms inherit Cache-Control from their source — so without this every
+# speaker avatar revalidates on each navigation despite the long edge TTL.
+[[headers]]
+  for = "/sessionize-speakers/*"
+  [headers.values]
+    Cache-Control = "public, max-age=86400, stale-while-revalidate=604800"
+
 [[headers]]
   for = "/documents/*"
   [headers.values]

--- a/scripts/optimize-images.ts
+++ b/scripts/optimize-images.ts
@@ -38,10 +38,12 @@ const RUNTIME_IMAGE_SOURCES_CATALOG_PATH = path.join(
 
 const CONCURRENCY = 4
 
-// WEBP_QUALITY and AVIF_QUALITY now live in @/utils/main/imagePaths so the
-// Netlify Image CDN URL builder encodes at the same settings as this script.
-// Bump when quality, target widths, or output naming changes so the content-hash
-// cache does not skip regeneration of already-processed sources.
+// WEBP_QUALITY and AVIF_QUALITY live in @/utils/main/imagePaths so the Netlify
+// Image CDN URL builder encodes at the same settings as this script. Both are
+// interpolated here, so a quality change invalidates the content-hash cache by
+// itself. Bump the trailing token by hand for anything they don't encode —
+// target widths or output naming — or already-processed sources are skipped and
+// keep variants built under the old rules.
 const PIPELINE_ID = `webp${WEBP_QUALITY}-avif${AVIF_QUALITY}-exactWidth`
 
 interface SourceConfig {

--- a/scripts/optimize-images.ts
+++ b/scripts/optimize-images.ts
@@ -47,16 +47,33 @@ const PIPELINE_ID = `webp${WEBP_QUALITY}-avif${AVIF_QUALITY}-exactWidth`
 interface SourceConfig {
   dir: string
   outputPrefix: string
+  /**
+   * Whether an oversized file fails the build. On for the directories we
+   * control, where an oversized image is an editor mistake fixable at source.
+   * Off for Sessionize photos: speakers upload those to a third party and
+   * nobody here can re-cut them, so one large headshot must not be able to
+   * block a deploy. Oversize is still reported, just not fatally.
+   */
+  enforceSizeLimit: boolean
 }
 
+// Must stay in step with `OPTIMIZED_SOURCE_PREFIXES` in
+// `src/utils/main/images.ts`, which looks up what this array produces.
 const SOURCES: SourceConfig[] = [
   {
     dir: getPublicAssetPath(IMAGE_URL_PATHS.publicSource),
-    outputPrefix: ''
+    outputPrefix: '',
+    enforceSizeLimit: true
   },
   {
     dir: getPublicAssetPath(IMAGE_URL_PATHS.uploadSource),
-    outputPrefix: 'uploads'
+    outputPrefix: 'uploads',
+    enforceSizeLimit: true
+  },
+  {
+    dir: getPublicAssetPath(IMAGE_URL_PATHS.sessionizeSource),
+    outputPrefix: 'sessionize-speakers',
+    enforceSizeLimit: false
   }
 ]
 
@@ -246,7 +263,7 @@ async function main(): Promise<void> {
   }> = []
   const oversizedErrors: string[] = []
 
-  for (const { dir, outputPrefix } of SOURCES) {
+  for (const { dir, outputPrefix, enforceSizeLimit } of SOURCES) {
     if (!fs.existsSync(dir)) {
       console.log(`  skip ${path.relative(PROJECT_ROOT, dir)} (not found)`)
       continue
@@ -258,11 +275,13 @@ async function main(): Promise<void> {
 
     for (const file of files) {
       const { size } = fs.statSync(file)
-      if (isImageOverSizeLimit(size)) {
-        oversizedErrors.push(
-          imageSizeLimitError(path.relative(PROJECT_ROOT, file), size)
-        )
-      }
+      if (!isImageOverSizeLimit(size)) continue
+      const message = imageSizeLimitError(
+        path.relative(PROJECT_ROOT, file),
+        size
+      )
+      if (enforceSizeLimit) oversizedErrors.push(message)
+      else console.warn(`    ⚠️ ${message}`)
     }
 
     sourceBatches.push({ dir, outputPrefix, files })

--- a/src/components/pages/SpeakerDetailPage.astro
+++ b/src/components/pages/SpeakerDetailPage.astro
@@ -46,7 +46,8 @@ const bio = translation?.bio ?? entry.bio
           height={400}
           sizes="400px"
           widths={AVATAR_CDN_WIDTHS}
-          loading="lazy"
+          loading="eager"
+          fetchpriority="high"
         />
       </div>
     </header>

--- a/src/components/pages/SpeakerDetailPage.astro
+++ b/src/components/pages/SpeakerDetailPage.astro
@@ -4,8 +4,10 @@ import {
   defaultLocale,
   useTranslations,
   getTranslation,
-  getTalks
+  getTalks,
+  AVATAR_CDN_WIDTHS
 } from '@/utils'
+import OptimizedImage from '@/components/shared/OptimizedImage.astro'
 import type { Speaker } from '@/types/summit'
 import TranslationDisclaimer from '@/components/shared/TranslationDisclaimer.astro'
 import TextParagraphs from '@/components/shared/TextParagraphs.astro'
@@ -37,11 +39,13 @@ const bio = translation?.bio ?? entry.bio
           <h1>{entry.name}</h1>
           <p class="mb-6">{entry.tagLine}</p>
         </div>
-        <img
+        <OptimizedImage
           src={entry.profilePicture}
           alt={t('summit.profile_image', { name: entry.name })}
-          width="400"
-          height="400"
+          width={400}
+          height={400}
+          sizes="400px"
+          widths={AVATAR_CDN_WIDTHS}
           loading="lazy"
         />
       </div>

--- a/src/components/shared/OptimizedImage.astro
+++ b/src/components/shared/OptimizedImage.astro
@@ -34,6 +34,15 @@ interface Props {
   fetchpriority?: 'high' | 'low' | 'auto'
   media?: string
   draggable?: boolean
+  /**
+   * CDN width ladder for `src`; defaults to `DEFAULT_CDN_WIDTHS`. Narrow it for
+   * images that never render large: every rung is a separately billed transform
+   * behind its own edge-cache entry, and because Netlify clamps rather than
+   * upscales, every rung above the source's intrinsic width returns pixels
+   * identical to the rung below it. `AVATAR_CDN_WIDTHS` is the ladder for
+   * profile photos.
+   */
+  widths?: readonly number[]
   /** Optional art-directed sources (most specific `media` first). */
   alternateSources?: OptimizedImageAlternateSource[]
 }
@@ -50,11 +59,12 @@ const {
   fetchpriority,
   media,
   draggable,
+  widths,
   alternateSources = []
 } = Astro.props
 
 const { variants, fullSrc, avifVariants, avifFullSrc } = src
-  ? getOptimizedImage(src)
+  ? getOptimizedImage(src, widths)
   : { variants: [], fullSrc: null, avifVariants: [], avifFullSrc: null }
 
 const alternatePictureSources = alternateSources.flatMap(

--- a/src/components/summit/SessionCard.astro
+++ b/src/components/summit/SessionCard.astro
@@ -5,9 +5,11 @@ import {
   truncateText,
   type Locale,
   getTranslation,
-  buildUmamiAttrs
+  buildUmamiAttrs,
+  AVATAR_CDN_WIDTHS
 } from '@/utils'
 import SessionSubheader from './SessionSubheader.astro'
+import OptimizedImage from '@/components/shared/OptimizedImage.astro'
 
 interface Props {
   talkPreview: TalkPreview
@@ -33,12 +35,14 @@ const attrs = buildUmamiAttrs({
 ---
 
 <li class="flex flex-col gap-2xl mb-6 md:flex-row">
-  <img
+  <OptimizedImage
     class="w-[200px] h-[200px] rounded-full border-2 border-[var(--color-primary)]"
     src={talkPreview.speakerImage}
-    alt={talkPreview.speakerName}
-    width="200"
-    height="200"
+    alt={talkPreview.speakerName ?? ''}
+    width={200}
+    height={200}
+    sizes="200px"
+    widths={AVATAR_CDN_WIDTHS}
     loading="lazy"
   />
   <div class="[&_p]:text-body-sm-standard">

--- a/src/components/summit/SessionCard.astro
+++ b/src/components/summit/SessionCard.astro
@@ -37,6 +37,7 @@ const attrs = buildUmamiAttrs({
 <li class="flex flex-col gap-2xl mb-6 md:flex-row">
   <OptimizedImage
     class="w-[200px] h-[200px] rounded-full border-2 border-[var(--color-primary)]"
+    pictureClass="shrink-0"
     src={talkPreview.speakerImage}
     alt={talkPreview.speakerName ?? ''}
     width={200}

--- a/src/components/summit/SpeakerCard.astro
+++ b/src/components/summit/SpeakerCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { Speaker } from '@/types/summit'
-import { generateSlug, buildUmamiAttrs } from '@/utils'
+import { generateSlug, buildUmamiAttrs, AVATAR_CDN_WIDTHS } from '@/utils'
+import OptimizedImage from '@/components/shared/OptimizedImage.astro'
 
 interface Props {
   speaker: Speaker
@@ -24,11 +25,13 @@ const attrs = buildUmamiAttrs({
 
 <li class="flex-1 min-w-[8em]">
   <a href={href} {...attrs}>
-    <img
+    <OptimizedImage
       src={speaker.profilePicture}
       alt={speaker.name}
-      width="240"
-      height="240"
+      width={240}
+      height={240}
+      sizes="240px"
+      widths={AVATAR_CDN_WIDTHS}
       loading="lazy"
     />
     <h2 class="text-h4 tablet:text-h4-md desktop:text-h4-lg! font-bold">

--- a/src/integrations/audit-image-optimization.test.ts
+++ b/src/integrations/audit-image-optimization.test.ts
@@ -17,6 +17,15 @@ describe('isOptimizableRasterPath', () => {
     expect(isOptimizableRasterPath('/img/a.webp')).toBe(true)
   })
 
+  it('accepts Sessionize speaker photos', () => {
+    expect(
+      isOptimizableRasterPath('/sessionize-speakers/img/2025/ed-cable.jpg')
+    ).toBe(true)
+    expect(
+      isOptimizableRasterPath('/sessionize-speakers/img/no-photo.svg')
+    ).toBe(false)
+  })
+
   it('rejects svgs, gifs, optimized output, and external paths', () => {
     expect(isOptimizableRasterPath('/img/logo.svg')).toBe(false)
     expect(isOptimizableRasterPath('/img/anim.gif')).toBe(false)
@@ -77,6 +86,16 @@ describe('findUnoptimizedImages', () => {
     const html = `<img src="/uploads/img/original/erica.png" alt="x" />`
     expect(findUnoptimizedImages(html)).toEqual([
       { src: '/uploads/img/original/erica.png', reason: 'standalone-raw' }
+    ])
+  })
+
+  it('flags a raw Sessionize speaker photo', () => {
+    const html = `<img src="/sessionize-speakers/img/2025/ed-cable.jpg" alt="Ed Cable" width="240" />`
+    expect(findUnoptimizedImages(html)).toEqual([
+      {
+        src: '/sessionize-speakers/img/2025/ed-cable.jpg',
+        reason: 'standalone-raw'
+      }
     ])
   })
 

--- a/src/integrations/audit-image-optimization.ts
+++ b/src/integrations/audit-image-optimization.ts
@@ -25,8 +25,9 @@
  *
  * Findings come in two severities, and the split is the point of this audit:
  *
- * - **Blocking** (`standalone-raw`, `picture-without-cdn`): a raw `/img/**` or
- *   `/uploads/**` raster reached the page without going through
+ * - **Blocking** (`standalone-raw`, `picture-without-cdn`): a raw raster from a
+ *   policed source tree (see `isOptimizableRasterPath`) reached the page
+ *   without going through
  *   `OptimizedImage`/`getOptimizedImage` at all. That is a code defect, it is
  *   deterministic from the repo tree, and whoever wrote the component can fix
  *   it — so it fails the build.
@@ -47,7 +48,10 @@ import { readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { isImageCdnEnabled } from '../utils/main/imageCdn'
-import { hasOptimizableRasterExtension } from '../utils/main/imagePaths'
+import {
+  IMAGE_URL_PATHS,
+  hasOptimizableRasterExtension
+} from '../utils/main/imagePaths'
 
 const CDN_MARKER = '/.netlify/images'
 const IMG_TAG_RE = /<img\b[^>]*>/gi
@@ -102,9 +106,25 @@ function hasAttr(tag: string, name: string): boolean {
   return new RegExp(`\\s${name}(\\s|=|>|/)`, 'i').test(tag)
 }
 
-/** A site-relative raster we expect to be optimized (not an SVG/GIF/external). */
+/**
+ * A site-relative raster we expect to be optimized (not an SVG/GIF/external).
+ *
+ * The Sessionize prefix comes from `IMAGE_URL_PATHS` rather than another string
+ * literal: this list, the resolver's and the encoder's each drifted apart once
+ * already, and that is precisely how ~240 speaker photos shipped raw past an
+ * audit whose whole job is to catch a raw raster. The `/img/` and `/uploads/`
+ * literals stay deliberately broader than their `IMAGE_URL_PATHS` equivalents
+ * (`/uploads/**` vs `/uploads/img/original/**`) so widening this does not
+ * quietly narrow what is already policed.
+ */
 export function isOptimizableRasterPath(src: string): boolean {
-  if (!src.startsWith('/img/') && !src.startsWith('/uploads/')) return false
+  if (
+    !src.startsWith('/img/') &&
+    !src.startsWith('/uploads/') &&
+    !src.startsWith(`${IMAGE_URL_PATHS.sessionizeSource}/`)
+  ) {
+    return false
+  }
   if (src.startsWith('/img/optimized/')) return false
   return hasOptimizableRasterExtension(src)
 }

--- a/src/types/summit.ts
+++ b/src/types/summit.ts
@@ -22,7 +22,13 @@ export interface Talk {
 }
 
 export type TalkPreview = Omit<Talk, 'speakers'> & {
-  speakerImage: string | null
+  /**
+   * Always populated: `getTalkPreviews` substitutes the no-photo SVG when
+   * Sessionize has no photo for the speaker, so components can pass this
+   * straight to `OptimizedImage`. Contrast `SessionizeSpeaker.profilePicture`,
+   * which is the nullable API shape.
+   */
+  speakerImage: string
   speakerName: string | null
 }
 
@@ -31,7 +37,8 @@ export interface Speaker {
   name: string
   bio: string | null
   tagLine: string | null
-  profilePicture: string | null
+  /** Always populated — see `TalkPreview.speakerImage`. */
+  profilePicture: string
   es: {
     bio: string
   } | null

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -158,6 +158,7 @@ export {
   encodeImageUrlPath,
   hasOptimizableRasterExtension,
   withIntrinsicWidthRung,
+  AVATAR_CDN_WIDTHS,
   IMAGE_URL_PATHS,
   TARGET_WIDTHS,
   pathToSegments,

--- a/src/utils/main/imagePaths.ts
+++ b/src/utils/main/imagePaths.ts
@@ -25,9 +25,14 @@ export const AVATAR_CDN_WIDTHS = [240, 480] as const
 /**
  * Encoding quality, shared by the two things that can produce a variant: the
  * build-time encoder (`scripts/optimize-images.ts`) and the Netlify Image CDN
- * URL builder (`imageCdn.ts`). Defined here so the two cannot drift, and so a
- * change to either lands in the CI cache key (this file is hashed by
- * `.github/actions/cache-optimized-images`).
+ * URL builder (`imageCdn.ts`). Defined here so the two cannot drift.
+ *
+ * Changing either value must be paired with a `PIPELINE_ID` bump in
+ * `scripts/optimize-images.ts`: the encode cache is keyed on
+ * `PIPELINE_ID:<source hash>`, so without it already-encoded sources are
+ * skipped and keep their old quality. (Build mode only —
+ * `netlify/plugins/cache-images` restores the whole variant tree and does not
+ * key on this file.)
  *
  * Higher than sharp's WebP default (80): blog/body images were looking soft
  * when the browser had to fall back to a small variant (INTORG-934).

--- a/src/utils/main/imagePaths.ts
+++ b/src/utils/main/imagePaths.ts
@@ -10,6 +10,19 @@ export const TARGET_WIDTHS = [640, 1280, 1920, 2560, 3840] as const
 export const DEFAULT_CDN_WIDTHS = [640, 1280, 1920] as const
 
 /**
+ * Width ladder for speaker avatars. Every rung is a separately billed transform
+ * and a separate edge-cache entry, and Netlify clamps rather than upscales — so
+ * for a source narrower than a rung, that rung returns the same pixels as the
+ * one below it at full price. No Sessionize photo is wider than 400px and they
+ * render at 200–400 CSS px, which makes all three default rungs collapse onto
+ * the same output: 6 transforms per photo (two formats) where 4 will do.
+ *
+ * 240 is a genuine downscale for the card grids at DPR 1; 480 covers DPR 2 and
+ * clamps to the source width for anything narrower.
+ */
+export const AVATAR_CDN_WIDTHS = [240, 480] as const
+
+/**
  * Encoding quality, shared by the two things that can produce a variant: the
  * build-time encoder (`scripts/optimize-images.ts`) and the Netlify Image CDN
  * URL builder (`imageCdn.ts`). Defined here so the two cannot drift, and so a
@@ -102,7 +115,18 @@ export const IMAGE_URL_PATHS = {
   publicSource: '/img',
   publicOptimized: '/img/optimized',
   uploadSource: '/uploads/img/original',
-  uploadOptimized: '/img/optimized/uploads'
+  uploadOptimized: '/img/optimized/uploads',
+  /**
+   * Speaker photos downloaded from Sessionize by `scripts/sync-sessionize.ts`.
+   * They sit outside `/img`, so every prefix check has to name them explicitly
+   * — the omission is why they were the one image family still shipping raw.
+   *
+   * Variants land under `publicOptimized` like every other source, which is
+   * what makes them inherit the `/img/optimized` gitignore entry, the CI
+   * encode cache, and the `/img/*` cache header without further wiring.
+   */
+  sessionizeSource: '/sessionize-speakers/img',
+  sessionizeOptimized: '/img/optimized/sessionize-speakers'
 } as const
 
 /**

--- a/src/utils/main/imagePaths.ts
+++ b/src/utils/main/imagePaths.ts
@@ -13,12 +13,18 @@ export const DEFAULT_CDN_WIDTHS = [640, 1280, 1920] as const
  * Width ladder for speaker avatars. Every rung is a separately billed transform
  * and a separate edge-cache entry, and Netlify clamps rather than upscales — so
  * for a source narrower than a rung, that rung returns the same pixels as the
- * one below it at full price. No Sessionize photo is wider than 400px and they
- * render at 200–400 CSS px, which makes all three default rungs collapse onto
- * the same output: 6 transforms per photo (two formats) where 4 will do.
+ * one below it at full price. Avatars render at 200–400 CSS px, so the 1280 and
+ * 1920 default rungs buy nothing: 6 transforms per photo (two formats) where 4
+ * will do.
  *
- * 240 is a genuine downscale for the card grids at DPR 1; 480 covers DPR 2 and
- * clamps to the source width for anything narrower.
+ * 240 is a genuine downscale for the card grids at DPR 1; 480 covers DPR 2.
+ *
+ * Sizing note, not an invariant: Sessionize hands us URLs that carry its own
+ * resize directive (`…/image/2363-400o400o1-….jpg`), so today every photo
+ * arrives 400×400, and `scripts/sync-sessionize.ts` saves whatever it is handed
+ * without resizing. Nothing in this repo enforces that bound. The ladder does
+ * not depend on it either way: at 400px the 480 rung clamps to the source, and
+ * for a larger source it simply becomes a real downscale.
  */
 export const AVATAR_CDN_WIDTHS = [240, 480] as const
 
@@ -27,12 +33,11 @@ export const AVATAR_CDN_WIDTHS = [240, 480] as const
  * build-time encoder (`scripts/optimize-images.ts`) and the Netlify Image CDN
  * URL builder (`imageCdn.ts`). Defined here so the two cannot drift.
  *
- * Changing either value must be paired with a `PIPELINE_ID` bump in
- * `scripts/optimize-images.ts`: the encode cache is keyed on
- * `PIPELINE_ID:<source hash>`, so without it already-encoded sources are
- * skipped and keep their old quality. (Build mode only —
- * `netlify/plugins/cache-images` restores the whole variant tree and does not
- * key on this file.)
+ * Changing either value invalidates the build-mode encode cache on its own:
+ * that cache is keyed `PIPELINE_ID:<source hash>`, and `PIPELINE_ID` in
+ * `scripts/optimize-images.ts` interpolates both constants. A manual bump of
+ * its trailing token is only needed for pipeline changes these values don't
+ * encode — width rules or output naming.
  *
  * Higher than sharp's WebP default (80): blog/body images were looking soft
  * when the browser had to fall back to a small variant (INTORG-934).

--- a/src/utils/main/images.test.ts
+++ b/src/utils/main/images.test.ts
@@ -16,6 +16,7 @@ import {
   NETLIFY_IMAGE_ENDPOINT
 } from './imageCdn'
 import {
+  AVATAR_CDN_WIDTHS,
   DEFAULT_CDN_WIDTHS,
   TARGET_WIDTHS,
   encodeImageUrlPath
@@ -370,6 +371,78 @@ describe('getOptimizedImage — Netlify Image CDN mode', () => {
     expect(getOptimizedImage('/img/hero.png').variants).toEqual([
       { src: '/img/optimized/hero-640.webp', width: 640 }
     ])
+  })
+})
+
+describe('getOptimizedImage — Sessionize speaker photos', () => {
+  const SPEAKER = '/sessionize-speakers/img/2025/ed-cable.jpg'
+
+  it('maps a speaker photo onto its optimized variants in build mode', () => {
+    setImageCdnEnabledForTests(false)
+    setOptimizedImageVariantCatalogForTests([
+      '/img/optimized/sessionize-speakers/2025/ed-cable-400.webp',
+      '/img/optimized/sessionize-speakers/2025/ed-cable-full.webp',
+      '/img/optimized/sessionize-speakers/2025/ed-cable-400.avif',
+      '/img/optimized/sessionize-speakers/2025/ed-cable-full.avif'
+    ])
+
+    expect(getOptimizedImage(SPEAKER)).toEqual({
+      variants: [
+        {
+          src: '/img/optimized/sessionize-speakers/2025/ed-cable-400.webp',
+          width: 400
+        }
+      ],
+      fullSrc: '/img/optimized/sessionize-speakers/2025/ed-cable-full.webp',
+      avifVariants: [
+        {
+          src: '/img/optimized/sessionize-speakers/2025/ed-cable-400.avif',
+          width: 400
+        }
+      ],
+      avifFullSrc: '/img/optimized/sessionize-speakers/2025/ed-cable-full.avif'
+    })
+  })
+
+  it('serves a speaker photo through the CDN when it ships in the deploy', () => {
+    setImageCdnEnabledForTests(true)
+    setDeployedImageSourcesForTests([SPEAKER])
+
+    const result = getOptimizedImage(SPEAKER)
+
+    expect(result.variants).toHaveLength(DEFAULT_CDN_WIDTHS.length)
+    expect(readCdnSourceParam(result.variants[0].src)).toBe(SPEAKER)
+  })
+
+  it('honours a narrowed ladder so clamped rungs are not billed twice', () => {
+    setImageCdnEnabledForTests(true)
+    setDeployedImageSourcesForTests([SPEAKER])
+
+    const result = getOptimizedImage(SPEAKER, AVATAR_CDN_WIDTHS)
+
+    expect(result.variants.map((v) => v.width)).toEqual([...AVATAR_CDN_WIDTHS])
+    expect(result.avifVariants.map((v) => v.width)).toEqual([
+      ...AVATAR_CDN_WIDTHS
+    ])
+  })
+
+  it('degrades when the photo is missing from the deploy', () => {
+    setImageCdnEnabledForTests(true)
+    setDeployedImageSourcesForTests([])
+
+    expect(getOptimizedImage(SPEAKER)).toEqual(EMPTY)
+  })
+
+  it('leaves the no-photo SVG fallback alone', () => {
+    setImageCdnEnabledForTests(true)
+    setDeployedImageSourcesForTests(['/sessionize-speakers/img/no-photo.svg'])
+
+    expect(getOptimizedImage('/sessionize-speakers/img/no-photo.svg')).toEqual(
+      EMPTY
+    )
+    expect(isOptimizableSource('/sessionize-speakers/img/no-photo.svg')).toBe(
+      false
+    )
   })
 })
 

--- a/src/utils/main/images.ts
+++ b/src/utils/main/images.ts
@@ -18,6 +18,7 @@ import {
 } from './imagePaths'
 
 export {
+  AVATAR_CDN_WIDTHS,
   IMAGE_URL_PATHS,
   OPTIMIZED_IMAGE_MANIFEST_RELATIVE_PATH,
   TARGET_WIDTHS,
@@ -48,7 +49,36 @@ interface ResolvedImageSource {
    * it becomes a URL, never before.
    */
   pathname: string
+  /**
+   * Base name of this source's pre-generated variants (`{base}-{width}.webp`),
+   * resolved alongside the pathname so the prefix that matched cannot be
+   * re-derived differently later. Unused in CDN mode.
+   */
+  optimizedBase: string
 }
+
+/**
+ * Source prefix → optimized-output prefix, in match order. Must stay in step
+ * with `SOURCES` in `scripts/optimize-images.ts`: that array decides what lands
+ * in the catalogs, this one decides what is looked up in them.
+ *
+ * `publicSource` goes last because it is the broadest — `/img/optimized` and
+ * nothing else sits inside it, and that case is rejected before the scan.
+ */
+const OPTIMIZED_SOURCE_PREFIXES = [
+  {
+    source: IMAGE_URL_PATHS.uploadSource,
+    optimized: IMAGE_URL_PATHS.uploadOptimized
+  },
+  {
+    source: IMAGE_URL_PATHS.sessionizeSource,
+    optimized: IMAGE_URL_PATHS.sessionizeOptimized
+  },
+  {
+    source: IMAGE_URL_PATHS.publicSource,
+    optimized: IMAGE_URL_PATHS.publicOptimized
+  }
+] as const
 
 const generatedManifestModules = import.meta.glob(
   '../../generated/optimized-image-manifest.json',
@@ -171,9 +201,10 @@ function replaceUrlPathPrefix(
  * Resolves an image reference to the source data we are allowed to optimize,
  * or `null` when it isn't one.
  *
- * Handles relative paths (/img/..., /uploads/img/original/...) and absolute
- * Strapi URLs (http://host/uploads/...). Rejects anything the encoder cannot
- * produce variants for (SVGs, GIFs, extensionless paths — see
+ * Handles relative paths (/img/..., /uploads/img/original/...,
+ * /sessionize-speakers/img/...) and absolute Strapi URLs
+ * (http://host/uploads/...). Rejects anything the encoder cannot produce
+ * variants for (SVGs, GIFs, extensionless paths — see
  * `hasOptimizableRasterExtension`), anything outside the known source
  * directories, and the generated output tree.
  *
@@ -202,40 +233,25 @@ function resolveOptimizableSource(src: string): ResolvedImageSource | null {
   // neither hide an extension nor invent one.
   if (!hasOptimizableRasterExtension(pathname)) return null
 
-  if (isWithinUrlPath(pathname, IMAGE_URL_PATHS.uploadSource)) {
-    return { pathname }
-  }
+  // The generated output tree is not a source. It lives inside `publicSource`,
+  // so it has to be rejected before the prefix scan rather than within it.
+  if (isWithinUrlPath(pathname, IMAGE_URL_PATHS.publicOptimized)) return null
 
-  if (
-    isWithinUrlPath(pathname, IMAGE_URL_PATHS.publicSource) &&
-    !isWithinUrlPath(pathname, IMAGE_URL_PATHS.publicOptimized)
-  ) {
-    return { pathname }
-  }
+  const prefix = OPTIMIZED_SOURCE_PREFIXES.find((candidate) =>
+    isWithinUrlPath(pathname, candidate.source)
+  )
+  if (!prefix) return null
 
-  return null
+  const stem = pathname.slice(0, -path.extname(pathname).length)
+  return {
+    pathname,
+    optimizedBase: replaceUrlPathPrefix(stem, prefix.source, prefix.optimized)
+  }
 }
 
 /** Whether a source is eligible for optimization (used to scope the warning). */
 export function isOptimizableSource(src: string): boolean {
   return resolveOptimizableSource(src) !== null
-}
-
-/** Maps a resolved source path to the base name of its pre-generated variants. */
-function getOptimizedBase(pathname: string): string {
-  const stem = pathname.slice(0, -path.extname(pathname).length)
-
-  return isWithinUrlPath(pathname, IMAGE_URL_PATHS.uploadSource)
-    ? replaceUrlPathPrefix(
-        stem,
-        IMAGE_URL_PATHS.uploadSource,
-        IMAGE_URL_PATHS.uploadOptimized
-      )
-    : replaceUrlPathPrefix(
-        stem,
-        IMAGE_URL_PATHS.publicSource,
-        IMAGE_URL_PATHS.publicOptimized
-      )
 }
 
 /**
@@ -310,12 +326,12 @@ export function getOptimizedImage(
     return buildCdnImage(source.pathname, cdnWidths)
   }
 
-  const base = getOptimizedBase(source.pathname)
-  const variants = listSizedVariants(base, 'webp')
-  const avifVariants = listSizedVariants(base, 'avif')
+  const { optimizedBase } = source
+  const variants = listSizedVariants(optimizedBase, 'webp')
+  const avifVariants = listSizedVariants(optimizedBase, 'avif')
 
-  const fullWebP = `${base}-full.webp`
-  const fullAvif = `${base}-full.avif`
+  const fullWebP = `${optimizedBase}-full.webp`
+  const fullAvif = `${optimizedBase}-full.avif`
 
   return {
     variants,

--- a/src/utils/main/navigation.test.ts
+++ b/src/utils/main/navigation.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import hackathonEn from '@/config/hackathon-navigation.json'
 import type { Locale } from './locales'
 
 // `./navigation` -> `./locales` reaches into Astro's virtual modules for
@@ -19,8 +20,13 @@ const { getNavigation } = await import('./navigation')
 
 describe('getNavigation', () => {
   it('returns the hackathon menu, not the summit one', () => {
-    const { mainMenu } = getNavigation('hackathon', 'en')
-    expect(mainMenu.map((group) => group.label)).toEqual(['Hackathon'])
+    // Compared against the config module rather than a hard-coded label list.
+    // These files are synced from Strapi, so an editor adding a nav group is
+    // expected content churn, not a regression — pinning the labels made this
+    // red when INTORG-1046 added a "Resources" group. The site → config
+    // mapping is what's under test, and that still fails loudly if
+    // `hackathon` ever resolves to the summit config.
+    expect(getNavigation('hackathon', 'en')).toEqual(hackathonEn)
   })
 
   it('returns the localized config for es', () => {


### PR DESCRIPTION
## Summary
We noticed that the `sessionize-speakers` images are not following the standard image optimisation path like the rest of the images. 

This PR attempts to refactor so that these images gets rendered and cached accordingly. To achieve this we had to modify the related components and update the tests accordingly.

## Manual Test
See the Netlify preview and where it is serving the speakers from previous conferences. Inspect the image. Notice it is optimized.

## Checks

- [x] `pnpm run format`
- [x] `pnpm run lint`

## PR Checklist

- [x] PR title follows Conventional Commits (e.g. `feat: ...`, `fix: ...`)
- [x] Linked issue included
- [x] Scope is focused (target ~10-20 files when possible)
- [NA] Screenshots for UI changes (if applicable)

## Automated description
This pull request introduces comprehensive support for Sessionize speaker photos as a first-class image source throughout the codebase. The changes ensure these images are optimized, properly cached, and consistently handled alongside other image sources, while also improving the maintainability and correctness of image-related utilities and audits. Additionally, the pull request introduces a dedicated CDN width ladder for speaker avatars to optimize performance and cost.

**Sessionize speaker photo support:**

- Added `public/sessionize-speakers/img/` as a new image source, updated documentation, and ensured the image optimization script recognizes and processes these images with a non-blocking size limit. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L811-R815) [[2]](diffhunk://#diff-ca2187bf71bc55d2241962e74d558278dd1ba59d15355a10fd63de612b62a89fL41-R78) [[3]](diffhunk://#diff-ca2187bf71bc55d2241962e74d558278dd1ba59d15355a10fd63de612b62a89fL249-R268) [[4]](diffhunk://#diff-ca2187bf71bc55d2241962e74d558278dd1ba59d15355a10fd63de612b62a89fL261-R286)
- Updated the Netlify configuration to apply appropriate cache headers to Sessionize speaker photos, ensuring efficient CDN caching.
- Extended the image audit logic to include Sessionize photos, preventing unoptimized images from bypassing the audit and adding corresponding tests. [[1]](diffhunk://#diff-945502c7dfe2d13cf7f25a4ad4adebbf4e3be81efc536f32715175982f6907caL28-R30) [[2]](diffhunk://#diff-945502c7dfe2d13cf7f25a4ad4adebbf4e3be81efc536f32715175982f6907caL50-R54) [[3]](diffhunk://#diff-945502c7dfe2d13cf7f25a4ad4adebbf4e3be81efc536f32715175982f6907caL105-R127) [[4]](diffhunk://#diff-790189262ef247659e44154221fe3e5b61449e6d5bb6d12d526ae030dc4ffe43R20-R28) [[5]](diffhunk://#diff-790189262ef247659e44154221fe3e5b61449e6d5bb6d12d526ae030dc4ffe43R92-R101)

**Image optimization and configuration:**

- Introduced `AVATAR_CDN_WIDTHS` for speaker avatars, reducing unnecessary CDN transforms and improving efficiency; updated `OptimizedImage` and all relevant components to use this ladder. [[1]](diffhunk://#diff-888bfb6d731e5e5f29cf9a5675ed9df651ccc464eabd665704023dd7478914cbR12-R40) [[2]](diffhunk://#diff-1dab9092706f28a3b8cef6068a2240badf218cffd0c7ae8c16920eb2c545c003L7-R10) [[3]](diffhunk://#diff-1dab9092706f28a3b8cef6068a2240badf218cffd0c7ae8c16920eb2c545c003L40-R50) [[4]](diffhunk://#diff-cf6ce851d125cb313c28a3b716fffcad982d20c95c627a9e623a58a9b3f9d9a2L8-R12) [[5]](diffhunk://#diff-cf6ce851d125cb313c28a3b716fffcad982d20c95c627a9e623a58a9b3f9d9a2L36-R46) [[6]](diffhunk://#diff-f94f3f595e3d619c40ad1fedd6bf69cf792ede6fc86cd0849e5ec9614715411aL3-R4) [[7]](diffhunk://#diff-f94f3f595e3d619c40ad1fedd6bf69cf792ede6fc86cd0849e5ec9614715411aL27-R34) [[8]](diffhunk://#diff-9f85bc621c06a22272a8ebcf27b93ac8aa83042a7945feeccc0c0f7c948d5ac5R37-R45) [[9]](diffhunk://#diff-9f85bc621c06a22272a8ebcf27b93ac8aa83042a7945feeccc0c0f7c948d5ac5R62-R67) [[10]](diffhunk://#diff-ab5b4a9bae3dcc344b5199c7517fbeb9949748a54afb94b176f6a7e6c5acd5caR19) [[11]](diffhunk://#diff-6147e3c1761df71fd40952dbcbac388a45f80b8c318f367ef41048351a2c0c99R161)
- Updated image source path constants in `IMAGE_URL_PATHS` to include Sessionize, and improved comments to clarify their roles and prevent future drift.

**Type and interface improvements:**

- Made `profilePicture` and `speakerImage` always populated in `Speaker` and `TalkPreview` types, respectively, simplifying component logic and improving type safety. [[1]](diffhunk://#diff-6e831999256625ab4332f25867880c6f0958cf6b6559ba79bd2862d0b5bd727fL25-R31) [[2]](diffhunk://#diff-6e831999256625ab4332f25867880c6f0958cf6b6559ba79bd2862d0b5bd727fL34-R41)

**Build and deployment configuration:**

- Added `public/sessionize-speakers/**/*` to file exclusions in the Astro build config to avoid including large image binaries in AWS Lambda deployments.

These changes collectively ensure that speaker photos are handled as robustly as other images, improve performance and maintainability, and close previous gaps in image optimization and auditing.